### PR TITLE
feat(ui): layout hardening + calm polish invariants

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -3627,3 +3627,106 @@ textarea:disabled {
 .todo-chip--priority.high {
   filter: saturate(0.82);
 }
+
+/* Post-M7 combined hardening: topbar/rail/header/row overflow + truncation invariants */
+.todos-layout,
+.todos-main-zone,
+.todos-top-bar,
+.todos-top-bar-left,
+.todos-top-bar-search,
+.todos-top-bar-actions,
+#todosScrollRegion,
+#todosContent,
+.todos-list-header,
+.todos-list-header__context,
+.todo-item,
+.todo-content,
+.todo-meta,
+.todo-row-actions,
+.projects-rail-row,
+.projects-rail-item,
+.projects-rail-item__label {
+  min-width: 0;
+}
+
+.todos-top-bar {
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
+}
+
+.projects-rail-mobile-open {
+  max-width: min(42vw, 320px);
+}
+
+#projectsRailTopbarLabel {
+  max-width: 100%;
+}
+
+.todos-top-bar-actions {
+  flex-wrap: nowrap;
+}
+
+.todos-top-bar-actions .top-add-btn,
+.todos-top-bar-actions .more-filters-toggle {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+
+.todos-list-header {
+  overflow: hidden;
+  flex-wrap: nowrap;
+}
+
+.todos-list-header__context {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.todos-list-header__title {
+  max-width: 100%;
+}
+
+#todosScrollRegion > * {
+  min-width: 0;
+}
+
+.projects-rail.projects-rail--collapsed .projects-rail-item {
+  overflow: hidden;
+}
+
+.projects-rail.projects-rail--collapsed .projects-rail-item__label {
+  max-width: 100%;
+}
+
+.todo-item {
+  grid-template-columns: auto auto auto minmax(0, 1fr) 34px;
+}
+
+.todo-row-actions {
+  width: 34px;
+  min-width: 34px;
+  max-width: 34px;
+  overflow: visible;
+}
+
+.todo-title,
+.todo-description {
+  min-width: 0;
+}
+
+.todo-meta {
+  overflow: hidden;
+}
+
+.todo-chip {
+  max-width: min(100%, 180px);
+}
+
+@media (max-width: 768px) {
+  .todos-list-header {
+    flex-wrap: wrap;
+  }
+
+  .projects-rail-mobile-open {
+    max-width: 100%;
+  }
+}

--- a/tests/ui/topbar-cta-invariants.spec.ts
+++ b/tests/ui/topbar-cta-invariants.spec.ts
@@ -227,6 +227,10 @@ test.describe("Topbar CTA invariants", () => {
 
     const topbarLabel = page.locator("#projectsRailTopbarLabel");
     await expect(topbarLabel).toBeVisible();
+    await expect(topbarLabel).toHaveAttribute(
+      "title",
+      `Projects: ${longProject}`,
+    );
     const labelMetrics = await topbarLabel.evaluate((el) => {
       const style = window.getComputedStyle(el);
       const lineHeight = Number.parseFloat(style.lineHeight);
@@ -245,6 +249,12 @@ test.describe("Topbar CTA invariants", () => {
       labelMetrics.lineHeight * 1.5,
     );
     await expect(addButton).toBeVisible();
+
+    const collapsedRailLabel = page.locator(
+      `#projectsRail .projects-rail-item[data-project-key="${longProject}"] .projects-rail-item__label`,
+    );
+    await expect(collapsedRailLabel).toHaveAttribute("title", longProject);
+    await expect(collapsedRailLabel).toHaveCSS("white-space", "nowrap");
 
     const searchH = await searchInput.evaluate((el) =>
       Math.round(el.getBoundingClientRect().height),


### PR DESCRIPTION
	CSS-only layout hardening for topbar/rail/list header/row grid (no behavior changes).
	•	Prevents CTA clipping and label overlap via shrink-safety + reserved action widths.
	•	Tightened truncation + tooltips for topbar/rail/header labels.
	•	Updated invariant tests only (no snapshots):
	•	layout-overflow.spec.ts
	•	topbar-cta-invariants.spec.ts
	•	Gates: tsc/format/lint/unit/ui all pass locally.