### PR TITLE
docs: add CLAUDE.md and AGENTS.md project instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# Codex Agent Instructions
+
+## Workspace Setup (REQUIRED)
+
+Always create a git worktree for your task. Never work in the main checkout.
+
+```bash
+BRANCH_NAME="codex/<short-feature-name>"
+WORKTREE_DIR="/private/tmp/todos-api-<short-feature-name>"
+git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" master
+cd "$WORKTREE_DIR"
+npm ci
+```
+
+Work entirely inside the worktree directory for the duration of the task.
+
+## Project Structure
+
+- **Frontend:** Static HTML/CSS/JS in `public/` (no build step, no framework).
+  - `public/app.js` — all client-side logic (vanilla JS, event delegation model).
+  - `public/styles.css` — all styles.
+  - `public/index.html` — single-page app shell.
+- **Backend:** Express + Prisma + PostgreSQL in `src/`.
+- **Tests:**
+  - Unit: `src/*.test.ts` (Jest).
+  - Integration: `src/*.integration.test.ts` (Jest + supertest).
+  - UI: `tests/ui/*.spec.ts` (Playwright).
+
+## UI Architecture Constraints
+
+These are load-bearing patterns. Do not change them.
+
+- **Event delegation:** `public/app.js` uses delegated event listeners on container elements. Do not attach listeners directly to dynamic child elements.
+- **Filter pipeline:** `#categoryFilter` + `filterTodos()` is the canonical filter path. All project/category/status filtering routes through it.
+- **Project selection:** Use `setSelectedProjectKey(...)` for all project selection entry points. Do not bypass it.
+- **DOM-ready signal:** After auth/navigation, wait for `#todosView.active` + `#todosContent` visible + no `.loading` children. See `waitForTodosViewIdle()` in `tests/ui/helpers/todos-view.ts`.
+
+## Test Requirements
+
+### After any change, run these checks (all must pass):
+
+```bash
+npx tsc --noEmit
+npm run format:check
+npm run lint:html
+npm run lint:css
+npm run test:unit
+CI=1 npm run test:ui:fast
+```
+
+### UI test rules
+
+- **Fast suite (`test:ui:fast`)** is the required CI gate. It excludes `@visual`-tagged tests.
+- **Full suite (`test:ui`)** includes visual snapshot tests. Run only when snapshots are affected.
+- Any test using `toHaveScreenshot()` MUST include `@visual` in the test title.
+- Use `openTodosViewWithStorageState()` or `bootstrapTodosContext()` from `tests/ui/helpers/todos-view.ts` for auth setup. Do not write registration/login flows inline.
+- Use deterministic DOM-ready waits (see `waitForTodosViewIdle()`). Never use `page.waitForTimeout()` or sleep-based waits.
+- Never delete or weaken existing tests to make CI pass.
+
+### Snapshot rules
+
+- CI runs on `ubuntu-latest`. Screenshots generated on macOS will NOT match.
+- Do not update snapshot PNGs unless visually intentional. Note why in the commit message.
+- If snapshots need updating, use Docker:
+  ```bash
+  docker run --rm -v "$(pwd)":/work -w /work \
+    mcr.microsoft.com/playwright:v1.58.2 \
+    /bin/bash -c "npm ci && npx playwright test <spec> --update-snapshots"
+  ```
+
+## Commit and Handoff
+
+### Commit scope
+
+- Only commit files you intentionally changed. Do not commit unrelated files.
+- Use conventional commit messages: `feat(ui):`, `fix(api):`, `test(ui):`, `ci:`, `docs:`.
+- One logical change per commit. Split if the change spans unrelated areas.
+
+### Push and handoff
+
+After all checks pass:
+
+```bash
+git push -u origin "$BRANCH_NAME"
+```
+
+Provide a handoff summary with:
+- Branch name and head SHA.
+- Files changed (list each file).
+- What was implemented (bullet points).
+- Verification results (which checks passed/failed).
+- PR creation URL: `https://github.com/karthikg80/todos-api/pull/new/<branch-name>`
+
+## Boundaries
+
+- Do not modify files outside the scope of your task.
+- Do not change CI workflow files (`.github/workflows/`) unless the task explicitly requires it.
+- Do not add new npm dependencies without stating why in the handoff.
+- Do not modify `prisma/schema.prisma` unless the task explicitly requires schema changes.
+- If a check fails for reasons unrelated to your change, note it in the handoff rather than trying to fix unrelated code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# Project: todos-api
+
+Full-stack todo application with Express/Prisma backend and vanilla JS frontend.
+
+## Project Structure
+
+- **Frontend:** Static HTML/CSS/JS in `public/` (no build step, no framework).
+  - `public/app.js` — all client-side logic (vanilla JS, event delegation model).
+  - `public/styles.css` — all styles.
+  - `public/index.html` — single-page app shell.
+- **Backend:** Express + Prisma + PostgreSQL in `src/`.
+- **Tests:**
+  - Unit: `src/*.test.ts` — Jest, run with `npm run test:unit`.
+  - Integration: `src/*.integration.test.ts` — Jest + supertest, requires Postgres.
+  - UI: `tests/ui/*.spec.ts` — Playwright (Chromium desktop + mobile).
+
+## Environment
+
+- Node 22 via nvm: commands must use `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && <command>'`.
+- gh CLI: `/opt/homebrew/Cellar/gh/2.86.0/bin/gh`.
+- Docker: `/usr/local/bin/docker`.
+- Git worktrees for feature branches live under `/private/tmp/todos-api-*`.
+
+## UI Architecture Constraints
+
+These are load-bearing patterns. Do not change them.
+
+- **Event delegation:** `public/app.js` uses delegated event listeners on container elements. Do not attach listeners directly to dynamic child elements.
+- **Filter pipeline:** `#categoryFilter` + `filterTodos()` is the canonical filter path. All project/category/status filtering routes through it.
+- **Project selection:** Use `setSelectedProjectKey(...)` for all project selection entry points. Do not bypass it.
+- **DOM-ready signal:** After auth/navigation, wait for `#todosView.active` + `#todosContent` visible + no `.loading` children. See `waitForTodosViewIdle()` in `tests/ui/helpers/todos-view.ts`.
+
+## Verification Checks
+
+After any change, run all applicable checks. All must pass before committing.
+
+```bash
+npx tsc --noEmit
+npm run format:check
+npm run lint:html
+npm run lint:css
+npm run test:unit
+CI=1 npm run test:ui:fast
+```
+
+## CI Gates (required to pass on every PR)
+
+- **unit** — typecheck + format + audit + unit tests.
+- **integration** — Prisma migrations + integration tests (Postgres service).
+- **ui-quality** — CSS lint + HTML validation + link crawl + fast UI tests.
+- **Railway** — preview deploy.
+
+## UI Test Rules
+
+- **Fast suite (`test:ui:fast`)** is the required CI gate. Excludes `@visual`-tagged tests.
+- **Full suite (`test:ui`)** includes visual snapshot tests. Run only when snapshots are affected.
+- Any test using `toHaveScreenshot()` MUST include `@visual` in the test title.
+- Use `openTodosViewWithStorageState()` or `bootstrapTodosContext()` from `tests/ui/helpers/todos-view.ts` for auth setup. Do not write registration/login flows inline in specs.
+- Use deterministic DOM-ready waits (`waitForTodosViewIdle()`). Never use `page.waitForTimeout()` or sleep-based waits.
+- Never delete or weaken existing tests to make CI pass.
+
+## Snapshot Rules
+
+- CI runs on `ubuntu-latest`. Screenshots generated on macOS will NOT match.
+- `maxDiffPixelRatio: 0.05` in Playwright config. Mobile snapshots diverge more than desktop.
+- Do not update snapshot PNGs unless visually intentional. Note why in the commit message.
+- To generate Linux-compatible baselines:
+  ```bash
+  /usr/local/bin/docker run --rm -v "$(pwd)":/work -w /work \
+    mcr.microsoft.com/playwright:v1.58.2 \
+    /bin/bash -c "npm ci && npx playwright test <spec> --update-snapshots"
+  ```
+
+## PR Workflow
+
+- Always check `mergeStateStatus` and `mergeable` before merging.
+- Prefer squash merge with `--delete-branch`.
+- When rebasing causes snapshot drift, regenerate in Docker, amend, force-push-with-lease.
+- `--delete-branch` may fail if a local worktree uses the branch (remote still gets deleted).
+
+## Commit Conventions
+
+- Use conventional commits: `feat(ui):`, `fix(api):`, `test(ui):`, `ci:`, `docs:`.
+- One logical change per commit. Split if the change spans unrelated areas.
+- Only commit files you intentionally changed. Do not stage unrelated files.
+
+## Boundaries
+
+- Do not modify files outside the scope of the current task.
+- Do not change CI workflow files (`.github/workflows/`) unless explicitly required.
+- Do not add new npm dependencies without justification.
+- Do not modify `prisma/schema.prisma` unless schema changes are explicitly required.
+- If a check fails for reasons unrelated to the current change, note it rather than fixing unrelated code.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` for Claude Code agent instructions.
- Adds `AGENTS.md` for OpenAI Codex agent instructions.
- Shared project knowledge: architecture constraints, test rules, CI gates, commit conventions, snapshot handling, PR workflow.

## What each file does
- **`CLAUDE.md`** — read by Claude Code at session start. Includes environment paths, UI architecture constraints, verification checks, CI gate names, UI test rules, snapshot rules, PR workflow, and commit conventions.
- **`AGENTS.md`** — read by Codex at task start. Same core rules plus Codex-specific worktree setup, push/handoff format, and boundary constraints.

## Safety
- Documentation only — no code changes
- No CI workflow changes
- No test changes

## Test plan
- [ ] Confirm only `CLAUDE.md` and `AGENTS.md` added
- [ ] Confirm CI checks pass (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)