### PR TITLE
M5 PR1: Command palette shell (Ctrl/Cmd+K) + minimal actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -973,6 +973,40 @@
       <button data-onclick="performUndo()">Undo</button>
     </div>
 
+    <!-- Command Palette -->
+    <div
+      id="commandPaletteOverlay"
+      class="command-palette-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="commandPaletteTitle"
+      aria-hidden="true"
+    >
+      <div id="commandPalettePanel" class="command-palette-panel">
+        <h2 id="commandPaletteTitle" class="sr-only">Command palette</h2>
+        <label for="commandPaletteInput" class="sr-only">Type a command</label>
+        <input
+          id="commandPaletteInput"
+          class="command-palette-input"
+          type="text"
+          placeholder="Type a command…"
+          autocomplete="off"
+          spellcheck="false"
+          role="combobox"
+          aria-controls="commandPaletteList"
+          aria-expanded="false"
+        />
+        <div
+          id="commandPaletteList"
+          class="command-palette-list"
+          role="listbox"
+        ></div>
+        <div id="commandPaletteEmpty" class="command-palette-empty" hidden>
+          No results
+        </div>
+      </div>
+    </div>
+
     <!-- Keyboard Shortcuts Overlay -->
     <div
       id="shortcutsOverlay"

--- a/public/styles.css
+++ b/public/styles.css
@@ -1661,6 +1661,86 @@ button.projects-rail-item {
   margin-right: 20px;
 }
 
+.command-palette-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  background: var(--overlay);
+  z-index: 2550;
+}
+
+.command-palette-overlay--open {
+  display: flex;
+}
+
+.command-palette-panel {
+  width: min(560px, 92vw);
+  max-height: 72vh;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  background: var(--container-bg);
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.command-palette-input {
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-base);
+  padding: var(--s-4);
+  width: 100%;
+}
+
+.command-palette-input:focus {
+  outline: none;
+  box-shadow: inset 0 -1px 0 0 var(--accent);
+}
+
+.command-palette-list {
+  display: grid;
+  gap: 6px;
+  padding: var(--s-3);
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.command-palette-option {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.command-palette-option:hover,
+.command-palette-option--active {
+  border-color: var(--border-color);
+  background: var(--surface-2);
+}
+
+.command-palette-option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.command-palette-empty {
+  color: var(--text-secondary);
+  padding: var(--s-4);
+  border-top: 1px solid var(--border-color);
+}
+
 /* ========== PHASE E: ANIMATIONS & TRANSITIONS ========== */
 @keyframes fadeIn {
   from {

--- a/tests/ui/command-palette.spec.ts
+++ b/tests/ui/command-palette.spec.ts
@@ -1,0 +1,280 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  category: string | null;
+  dueDate: string | null;
+  priority: "low" | "medium" | "high";
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installCommandPaletteMockApi(page: Page, todosSeed: TodoSeed[]) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    return raw ? JSON.parse(raw) : {};
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(
+        id,
+        todosSeed.map((todo, index) => ({
+          ...todo,
+          completed: false,
+          order: index,
+          userId: id,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+          subtasks: [],
+        })),
+      );
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Command Palette Tester",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET") {
+      return json(route, 200, []);
+    }
+
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Command Palette User");
+  await page.locator("#registerEmail").fill("command-palette@example.com");
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+async function openCommandPalette(page: Page) {
+  await page.keyboard.press("ControlOrMeta+K");
+  await expect(page.locator("#commandPaletteOverlay")).toHaveClass(
+    /command-palette-overlay--open/,
+  );
+}
+
+test.describe("Command palette", () => {
+  test.beforeEach(async ({ page }) => {
+    await installCommandPaletteMockApi(page, [
+      {
+        id: "todo-1",
+        title: "Work task",
+        description: null,
+        notes: null,
+        category: "Work",
+        dueDate: null,
+        priority: "medium",
+      },
+      {
+        id: "todo-2",
+        title: "Home task",
+        description: null,
+        notes: null,
+        category: "Home",
+        dueDate: null,
+        priority: "high",
+      },
+      {
+        id: "todo-3",
+        title: "Second Home task",
+        description: null,
+        notes: null,
+        category: "Home",
+        dueDate: null,
+        priority: "low",
+      },
+    ]);
+
+    await registerAndOpenTodos(page);
+  });
+
+  test("Ctrl/Cmd+K opens palette and Escape closes with focus restore", async ({
+    page,
+  }) => {
+    const searchInput = page.locator("#searchInput");
+    await searchInput.focus();
+
+    await openCommandPalette(page);
+    await expect(page.locator("#commandPaletteInput")).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#commandPaletteOverlay")).not.toHaveClass(
+      /command-palette-overlay--open/,
+    );
+    await expect(searchInput).toBeFocused();
+  });
+
+  test('typing filters commands and shows "Go to All tasks"', async ({
+    page,
+  }) => {
+    await openCommandPalette(page);
+
+    const input = page.locator("#commandPaletteInput");
+    await input.fill("all");
+
+    await expect(page.locator("#commandPaletteList")).toContainText(
+      "Go to All tasks",
+    );
+    await expect(page.locator("#commandPaletteEmpty")).toBeHidden();
+  });
+
+  test("project command sets category filter and updates list header count", async ({
+    page,
+  }) => {
+    await openCommandPalette(page);
+
+    const input = page.locator("#commandPaletteInput");
+    await input.fill("home");
+    await page
+      .locator("#commandPaletteList button", { hasText: "Go to project: Home" })
+      .first()
+      .click();
+
+    await expect(page.locator("#categoryFilter")).toHaveValue("Home");
+    await expect(page.locator("#todosListHeaderTitle")).toHaveText("Home");
+    await expect(page.locator("#todosListHeaderCount")).toHaveText("2 tasks");
+  });
+
+  test("Enter on Add task focuses quick entry input", async ({ page }) => {
+    await page.getByRole("button", { name: "Profile" }).click();
+    await expect(page.locator("#profileView")).toHaveClass(/active/);
+
+    await openCommandPalette(page);
+    const input = page.locator("#commandPaletteInput");
+    await input.fill("add");
+    await page.keyboard.press("Enter");
+
+    await expect(page.locator("#todosView")).toHaveClass(/active/);
+    await expect(page.locator("#todoInput")).toBeFocused();
+  });
+
+  test("Arrow navigation updates aria-selected", async ({ page }) => {
+    await openCommandPalette(page);
+
+    await expect(page.locator("#commandPaletteOption-0")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator("#commandPaletteOption-0")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    await expect(page.locator("#commandPaletteOption-1")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+});


### PR DESCRIPTION
Summary\n- Adds a calm command palette overlay opened with Ctrl/Cmd+K.\n- Supports client-side filtering and keyboard navigation (Up/Down/Enter/Escape) with focus restore.\n- Implements v1 commands:\n  - Add task\n  - Go to All tasks\n  - Go to project: <name> (dynamic from existing project source)\n\nImplementation\n- Added command palette markup and token-driven styles.\n- Added palette state/wiring in app.js (single listener registration, focus trap, backdrop close).\n- Added Playwright coverage in tests/ui/command-palette.spec.ts.\n\nNo behavior semantics changes\n- Project selection still routes through #categoryFilter + filterTodos().\n- No backend/API changes.\n- No drawer/drag/bulk/AI behavior changes.\n\nFiles changed\n- public/index.html\n- public/styles.css\n- public/app.js\n- tests/ui/command-palette.spec.ts\n\nVerification\n- npx tsc --noEmit\n- npm run format:check\n- npm run lint:html\n- npm run lint:css\n- npm run test:unit\n- CI=1 npm run test:ui