### PR TITLE
Add projects API and backend-synced project catalog

### DIFF
--- a/src/api.contract.test.ts
+++ b/src/api.contract.test.ts
@@ -127,6 +127,10 @@ describe("API Contract", () => {
     it("includes AI endpoints in the OpenAPI spec", async () => {
       const response = await request(app).get("/api-docs.json").expect(200);
 
+      expect(response.body?.paths?.["/projects"]?.get).toBeDefined();
+      expect(response.body?.paths?.["/projects"]?.post).toBeDefined();
+      expect(response.body?.paths?.["/projects/{id}"]?.put).toBeDefined();
+      expect(response.body?.paths?.["/projects/{id}"]?.delete).toBeDefined();
       expect(response.body?.paths?.["/ai/task-critic"]?.post).toBeDefined();
       expect(response.body?.paths?.["/ai/plan-from-goal"]?.post).toBeDefined();
       expect(response.body?.paths?.["/ai/usage"]?.get).toBeDefined();

--- a/src/interfaces/IProjectService.ts
+++ b/src/interfaces/IProjectService.ts
@@ -1,0 +1,12 @@
+import { CreateProjectDto, Project, UpdateProjectDto } from "../types";
+
+export interface IProjectService {
+  findAll(userId: string): Promise<Project[]>;
+  create(userId: string, dto: CreateProjectDto): Promise<Project>;
+  update(
+    userId: string,
+    projectId: string,
+    dto: UpdateProjectDto,
+  ): Promise<Project | null>;
+  delete(userId: string, projectId: string): Promise<boolean>;
+}

--- a/src/projectService.ts
+++ b/src/projectService.ts
@@ -1,0 +1,145 @@
+import { PrismaClient } from "@prisma/client";
+import { IProjectService } from "./interfaces/IProjectService";
+import { CreateProjectDto, Project, UpdateProjectDto } from "./types";
+
+export class DuplicateProjectNameError extends Error {
+  constructor() {
+    super("Project name already exists");
+    this.name = "DuplicateProjectNameError";
+  }
+}
+
+export class PrismaProjectService implements IProjectService {
+  constructor(private prisma: PrismaClient) {}
+
+  private hasPrismaCode(error: unknown, codes: string[]): boolean {
+    if (!error || typeof error !== "object" || !("code" in error)) {
+      return false;
+    }
+    const code = (error as { code?: unknown }).code;
+    return typeof code === "string" && codes.includes(code);
+  }
+
+  async findAll(userId: string): Promise<Project[]> {
+    const rows = await this.prisma.project.findMany({
+      where: { userId },
+      orderBy: { name: "asc" },
+      include: {
+        _count: {
+          select: { todos: true },
+        },
+      },
+    });
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      userId: row.userId,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      todoCount: row._count.todos,
+    }));
+  }
+
+  async create(userId: string, dto: CreateProjectDto): Promise<Project> {
+    try {
+      const row = await this.prisma.project.create({
+        data: {
+          name: dto.name,
+          userId,
+        },
+      });
+      return {
+        id: row.id,
+        name: row.name,
+        userId: row.userId,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        todoCount: 0,
+      };
+    } catch (error: unknown) {
+      if (this.hasPrismaCode(error, ["P2002"])) {
+        throw new DuplicateProjectNameError();
+      }
+      throw error;
+    }
+  }
+
+  async update(
+    userId: string,
+    projectId: string,
+    dto: UpdateProjectDto,
+  ): Promise<Project | null> {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const existing = await tx.project.findFirst({
+          where: { id: projectId, userId },
+        });
+        if (!existing) {
+          return null;
+        }
+
+        const updated = await tx.project.update({
+          where: { id: projectId },
+          data: { name: dto.name },
+        });
+
+        // Keep legacy category column synchronized until full API migration is complete.
+        await tx.todo.updateMany({
+          where: { userId, projectId },
+          data: { category: dto.name },
+        });
+
+        const count = await tx.todo.count({ where: { userId, projectId } });
+        return {
+          id: updated.id,
+          name: updated.name,
+          userId: updated.userId,
+          createdAt: updated.createdAt,
+          updatedAt: updated.updatedAt,
+          todoCount: count,
+        };
+      });
+    } catch (error: unknown) {
+      if (this.hasPrismaCode(error, ["P2002"])) {
+        throw new DuplicateProjectNameError();
+      }
+      if (this.hasPrismaCode(error, ["P2023"])) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async delete(userId: string, projectId: string): Promise<boolean> {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const existing = await tx.project.findFirst({
+          where: { id: projectId, userId },
+          select: { id: true },
+        });
+        if (!existing) {
+          return false;
+        }
+
+        await tx.todo.updateMany({
+          where: { userId, projectId },
+          data: {
+            projectId: null,
+            category: null,
+          },
+        });
+
+        await tx.project.delete({
+          where: { id: projectId },
+        });
+
+        return true;
+      });
+    } catch (error: unknown) {
+      if (this.hasPrismaCode(error, ["P2023"])) {
+        return false;
+      }
+      throw error;
+    }
+  }
+}

--- a/src/routes/projectsRouter.ts
+++ b/src/routes/projectsRouter.ts
@@ -1,0 +1,154 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { IProjectService } from "../interfaces/IProjectService";
+import {
+  validateCreateProject,
+  validateId,
+  validateUpdateProject,
+} from "../validation";
+import { DuplicateProjectNameError } from "../projectService";
+
+interface ProjectRouterDeps {
+  projectService?: IProjectService;
+  resolveProjectUserId: (req: Request, res: Response) => string | null;
+}
+
+export function createProjectsRouter({
+  projectService,
+  resolveProjectUserId,
+}: ProjectRouterDeps): Router {
+  const router = Router();
+
+  /**
+   * @openapi
+   * /projects:
+   *   get:
+   *     tags:
+   *       - Projects
+   *     summary: List projects for the authenticated user
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: List of projects
+   *   post:
+   *     tags:
+   *       - Projects
+   *     summary: Create a project for the authenticated user
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       201:
+   *         description: Created project
+   *       409:
+   *         description: Project name already exists
+   */
+  router.get("/", async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!projectService) {
+        return res.status(501).json({ error: "Projects not configured" });
+      }
+      const userId = resolveProjectUserId(req, res);
+      if (!userId) return;
+      const projects = await projectService.findAll(userId);
+      res.json(projects);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/", async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!projectService) {
+        return res.status(501).json({ error: "Projects not configured" });
+      }
+      const userId = resolveProjectUserId(req, res);
+      if (!userId) return;
+      const dto = validateCreateProject(req.body);
+      const project = await projectService.create(userId, dto);
+      res.status(201).json(project);
+    } catch (error) {
+      if (error instanceof DuplicateProjectNameError) {
+        return res.status(409).json({ error: "Project name already exists" });
+      }
+      next(error);
+    }
+  });
+
+  /**
+   * @openapi
+   * /projects/{id}:
+   *   put:
+   *     tags:
+   *       - Projects
+   *     summary: Rename a project
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Updated project
+   *       404:
+   *         description: Project not found
+   *       409:
+   *         description: Project name already exists
+   *   delete:
+   *     tags:
+   *       - Projects
+   *     summary: Delete a project and unassign linked todos
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       204:
+   *         description: Project deleted
+   *       404:
+   *         description: Project not found
+   */
+  router.put(
+    "/:id",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        if (!projectService) {
+          return res.status(501).json({ error: "Projects not configured" });
+        }
+        const userId = resolveProjectUserId(req, res);
+        if (!userId) return;
+        const id = req.params.id as string;
+        validateId(id);
+        const dto = validateUpdateProject(req.body);
+        const project = await projectService.update(userId, id, dto);
+        if (!project) {
+          return res.status(404).json({ error: "Project not found" });
+        }
+        res.json(project);
+      } catch (error) {
+        if (error instanceof DuplicateProjectNameError) {
+          return res.status(409).json({ error: "Project name already exists" });
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.delete(
+    "/:id",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        if (!projectService) {
+          return res.status(501).json({ error: "Projects not configured" });
+        }
+        const userId = resolveProjectUserId(req, res);
+        if (!userId) return;
+        const id = req.params.id as string;
+        validateId(id);
+        const deleted = await projectService.delete(userId, id);
+        if (!deleted) {
+          return res.status(404).json({ error: "Project not found" });
+        }
+        res.status(204).send();
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,13 +4,23 @@ import { AuthService } from "./authService";
 import { prisma, disconnectPrisma } from "./prismaClient";
 import { config } from "./config";
 import { PrismaAiSuggestionStore } from "./aiSuggestionStore";
+import { PrismaProjectService } from "./projectService";
 
 const PORT = config.port;
 
 const todoService = new PrismaTodoService(prisma);
 const authService = new AuthService(prisma);
 const aiSuggestionStore = new PrismaAiSuggestionStore(prisma);
-const app = createApp(todoService, authService, aiSuggestionStore);
+const projectService = new PrismaProjectService(prisma);
+const app = createApp(
+  todoService,
+  authService,
+  aiSuggestionStore,
+  undefined,
+  undefined,
+  undefined,
+  projectService,
+);
 
 const server = app.listen(PORT, () => {
   console.log(`Todos API server running on port ${PORT}`);

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -149,6 +149,40 @@ const options: swaggerJsdoc.Options = {
             },
           },
         },
+        Project: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
+              description: "Project ID",
+            },
+            name: {
+              type: "string",
+              maxLength: 50,
+              description: "Project path/name",
+            },
+            userId: {
+              type: "string",
+              format: "uuid",
+              description: "Owner user ID",
+            },
+            todoCount: {
+              type: "integer",
+              description: "Number of todos linked to this project",
+            },
+            createdAt: {
+              type: "string",
+              format: "date-time",
+              description: "Creation timestamp",
+            },
+            updatedAt: {
+              type: "string",
+              format: "date-time",
+              description: "Last update timestamp",
+            },
+          },
+        },
         Subtask: {
           type: "object",
           properties: {
@@ -249,6 +283,10 @@ const options: swaggerJsdoc.Options = {
       {
         name: "Todos",
         description: "Todo CRUD operations",
+      },
+      {
+        name: "Projects",
+        description: "Project management and organization",
       },
       {
         name: "AI",

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,15 @@ export interface Subtask {
   updatedAt: Date;
 }
 
+export interface Project {
+  id: string;
+  name: string;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  todoCount?: number;
+}
+
 export interface Todo {
   id: string;
   title: string;
@@ -32,6 +41,14 @@ export interface Todo {
   createdAt: Date;
   updatedAt: Date;
   subtasks?: Subtask[];
+}
+
+export interface CreateProjectDto {
+  name: string;
+}
+
+export interface UpdateProjectDto {
+  name: string;
 }
 
 export interface CreateTodoDto {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,4 +1,5 @@
 import {
+  CreateProjectDto,
   CreateTodoDto,
   UpdateTodoDto,
   ReorderTodoItemDto,
@@ -6,6 +7,7 @@ import {
   Priority,
   TodoSortBy,
   SortOrder,
+  UpdateProjectDto,
 } from "./types";
 
 export class ValidationError extends Error {
@@ -27,6 +29,42 @@ const VALID_SORT_FIELDS: TodoSortBy[] = [
 ];
 const VALID_SORT_ORDERS: SortOrder[] = ["asc", "desc"];
 const VALID_PRIORITIES: Priority[] = ["low", "medium", "high"];
+
+function validateProjectName(name: unknown): string {
+  if (typeof name !== "string") {
+    throw new ValidationError("Project name must be a string");
+  }
+  const normalized = name
+    .split("/")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(" / ");
+  if (!normalized) {
+    throw new ValidationError("Project name cannot be empty");
+  }
+  if (normalized.length > 50) {
+    throw new ValidationError("Project name cannot exceed 50 characters");
+  }
+  return normalized;
+}
+
+export function validateCreateProject(data: any): CreateProjectDto {
+  if (!data || typeof data !== "object") {
+    throw new ValidationError("Request body must be an object");
+  }
+  return {
+    name: validateProjectName(data.name),
+  };
+}
+
+export function validateUpdateProject(data: any): UpdateProjectDto {
+  if (!data || typeof data !== "object") {
+    throw new ValidationError("Request body must be an object");
+  }
+  return {
+    name: validateProjectName(data.name),
+  };
+}
 
 function parsePositiveInt(value: unknown, field: string): number {
   if (typeof value !== "string" || !/^\d+$/.test(value)) {


### PR DESCRIPTION
## Summary
- add authenticated `/projects` CRUD endpoints backed by a dedicated project service
- wire app/server to expose project APIs and enforce user isolation
- update UI project catalog to sync with backend projects API instead of local-only state
- update OpenAPI/docs contract checks and auth integration coverage for projects

## Validation
- npm run build
- npm run test:unit
- npm run test:integration