### PR TITLE
feat(auth): add first-admin bootstrap flow and profile UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ NODE_ENV=development
 JWT_SECRET=your-secret-key-change-in-production
 JWT_ACCESS_SECRET=your-access-jwt-secret-change-in-production
 JWT_REFRESH_SECRET=your-refresh-jwt-secret-change-in-production
+# Optional: one-time first-admin provisioning secret used by /auth/bootstrap-admin
+ADMIN_BOOTSTRAP_SECRET=
 
 # CORS (required in production, comma-separated origins)
 # Example: CORS_ORIGINS=https://todos.karthikg.in,https://admin.example.com

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ NODE_ENV=development
 JWT_SECRET=your-secret-key-change-in-production
 JWT_ACCESS_SECRET=your-access-jwt-secret-change-in-production
 JWT_REFRESH_SECRET=your-refresh-jwt-secret-change-in-production
+ADMIN_BOOTSTRAP_SECRET=
 CORS_ORIGINS=
 ```
 
@@ -55,6 +56,7 @@ Production notes:
 - `JWT_ACCESS_SECRET` and `JWT_REFRESH_SECRET` must be set to strong, different values.
 - `JWT_SECRET` is supported as a backward-compatibility fallback only.
 - `CORS_ORIGINS` must be set (comma-separated allowlist).
+- `ADMIN_BOOTSTRAP_SECRET` is optional, and enables first-admin provisioning from the Profile UI.
 
 ### 3. Start Database
 

--- a/public/index.html
+++ b/public/index.html
@@ -214,6 +214,26 @@
                         <button type="submit" class="btn">Update Profile</button>
                     </form>
                 </div>
+
+                <div class="profile-section" id="adminBootstrapSection" style="display: none;">
+                    <h3>Admin Provisioning</h3>
+                    <p style="margin-bottom: 12px; color: var(--text-secondary);">
+                        No admin user exists yet. Enter the bootstrap secret to grant admin access to this account.
+                    </p>
+                    <form data-onsubmit="handleAdminBootstrap(event)">
+                        <div class="form-group">
+                            <label for="adminBootstrapSecret">Bootstrap Secret</label>
+                            <input
+                                type="password"
+                                id="adminBootstrapSecret"
+                                autocomplete="current-password"
+                                placeholder="Enter admin bootstrap secret"
+                                required
+                            >
+                        </div>
+                        <button type="submit" class="btn">Grant Admin Access</button>
+                    </form>
+                </div>
             </div>
 
             <!-- Admin View -->

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,9 @@ const corsOrigins = (process.env.CORS_ORIGINS || '')
   .split(',')
   .map((origin) => origin.trim())
   .filter((origin) => origin.length > 0);
+const adminBootstrapSecret = nodeEnv === 'test'
+  ? (process.env.ADMIN_BOOTSTRAP_SECRET || 'test-admin-bootstrap-secret')
+  : (process.env.ADMIN_BOOTSTRAP_SECRET || '').trim();
 
 if (nodeEnv === 'production') {
   if (accessJwtSecret === insecureDefaultJwtSecret) {
@@ -40,4 +43,5 @@ export const config = {
   accessJwtSecret,
   refreshJwtSecret,
   corsOrigins,
+  adminBootstrapSecret,
 };


### PR DESCRIPTION
Summary:
- add first-admin bootstrap endpoints for status and promotion
- add constant-time bootstrap secret verification with transactional first-admin guard
- add Profile UI section to provision first admin with bootstrap secret
- add integration tests for bootstrap success and failure paths
- document ADMIN_BOOTSTRAP_SECRET in env template and README

Validation:
- npm run build
- npm run test:integration
- npm run test:ui
- note: npm run test:unit has a pre-existing unrelated failure in src/app.test.ts