### PR TITLE
feat(ui): M4 PR4 top bar cleanup for projects rail

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -331,10 +331,12 @@
                     id="projectsRailMobileOpen"
                     class="mini-btn projects-rail-mobile-open"
                     type="button"
-                    aria-controls="projectsRailSheet"
+                    aria-controls="projectsRail projectsRailSheet"
                     aria-expanded="false"
                   >
-                    Projects
+                    <span id="projectsRailTopbarLabel"
+                      >Projects: All tasks</span
+                    >
                   </button>
                   <h2>Todos</h2>
                   <span
@@ -372,7 +374,7 @@
                 </div>
               </div>
 
-              <div class="todos-minimal-filters">
+              <div class="todos-minimal-filters todos-minimal-filters--legacy">
                 <label class="project-filter-label" for="categoryFilter"
                   >Project</label
                 >

--- a/public/styles.css
+++ b/public/styles.css
@@ -1183,6 +1183,17 @@ button.projects-rail-item {
   display: none;
 }
 
+.projects-rail-mobile-open.projects-rail-mobile-open--show {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.projects-rail-mobile-open .projects-active-label {
+  color: var(--text-secondary);
+  font-size: 0.82em;
+}
+
 .projects-rail-backdrop,
 .projects-rail-sheet {
   display: none;
@@ -1296,6 +1307,18 @@ button.projects-rail-item {
   background: var(--input-bg);
   color: var(--text-primary);
   cursor: pointer;
+}
+
+.todos-minimal-filters--legacy {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .more-filters-panel {
@@ -1806,9 +1829,6 @@ button.projects-rail-item {
   }
 
   .projects-rail-mobile-open {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
     white-space: nowrap;
   }
 

--- a/tests/ui/topbar-projects.spec.ts
+++ b/tests/ui/topbar-projects.spec.ts
@@ -1,0 +1,283 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  category: string | null;
+  dueDate: string | null;
+  priority: "low" | "medium" | "high";
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installTopbarProjectsMockApi(page: Page, todosSeed: TodoSeed[]) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    if (!raw) return {};
+    return JSON.parse(raw);
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(
+        id,
+        todosSeed.map((todo, index) => ({
+          ...todo,
+          completed: false,
+          order: index,
+          userId: id,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+          subtasks: [],
+        })),
+      );
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Topbar Tester",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET") {
+      return json(route, 200, []);
+    }
+
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET") {
+      return json(route, 200, []);
+    }
+
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Topbar User");
+  await page.locator("#registerEmail").fill("topbar-projects@example.com");
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+test.describe("Top bar projects cleanup", () => {
+  test.beforeEach(async ({ page }) => {
+    await installTopbarProjectsMockApi(page, [
+      {
+        id: "todo-work",
+        title: "Work task",
+        description: null,
+        notes: null,
+        category: "Work",
+        dueDate: null,
+        priority: "medium",
+      },
+      {
+        id: "todo-home",
+        title: "Home task",
+        description: null,
+        notes: null,
+        category: "Home",
+        dueDate: null,
+        priority: "low",
+      },
+    ]);
+
+    await registerAndOpenTodos(page);
+  });
+
+  test("desktop rail visible hides projects button and keeps essentials visible", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-only assertion");
+
+    await expect(page.locator(".todos-top-bar #searchInput")).toBeVisible();
+    await expect(page.locator(".todos-top-bar .top-add-btn")).toBeVisible();
+    await expect(
+      page.locator(".todos-top-bar #moreFiltersToggle"),
+    ).toBeVisible();
+    await expect(page.locator(".todos-top-bar #categoryFilter")).toHaveCount(0);
+    await expect(page.locator("#projectsRailMobileOpen")).toBeHidden();
+  });
+
+  test("desktop collapsed rail shows projects button and restores focus into rail", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-only assertion");
+
+    await page.locator("#projectsRailToggle").click();
+    await expect(page.locator("#projectsRail")).toHaveClass(
+      /projects-rail--collapsed/,
+    );
+    await expect(page.locator("#projectsRailMobileOpen")).toBeVisible();
+
+    await page.locator("#projectsRailMobileOpen").click();
+    await expect(page.locator("#projectsRail")).not.toHaveClass(
+      /projects-rail--collapsed/,
+    );
+    await expect(
+      page.locator('#projectsRail .projects-rail-item[aria-current="page"]'),
+    ).toBeFocused();
+  });
+
+  test("mobile projects button opens sheet and restores focus on close", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!isMobile, "Mobile-only assertion");
+
+    await expect(page.locator("#projectsRailMobileOpen")).toBeVisible();
+    await page.locator("#projectsRailMobileOpen").click();
+
+    await expect(page.locator("#projectsRailSheet")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#projectsRailSheet")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+    await expect(page.locator("#projectsRailMobileOpen")).toBeFocused();
+
+    await page.locator("#projectsRailMobileOpen").click();
+    const viewport = page.viewportSize();
+    await page.locator("#projectsRailBackdrop").click({
+      position: {
+        x: Math.max(4, (viewport?.width || 320) - 12),
+        y: 12,
+      },
+    });
+    await expect(page.locator("#projectsRailSheet")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  test("projects button label updates when active project changes", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-only assertion");
+
+    await page.locator("#projectsRailToggle").click();
+    await expect(page.locator("#projectsRailMobileOpen")).toBeVisible();
+    await expect(page.locator("#projectsRailTopbarLabel")).toContainText(
+      "All tasks",
+    );
+
+    await page
+      .locator('#projectsRail .projects-rail-item[data-project-key="Home"]')
+      .click();
+
+    await expect(page.locator("#projectsRailTopbarLabel")).toContainText(
+      "Home",
+    );
+  });
+});


### PR DESCRIPTION
Summary
Cleans up the Todos top bar to align with the new Projects rail: reduces always-visible controls, removes redundant project dropdown UI, and introduces a calm Projects button that opens the rail/sheet with correct focus behavior.

What changed
- Top bar is now minimal: Search + Add Task + More Filters + Projects button (contextual)
- Desktop:
  - When rail is visible: no top-bar project dropdown UI
  - When rail is collapsed: Projects button appears to open/expand rail and focus inside
- Mobile:
  - Projects button always available to open the projects sheet
- Active label updates:
  - Added stable label hook: #projectsRailTopbarLabel
- Compatibility:
  - Kept legacy #categoryFilter in DOM but visually hidden via .todos-minimal-filters--legacy
- Tests:
  - Added tests/ui/topbar-projects.spec.ts covering desktop/mobile visibility, open/close, focus restore, and active label updates

Files changed
- public/app.js
- public/index.html
- public/styles.css
- tests/ui/topbar-projects.spec.ts

Verification
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- CI=1 npm run test:ui (83 passed, 15 skipped)

Commit
- 34bc7c2