### PR TITLE
Prevent duplicate resend verification requests

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1680,6 +1680,7 @@ function bindCriticalHandlers() {
     }
     element.addEventListener("click", (event) => {
       event.preventDefault();
+      event.stopPropagation();
       handler(element, event);
     });
     element.dataset.bound = "true";
@@ -1705,6 +1706,7 @@ function bindCriticalHandlers() {
   if (resendBtn && !resendBtn.dataset.bound) {
     resendBtn.addEventListener("click", (event) => {
       event.preventDefault();
+      event.stopPropagation();
       resendVerification();
     });
     resendBtn.dataset.bound = "true";


### PR DESCRIPTION
## Summary
- stop event propagation in fallback auth click handlers
- prevents duplicate invocation when both direct and declarative handlers are present
- fixes duplicate network requests for resend verification and forgot password clicks