### PR TITLE
ci: skip ui-quality heavy steps on docs-only PRs

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -14,32 +14,72 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect changed paths
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+              - 'LICENSE'
+              - '.gitignore'
+              - '.editorconfig'
+            needs_ui:
+              - 'public/**'
+              - 'src/**'
+              - 'tests/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/**'
+
+      - name: Decide whether to run UI quality checks
+        id: run
+        run: |
+          run_ui=true
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ steps.changes.outputs.docs_only }}" = "true" ] && [ "${{ steps.changes.outputs.needs_ui }}" != "true" ]; then
+            run_ui=false
+          fi
+          echo "run_ui=${run_ui}" >> "$GITHUB_OUTPUT"
+
+      - name: Docs-only change detected; skipping UI-quality heavy steps
+        if: steps.run.outputs.run_ui != 'true'
+        run: echo "Docs/minor-only PR detected. Skipping UI-quality heavy steps."
+
       - name: Setup Node
+        if: steps.run.outputs.run_ui == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
 
       - name: Install dependencies
+        if: steps.run.outputs.run_ui == 'true'
         run: npm ci
 
       - name: Lint CSS
+        if: steps.run.outputs.run_ui == 'true'
         run: npm run lint:css
 
       - name: Validate HTML
+        if: steps.run.outputs.run_ui == 'true'
         run: npm run lint:html
 
       - name: Crawl links
+        if: steps.run.outputs.run_ui == 'true'
         run: npm run test:links
 
       - name: Install Playwright browser
+        if: steps.run.outputs.run_ui == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run UI tests (fast tier)
+        if: steps.run.outputs.run_ui == 'true'
         run: npm run test:ui:fast
 
       - name: Upload Playwright report
-        if: always()
+        if: always() && steps.run.outputs.run_ui == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
- Keep required check ui-quality intact (same workflow/job name) so branch protection behavior is preserved.
- Add docs-only PR detection and skip heavy ui-quality steps only when docs_only == true and needs_ui != true on pull_request.
- Keep push to master running full ui-quality unconditionally.

## Behavior
- ui-quality still runs and reports success in all cases.
- Heavy steps (Node setup/install/lint/links/Playwright/UI fast/artifact) are skipped only for safe docs-only PRs.
- Any app-impacting changes or workflow/package/test/source/public changes still trigger the full run.
