### PR TITLE
fix(ui): harden todos panel against horizontal overflow

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -961,6 +961,7 @@ textarea:focus-visible,
   grid-template-columns: minmax(208px, 240px) minmax(0, 1fr);
   gap: 14px;
   align-items: start;
+  min-width: 0;
 }
 
 .todos-layout--rail-collapsed {
@@ -969,6 +970,7 @@ textarea:focus-visible,
 
 .todos-main-zone {
   min-width: 0;
+  overflow-x: hidden;
 }
 
 .todos-list-header {
@@ -1094,6 +1096,14 @@ textarea:focus-visible,
   font: inherit;
   line-height: var(--lh-tight);
   text-align: left;
+  min-width: 0;
+}
+
+.projects-rail-item > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 button.projects-rail-item {
@@ -1222,6 +1232,14 @@ button.projects-rail-item {
 .projects-rail-mobile-open .projects-active-label {
   color: var(--text-secondary);
   font-size: 0.82em;
+}
+
+#projectsRailTopbarLabel {
+  display: inline-block;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .projects-rail-backdrop,
@@ -1628,6 +1646,7 @@ button.projects-rail-item {
   justify-self: end;
   align-self: start;
   position: relative;
+  min-width: 0;
 }
 
 .todo-kebab {
@@ -2908,6 +2927,7 @@ body.is-drawer-open {
     background 140ms ease,
     border-color 140ms ease,
     box-shadow 140ms ease;
+  min-width: 0;
 }
 
 .todo-item:hover {
@@ -2933,6 +2953,10 @@ body.is-drawer-open {
   font-size: 0.98rem;
   font-weight: var(--fw-semibold);
   line-height: var(--lh-tight);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .todo-description {
@@ -2953,6 +2977,7 @@ body.is-drawer-open {
   align-items: center;
   gap: var(--s-2);
   min-height: 24px;
+  min-width: 0;
 }
 
 .todo-meta > :not(.todo-chip) {
@@ -2974,6 +2999,9 @@ body.is-drawer-open {
   line-height: 1.25;
   white-space: nowrap;
   max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .todo-chip--project {

--- a/tests/ui/layout-overflow.spec.ts
+++ b/tests/ui/layout-overflow.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  category: string | null;
+  dueDate: string | null;
+  priority: "low" | "medium" | "high";
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installOverflowMockApi(page: Page, todosSeed: TodoSeed[]) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    return raw ? JSON.parse(raw) : {};
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(
+        id,
+        todosSeed.map((todo, index) => ({
+          ...todo,
+          completed: false,
+          order: index,
+          userId: id,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+          subtasks: [],
+        })),
+      );
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Overflow Tester",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Overflow User");
+  await page.locator("#registerEmail").fill("layout-overflow@example.com");
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+test.describe("Todos layout overflow hardening", () => {
+  test("no horizontal overflow after selecting long-name project and row remains usable", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-focused overflow assertion");
+
+    const longProject =
+      "Project-With-Very-Long-Name-For-Overflow-Hardening-12345";
+
+    await installOverflowMockApi(page, [
+      {
+        id: "todo-long",
+        title:
+          "This is an intentionally very long todo title designed to test overflow handling in the todos main panel while chips and actions are present",
+        description:
+          "This description is deliberately long to ensure single-line clamp and no panel overflow when project filters are active.",
+        notes: null,
+        category: longProject,
+        dueDate: "2026-03-18T09:00:00.000Z",
+        priority: "high",
+      },
+    ]);
+
+    await registerAndOpenTodos(page);
+
+    await page
+      .locator(
+        `#projectsRail .projects-rail-item[data-project-key="${longProject}"]`,
+      )
+      .click();
+
+    const dimensions = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(dimensions.scrollWidth).toBe(dimensions.clientWidth);
+
+    const firstRow = page.locator(".todo-item").first();
+    await expect(firstRow).toBeVisible();
+    await firstRow.locator(".todo-title").click();
+    await expect(page.locator("#todoDetailsDrawer")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+  });
+});


### PR DESCRIPTION
What CSS rules were added:

[styles.css](app://-/index.html#)
.todos-layout { min-width: 0; }
.todos-main-zone { overflow-x: hidden; }
.projects-rail-item { min-width: 0; }
.projects-rail-item > span:first-child truncation: overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
#projectsRailTopbarLabel truncation with max-width: 220px
.todo-item { min-width: 0; }
.todo-title ellipsis + white-space: nowrap + min-width: 0
.todo-meta { min-width: 0; }
.todo-chip overflow hardening: min-width: 0; overflow: hidden; text-overflow: ellipsis
.todo-row-actions { min-width: 0; }
Files changed:

[styles.css](app://-/index.html#)
[layout-overflow.spec.ts](app://-/index.html#)
Verification:

npx tsc --noEmit PASS
npm run format:check PASS
npm run lint:css PASS
CI=1 npm run test:ui PASS (99 passed, 19 skipped)
Note:

Added [layout-overflow.spec.ts](app://-/index.html#) with long project + long todo content, project selection, no-horizontal-overflow assertion, row visibility, and drawer open sanity.