### PR TITLE
feat(ui): blocklist AI-internal categories from nav surfaces

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -33,6 +33,14 @@ function isTaskDrawerDecisionAssistEnabled() {
 
 const FEATURE_TASK_DRAWER_DECISION_ASSIST = isTaskDrawerDecisionAssistEnabled();
 
+// Categories that are assigned automatically by server-side AI flows and must
+// not surface as user-navigable project entries in the rail, the
+// #categoryFilter dropdown, or the create-form project picker.
+// Todos that carry these categories are intentionally preserved in the data
+// layer and remain visible under "All Tasks"; they are only excluded from
+// navigation surfaces.
+const AI_INTERNAL_CATEGORIES = new Set(["AI Plan"]);
+
 const hasValidAppState =
   !!window.AppState &&
   typeof window.AppState.loadStoredSession === "function" &&
@@ -2869,7 +2877,7 @@ function renderProjectOptionEntry(projectPath, selectedValue = "") {
 function getAllProjects() {
   const fromTodos = todos
     .map((todo) => normalizeProjectPath(todo.category))
-    .filter((value) => value.length > 0);
+    .filter((value) => value.length > 0 && !AI_INTERNAL_CATEGORIES.has(value));
   return expandProjectTree([...customProjects, ...fromTodos]);
 }
 


### PR DESCRIPTION
## Summary

Resolves Task 102 (Green).

Adds `AI_INTERNAL_CATEGORIES` (`Set<string>`) near the feature-flag declarations in `public/app.js` and uses it to filter `getAllProjects()` — the single upstream source for all three navigation surfaces:

| Surface | Code path |
|---|---|
| Projects rail | `renderProjectsRail()` → `getAllProjects()` |
| `#categoryFilter` dropdown | `updateCategoryFilter()` → `getAllProjects()` |
| Create-form project picker | `updateProjectSelectOptions()` → `getAllProjects()` |

Todos with `category: "AI Plan"` are **not mutated** — they remain fully visible under All Tasks. The filter is purely presentational.

## Changes

- `public/app.js` — +9 lines, −1 line (one-line filter in `getAllProjects()` + 8-line constant declaration with explanatory comment)

## Test plan

- [x] `npx tsc --noEmit` — PASS
- [x] `npm run format:check` — PASS
- [x] `npm run lint:html` — PASS
- [x] `npm run lint:css` — PASS
- [x] `npm run test:unit` — PASS (117/117)
- [x] `CI=1 npm run test:ui:fast` — PASS (201 passed, 41 skipped/mobile-viewport, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)