### PR TITLE
style: fix Prettier formatting in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ git push -u origin "$BRANCH_NAME"
 ```
 
 Provide a handoff summary with:
+
 - Branch name and head SHA.
 - Files changed (list each file).
 - What was implemented (bullet points).


### PR DESCRIPTION
Fixes missing blank line before bullet list in `AGENTS.md` that caused `unit` CI check (Prettier format:check) to fail on PR #86.

One-line whitespace fix, no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)