### PR TITLE
UI M2 PR2: Drawer open/close + focus restore (read-only)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -759,6 +759,10 @@ body {
   opacity: 0.6;
 }
 
+.todo-item.todo-item--active {
+  border: 2px solid #667eea;
+}
+
 .todo-item.dragging {
   opacity: 0.5;
   transform: rotate(2deg);
@@ -1956,6 +1960,91 @@ body {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+}
+
+.todo-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: none;
+  z-index: 2390;
+}
+
+.todo-drawer-backdrop--open {
+  display: block;
+}
+
+.todo-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(420px, 100%);
+  height: 100vh;
+  display: none;
+  flex-direction: column;
+  background: var(--container-bg);
+  border-left: 1px solid var(--border-color);
+  z-index: 2400;
+}
+
+.todo-drawer--open {
+  display: flex;
+}
+
+.todo-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.todo-drawer__header h2 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.todo-drawer__content {
+  padding: 14px 16px;
+  overflow-y: auto;
+}
+
+.todo-drawer__section {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 10px;
+  background: var(--card-bg);
+  margin-bottom: 10px;
+}
+
+.todo-drawer__section-title {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.todo-drawer__section p {
+  color: var(--text-primary);
+  margin-bottom: 6px;
+  font-size: 0.9rem;
+}
+
+.btn-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+.btn-icon:hover {
+  background: var(--card-bg);
 }
 
 .add-subtask-form {


### PR DESCRIPTION
## Summary\n- add todo drawer selection/open/close state in public/app.js\n- open drawer from todo row click (excluding form/action controls)\n- support Escape + close button close with focus restoration to row trigger\n- render read-only todo details in drawer (no edit/save mutation logic)\n- add minimal drawer/backdrop open-state CSS hooks and active-row styling\n\n## Constraints honored\n- no save/update mutation behavior added\n- existing delegated handlers and render loop retained\n- existing edit modal flow preserved\n\n## Verification\n- npx tsc --noEmit\n- npm run format:check\n- npm run lint:html\n- npm run lint:css\n- npm run test:unit\n- CI=1 npm run test:ui