### PR TITLE
fix(ui): harden todo row text clipping without overflow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4500,20 +4500,21 @@ function renderTodoChips(todo, { isOverdue, dueDateStr }) {
   const chips = [];
 
   if (todo.dueDate) {
+    const dueLabel = `${isOverdue ? "⚠️" : "📅"} ${dueDateStr}`;
     chips.push(
-      `<span class="todo-chip todo-chip--due ${isOverdue ? "todo-chip--due-overdue" : ""}">${isOverdue ? "⚠️" : "📅"} ${escapeHtml(dueDateStr)}</span>`,
+      `<span class="todo-chip todo-chip--due ${isOverdue ? "todo-chip--due-overdue" : ""}" title="${escapeHtml(dueLabel)}">${escapeHtml(dueLabel)}</span>`,
     );
   }
 
   if (todo.category) {
     chips.push(
-      `<span class="todo-chip todo-chip--project">🏷️ ${escapeHtml(todo.category)}</span>`,
+      `<span class="todo-chip todo-chip--project" title="${escapeHtml(todo.category)}">🏷️ ${escapeHtml(todo.category)}</span>`,
     );
   }
 
   if (todo.priority === "high" && chips.length < 2) {
     chips.push(
-      `<span class="todo-chip todo-chip--priority priority-badge high">HIGH</span>`,
+      `<span class="todo-chip todo-chip--priority priority-badge high" title="High priority">HIGH</span>`,
     );
   }
 
@@ -4703,7 +4704,7 @@ function renderTodos() {
                 data-onchange="toggleTodo('${todo.id}')"
             >
             <div class="todo-content">
-                <div class="todo-title">${escapeHtml(todo.title)}</div>
+                <div class="todo-title" title="${escapeHtml(todo.title)}">${escapeHtml(todo.title)}</div>
                 ${todo.description ? `<div class="todo-description">${escapeHtml(todo.description)}</div>` : ""}
                 <div class="todo-meta">
                     ${renderTodoChips(todo, { isOverdue, dueDateStr })}

--- a/public/styles.css
+++ b/public/styles.css
@@ -3210,3 +3210,14 @@ body.dark-mode .todo-chip--due-overdue {
     pointer-events: auto;
   }
 }
+
+@media (max-width: 640px) {
+  .todo-title {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/tests/ui/text-clipping.spec.ts
+++ b/tests/ui/text-clipping.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  category: string | null;
+  dueDate: string | null;
+  priority: "low" | "medium" | "high";
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installTextClippingMockApi(page: Page, todosSeed: TodoSeed[]) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    return raw ? JSON.parse(raw) : {};
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(
+        id,
+        todosSeed.map((todo, index) => ({
+          ...todo,
+          completed: false,
+          order: index,
+          userId: id,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+          subtasks: [],
+        })),
+      );
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Text Clipping Tester",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Text Clipping User");
+  await page.locator("#registerEmail").fill("text-clipping@example.com");
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+test.describe("Todos text clipping hardening", () => {
+  test("keeps row readable without horizontal overflow and exposes full text via tooltip/drawer", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-focused clipping assertion");
+
+    const longProject =
+      "Project-Name-With-Extreme-Length-For-Text-Clipping-Regression-12345";
+    const longTitle =
+      "This is an intentionally very long todo title that should not clip awkwardly or overlap row actions while still remaining accessible through tooltip and drawer content";
+
+    await installTextClippingMockApi(page, [
+      {
+        id: "todo-long-text",
+        title: longTitle,
+        description:
+          "Long description text should stay calm in list view and remain readable in drawer without causing row overlap.",
+        notes: null,
+        category: longProject,
+        dueDate: "2026-05-06T09:00:00.000Z",
+        priority: "high",
+      },
+    ]);
+
+    await registerAndOpenTodos(page);
+
+    await page
+      .locator(
+        `#projectsRail .projects-rail-item[data-project-key="${longProject}"]`,
+      )
+      .click();
+
+    const scrollRegion = page.locator("#todosScrollRegion");
+    const regionMetrics = await scrollRegion.evaluate((node) => ({
+      scrollWidth: node.scrollWidth,
+      clientWidth: node.clientWidth,
+    }));
+    expect(regionMetrics.scrollWidth).toBe(regionMetrics.clientWidth);
+
+    const row = page.locator('.todo-item[data-todo-id="todo-long-text"]');
+    const title = row.locator(".todo-title");
+    await expect(title).toHaveAttribute("title", longTitle);
+
+    await row.hover();
+    const kebab = row.locator(".todo-kebab");
+    await expect(kebab).toBeVisible();
+    await kebab.click();
+    await expect(row.locator(".todo-kebab-menu")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(row.locator(".todo-kebab-menu")).toBeHidden();
+
+    await title.click();
+    await expect(page.locator("#todoDetailsDrawer")).toHaveAttribute(
+      "aria-hidden",
+      "false",
+    );
+    await expect(page.locator("#drawerTitleInput")).toHaveValue(longTitle);
+  });
+});


### PR DESCRIPTION
## What
Fixes “content cutting off” in Todos rows while preserving zero horizontal overflow.

- Mobile: `.todo-title` uses a 2-line clamp at narrow widths to avoid hard cut-off.
- Desktop: keeps single-line ellipsis calm row style.
- Adds tooltip `title` attributes in `renderTodos()` for long title and chips (project/due/high priority).
- Adds UI regression test to prevent reintroducing clipping/overflow issues.

## Why
After adopting the single-scroll container, strict one-line truncation on narrow rows made titles appear cut off. This keeps the calm SaaS style while restoring readability and access to full content (drawer + tooltip).

## Tests
- Added `tests/ui/text-clipping.spec.ts` asserting:
  - no horizontal overflow on `#todosScrollRegion`
  - title tooltip exists for long titles
  - kebab is visible/clickable
  - drawer shows full title

Verified:
- npx tsc --noEmit
- npm run format:check
- npm run lint:css
- CI=1 npm run test:ui