### PR TITLE
Add custom AI feedback reasons in UI and apply flow

### DIFF
--- a/src/aiValidation.ts
+++ b/src/aiValidation.ts
@@ -149,6 +149,32 @@ export function validateSuggestionStatusInput(data: any): {
   return { status: normalized, reason };
 }
 
+export function validateApplySuggestionInput(data: any): {
+  reason?: string;
+} {
+  if (data === undefined || data === null) {
+    return {};
+  }
+  if (typeof data !== "object") {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  let reason: string | undefined;
+  if ((data as Record<string, unknown>).reason !== undefined) {
+    const raw = (data as Record<string, unknown>).reason;
+    if (typeof raw !== "string") {
+      throw new ValidationError("reason must be a string");
+    }
+    const trimmed = raw.trim();
+    if (trimmed.length > 300) {
+      throw new ValidationError("reason cannot exceed 300 characters");
+    }
+    reason = trimmed || undefined;
+  }
+
+  return { reason };
+}
+
 export function validateFeedbackSummaryQuery(query: any): {
   days: number;
   reasonLimit: number;

--- a/src/api.contract.test.ts
+++ b/src/api.contract.test.ts
@@ -338,12 +338,19 @@ describe("API Contract", () => {
 
       const applied = await request(app)
         .post(`/ai/suggestions/${suggestionId}/apply`)
+        .send({ reason: "Plan matched my execution approach" })
         .expect(200);
 
       expect(applied.body.createdCount).toBe(3);
       expect(Array.isArray(applied.body.todos)).toBe(true);
       expect(applied.body.todos).toHaveLength(3);
       expect(applied.body.suggestion.status).toBe("accepted");
+      expect(applied.body.suggestion.feedback).toEqual(
+        expect.objectContaining({
+          reason: "Plan matched my execution approach",
+          source: "apply_endpoint",
+        }),
+      );
       expect(applied.body.todos[0].category).toBe("AI Plan");
       expect(applied.body.idempotent).toBe(false);
 

--- a/src/routes/aiRouter.ts
+++ b/src/routes/aiRouter.ts
@@ -5,6 +5,7 @@ import {
   InMemoryAiSuggestionStore,
 } from "../aiSuggestionStore";
 import {
+  validateApplySuggestionInput,
   validateCritiqueTaskInput,
   validateFeedbackSummaryQuery,
   validateInsightsQuery,
@@ -531,6 +532,7 @@ export function createAiRouter({
 
         const id = String(req.params.id);
         validateId(id);
+        const { reason } = validateApplySuggestionInput(req.body);
 
         const suggestion = await suggestionStore.getById(userId, id);
         if (!suggestion) {
@@ -592,7 +594,7 @@ export function createAiRouter({
           id,
           createdIds,
           {
-            reason: "applied_via_endpoint",
+            reason: reason || "applied_via_endpoint",
             source: "apply_endpoint",
             updatedAt: new Date().toISOString(),
           },


### PR DESCRIPTION
## Summary
- add optional custom feedback reason input in AI critique and plan panels
- send custom reason when accepting/rejecting critique suggestions
- allow optional reason in POST /ai/suggestions/{id}/apply request body
- persist custom apply reason in suggestion feedback metadata
- add contract/integration tests for reason persistence and validation

## Testing
- npm run format:check
- npm run test:unit
- npm run test:integration
- npm run build