### PR TITLE
fix(sw): avoid response clone race and add favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" version="1.2" baseProfile="tiny-ps">
+  <title>Todos App Favicon</title>
+  <rect width="512" height="512" fill="#4F46E5"/>
+  <circle cx="256" cy="256" r="150" fill="white"/>
+  <path d="M 200 256 L 230 286 L 312 204" stroke="#4F46E5" stroke-width="20" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Todo App - Complete</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -102,8 +102,9 @@ self.addEventListener("fetch", (event) => {
             response.status === 200 &&
             response.type === "basic"
           ) {
+            const responseToCache = response.clone();
             caches.open(CACHE_NAME).then((cache) => {
-              cache.put(event.request, response.clone());
+              cache.put(event.request, responseToCache);
             });
           }
           return response;


### PR DESCRIPTION
- clone network response before async cache write in service worker network-first path\n- add favicon link and static favicon asset to remove /favicon.ico 404 noise