### PR TITLE
build(railway): optimize nixpacks build command

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm install"
+    "buildCommand": "npm ci --omit=dev --ignore-scripts && npm run build"
   },
   "deploy": {
     "startCommand": "npm start",


### PR DESCRIPTION
Replace npm install with npm ci --omit=dev --ignore-scripts and explicit build step to reduce Railway build time and improve determinism.