### PR TITLE
M6: Composition + spacing polish

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -462,8 +462,8 @@ textarea:focus-visible,
 
 .add-todo {
   display: flex;
-  gap: 10px;
-  margin-bottom: 30px;
+  gap: var(--s-3);
+  margin-bottom: 0;
 }
 
 .add-todo input {
@@ -476,7 +476,7 @@ textarea:focus-visible,
 
 .quick-entry {
   flex-direction: column;
-  gap: 12px;
+  gap: var(--s-3);
 }
 
 .quick-entry > input {
@@ -491,7 +491,7 @@ textarea:focus-visible,
 
 .field-row {
   display: flex;
-  gap: 10px;
+  gap: var(--s-3);
   width: 100%;
   flex-wrap: wrap;
 }
@@ -518,7 +518,7 @@ textarea:focus-visible,
 
 .action-row {
   display: flex;
-  gap: 10px;
+  gap: var(--s-3);
   align-items: center;
   flex-wrap: wrap;
 }
@@ -529,8 +529,8 @@ textarea:focus-visible,
 }
 
 .ai-workspace {
-  margin-top: 16px;
-  padding: 14px;
+  margin-top: var(--s-3);
+  padding: var(--s-3);
   border: 1px solid var(--border-color);
   border-radius: var(--r-md);
   background: var(--card-bg);
@@ -538,20 +538,20 @@ textarea:focus-visible,
 
 .ai-workspace-header {
   font-weight: 600;
-  margin-bottom: 10px;
+  margin-bottom: var(--s-2);
   color: var(--text-primary);
 }
 
 .ai-workspace-inputs {
   display: flex;
-  gap: 10px;
+  gap: var(--s-3);
   flex-wrap: wrap;
 }
 
 .ai-workspace-inputs input {
   flex: 1;
   min-width: 220px;
-  padding: 10px;
+  padding: var(--s-3);
   border: 1px solid var(--border-color);
   border-radius: var(--r-sm);
   background: var(--input-bg);
@@ -564,7 +564,7 @@ textarea:focus-visible,
 }
 
 .ai-brain-dump {
-  margin-top: 10px;
+  margin-top: var(--s-3);
 }
 
 .ai-brain-dump label {
@@ -983,7 +983,7 @@ textarea:focus-visible,
 .todos-layout {
   display: grid;
   grid-template-columns: minmax(208px, 240px) minmax(0, 1fr);
-  gap: 14px;
+  gap: var(--s-3);
   align-items: stretch;
   flex: 1 1 auto;
   min-height: 0;
@@ -1008,11 +1008,10 @@ textarea:focus-visible,
   top: 0;
   z-index: 20;
   margin-bottom: 0;
-  padding: 10px 12px;
+  padding: var(--s-3);
   border: 1px solid var(--border-color);
   border-radius: var(--r-sm);
-  background: color-mix(in oklab, var(--card-bg) 88%, transparent);
-  backdrop-filter: blur(4px);
+  background: var(--card-bg);
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -1043,6 +1042,7 @@ textarea:focus-visible,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: var(--lh-tight);
 }
 
 .todos-list-header__count {
@@ -1346,7 +1346,8 @@ button.projects-rail-item {
   overflow-x: hidden;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--s-3);
+  padding-bottom: var(--s-3);
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
@@ -1371,10 +1372,10 @@ button.projects-rail-item {
 .todos-top-bar {
   display: grid;
   grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
-  gap: 12px;
+  gap: var(--s-3);
   align-items: center;
-  margin-bottom: 12px;
-  padding: 12px 14px;
+  margin-bottom: var(--s-3);
+  padding: var(--s-3) var(--s-4);
   border: 1px solid var(--border-color);
   border-radius: 10px;
   background: var(--card-bg);
@@ -1465,9 +1466,9 @@ button.projects-rail-item {
 }
 
 .todos-minimal-filters {
-  margin-bottom: 12px;
+  margin-bottom: 0;
   display: flex;
-  gap: 10px;
+  gap: var(--s-2);
   align-items: center;
   flex-wrap: wrap;
 }
@@ -1500,8 +1501,8 @@ button.projects-rail-item {
 
 .more-filters-panel {
   display: none;
-  margin-bottom: 16px;
-  padding: 12px;
+  margin-bottom: 0;
+  padding: var(--s-3);
   border: 1px solid var(--border-color);
   border-radius: 10px;
   background: var(--card-bg);
@@ -1512,7 +1513,7 @@ button.projects-rail-item {
 }
 
 .more-filters-actions {
-  margin-top: 10px;
+  margin-top: var(--s-2);
   display: flex;
   gap: 8px;
   align-items: center;
@@ -1529,7 +1530,7 @@ button.projects-rail-item {
 }
 
 .ics-export-helper {
-  margin-top: 8px;
+  margin-top: var(--s-2);
   font-size: 0.82rem;
   color: var(--text-secondary);
 }
@@ -1564,12 +1565,12 @@ button.projects-rail-item {
 .bulk-actions-toolbar {
   background: var(--accent);
   color: white;
-  padding: 12px 20px;
+  padding: var(--s-3) var(--s-4);
   border-radius: var(--r-sm);
-  margin-bottom: 15px;
+  margin-bottom: 0;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--s-2);
   flex-wrap: wrap;
 }
 
@@ -2391,14 +2392,24 @@ button.projects-rail-item {
 
 .empty-state {
   text-align: center;
-  padding: 60px 20px;
+  padding: calc(var(--s-6) + var(--s-5)) var(--s-5);
   color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .todo-list-state {
   text-align: center;
-  padding: 28px 20px 20px;
+  padding: var(--s-6) var(--s-5);
   color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .todo-list-state h3 {
@@ -2412,11 +2423,11 @@ button.projects-rail-item {
 }
 
 .todo-list-state--error .mini-btn {
-  margin-top: 14px;
+  margin-top: var(--s-3);
 }
 
 .todos-list--skeleton {
-  margin-top: 10px;
+  margin-top: 0;
 }
 
 .todo-skeleton-row {
@@ -2425,7 +2436,7 @@ button.projects-rail-item {
 }
 
 .todo-skeleton-row .todo-content {
-  gap: 10px;
+  gap: var(--s-2);
 }
 
 .skeleton-block {
@@ -2459,11 +2470,11 @@ button.projects-rail-item {
 
 .empty-state-icon {
   font-size: 4em;
-  margin-bottom: 20px;
+  margin-bottom: var(--s-4);
 }
 
 .empty-state-hint {
-  margin-top: 10px;
+  margin-top: var(--s-2);
   font-size: var(--fs-sm);
 }
 
@@ -3304,6 +3315,11 @@ body.is-drawer-open {
 }
 
 .todo-item.todo-item--active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.16);
+}
+
+.todo-item.todo-item--active:hover {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.16);
 }

--- a/tests/ui/composition-spacing.spec.ts
+++ b/tests/ui/composition-spacing.spec.ts
@@ -1,0 +1,326 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type TodoSeed = {
+  id: string;
+  title: string;
+  description?: string | null;
+  completed?: boolean;
+  category?: string | null;
+  dueDate?: string | null;
+  priority?: "low" | "medium" | "high";
+  notes?: string | null;
+};
+
+type TodosResponse = {
+  status: number;
+  body: unknown;
+};
+
+function mapTodosForUser(
+  todos: TodoSeed[],
+  userId: string,
+  nowIso: string,
+): Array<Record<string, unknown>> {
+  return todos.map((todo, index) => ({
+    id: todo.id,
+    title: todo.title,
+    description: todo.description ?? null,
+    completed: todo.completed ?? false,
+    category: todo.category ?? null,
+    dueDate: todo.dueDate ?? null,
+    priority: todo.priority ?? "medium",
+    notes: todo.notes ?? null,
+    userId,
+    order: index,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+    subtasks: [],
+  }));
+}
+
+async function installMockApi(
+  page: Page,
+  resolveTodos: (callCount: number, userId: string) => Promise<TodosResponse>,
+) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+  let todosCallCount = 0;
+
+  const nowIso = () => new Date().toISOString();
+  const nextUserId = () => `user-${userSeq++}`;
+  const nextToken = () => `token-${tokenSeq++}`;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    if (!raw) return {};
+    return JSON.parse(raw);
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+
+      const id = nextUserId();
+      users.set(email, { id, email, password });
+      const token = nextToken();
+      const refreshToken = nextToken();
+      accessTokens.set(token, id);
+
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken,
+      });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const user = Array.from(users.values()).find(
+        (item) => item.id === userId,
+      );
+      if (!user) return json(route, 404, { error: "User not found" });
+      return json(route, 200, {
+        id: user.id,
+        email: user.email,
+        name: "Composition Spacing User",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+
+    if (pathname === "/projects" && method === "GET") {
+      return json(route, 200, []);
+    }
+
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      todosCallCount += 1;
+      const response = await resolveTodos(todosCallCount, userId);
+      return json(route, response.status, response.body);
+    }
+
+    if (pathname === "/ai/suggestions" && method === "GET") {
+      return json(route, 200, []);
+    }
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+
+    if (pathname === "/auth/logout" && method === "POST") {
+      return json(route, 200, { ok: true });
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpenTodos(page: Page, email: string) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Composition Spacing User");
+  await page.locator("#registerEmail").fill(email);
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+test.describe("Todos composition and spacing", () => {
+  test("sticky list header stays above first visible row while scrolling", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop-only sticky header composition check");
+
+    const todos = Array.from({ length: 36 }).map((_, index) => ({
+      id: `todo-${index + 1}`,
+      title: `Scrollable task ${index + 1}`,
+      description: "Composition spacing check",
+      priority: "medium" as const,
+    }));
+
+    await installMockApi(page, async (_count, userId) => ({
+      status: 200,
+      body: mapTodosForUser(todos, userId, new Date().toISOString()),
+    }));
+
+    await registerAndOpenTodos(page, "composition-scroll@example.com");
+
+    const scrollRegion = page.locator("#todosScrollRegion");
+    await expect(scrollRegion).toBeVisible();
+    await scrollRegion.evaluate((node) => {
+      node.scrollTop = 560;
+    });
+
+    const geometry = await page.evaluate(() => {
+      const header = document.getElementById("todosListHeader");
+      const rows = Array.from(document.querySelectorAll(".todo-item"));
+      if (!(header instanceof HTMLElement) || rows.length === 0) {
+        return null;
+      }
+      const headerRect = header.getBoundingClientRect();
+      const firstVisibleRow = rows.find((row) => {
+        const rect = row.getBoundingClientRect();
+        return rect.bottom > headerRect.bottom + 1;
+      });
+      if (!(firstVisibleRow instanceof HTMLElement)) {
+        return null;
+      }
+      const rowRect = firstVisibleRow.getBoundingClientRect();
+      return {
+        headerBottom: headerRect.bottom,
+        rowTop: rowRect.top,
+      };
+    });
+
+    expect(geometry).not.toBeNull();
+    if (geometry) {
+      expect(geometry.rowTop).toBeGreaterThanOrEqual(geometry.headerBottom - 1);
+    }
+  });
+
+  test("empty state stays composed within the list container", async ({
+    page,
+  }) => {
+    await installMockApi(page, async () => ({
+      status: 200,
+      body: [],
+    }));
+
+    await registerAndOpenTodos(page, "composition-empty@example.com");
+
+    const scrollRegion = page.locator("#todosScrollRegion");
+    const emptyState = page.locator("#todosEmptyState");
+    await expect(emptyState).toBeVisible();
+
+    const emptyBounds = await emptyState.boundingBox();
+    const regionBounds = await scrollRegion.boundingBox();
+    expect(emptyBounds).not.toBeNull();
+    expect(regionBounds).not.toBeNull();
+    if (emptyBounds && regionBounds) {
+      expect(emptyBounds.x).toBeGreaterThanOrEqual(regionBounds.x - 1);
+      expect(emptyBounds.x + emptyBounds.width).toBeLessThanOrEqual(
+        regionBounds.x + regionBounds.width + 1,
+      );
+    }
+    const emptyPaddingLeft = await emptyState.evaluate((el) =>
+      Number.parseFloat(window.getComputedStyle(el).paddingLeft),
+    );
+    expect(emptyPaddingLeft).toBeGreaterThan(0);
+  });
+
+  test("error state stays composed within the list container", async ({
+    page,
+  }) => {
+    await installMockApi(page, async () => ({
+      status: 500,
+      body: { error: "temporary failure" },
+    }));
+    await registerAndOpenTodos(page, "composition-error@example.com");
+
+    await expect(page.locator("#todosErrorState")).toBeVisible();
+    await expect(page.locator("#todosRetryLoadButton")).toBeVisible();
+
+    const scrollRegion = page.locator("#todosScrollRegion");
+    const regionBounds = await scrollRegion.boundingBox();
+    const errorBounds = await page.locator("#todosErrorState").boundingBox();
+    expect(regionBounds).not.toBeNull();
+    expect(errorBounds).not.toBeNull();
+    if (regionBounds && errorBounds) {
+      expect(errorBounds.x).toBeGreaterThanOrEqual(regionBounds.x - 1);
+      expect(errorBounds.x + errorBounds.width).toBeLessThanOrEqual(
+        regionBounds.x + regionBounds.width + 1,
+      );
+    }
+    const errorPaddingLeft = await page
+      .locator("#todosErrorState")
+      .evaluate((el) =>
+        Number.parseFloat(window.getComputedStyle(el).paddingLeft),
+      );
+    expect(errorPaddingLeft).toBeGreaterThan(0);
+  });
+
+  test("loading skeleton appears in-flight and resolves cleanly", async ({
+    page,
+  }) => {
+    let resolveTodosRequest: ((value: TodosResponse) => void) | null = null;
+    const todosPromise = new Promise<TodosResponse>((resolve) => {
+      resolveTodosRequest = resolve;
+    });
+
+    await installMockApi(page, async () => todosPromise);
+    await registerAndOpenTodos(page, "composition-loading@example.com");
+
+    await expect(page.locator("#todosLoadingState")).toBeVisible();
+    await expect(page.locator(".todo-skeleton-row")).toHaveCount(6);
+
+    resolveTodosRequest?.({
+      status: 200,
+      body: [],
+    });
+
+    await expect(page.locator("#todosLoadingState")).toBeHidden();
+    await expect(page.locator(".todo-skeleton-row")).toHaveCount(0);
+    await expect(page.locator("#todosEmptyState")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- CSS-only composition pass to normalize Todos vertical rhythm and block spacing
- tightened sticky header composition so rows do not visually bleed under header while scrolling
- aligned empty/loading/error states to the same card surface, spacing, and containment rules as the main list
- added one Playwright regression spec for sticky-header overlap and state composition/layout checks

## Files changed
- public/styles.css
- tests/ui/composition-spacing.spec.ts

## Verification
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- CI=1 npm run test:ui

## Notes
- No JS behavior changes
- No backend/API changes
- No snapshot updates