### PR TITLE
Add project assignment and task editing workflow

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -335,14 +335,17 @@
               data-onkeypress="handleTodoKeyPress(event)"
             />
             <div class="field-row">
-              <label for="todoCategoryInput" class="sr-only"
-                >Todo category</label
+              <label for="todoProjectSelect" class="sr-only">Project</label>
+              <select id="todoProjectSelect">
+                <option value="">No project</option>
+              </select>
+              <button
+                class="add-btn"
+                data-onclick="createProject()"
+                style="width: auto; padding: 10px 14px"
               >
-              <input
-                type="text"
-                id="todoCategoryInput"
-                placeholder="Category (e.g., Work, Personal)"
-              />
+                + Project
+              </button>
               <label for="todoDueDateInput" class="sr-only"
                 >Todo due date</label
               >
@@ -434,6 +437,60 @@
             <div class="loading">
               <div class="spinner"></div>
               Loading todos...
+            </div>
+          </div>
+
+          <div id="editTodoModal" class="modal-overlay" style="display: none">
+            <div class="modal-card">
+              <h3>Edit Task</h3>
+              <div class="form-group">
+                <label for="editTodoTitle">Title</label>
+                <input type="text" id="editTodoTitle" maxlength="200" />
+              </div>
+              <div class="form-group">
+                <label for="editTodoDescription">Description</label>
+                <textarea id="editTodoDescription" rows="3"></textarea>
+              </div>
+              <div class="field-row">
+                <div class="form-group" style="flex: 1; margin-bottom: 0">
+                  <label for="editTodoProjectSelect">Project</label>
+                  <select id="editTodoProjectSelect">
+                    <option value="">No project</option>
+                  </select>
+                </div>
+                <div class="form-group" style="flex: 1; margin-bottom: 0">
+                  <label for="editTodoPriority">Priority</label>
+                  <select id="editTodoPriority">
+                    <option value="low">Low</option>
+                    <option value="medium">Medium</option>
+                    <option value="high">High</option>
+                  </select>
+                </div>
+                <div class="form-group" style="flex: 1; margin-bottom: 0">
+                  <label for="editTodoDueDate">Due date</label>
+                  <input type="datetime-local" id="editTodoDueDate" />
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="editTodoNotes">Notes</label>
+                <textarea id="editTodoNotes" rows="3"></textarea>
+              </div>
+              <div class="modal-actions">
+                <button
+                  class="add-btn"
+                  data-onclick="saveEditedTodo()"
+                  style="width: auto"
+                >
+                  Save
+                </button>
+                <button
+                  class="add-btn"
+                  data-onclick="closeEditTodoModal()"
+                  style="width: auto; background: #64748b"
+                >
+                  Cancel
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -371,6 +371,16 @@ body {
   color: var(--text-primary);
 }
 
+.field-row select {
+  flex: 1;
+  min-width: 180px;
+  padding: 12px;
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
 .action-row {
   display: flex;
   gap: 10px;
@@ -1294,6 +1304,68 @@ body {
 
 .subtask-delete:hover {
   opacity: 1;
+}
+
+.todo-inline-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.todo-inline-actions select {
+  min-width: 160px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.mini-btn {
+  padding: 6px 10px;
+  border: none;
+  border-radius: 6px;
+  background: #334155;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.82em;
+  font-weight: 600;
+}
+
+.mini-btn:hover {
+  opacity: 0.9;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2500;
+  padding: 16px;
+}
+
+.modal-card {
+  width: min(760px, 100%);
+  background: var(--container-bg);
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+}
+
+.modal-card h3 {
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 .add-subtask-form {


### PR DESCRIPTION
## Summary
- treat existing category field as a Project with dedicated UI controls
- add project creation flow and persistent project catalog in local storage
- add per-task project move dropdown to reassign tasks under projects
- add task edit modal supporting title, description, priority, due date, notes, and project
- keep existing todo API unchanged while exposing richer editing in UI

## Testing
- npm run format:check
- npm run test:unit
- npm run build