### PR TITLE
M5 PR2: Command palette task search opens drawer

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1712,6 +1712,14 @@ button.projects-rail-item {
   overflow-y: auto;
 }
 
+.command-palette-section {
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+}
+
 .command-palette-option {
   width: 100%;
   text-align: left;
@@ -1733,6 +1741,34 @@ button.projects-rail-item {
 .command-palette-option:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
+}
+
+.command-palette-option--task {
+  display: grid;
+  gap: 2px;
+}
+
+.command-palette-option__title {
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
+}
+
+.command-palette-option__meta {
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-base);
+}
+
+.command-palette-option--completed .command-palette-option__title,
+.command-palette-option--completed .command-palette-option__meta {
+  color: var(--text-muted);
+}
+
+.command-palette-inline-empty {
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  padding: 8px 10px;
 }
 
 .command-palette-empty {

--- a/tests/ui/command-palette-task-search.spec.ts
+++ b/tests/ui/command-palette-task-search.spec.ts
@@ -1,0 +1,282 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  category: string | null;
+  dueDate: string | null;
+  priority: "low" | "medium" | "high";
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installCommandPaletteTaskSearchMockApi(
+  page: Page,
+  todosSeed: TodoSeed[],
+) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    return raw ? JSON.parse(raw) : {};
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(
+        id,
+        todosSeed.map((todo, index) => ({
+          ...todo,
+          completed: false,
+          order: index,
+          userId: id,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+          subtasks: [],
+        })),
+      );
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Command Task Search User",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET") {
+      return json(route, 200, []);
+    }
+
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Task Search User");
+  await page.locator("#registerEmail").fill("command-task-search@example.com");
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+async function openCommandPalette(page: Page) {
+  await page.keyboard.press("ControlOrMeta+K");
+  await expect(page.locator("#commandPaletteOverlay")).toHaveClass(
+    /command-palette-overlay--open/,
+  );
+}
+
+test.describe("Command palette task search", () => {
+  test.beforeEach(async ({ page }) => {
+    await installCommandPaletteTaskSearchMockApi(page, [
+      {
+        id: "todo-rent",
+        title: "Pay rent",
+        description: "Monthly rent payment",
+        notes: null,
+        category: "Home",
+        dueDate: null,
+        priority: "high",
+      },
+      {
+        id: "todo-flight",
+        title: "Book flights",
+        description: "Travel planning",
+        notes: null,
+        category: "Travel",
+        dueDate: null,
+        priority: "medium",
+      },
+    ]);
+
+    await registerAndOpenTodos(page);
+  });
+
+  test("query filters tasks by title", async ({ page }) => {
+    await openCommandPalette(page);
+    await page.locator("#commandPaletteInput").fill("rent");
+
+    await expect(page.locator("#commandPaletteList")).toContainText("Pay rent");
+    await expect(page.locator("#commandPaletteList")).not.toContainText(
+      "Book flights",
+    );
+  });
+
+  test("Enter on task result opens drawer and closes palette", async ({
+    page,
+  }) => {
+    await openCommandPalette(page);
+    await page.locator("#commandPaletteInput").fill("rent");
+
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Enter");
+
+    await expect(page.locator("#commandPaletteOverlay")).not.toHaveClass(
+      /command-palette-overlay--open/,
+    );
+    await expect(page.locator("#todoDetailsDrawer")).toHaveClass(
+      /todo-drawer--open/,
+    );
+    await expect(page.locator("#drawerTitleInput")).toHaveValue("Pay rent");
+  });
+
+  test("clicking task result opens drawer", async ({ page }) => {
+    await openCommandPalette(page);
+    await page.locator("#commandPaletteInput").fill("flight");
+
+    await page
+      .locator("#commandPaletteList button", { hasText: "Book flights" })
+      .first()
+      .click();
+
+    await expect(page.locator("#todoDetailsDrawer")).toHaveClass(
+      /todo-drawer--open/,
+    );
+    await expect(page.locator("#drawerTitleInput")).toHaveValue("Book flights");
+  });
+
+  test("keyboard navigation skips section headers", async ({ page }) => {
+    await openCommandPalette(page);
+    await page.locator("#commandPaletteInput").fill("o");
+
+    await expect(page.locator("#commandPaletteList")).toContainText("Commands");
+    await expect(page.locator("#commandPaletteList")).toContainText("Tasks");
+
+    await expect(page.locator("#commandPaletteOption-0")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.locator("#commandPaletteOption-0")).toContainText(
+      "Go to All tasks",
+    );
+
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await expect(page.locator("#commandPaletteOption-1")).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    await expect(page.locator("#commandPaletteOption-3")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.locator("#commandPaletteOption-3")).toContainText(
+      "Book flights",
+    );
+  });
+
+  test("no task matches shows 'No tasks found' in tasks section", async ({
+    page,
+  }) => {
+    await openCommandPalette(page);
+    await page.locator("#commandPaletteInput").fill("zzz-no-match");
+
+    await expect(page.locator("#commandPaletteList")).toContainText("Tasks");
+    await expect(page.locator("#commandPaletteList")).toContainText(
+      "No tasks found",
+    );
+    await expect(page.locator("#commandPaletteEmpty")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Summary\n- Extends command palette with task search results (client-side only) while keeping existing command actions intact.\n- Adds sectioned palette rows: Commands + Tasks, with non-selectable section headers and keyboard navigation over selectable items only.\n- Selecting a task result (Enter/click) opens the existing todo drawer directly and closes the palette.\n\nBehavior\n- Task matching: case-insensitive substring across title (and description fallback).\n- Ranking: title startsWith > title includes > description includes, then deterministic tie-breakers.\n- Result limit: 6 task results.\n- No query: commands only (tasks hidden by default).\n- Query with no task matches: shows "No tasks found" in Tasks section; global "No results" only when both command + task matches are empty.\n\nSafety\n- No API/backend changes.\n- No filter semantics change: project/all commands still use #categoryFilter + filterTodos().\n- No screenshot/snapshot updates.\n\nFiles changed\n- public/app.js\n- public/styles.css\n- tests/ui/command-palette-task-search.spec.ts\n\nVerification\n- npx tsc --noEmit\n- npm run format:check\n- npm run lint:css\n- npm run test:unit\n- CI=1 npm run test:ui -- tests/ui/command-palette-task-search.spec.ts\n- CI=1 npm run test:ui