### PR TITLE
feat: add AI planning baseline with persisted suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,9 @@ SMTP_USER=your-ethereal-username
 SMTP_PASS=your-ethereal-password
 SMTP_FROM="Todo App <noreply@todoapp.com>"
 BASE_URL=http://localhost:3000
+
+# AI Provider (optional; deterministic fallback is used when disabled)
+AI_PROVIDER_ENABLED=false
+AI_PROVIDER_BASE_URL=https://api.openai.com/v1
+AI_PROVIDER_API_KEY=
+AI_PROVIDER_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A production-ready REST API for managing todos with JWT auth, PostgreSQL persist
 - 🔄 Graceful shutdown handling
 - 🌍 Environment-based configuration (dev/test/prod)
 - 🔐 Refresh token rotation and auth route protection
+- 🤖 AI-assisted task critique and goal-to-plan suggestions
 
 ## Prerequisites
 
@@ -62,6 +63,7 @@ Production notes:
 - `ADMIN_BOOTSTRAP_SECRET` is optional, and enables first-admin provisioning from the Profile UI.
 - `DATABASE_URL` must be set in production.
 - If `EMAIL_FEATURES_ENABLED=true`, set `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`, and `BASE_URL`.
+- AI model integration is optional: set `AI_PROVIDER_ENABLED=true` and configure `AI_PROVIDER_API_KEY` to call a live provider.
 
 ### 3. Start Database
 

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -3,6 +3,7 @@ const base = require("./jest.config");
 module.exports = {
   ...base,
   testMatch: [
+    "**/src/ai.api.integration.test.ts",
     "**/src/auth.api.test.ts",
     "**/src/authService.test.ts",
     "**/src/prismaTodoService.test.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:unit",
     "test:all": "NODE_ENV=test jest --runInBand",
     "test:unit": "NODE_ENV=test SKIP_DB_SETUP=true jest --config jest.unit.config.js --runInBand",
-    "test:integration": "NODE_ENV=test jest --config jest.integration.config.js --runInBand",
+    "test:integration": "NODE_ENV=test EMAIL_FEATURES_ENABLED=false jest --config jest.integration.config.js --runInBand",
     "test:ci": "npx tsc --noEmit && npm run test:unit",
     "test:watch": "NODE_ENV=test jest --watch",
     "test:coverage": "NODE_ENV=test jest --coverage --runInBand",

--- a/prisma/migrations/20260210120000_add_ai_suggestions/migration.sql
+++ b/prisma/migrations/20260210120000_add_ai_suggestions/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "AiSuggestionType" AS ENUM ('task_critic', 'plan_from_goal');
+
+-- CreateEnum
+CREATE TYPE "AiSuggestionStatus" AS ENUM ('pending', 'accepted', 'rejected');
+
+-- CreateTable
+CREATE TABLE "ai_suggestions" (
+  "id" TEXT NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "type" "AiSuggestionType" NOT NULL,
+  "input" JSONB NOT NULL,
+  "output" JSONB NOT NULL,
+  "status" "AiSuggestionStatus" NOT NULL DEFAULT 'pending',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "ai_suggestions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ai_suggestions_user_id_created_at_idx" ON "ai_suggestions"("user_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "ai_suggestions_user_id_status_idx" ON "ai_suggestions"("user_id", "status");
+
+-- AddForeignKey
+ALTER TABLE "ai_suggestions"
+ADD CONSTRAINT "ai_suggestions_user_id_fkey"
+FOREIGN KEY ("user_id") REFERENCES "users"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,17 @@ enum TodoPriority {
   high
 }
 
+enum AiSuggestionType {
+  task_critic
+  plan_from_goal
+}
+
+enum AiSuggestionStatus {
+  pending
+  accepted
+  rejected
+}
+
 model User {
   id                String         @id @default(uuid())
   email             String         @unique @db.VarChar(255)
@@ -39,6 +50,7 @@ model User {
 
   todos             Todo[]
   refreshTokens     RefreshToken[]
+  aiSuggestions     AiSuggestion[]
 
   @@map("users")
 }
@@ -93,4 +105,21 @@ model Subtask {
 
   @@map("subtasks")
   @@index([todoId, order])
+}
+
+model AiSuggestion {
+  id        String            @id @default(uuid())
+  userId    String            @map("user_id")
+  type      AiSuggestionType
+  input     Json
+  output    Json
+  status    AiSuggestionStatus @default(pending)
+  createdAt DateTime          @default(now()) @map("created_at")
+  updatedAt DateTime          @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("ai_suggestions")
+  @@index([userId, createdAt])
+  @@index([userId, status])
 }

--- a/public/index.html
+++ b/public/index.html
@@ -213,6 +213,8 @@
 
         <!-- Todos View -->
         <div id="todosView" class="view">
+          <div class="message" id="todosMessage"></div>
+
           <!-- Search Bar -->
           <div class="search-bar">
             <label for="searchInput" class="sr-only">Search todos</label>
@@ -375,6 +377,13 @@
               </div>
               <button
                 class="add-btn"
+                data-onclick="critiqueDraftWithAi()"
+                style="background: #334155"
+              >
+                Critique Draft (AI)
+              </button>
+              <button
+                class="add-btn"
                 data-onclick="addTodo()"
                 style="margin-left: auto"
               >
@@ -394,6 +403,55 @@
                 style="display: none; margin-top: 8px"
               ></textarea>
             </div>
+          </div>
+
+          <div
+            style="
+              margin-top: 16px;
+              padding: 12px;
+              border: 1px solid var(--border-color);
+              border-radius: 10px;
+              background: var(--card-bg);
+            "
+          >
+            <div style="font-weight: 600; margin-bottom: 10px">
+              AI Goal Planner
+            </div>
+            <div style="display: flex; gap: 10px; flex-wrap: wrap">
+              <input
+                type="text"
+                id="goalInput"
+                placeholder="Describe an outcome (e.g., Launch onboarding revamp)"
+                style="
+                  flex: 2;
+                  min-width: 260px;
+                  padding: 10px;
+                  border: 2px solid var(--border-color);
+                  border-radius: 8px;
+                  background: var(--input-bg);
+                  color: var(--text-primary);
+                "
+              />
+              <input
+                type="datetime-local"
+                id="goalTargetDateInput"
+                style="
+                  flex: 1;
+                  min-width: 200px;
+                  padding: 10px;
+                  border: 2px solid var(--border-color);
+                  border-radius: 8px;
+                  background: var(--input-bg);
+                  color: var(--text-primary);
+                "
+              />
+              <button class="add-btn" data-onclick="generatePlanWithAi()">
+                Generate Plan
+              </button>
+            </div>
+            <div id="aiCritiquePanel" style="display: none; margin-top: 12px"></div>
+            <div id="aiPlanPanel" style="display: none; margin-top: 12px"></div>
+            <div id="aiSuggestionHistory" style="margin-top: 12px"></div>
           </div>
 
           <div id="todosContent">

--- a/src/ai.api.integration.test.ts
+++ b/src/ai.api.integration.test.ts
@@ -1,0 +1,97 @@
+import request from "supertest";
+import { createApp } from "./app";
+import { PrismaTodoService } from "./prismaTodoService";
+import { AuthService } from "./authService";
+import { PrismaAiSuggestionStore } from "./aiSuggestionStore";
+import { prisma } from "./prismaClient";
+
+describe("AI API Integration", () => {
+  let app: any;
+  let authToken: string;
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = "test-secret-for-ai-api-tests";
+    const todoService = new PrismaTodoService(prisma);
+    const authService = new AuthService(prisma);
+    const aiSuggestionStore = new PrismaAiSuggestionStore(prisma);
+    app = createApp(todoService, authService, aiSuggestionStore);
+  });
+
+  beforeEach(async () => {
+    await prisma.aiSuggestion.deleteMany();
+    await prisma.todo.deleteMany();
+    await prisma.refreshToken.deleteMany();
+    await prisma.user.deleteMany();
+
+    const registerResponse = await request(app).post("/auth/register").send({
+      email: "ai-test@example.com",
+      password: "password123",
+      name: "AI Tester",
+    });
+
+    authToken = registerResponse.body.token;
+  });
+
+  it("persists task critic suggestion and updates status", async () => {
+    const critiqueResponse = await request(app)
+      .post("/ai/task-critic")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        title: "Docs",
+        description: "Need docs",
+        priority: "medium",
+      })
+      .expect(200);
+
+    expect(critiqueResponse.body.suggestionId).toBeDefined();
+    expect(critiqueResponse.body.qualityScore).toBeLessThanOrEqual(100);
+
+    const suggestionId = critiqueResponse.body.suggestionId as string;
+
+    const listResponse = await request(app)
+      .get("/ai/suggestions")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(listResponse.body).toHaveLength(1);
+    expect(listResponse.body[0].id).toBe(suggestionId);
+    expect(listResponse.body[0].status).toBe("pending");
+
+    const updateResponse = await request(app)
+      .put(`/ai/suggestions/${suggestionId}/status`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ status: "accepted" })
+      .expect(200);
+
+    expect(updateResponse.body.status).toBe("accepted");
+
+    const persisted = await prisma.aiSuggestion.findUnique({
+      where: { id: suggestionId },
+    });
+    expect(persisted).toBeTruthy();
+    expect(persisted?.status).toBe("accepted");
+  });
+
+  it("creates plan suggestion and supports rejection status", async () => {
+    const planResponse = await request(app)
+      .post("/ai/plan-from-goal")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        goal: "Ship onboarding improvements",
+        maxTasks: 4,
+      })
+      .expect(200);
+
+    expect(planResponse.body.tasks).toHaveLength(4);
+    const suggestionId = planResponse.body.suggestionId as string;
+    expect(suggestionId).toBeDefined();
+
+    const rejectResponse = await request(app)
+      .put(`/ai/suggestions/${suggestionId}/status`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ status: "rejected" })
+      .expect(200);
+
+    expect(rejectResponse.body.status).toBe("rejected");
+  });
+});

--- a/src/aiService.ts
+++ b/src/aiService.ts
@@ -1,0 +1,375 @@
+import { Priority } from "./types";
+import { config } from "./config";
+
+export interface CritiqueTaskInput {
+  title: string;
+  description?: string;
+  dueDate?: Date;
+  priority?: Priority;
+}
+
+export interface CritiqueTaskOutput {
+  qualityScore: number;
+  improvedTitle: string;
+  improvedDescription?: string;
+  suggestions: string[];
+}
+
+export interface PlanFromGoalInput {
+  goal: string;
+  targetDate?: Date;
+  maxTasks: number;
+}
+
+export interface PlanTaskSuggestion {
+  title: string;
+  description: string;
+  priority: Priority;
+  dueDate?: Date;
+}
+
+export interface PlanFromGoalOutput {
+  goal: string;
+  summary: string;
+  tasks: PlanTaskSuggestion[];
+}
+
+interface AiProvider {
+  generateJson<T>(systemPrompt: string, userPrompt: string): Promise<T>;
+}
+
+const ACTION_VERBS = new Set([
+  "define",
+  "draft",
+  "review",
+  "build",
+  "write",
+  "design",
+  "prepare",
+  "schedule",
+  "ship",
+  "publish",
+  "launch",
+  "test",
+  "fix",
+  "plan",
+  "create",
+  "update",
+  "complete",
+]);
+
+function startsWithActionVerb(title: string): boolean {
+  const firstWord = title.trim().split(/\s+/)[0]?.toLowerCase();
+  return !!firstWord && ACTION_VERBS.has(firstWord);
+}
+
+function cap(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function daysUntil(date: Date): number {
+  const now = Date.now();
+  const diff = date.getTime() - now;
+  return Math.ceil(diff / (24 * 60 * 60 * 1000));
+}
+
+export function critiqueTaskDeterministic(
+  input: CritiqueTaskInput,
+): CritiqueTaskOutput {
+  const suggestions: string[] = [];
+  let score = 100;
+  let improvedTitle = input.title.trim();
+  let improvedDescription = input.description?.trim();
+
+  if (improvedTitle.length < 12) {
+    score -= 15;
+    suggestions.push(
+      "Make the title more specific so it is understandable out of context",
+    );
+  }
+
+  if (!startsWithActionVerb(improvedTitle)) {
+    score -= 10;
+    suggestions.push("Start the title with a clear action verb");
+    improvedTitle = `Complete ${improvedTitle}`;
+  }
+
+  if (!improvedDescription) {
+    score -= 20;
+    suggestions.push(
+      "Add acceptance criteria in the description to define done status",
+    );
+    improvedDescription =
+      "Definition of done: clear output produced, reviewed, and shared with stakeholders.";
+  } else if (improvedDescription.length < 30) {
+    score -= 10;
+    suggestions.push("Expand the description with success criteria");
+  }
+
+  if (!input.dueDate) {
+    score -= 15;
+    suggestions.push("Set a due date to improve execution priority");
+  } else {
+    const remainingDays = daysUntil(input.dueDate);
+    if (remainingDays <= 1 && input.priority !== "high") {
+      score -= 10;
+      suggestions.push(
+        "Task is due soon, consider raising priority to high or splitting scope",
+      );
+    }
+  }
+
+  if (!input.priority || input.priority === "medium") {
+    score -= 5;
+    suggestions.push(
+      "Assign explicit priority (high/medium/low) based on business impact",
+    );
+  }
+
+  return {
+    qualityScore: cap(score, 0, 100),
+    improvedTitle,
+    improvedDescription,
+    suggestions,
+  };
+}
+
+function distributeDueDates(
+  startDate: Date,
+  targetDate: Date,
+  count: number,
+): Array<Date | undefined> {
+  if (count <= 0) return [];
+  const msGap = targetDate.getTime() - startDate.getTime();
+  if (msGap <= 0) return Array.from({ length: count }, () => undefined);
+  const step = msGap / count;
+  return Array.from({ length: count }, (_, index) => {
+    const date = new Date(startDate.getTime() + step * (index + 1));
+    return date;
+  });
+}
+
+function buildTaskTemplate(goal: string): Omit<PlanTaskSuggestion, "dueDate">[] {
+  return [
+    {
+      title: `Define scope for: ${goal}`,
+      description:
+        "Clarify success criteria, constraints, and stakeholders for this goal.",
+      priority: "high",
+    },
+    {
+      title: `Break down execution plan for: ${goal}`,
+      description:
+        "Create milestones with measurable checkpoints and clear ownership.",
+      priority: "high",
+    },
+    {
+      title: `Execute core work for: ${goal}`,
+      description:
+        "Deliver the highest-impact implementation tasks first to reduce risk.",
+      priority: "high",
+    },
+    {
+      title: `Review and QA for: ${goal}`,
+      description:
+        "Validate quality, test edge cases, and confirm readiness for release.",
+      priority: "medium",
+    },
+    {
+      title: `Publish update and retrospective for: ${goal}`,
+      description:
+        "Communicate outcomes, capture lessons learned, and document next steps.",
+      priority: "medium",
+    },
+  ];
+}
+
+export function planFromGoalDeterministic(
+  input: PlanFromGoalInput,
+): PlanFromGoalOutput {
+  const baseTasks = buildTaskTemplate(input.goal).slice(0, input.maxTasks);
+  const dueDates = input.targetDate
+    ? distributeDueDates(new Date(), input.targetDate, baseTasks.length)
+    : [];
+
+  const tasks = baseTasks.map((task, index) => ({
+    ...task,
+    dueDate: dueDates[index],
+  }));
+
+  return {
+    goal: input.goal,
+    summary: `Execution plan with ${tasks.length} steps generated for "${input.goal}".`,
+    tasks,
+  };
+}
+
+class OpenAiCompatibleProvider implements AiProvider {
+  async generateJson<T>(systemPrompt: string, userPrompt: string): Promise<T> {
+    const response = await fetch(`${config.aiProviderBaseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.aiProviderApiKey}`,
+      },
+      body: JSON.stringify({
+        model: config.aiProviderModel,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.2,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`AI provider request failed with status ${response.status}`);
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error("AI provider returned empty content");
+    }
+
+    return JSON.parse(content) as T;
+  }
+}
+
+function parseCritiqueOutput(value: unknown): CritiqueTaskOutput | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.qualityScore !== "number" ||
+    typeof v.improvedTitle !== "string" ||
+    !Array.isArray(v.suggestions)
+  ) {
+    return null;
+  }
+
+  return {
+    qualityScore: cap(v.qualityScore, 0, 100),
+    improvedTitle: v.improvedTitle,
+    improvedDescription:
+      typeof v.improvedDescription === "string"
+        ? v.improvedDescription
+        : undefined,
+    suggestions: v.suggestions
+      .filter((item): item is string => typeof item === "string")
+      .slice(0, 8),
+  };
+}
+
+function parsePlanOutput(value: unknown): PlanFromGoalOutput | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if (
+    typeof v.goal !== "string" ||
+    typeof v.summary !== "string" ||
+    !Array.isArray(v.tasks)
+  ) {
+    return null;
+  }
+
+  const tasks: PlanTaskSuggestion[] = [];
+  for (const task of v.tasks) {
+    if (!task || typeof task !== "object") {
+      continue;
+    }
+    const t = task as Record<string, unknown>;
+    if (
+      typeof t.title !== "string" ||
+      typeof t.description !== "string" ||
+      (t.priority !== "low" && t.priority !== "medium" && t.priority !== "high")
+    ) {
+      continue;
+    }
+
+    const dueDate =
+      typeof t.dueDate === "string" && !Number.isNaN(Date.parse(t.dueDate))
+        ? new Date(t.dueDate)
+        : undefined;
+
+    tasks.push({
+      title: t.title,
+      description: t.description,
+      priority: t.priority as Priority,
+      dueDate,
+    });
+  }
+
+  if (tasks.length === 0) return null;
+
+  return {
+    goal: v.goal,
+    summary: v.summary,
+    tasks,
+  };
+}
+
+export class AiPlannerService {
+  private readonly provider?: AiProvider;
+
+  constructor() {
+    if (config.aiProviderEnabled) {
+      this.provider = new OpenAiCompatibleProvider();
+    }
+  }
+
+  async critiqueTask(input: CritiqueTaskInput): Promise<CritiqueTaskOutput> {
+    const fallback = critiqueTaskDeterministic(input);
+    if (!this.provider) {
+      return fallback;
+    }
+
+    try {
+      const response = await this.provider.generateJson<unknown>(
+        "You are an execution coach. Return JSON with: qualityScore (0-100), improvedTitle, improvedDescription, suggestions (string[]). Keep suggestions actionable.",
+        JSON.stringify({
+          title: input.title,
+          description: input.description || "",
+          dueDate: input.dueDate?.toISOString(),
+          priority: input.priority || "medium",
+        }),
+      );
+      return parseCritiqueOutput(response) || fallback;
+    } catch (error) {
+      console.warn("AI provider critique failed, using deterministic fallback", error);
+      return fallback;
+    }
+  }
+
+  async planFromGoal(input: PlanFromGoalInput): Promise<PlanFromGoalOutput> {
+    const fallback = planFromGoalDeterministic(input);
+    if (!this.provider) {
+      return fallback;
+    }
+
+    try {
+      const response = await this.provider.generateJson<unknown>(
+        "You are an execution planner. Return JSON with: goal, summary, tasks[]. Each task must include title, description, priority(low|medium|high), optional dueDate ISO string.",
+        JSON.stringify({
+          goal: input.goal,
+          targetDate: input.targetDate?.toISOString(),
+          maxTasks: input.maxTasks,
+        }),
+      );
+
+      const parsed = parsePlanOutput(response);
+      if (!parsed) {
+        return fallback;
+      }
+
+      return {
+        ...parsed,
+        tasks: parsed.tasks.slice(0, input.maxTasks),
+      };
+    } catch (error) {
+      console.warn("AI provider plan failed, using deterministic fallback", error);
+      return fallback;
+    }
+  }
+}

--- a/src/aiSuggestionStore.ts
+++ b/src/aiSuggestionStore.ts
@@ -1,0 +1,163 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { randomUUID } from "crypto";
+
+export type AiSuggestionType = "task_critic" | "plan_from_goal";
+export type AiSuggestionStatus = "pending" | "accepted" | "rejected";
+
+export interface AiSuggestionRecord {
+  id: string;
+  userId: string;
+  type: AiSuggestionType;
+  input: Record<string, unknown>;
+  output: Record<string, unknown>;
+  status: AiSuggestionStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IAiSuggestionStore {
+  create(record: {
+    userId: string;
+    type: AiSuggestionType;
+    input: Record<string, unknown>;
+    output: Record<string, unknown>;
+  }): Promise<AiSuggestionRecord>;
+  listByUser(userId: string, limit: number): Promise<AiSuggestionRecord[]>;
+  updateStatus(
+    userId: string,
+    id: string,
+    status: AiSuggestionStatus,
+  ): Promise<AiSuggestionRecord | null>;
+}
+
+export class InMemoryAiSuggestionStore implements IAiSuggestionStore {
+  private records: AiSuggestionRecord[] = [];
+
+  async create(record: {
+    userId: string;
+    type: AiSuggestionType;
+    input: Record<string, unknown>;
+    output: Record<string, unknown>;
+  }): Promise<AiSuggestionRecord> {
+    const now = new Date();
+    const created: AiSuggestionRecord = {
+      id: randomUUID(),
+      userId: record.userId,
+      type: record.type,
+      input: record.input,
+      output: record.output,
+      status: "pending",
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.records.unshift(created);
+    return created;
+  }
+
+  async listByUser(userId: string, limit: number): Promise<AiSuggestionRecord[]> {
+    return this.records.filter((record) => record.userId === userId).slice(0, limit);
+  }
+
+  async updateStatus(
+    userId: string,
+    id: string,
+    status: AiSuggestionStatus,
+  ): Promise<AiSuggestionRecord | null> {
+    const index = this.records.findIndex(
+      (record) => record.id === id && record.userId === userId,
+    );
+    if (index === -1) {
+      return null;
+    }
+    const updated = {
+      ...this.records[index],
+      status,
+      updatedAt: new Date(),
+    };
+    this.records[index] = updated;
+    return updated;
+  }
+}
+
+export class PrismaAiSuggestionStore implements IAiSuggestionStore {
+  constructor(private prisma: PrismaClient) {}
+
+  async create(record: {
+    userId: string;
+    type: AiSuggestionType;
+    input: Record<string, unknown>;
+    output: Record<string, unknown>;
+  }): Promise<AiSuggestionRecord> {
+    const created = await this.prisma.aiSuggestion.create({
+      data: {
+        userId: record.userId,
+        type: record.type,
+        input: record.input as Prisma.InputJsonValue,
+        output: record.output as Prisma.InputJsonValue,
+        status: "pending",
+      },
+    });
+
+    return {
+      id: created.id,
+      userId: created.userId,
+      type: created.type as AiSuggestionType,
+      input: created.input as Record<string, unknown>,
+      output: created.output as Record<string, unknown>,
+      status: created.status as AiSuggestionStatus,
+      createdAt: created.createdAt,
+      updatedAt: created.updatedAt,
+    };
+  }
+
+  async listByUser(userId: string, limit: number): Promise<AiSuggestionRecord[]> {
+    const records = await this.prisma.aiSuggestion.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    });
+
+    return records.map((record) => ({
+      id: record.id,
+      userId: record.userId,
+      type: record.type as AiSuggestionType,
+      input: record.input as Record<string, unknown>,
+      output: record.output as Record<string, unknown>,
+      status: record.status as AiSuggestionStatus,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    }));
+  }
+
+  async updateStatus(
+    userId: string,
+    id: string,
+    status: AiSuggestionStatus,
+  ): Promise<AiSuggestionRecord | null> {
+    const result = await this.prisma.aiSuggestion.updateMany({
+      where: { id, userId },
+      data: { status },
+    });
+
+    if (result.count !== 1) {
+      return null;
+    }
+
+    const record = await this.prisma.aiSuggestion.findUnique({
+      where: { id },
+    });
+    if (!record || record.userId !== userId) {
+      return null;
+    }
+    return {
+      id: record.id,
+      userId: record.userId,
+      type: record.type as AiSuggestionType,
+      input: record.input as Record<string, unknown>,
+      output: record.output as Record<string, unknown>,
+      status: record.status as AiSuggestionStatus,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    };
+  }
+}

--- a/src/aiValidation.ts
+++ b/src/aiValidation.ts
@@ -1,0 +1,137 @@
+import { ValidationError } from "./validation";
+import { Priority } from "./types";
+import { CritiqueTaskInput, PlanFromGoalInput } from "./aiService";
+import { AiSuggestionStatus } from "./aiSuggestionStore";
+
+const PRIORITIES: Priority[] = ["low", "medium", "high"];
+const MIN_PLAN_TASKS = 3;
+const MAX_PLAN_TASKS = 8;
+const ALLOWED_SUGGESTION_STATUSES: AiSuggestionStatus[] = [
+  "accepted",
+  "rejected",
+];
+
+function parseDate(value: unknown, field: string): Date {
+  if (typeof value !== "string") {
+    throw new ValidationError(`${field} must be an ISO date string`);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new ValidationError(`${field} must be a valid date`);
+  }
+  return parsed;
+}
+
+export function validateCritiqueTaskInput(data: any): CritiqueTaskInput {
+  if (!data || typeof data !== "object") {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  if (typeof data.title !== "string" || data.title.trim().length === 0) {
+    throw new ValidationError("title is required");
+  }
+  if (data.title.length > 200) {
+    throw new ValidationError("title cannot exceed 200 characters");
+  }
+
+  if (data.description !== undefined && typeof data.description !== "string") {
+    throw new ValidationError("description must be a string");
+  }
+
+  let dueDate: Date | undefined;
+  if (data.dueDate !== undefined) {
+    dueDate = parseDate(data.dueDate, "dueDate");
+  }
+
+  let priority: Priority | undefined;
+  if (data.priority !== undefined) {
+    if (typeof data.priority !== "string") {
+      throw new ValidationError("priority must be low, medium, or high");
+    }
+    const normalized = data.priority.toLowerCase() as Priority;
+    if (!PRIORITIES.includes(normalized)) {
+      throw new ValidationError("priority must be low, medium, or high");
+    }
+    priority = normalized;
+  }
+
+  return {
+    title: data.title.trim(),
+    description: data.description?.trim(),
+    dueDate,
+    priority,
+  };
+}
+
+export function validatePlanFromGoalInput(data: any): PlanFromGoalInput {
+  if (!data || typeof data !== "object") {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  if (typeof data.goal !== "string" || data.goal.trim().length === 0) {
+    throw new ValidationError("goal is required");
+  }
+  if (data.goal.length > 200) {
+    throw new ValidationError("goal cannot exceed 200 characters");
+  }
+
+  let targetDate: Date | undefined;
+  if (data.targetDate !== undefined) {
+    targetDate = parseDate(data.targetDate, "targetDate");
+  }
+
+  let maxTasks = 5;
+  if (data.maxTasks !== undefined) {
+    if (!Number.isInteger(data.maxTasks)) {
+      throw new ValidationError("maxTasks must be an integer");
+    }
+    if (data.maxTasks < MIN_PLAN_TASKS || data.maxTasks > MAX_PLAN_TASKS) {
+      throw new ValidationError(
+        `maxTasks must be between ${MIN_PLAN_TASKS} and ${MAX_PLAN_TASKS}`,
+      );
+    }
+    maxTasks = data.maxTasks;
+  }
+
+  return {
+    goal: data.goal.trim(),
+    targetDate,
+    maxTasks,
+  };
+}
+
+export function validateSuggestionListQuery(query: any): { limit: number } {
+  if (query.limit === undefined) {
+    return { limit: 20 };
+  }
+
+  if (typeof query.limit !== "string" || !/^\d+$/.test(query.limit)) {
+    throw new ValidationError("limit must be a positive integer");
+  }
+
+  const limit = Number.parseInt(query.limit, 10);
+  if (limit < 1 || limit > 100) {
+    throw new ValidationError("limit must be between 1 and 100");
+  }
+
+  return { limit };
+}
+
+export function validateSuggestionStatusInput(data: any): {
+  status: AiSuggestionStatus;
+} {
+  if (!data || typeof data !== "object") {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  if (typeof data.status !== "string") {
+    throw new ValidationError('status must be "accepted" or "rejected"');
+  }
+
+  const normalized = data.status.toLowerCase() as AiSuggestionStatus;
+  if (!ALLOWED_SUGGESTION_STATUSES.includes(normalized)) {
+    throw new ValidationError('status must be "accepted" or "rejected"');
+  }
+
+  return { status: normalized };
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,13 @@ const smtpUser = (process.env.SMTP_USER || "").trim();
 const smtpPass = (process.env.SMTP_PASS || "").trim();
 const smtpFrom = (process.env.SMTP_FROM || "").trim();
 const baseUrl = (process.env.BASE_URL || "").trim();
+const aiProviderEnabled =
+  (process.env.AI_PROVIDER_ENABLED || "false").toLowerCase() === "true";
+const aiProviderBaseUrl = (
+  process.env.AI_PROVIDER_BASE_URL || "https://api.openai.com/v1"
+).trim();
+const aiProviderApiKey = (process.env.AI_PROVIDER_API_KEY || "").trim();
+const aiProviderModel = (process.env.AI_PROVIDER_MODEL || "gpt-4o-mini").trim();
 
 if (nodeEnv === "production") {
   if (!databaseUrl) {
@@ -104,4 +111,8 @@ export const config = {
   smtpPass,
   smtpFrom,
   baseUrl: baseUrl || "http://localhost:3000",
+  aiProviderEnabled,
+  aiProviderBaseUrl,
+  aiProviderApiKey,
+  aiProviderModel,
 };

--- a/src/routes/aiRouter.ts
+++ b/src/routes/aiRouter.ts
@@ -1,0 +1,166 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { AiPlannerService } from "../aiService";
+import {
+  IAiSuggestionStore,
+  InMemoryAiSuggestionStore,
+} from "../aiSuggestionStore";
+import {
+  validateCritiqueTaskInput,
+  validatePlanFromGoalInput,
+  validateSuggestionListQuery,
+  validateSuggestionStatusInput,
+} from "../aiValidation";
+import { validateId } from "../validation";
+
+interface AiRouterDeps {
+  aiPlannerService?: AiPlannerService;
+  suggestionStore?: IAiSuggestionStore;
+  resolveAiUserId: (req: Request, res: Response) => string | null;
+}
+
+export function createAiRouter({
+  aiPlannerService = new AiPlannerService(),
+  suggestionStore = new InMemoryAiSuggestionStore(),
+  resolveAiUserId,
+}: AiRouterDeps): Router {
+  const router = Router();
+
+  /**
+   * @openapi
+   * /ai/task-critic:
+   *   post:
+   *     tags:
+   *       - AI
+   *     summary: Improve clarity and execution quality of a task
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Task critique with suggested improvements
+   *       400:
+   *         description: Validation error
+   */
+  router.post(
+    "/task-critic",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = resolveAiUserId(req, res);
+        if (!userId) return;
+
+        const input = validateCritiqueTaskInput(req.body);
+        const result = await aiPlannerService.critiqueTask(input);
+
+        const suggestion = await suggestionStore.create({
+          userId,
+          type: "task_critic",
+          input: {
+            ...input,
+            dueDate: input.dueDate?.toISOString(),
+          },
+          output: {
+            ...result,
+          },
+        });
+
+        res.json({
+          ...result,
+          suggestionId: suggestion.id,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  /**
+   * @openapi
+   * /ai/plan-from-goal:
+   *   post:
+   *     tags:
+   *       - AI
+   *     summary: Generate a practical execution plan from a goal statement
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Generated plan and task suggestions
+   *       400:
+   *         description: Validation error
+   */
+  router.post(
+    "/plan-from-goal",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = resolveAiUserId(req, res);
+        if (!userId) return;
+
+        const input = validatePlanFromGoalInput(req.body);
+        const result = await aiPlannerService.planFromGoal(input);
+
+        const suggestion = await suggestionStore.create({
+          userId,
+          type: "plan_from_goal",
+          input: {
+            ...input,
+            targetDate: input.targetDate?.toISOString(),
+          },
+          output: {
+            ...result,
+            tasks: result.tasks.map((task) => ({
+              ...task,
+              dueDate: task.dueDate?.toISOString(),
+            })),
+          },
+        });
+
+        res.json({
+          ...result,
+          suggestionId: suggestion.id,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/suggestions",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = resolveAiUserId(req, res);
+        if (!userId) return;
+
+        const { limit } = validateSuggestionListQuery(req.query);
+        const records = await suggestionStore.listByUser(userId, limit);
+        res.json(records);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.put(
+    "/suggestions/:id/status",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = resolveAiUserId(req, res);
+        if (!userId) return;
+
+        const id = String(req.params.id);
+        validateId(id);
+        const { status } = validateSuggestionStatusInput(req.body);
+
+        const updated = await suggestionStore.updateStatus(userId, id, status);
+        if (!updated) {
+          return res.status(404).json({ error: "Suggestion not found" });
+        }
+
+        res.json(updated);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,12 +3,14 @@ import { PrismaTodoService } from "./prismaTodoService";
 import { AuthService } from "./authService";
 import { prisma, disconnectPrisma } from "./prismaClient";
 import { config } from "./config";
+import { PrismaAiSuggestionStore } from "./aiSuggestionStore";
 
 const PORT = config.port;
 
 const todoService = new PrismaTodoService(prisma);
 const authService = new AuthService(prisma);
-const app = createApp(todoService, authService);
+const aiSuggestionStore = new PrismaAiSuggestionStore(prisma);
+const app = createApp(todoService, authService, aiSuggestionStore);
 
 const server = app.listen(PORT, () => {
   console.log(`Todos API server running on port ${PORT}`);

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -245,6 +245,10 @@ const options: swaggerJsdoc.Options = {
         name: "Todos",
         description: "Todo CRUD operations",
       },
+      {
+        name: "AI",
+        description: "AI-assisted planning and task quality endpoints",
+      },
     ],
   },
   apis: ["./src/app.ts", "./src/routes/*.ts"], // Path to API docs


### PR DESCRIPTION
## Summary\n- add AI task critic and goal-to-plan endpoints\n- persist AI suggestions with status tracking (pending/accepted/rejected)\n- add frontend AI controls for critique/plan workflows\n- add Prisma migration and integration tests\n- stabilize integration suite by disabling email features and rate limiting in test mode\n\n## Validation\n- npm run test:unit\n- npm run test:integration\n- npm run build