### PR TITLE
M5: Row actions + density + layout invariants

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1329,6 +1329,7 @@ button.projects-rail-item {
 #projectsRailTopbarLabel {
   display: block;
   max-width: 220px;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1341,7 +1342,8 @@ button.projects-rail-item {
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -1376,6 +1378,11 @@ button.projects-rail-item {
   border: 1px solid var(--border-color);
   border-radius: 10px;
   background: var(--card-bg);
+  min-width: 0;
+}
+
+.todos-top-bar > * {
+  min-width: 0;
 }
 
 .todos-top-bar-left {
@@ -1400,6 +1407,7 @@ button.projects-rail-item {
   width: 100%;
   flex: 1 1 auto;
   min-width: 0;
+  overflow: hidden;
 }
 
 .search-bar {
@@ -1442,11 +1450,13 @@ button.projects-rail-item {
   justify-content: flex-end;
   flex: 0 0 auto;
   min-width: max-content;
+  overflow: visible;
 }
 
 .top-add-btn {
   width: auto;
   flex: 0 0 auto;
+  flex-shrink: 0;
   white-space: nowrap;
 }
 
@@ -1878,10 +1888,15 @@ button.projects-rail-item {
 }
 
 .todo-row-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
   justify-self: end;
   align-self: start;
   position: relative;
-  min-width: 0;
+  width: 34px;
+  min-width: 34px;
+  max-width: 34px;
 }
 
 .todo-kebab {
@@ -1896,7 +1911,7 @@ button.projects-rail-item {
   cursor: pointer;
   transition:
     background 0.2s,
-    opacity 0.2s ease;
+    opacity 140ms ease;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -1908,6 +1923,7 @@ button.projects-rail-item {
 
 .todo-item:hover .todo-kebab,
 .todo-item:focus-within .todo-kebab,
+.todo-item--active .todo-kebab,
 .todo-kebab[aria-expanded="true"] {
   opacity: 1;
   visibility: visible;
@@ -3218,6 +3234,7 @@ body.is-drawer-open {
   gap: var(--s-2);
   min-height: 24px;
   min-width: 0;
+  max-width: 100%;
 }
 
 .todo-meta > :not(.todo-chip) {
@@ -3238,10 +3255,11 @@ body.is-drawer-open {
   font-weight: var(--fw-medium);
   line-height: 1.25;
   white-space: nowrap;
-  max-width: 100%;
+  max-width: min(100%, 220px);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 0 1 auto;
 }
 
 .todo-chip--project {
@@ -3379,6 +3397,9 @@ body.dark-mode .todo-chip--due-overdue {
     grid-column: 5;
     grid-row: 1;
     justify-self: end;
+    width: 34px;
+    min-width: 34px;
+    max-width: 34px;
   }
 
   .todo-content {

--- a/tests/ui/layout-invariants.spec.ts
+++ b/tests/ui/layout-invariants.spec.ts
@@ -1,0 +1,295 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  category: string | null;
+  dueDate: string | null;
+  priority: "low" | "medium" | "high";
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installLayoutInvariantMockApi(
+  page: Page,
+  todosSeed: TodoSeed[],
+) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    return raw ? JSON.parse(raw) : {};
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(
+        id,
+        todosSeed.map((todo, index) => ({
+          ...todo,
+          completed: false,
+          order: index,
+          userId: id,
+          createdAt: nowIso(),
+          updatedAt: nowIso(),
+          subtasks: [],
+        })),
+      );
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Layout Invariants User",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET")
+      return json(route, 200, []);
+
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET")
+      return json(route, 200, []);
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page, email: string) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Layout Invariants User");
+  await page.locator("#registerEmail").fill(email);
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+test.describe("Todos layout invariants", () => {
+  test("desktop rail/topbar/row invariants hold without overflow", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-only invariants");
+
+    const longProject =
+      "Project-Label-With-Extreme-Length-To-Verify-Collapsed-Rail-Ellipsis-1234567890";
+    await installLayoutInvariantMockApi(page, [
+      {
+        id: "todo-long",
+        title:
+          "Very long todo title that should ellipsize correctly without clipping row actions or forcing horizontal overflow in the list region",
+        description:
+          "Long description preview that should remain calm and single-line in the default desktop list density.",
+        notes: null,
+        category: longProject,
+        dueDate: null,
+        priority: "high",
+      },
+    ]);
+
+    await registerAndOpenTodos(page, "layout-invariants@example.com");
+
+    const rail = page.locator("#projectsRail");
+    if (
+      await rail.evaluate((node) =>
+        node.classList.contains("projects-rail--collapsed"),
+      )
+    ) {
+      await page.locator("#projectsRailToggle").click();
+      await expect(rail).not.toHaveClass(/projects-rail--collapsed/);
+    }
+
+    const topbar = page.locator(".todos-top-bar");
+    const addBtn = page.locator(".todos-top-bar .top-add-btn");
+    await expect(addBtn).toBeVisible();
+    await expect(topbar).toBeVisible();
+
+    const topbarMetrics = await topbar.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(topbarMetrics.scrollWidth).toBeLessThanOrEqual(
+      topbarMetrics.clientWidth + 1,
+    );
+
+    const addBox = await addBtn.boundingBox();
+    const viewport = page.viewportSize();
+    expect(addBox).not.toBeNull();
+    if (addBox) {
+      expect(addBox.x + addBox.width).toBeLessThanOrEqual(
+        (viewport?.width || 1280) - 1,
+      );
+    }
+
+    await page
+      .locator(
+        `#projectsRail .projects-rail-item[data-project-key="${longProject}"]`,
+      )
+      .click();
+
+    const scrollRegion = page.locator("#todosScrollRegion");
+    const regionMetrics = await scrollRegion.evaluate((node) => ({
+      scrollWidth: node.scrollWidth,
+      clientWidth: node.clientWidth,
+    }));
+    expect(regionMetrics.scrollWidth).toBe(regionMetrics.clientWidth);
+
+    const firstRow = page.locator(".todo-item").first();
+    const kebab = firstRow.locator(".todo-kebab");
+    await expect(kebab).toHaveCSS("opacity", "0");
+
+    const rowBeforeHover = await firstRow.boundingBox();
+    await firstRow.hover();
+    await expect(kebab).toHaveCSS("opacity", "1");
+    const rowAfterHover = await firstRow.boundingBox();
+    expect(rowBeforeHover).not.toBeNull();
+    expect(rowAfterHover).not.toBeNull();
+    if (rowBeforeHover && rowAfterHover) {
+      expect(Math.abs(rowAfterHover.height - rowBeforeHover.height)).toBe(0);
+    }
+
+    await firstRow.focus();
+    await expect(kebab).toHaveCSS("opacity", "1");
+    await kebab.click();
+    await expect(firstRow.locator(".todo-kebab-menu")).toHaveClass(
+      /todo-kebab-menu--open/,
+    );
+
+    await page.locator("#projectsRailToggle").click();
+    await expect(rail).toHaveClass(/projects-rail--collapsed/);
+    const railLabel = page.locator(
+      `#projectsRail .projects-rail-item[data-project-key="${longProject}"] .projects-rail-item__label`,
+    );
+    const labelMetrics = await railLabel.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        whiteSpace: style.whiteSpace,
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+      };
+    });
+    expect(labelMetrics.whiteSpace).toBe("nowrap");
+    expect(labelMetrics.scrollWidth).toBeGreaterThan(labelMetrics.clientWidth);
+  });
+
+  test("mobile keeps row actions visible by default", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!isMobile, "Mobile-only action visibility");
+
+    await installLayoutInvariantMockApi(page, [
+      {
+        id: "todo-mobile",
+        title: "Mobile action visibility task",
+        description: null,
+        notes: null,
+        category: "Mobile Project",
+        dueDate: null,
+        priority: "medium",
+      },
+    ]);
+
+    await registerAndOpenTodos(page, "layout-invariants-mobile@example.com");
+
+    const kebab = page.locator(".todo-item .todo-kebab").first();
+    await expect(kebab).toBeVisible();
+    await expect(kebab).toHaveCSS("opacity", "1");
+    await expect(kebab).toHaveCSS("visibility", "visible");
+  });
+});


### PR DESCRIPTION
## Summary
- CSS-first calm list hardening with reserved row action slot to prevent jitter
- desktop row actions show on hover/focus-within/active row; mobile keeps actions visible
- overflow/ellipsis hardening for top bar, rail labels, chips, and Todos scroll region
- adds one Playwright invariants suite to guard clipping/overflow/action-visibility regressions

## Files changed
- public/styles.css
- tests/ui/layout-invariants.spec.ts

## Verification
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- CI=1 npm run test:ui

## Notes
- No backend/API changes
- No filter or drawer semantics changes
- No snapshot updates