### PR TITLE
UI: Rail keyboard navigation + sync/focus hardening

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1291,6 +1291,17 @@ button.projects-rail-item {
   border-color: rgb(79 110 247 / 28%);
 }
 
+.projects-rail-item[role="option"][aria-selected="true"] {
+  background: rgb(79 110 247 / 8%);
+  border-color: rgb(79 110 247 / 28%);
+}
+
+.projects-rail-item[role="option"]:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-color: rgb(79 110 247 / 40%);
+}
+
 .projects-rail-item__count {
   color: var(--text-secondary);
   font-size: var(--fs-xs);

--- a/tests/ui/projects-rail.spec.ts
+++ b/tests/ui/projects-rail.spec.ts
@@ -243,6 +243,11 @@ test.describe("Projects rail wiring", () => {
       "aria-expanded",
       "true",
     );
+    await expect(
+      page.locator(
+        '#projectsRailSheet .projects-rail-item[data-project-key=""]',
+      ),
+    ).toBeFocused();
 
     await page.keyboard.press("Escape");
     await expect(page.locator("#projectsRailSheet")).toHaveAttribute(
@@ -321,6 +326,36 @@ test.describe("Projects rail wiring", () => {
     await page.locator(".todo-item .todo-checkbox").first().click();
 
     await expect(homeRailItem).toHaveAttribute("aria-current", "page");
+    await expect(homeRailItem).toHaveAttribute("aria-selected", "true");
     await expect(page.locator("#categoryFilter")).toHaveValue("Home");
+  });
+
+  test("desktop keyboard navigation selects project and keeps header/topbar/count in sync", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, "Desktop keyboard rail behavior");
+
+    const allTasks = page.locator(
+      '#projectsRail .projects-rail-item[data-project-key=""]',
+    );
+    await allTasks.focus();
+    await expect(allTasks).toBeFocused();
+
+    await page.keyboard.press("ArrowDown");
+    const homeRailItem = page.locator(
+      '#projectsRail .projects-rail-item[data-project-key="Home"]',
+    );
+    await expect(homeRailItem).toBeFocused();
+
+    await page.keyboard.press("Enter");
+    await expect(page.locator("#categoryFilter")).toHaveValue("Home");
+    await expect(homeRailItem).toHaveAttribute("aria-selected", "true");
+    await expect(homeRailItem).toHaveAttribute("aria-current", "page");
+    await expect(page.locator("#projectsRailTopbarLabel")).toContainText(
+      "Home",
+    );
+    await expect(page.locator("#todosListHeaderTitle")).toHaveText("Home");
+    await expect(page.locator("#todosListHeaderCount")).toHaveText("1 task");
   });
 });

--- a/tests/ui/todo-drawer-details.spec.ts
+++ b/tests/ui/todo-drawer-details.spec.ts
@@ -427,6 +427,7 @@ test.describe("Todo drawer details + kebab actions", () => {
       "aria-hidden",
       "true",
     );
+    await expect(firstRow).toBeFocused();
   });
 
   test("drawer close restores focus to originating row", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Adds full keyboard navigation to the projects rail (ArrowUp/Down roving focus, Enter to select, Escape to close mobile sheet).
- Hardens rail accessibility with `role="listbox"`, `role="option"`, `aria-selected`, and roving `tabindex`.
- Syncs selected project state across rail, topbar, and list header from a single filter source.
- Improves drawer focus restoration on close (`preventScroll`, fallback by `data-todo-id` after rerender, Escape priority: kebab → drawer).

## What changed

### 1) Rail keyboard navigation (`public/app.js`)
- ArrowUp/ArrowDown cycles through rail options with roving focus.
- Enter selects the focused project via the existing project filter path.
- Escape closes the mobile rail sheet and restores focus to the trigger.

### 2) Rail a11y + sync (`public/app.js`, `public/styles.css`)
- `role="listbox"` on rail containers, `role="option"` + `aria-selected` + roving `tabindex` on rail items.
- Selected project syncs rail highlight, topbar label, and list header from the same filter source.
- Added focus-visible styles for rail options.

### 3) Drawer focus hardening (`public/app.js`)
- Close restores focus with `preventScroll`.
- Fallback focus lookup by `data-todo-id` after rerender.
- Escape key priority: kebab menu closes first, then drawer.

### 4) Tests
- `projects-rail.spec.ts`: desktop rail keyboard selection + header/topbar/count sync.
- `todo-drawer-details.spec.ts`: drawer Escape path asserts focus restoration.

## Safety
- Only `public/app.js`, `public/styles.css`, and `tests/ui/` changed
- No backend/API changes
- No snapshot PNG updates
- No filter semantic changes (uses existing project filter path)

## Verification
- `npm run lint:html` ✅
- `npm run lint:css` ✅
- `CI=1 npm run test:ui:fast` ✅ (147 passed, 35 skipped)
- No snapshot updates

## Test plan
- [ ] Confirm rail keyboard navigation works (Arrow keys cycle, Enter selects, Escape closes mobile)
- [ ] Confirm a11y attributes present (`role="listbox"`, `role="option"`, `aria-selected`)
- [ ] Confirm project selection syncs across rail, topbar, and list header
- [ ] Confirm drawer Escape restores focus to the triggering row
- [ ] Confirm CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)