### PR TITLE
Add AI insights endpoint and dashboard panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -455,6 +455,7 @@
             ></div>
             <div id="aiPlanPanel" style="display: none; margin-top: 12px"></div>
             <div id="aiUsageSummary" style="margin-top: 12px"></div>
+            <div id="aiPerformanceInsights" style="margin-top: 12px"></div>
             <div id="aiFeedbackInsights" style="margin-top: 12px"></div>
             <div id="aiSuggestionHistory" style="margin-top: 12px"></div>
           </div>

--- a/src/aiValidation.ts
+++ b/src/aiValidation.ts
@@ -180,3 +180,20 @@ export function validateFeedbackSummaryQuery(query: any): {
 
   return { days, reasonLimit };
 }
+
+export function validateInsightsQuery(query: any): {
+  days: number;
+} {
+  let days = 7;
+  if (query.days !== undefined) {
+    if (typeof query.days !== "string" || !/^\d+$/.test(query.days)) {
+      throw new ValidationError("days must be a positive integer");
+    }
+    days = Number.parseInt(query.days, 10);
+    if (days < 1 || days > 90) {
+      throw new ValidationError("days must be between 1 and 90");
+    }
+  }
+
+  return { days };
+}


### PR DESCRIPTION
## Summary
- add GET /ai/insights with weekly KPIs and actionable recommendation
- compute generated/rated/acceptance metrics with top feedback reasons
- include plan-aware upgrade recommendation when user nears daily cap
- add UI performance panel in AI section showing 7-day metrics and recommendation
- add contract/integration coverage for endpoint and validation

## Testing
- npm run format:check
- npm run test:unit
- npm run test:integration
- npm run build