### PR TITLE
chore(format): fix prettier violations from CI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -340,8 +340,9 @@ function getProjectRecordByName(projectName) {
     return null;
   }
   return (
-    projectRecords.find((record) => normalizeProjectPath(record?.name) === normalized) ||
-    null
+    projectRecords.find(
+      (record) => normalizeProjectPath(record?.name) === normalized,
+    ) || null
   );
 }
 
@@ -1709,7 +1710,9 @@ function updateCategoryFilter() {
 
   filterSelect.innerHTML =
     '<option value="">All Projects</option>' +
-    categories.map((cat) => renderProjectOptionEntry(cat, currentValue)).join("");
+    categories
+      .map((cat) => renderProjectOptionEntry(cat, currentValue))
+      .join("");
 
   if (categories.includes(currentValue)) {
     filterSelect.value = currentValue;
@@ -1775,9 +1778,7 @@ function renderProjectOptionEntry(projectPath, selectedValue = "") {
 
 function getAllProjects() {
   const fromTodos = todos
-    .map((todo) =>
-      normalizeProjectPath(todo.category),
-    )
+    .map((todo) => normalizeProjectPath(todo.category))
     .filter((value) => value.length > 0);
   return expandProjectTree([...customProjects, ...fromTodos]);
 }
@@ -1812,7 +1813,9 @@ function updateProjectSelectOptions() {
 }
 
 async function createProject() {
-  const name = prompt("Project path (use / for hierarchy, e.g. Work / Client A):");
+  const name = prompt(
+    "Project path (use / for hierarchy, e.g. Work / Client A):",
+  );
   if (name === null) {
     return;
   }
@@ -1895,7 +1898,11 @@ async function createSubproject() {
     projectSelect.value = combinedPath;
   }
   await loadProjects();
-  showMessage("todosMessage", `Subproject "${combinedPath}" created`, "success");
+  showMessage(
+    "todosMessage",
+    `Subproject "${combinedPath}" created`,
+    "success",
+  );
 }
 
 async function renameProjectTree() {
@@ -1916,7 +1923,11 @@ async function renameProjectTree() {
     return;
   }
   if (renamedPath.length > 50) {
-    showMessage("todosMessage", "Project name cannot exceed 50 characters", "error");
+    showMessage(
+      "todosMessage",
+      "Project name cannot exceed 50 characters",
+      "error",
+    );
     return;
   }
   if (renamedPath === selectedPath) {

--- a/src/auth.api.test.ts
+++ b/src/auth.api.test.ts
@@ -547,7 +547,9 @@ describe("Authentication API", () => {
           .set("Authorization", `Bearer ${authToken}`)
           .expect(200);
         expect(Array.isArray(listed.body)).toBe(true);
-        expect(listed.body.map((p: any) => p.name)).toContain("Work / Client A");
+        expect(listed.body.map((p: any) => p.name)).toContain(
+          "Work / Client A",
+        );
 
         const updated = await request(app)
           .put(`/projects/${created.body.id}`)

--- a/src/prismaTodoService.ts
+++ b/src/prismaTodoService.ts
@@ -186,7 +186,11 @@ export class PrismaTodoService implements ITodoService {
             updateData.projectId = null;
           } else {
             updateData.category = category;
-            updateData.projectId = await this.ensureProjectId(tx, userId, category);
+            updateData.projectId = await this.ensureProjectId(
+              tx,
+              userId,
+              category,
+            );
           }
         }
 


### PR DESCRIPTION
## Summary\n- Apply Prettier formatting to files flagged by CI format check.\n- No logic or behavior changes.\n\n## Files\n- public/app.js\n- src/auth.api.test.ts\n- src/prismaTodoService.ts\n\n## Validation\n- npm run format:check\n- npx tsc --noEmit\n- npm test