### PR TITLE
Harden auth link click handlers for stale local state

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -24,6 +24,8 @@ function setAuthState(nextState) {
 
 // Initialize app
 function init() {
+  bindCriticalHandlers();
+
   // Check for reset token in URL
   const urlParams = new URLSearchParams(window.location.search);
   const resetToken = urlParams.get("token");
@@ -35,20 +37,30 @@ function init() {
 
   const token = localStorage.getItem("authToken");
   const refresh = localStorage.getItem("refreshToken");
-  const user = localStorage.getItem("user");
+  const userRaw = localStorage.getItem("user");
+  let user = null;
+
+  if (userRaw) {
+    try {
+      user = JSON.parse(userRaw);
+    } catch (error) {
+      console.error("Invalid stored user data. Clearing auth state.", error);
+      localStorage.removeItem("authToken");
+      localStorage.removeItem("refreshToken");
+      localStorage.removeItem("user");
+    }
+  }
 
   if (token && user) {
     authToken = token;
     refreshToken = refresh;
-    currentUser = JSON.parse(user);
+    currentUser = user;
     setAuthState(AUTH_STATE.AUTHENTICATED);
     showAppView();
     loadUserProfile();
   } else {
     setAuthState(AUTH_STATE.UNAUTHENTICATED);
   }
-
-  bindCriticalHandlers();
   handleVerificationStatusFromUrl();
 }
 

--- a/tests/ui/auth-ui.spec.ts
+++ b/tests/ui/auth-ui.spec.ts
@@ -37,4 +37,50 @@ test.describe("Auth UI", () => {
       fullPage: true,
     });
   });
+
+  test("forgot password link opens reset form", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Forgot Password?" }).click();
+
+    await expect(page.locator("#forgotPasswordForm")).toBeVisible();
+    await expect(page.locator("#loginForm")).toBeHidden();
+  });
+
+  test("resend verification click shows response message", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("authToken", "test-token");
+      window.localStorage.setItem(
+        "user",
+        JSON.stringify({
+          id: "user-1",
+          email: "user@example.com",
+          name: "Test User",
+          role: "user",
+          isVerified: false,
+          createdAt: "2026-02-09T00:00:00.000Z",
+        }),
+      );
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Profile" }).click();
+    await expect(page.locator("#verificationBanner")).toBeVisible();
+
+    await page.getByRole("button", { name: "Resend Email" }).click();
+    await expect(page.locator("#profileMessage")).toHaveClass(/show/);
+  });
+
+  test("forgot password still works with corrupted stored user state", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("authToken", "stale-token");
+      window.localStorage.setItem("user", "{invalid-json");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Forgot Password?" }).click();
+    await expect(page.locator("#forgotPasswordForm")).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- bind critical auth link handlers before auth-state parsing
- gracefully recover when localStorage user payload is invalid JSON
- add UI tests for forgot-password/resend link interactions, including corrupted local storage