### PR TITLE
Add project rename edit flow in UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -353,6 +353,13 @@
               >
                 + Subproject
               </button>
+              <button
+                class="add-btn"
+                data-onclick="renameProjectTree()"
+                style="width: auto; padding: 10px 14px; background: #334155"
+              >
+                Rename Project
+              </button>
               <label for="todoDueDateInput" class="sr-only"
                 >Todo due date</label
               >


### PR DESCRIPTION
## Summary
- add project edit flow in UI with Rename Project action
- rename supports hierarchical project trees (renames selected project + descendants)
- sync rename through backend `/projects/:id` API and refresh todos/projects after update

## Validation
- npm run build
- npm run test:unit