### PR TITLE
build(railway): fix nixpacks npm ci EBUSY failure

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm ci --omit=dev --ignore-scripts && npm run build"
+    "buildCommand": "npm install --omit=dev --ignore-scripts --no-audit --no-fund && npm run build"
   },
   "deploy": {
     "startCommand": "npm start",


### PR DESCRIPTION
Switch Railway Nixpacks build install step from npm ci to npm install with omit dev to avoid EBUSY on /app/node_modules/.cache mount during Docker build.