### PR TITLE
feat(ai): add decision assist telemetry events

### DIFF
--- a/src/decisionAssistTelemetry.ts
+++ b/src/decisionAssistTelemetry.ts
@@ -1,0 +1,52 @@
+import { DecisionAssistSurface } from "./aiContracts";
+
+export type DecisionAssistTelemetryEventName =
+  | "ai_suggestion_generated"
+  | "ai_suggestion_viewed"
+  | "ai_suggestion_applied"
+  | "ai_suggestion_dismissed"
+  | "ai_suggestion_undo";
+
+export interface DecisionAssistTelemetryEvent {
+  eventName: DecisionAssistTelemetryEventName;
+  surface: DecisionAssistSurface;
+  aiSuggestionDbId?: string;
+  suggestionId?: string;
+  todoId?: string;
+  suggestionCount?: number;
+  selectedTodoIdsCount?: number;
+  ts?: string;
+}
+
+const normalizeCount = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return value >= 0 ? Math.floor(value) : undefined;
+};
+
+export function emitDecisionAssistTelemetry(
+  event: DecisionAssistTelemetryEvent,
+): void {
+  const payload = {
+    eventName: event.eventName,
+    surface: event.surface,
+    aiSuggestionDbId:
+      typeof event.aiSuggestionDbId === "string"
+        ? event.aiSuggestionDbId
+        : undefined,
+    suggestionId:
+      typeof event.suggestionId === "string" ? event.suggestionId : undefined,
+    todoId: typeof event.todoId === "string" ? event.todoId : undefined,
+    suggestionCount: normalizeCount(event.suggestionCount),
+    selectedTodoIdsCount: normalizeCount(event.selectedTodoIdsCount),
+    ts: typeof event.ts === "string" ? event.ts : new Date().toISOString(),
+  };
+
+  console.info(
+    JSON.stringify({
+      type: "ai_decision_assist_telemetry",
+      ...payload,
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- Add non-fatal Decision Assist telemetry lifecycle events.
- Keep implementation additive with no API contract/schema/dependency changes.

## Telemetry Coverage
- Events: generated / viewed / applied / dismissed / undo
- Surfaces: task_drawer / on_create / today_plan

## Safety
- Telemetry emits are wrapped in try/catch and never block user flows.
- Payloads are privacy-safe and compact (IDs/counts/timestamps only).
- No new dependencies.
- No Prisma schema changes.
- No endpoint response-shape/contract changes.

## Test Matrix
- npx tsc --noEmit PASS
- npm run format:check PASS
- npm run lint:html PASS
- npm run lint:css PASS
- npm run test:unit PASS
- npm run test:integration PASS
- CI=1 npm run test:ui:fast PASS

## Pre-mortem
1. Most likely failure mode: telemetry emit throws during lifecycle handlers.
2. Blast radius: could affect generate/view/apply/dismiss request paths if not isolated.
3. Rollback: revert this additive commit (no schema/contract migration required).

## Notes
- viewed currently emits per successful latest-envelope return (no persistence-based dedupe in this PR).
