### PR TITLE
Add AI feedback insights panel in UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -455,6 +455,7 @@
             ></div>
             <div id="aiPlanPanel" style="display: none; margin-top: 12px"></div>
             <div id="aiUsageSummary" style="margin-top: 12px"></div>
+            <div id="aiFeedbackInsights" style="margin-top: 12px"></div>
             <div id="aiSuggestionHistory" style="margin-top: 12px"></div>
           </div>
 


### PR DESCRIPTION
## Summary
- add AI feedback insights panel to the todo AI section
- load feedback summary from GET /ai/feedback-summary (30 days)
- render acceptance rate and top accepted/rejected reasons
- refresh insights after status updates and plan apply

## Testing
- npm run format:check
- npm run test:unit
- npm run build