### PR TITLE
feat(ui): lint-first silent-executor AI UX (Task 103)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -760,6 +760,45 @@ textarea:focus-visible,
   color: var(--text-muted);
 }
 
+/* Lint-first chip — shown in place of the full AI assist row until user
+   clicks Fix or Review to reveal server-backed suggestions. */
+.ai-lint-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-1) var(--s-2);
+  border-radius: var(--r-sm);
+  background: var(--color-warning-bg, #fffbe6);
+  border: 1px solid var(--color-warning-border, #ffe58f);
+  font-size: var(--fs-sm);
+  color: var(--text-secondary, var(--text-muted));
+}
+
+.ai-lint-chip__icon {
+  flex-shrink: 0;
+}
+
+.ai-lint-chip__message {
+  flex: 1;
+  min-width: 0;
+}
+
+.ai-lint-chip__action {
+  flex-shrink: 0;
+  padding: 2px var(--s-2);
+  border-radius: var(--r-sm);
+  border: 1px solid currentColor;
+  background: transparent;
+  cursor: pointer;
+  font-size: var(--fs-xs, 0.72rem);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.ai-lint-chip__action--secondary {
+  opacity: 0.65;
+}
+
 .today-plan-panel {
   margin-top: var(--s-3);
   margin-bottom: var(--s-3);

--- a/tests/ui/ai-on-create-assist.spec.ts
+++ b/tests/ui/ai-on-create-assist.spec.ts
@@ -172,6 +172,17 @@ async function registerAndOpenTodos(page: Page) {
   await expect(page.locator("#todosView")).toHaveClass(/active/);
 }
 
+// Lint-first: after filling a title the lint chip may show. Click Fix to
+// reveal the full AI assist row before asserting on individual chips.
+async function revealOnCreateFullAssist(page: Page) {
+  const lintFix = page.locator(
+    "#aiOnCreateAssistRow .ai-lint-chip__action[data-ai-lint-action='fix']",
+  );
+  if (await lintFix.isVisible()) {
+    await lintFix.click();
+  }
+}
+
 test.describe("AI on-create assist chips", () => {
   test.beforeEach(async ({ page }) => {
     await installOnCreateMockApi(page);
@@ -184,6 +195,7 @@ test.describe("AI on-create assist chips", () => {
     await page
       .locator("#todoInput")
       .fill("urgent tomorrow website marketing email stuff personal unknown");
+    await revealOnCreateFullAssist(page);
 
     const assistRow = page.locator('[data-testid="ai-on-create-row"]');
     await expect(assistRow).toBeVisible();
@@ -205,6 +217,7 @@ test.describe("AI on-create assist chips", () => {
     page,
   }) => {
     await page.locator("#todoInput").fill("email follow up");
+    await revealOnCreateFullAssist(page);
 
     await page
       .locator('[data-testid="ai-chip-apply-oc-rewrite-vague"]')
@@ -221,6 +234,7 @@ test.describe("AI on-create assist chips", () => {
     page,
   }) => {
     await page.locator("#todoInput").fill("urgent task to finish");
+    await revealOnCreateFullAssist(page);
 
     await page
       .locator('[data-testid="ai-chip-apply-oc-set-priority-urgent"]')
@@ -230,6 +244,7 @@ test.describe("AI on-create assist chips", () => {
 
   test("apply set_due_date updates due input", async ({ page }) => {
     await page.locator("#todoInput").fill("finish report tomorrow");
+    await revealOnCreateFullAssist(page);
 
     await page
       .locator('[data-testid="ai-chip-apply-oc-set-due-tomorrow"]')
@@ -239,6 +254,7 @@ test.describe("AI on-create assist chips", () => {
 
   test("dismiss hides chip", async ({ page }) => {
     await page.locator("#todoInput").fill("website update");
+    await revealOnCreateFullAssist(page);
 
     await expect(
       page.locator('[data-testid="ai-chip-oc-set-project-website"]'),
@@ -253,6 +269,7 @@ test.describe("AI on-create assist chips", () => {
 
   test("requiresConfirmation enforces confirm step", async ({ page }) => {
     await page.locator("#todoInput").fill("asap yesterday fix bug");
+    await revealOnCreateFullAssist(page);
 
     await page.locator('[data-testid="ai-chip-apply-oc-set-due-past"]').click();
     await expect(
@@ -269,6 +286,7 @@ test.describe("AI on-create assist chips", () => {
     page,
   }) => {
     await page.locator("#todoInput").fill("website marketing follow up");
+    await revealOnCreateFullAssist(page);
 
     await page
       .locator('[data-testid="ai-chip-apply-oc-clarify-project"]')

--- a/tests/ui/lint-chip.spec.ts
+++ b/tests/ui/lint-chip.spec.ts
@@ -1,0 +1,402 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Minimal mock API — covers auth, todos, and the AI endpoints that the full
+// assist row calls so Fix/Review tests don't hit the real network.
+// ---------------------------------------------------------------------------
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+async function installMockApi(page: Page) {
+  const users = new Map<
+    string,
+    { id: string; email: string; password: string }
+  >();
+  const accessTokens = new Map<string, string>();
+  const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let userSeq = 1;
+  let tokenSeq = 1;
+  let todoSeq = 1;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    return raw ? JSON.parse(raw) : {};
+  };
+
+  const authUserId = (route: Route) => {
+    const authHeader = route.request().headers().authorization || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    return accessTokens.get(token) || "user-1";
+  };
+
+  const json = (route: Route, status: number, body: unknown) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(route, 200, {
+        enabled: false,
+        reason: "already_provisioned",
+      });
+    }
+    if (pathname === "/auth/register" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      if (users.has(email)) {
+        return json(route, 409, { error: "Email already registered" });
+      }
+      const id = `user-${userSeq++}`;
+      users.set(email, { id, email, password: String(body.password || "") });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, id);
+      todosByUser.set(id, []);
+      return json(route, 201, {
+        user: { id, email, name: body.name || null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+    if (pathname === "/auth/login" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const user = users.get(email);
+      if (!user) return json(route, 401, { error: "Invalid credentials" });
+      const token = `token-${tokenSeq++}`;
+      accessTokens.set(token, user.id);
+      return json(route, 200, {
+        user: { id: user.id, email, name: null },
+        token,
+        refreshToken: `refresh-${tokenSeq++}`,
+      });
+    }
+    if (pathname === "/auth/logout" && method === "POST") {
+      return json(route, 200, { ok: true });
+    }
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = authUserId(route);
+      return json(route, 200, {
+        id: userId,
+        email: "lint-test@example.com",
+        name: "Lint Tester",
+        role: "user",
+        isVerified: true,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      });
+    }
+    if (pathname === "/projects" && method === "GET") {
+      return json(route, 200, []);
+    }
+    if (pathname === "/todos" && method === "GET") {
+      const userId = authUserId(route);
+      return json(route, 200, todosByUser.get(userId) || []);
+    }
+    if (pathname === "/todos" && method === "POST") {
+      const userId = authUserId(route);
+      const body = await parseBody(route);
+      const existing = todosByUser.get(userId) || [];
+      const created = {
+        id: `todo-${todoSeq++}`,
+        title: String(body.title || "").trim() || "Untitled",
+        completed: false,
+        category: body.category ? String(body.category) : null,
+        dueDate: body.dueDate ? String(body.dueDate) : null,
+        priority:
+          body.priority === "low" || body.priority === "high"
+            ? body.priority
+            : "medium",
+        notes: body.notes ? String(body.notes) : null,
+        createdAt: nowIso(),
+        updatedAt: nowIso(),
+      };
+      existing.unshift(created);
+      todosByUser.set(userId, existing);
+      return json(route, 201, created);
+    }
+    if (pathname.startsWith("/todos/") && method === "PUT") {
+      const userId = authUserId(route);
+      const body = await parseBody(route);
+      const id = pathname.split("/")[2];
+      const existing = todosByUser.get(userId) || [];
+      const idx = existing.findIndex((t) => t.id === id);
+      if (idx >= 0) {
+        existing[idx] = { ...existing[idx], ...body, updatedAt: nowIso() };
+        todosByUser.set(userId, existing);
+        return json(route, 200, existing[idx]);
+      }
+      return json(route, 404, { error: "Not found" });
+    }
+    if (pathname === "/ai/suggestions" && method === "GET") {
+      return json(route, 200, []);
+    }
+    if (pathname === "/ai/usage" && method === "GET") {
+      return json(route, 200, {
+        plan: "free",
+        used: 0,
+        limit: 10,
+        remaining: 10,
+        resetAt: nowIso(),
+      });
+    }
+    if (pathname === "/ai/insights" && method === "GET") {
+      return json(route, 200, {
+        generatedCount: 0,
+        ratedCount: 0,
+        acceptanceRate: null,
+        recommendation: "",
+      });
+    }
+    if (pathname === "/ai/feedback-summary" && method === "GET") {
+      return json(route, 200, {
+        totalRated: 0,
+        acceptedCount: 0,
+        rejectedCount: 0,
+      });
+    }
+    // AI decision-assist: return empty suggestions so the full assist row
+    // renders (without chips), confirming the transition from lint to full UI.
+    if (pathname === "/ai/decision-assist/stub" && method === "POST") {
+      return json(route, 200, { ok: true });
+    }
+    if (pathname === "/ai/suggestions/latest" && method === "GET") {
+      return json(route, 200, null);
+    }
+
+    return route.continue();
+  });
+}
+
+async function registerAndOpen(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Register" }).click();
+  await page.locator("#registerName").fill("Lint Test User");
+  await page.locator("#registerEmail").fill("lint-test@example.com");
+  await page.locator("#registerPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Create Account" }).click();
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+}
+
+// ---------------------------------------------------------------------------
+// On-create surface
+// ---------------------------------------------------------------------------
+
+test.describe("Lint-first on-create chip", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockApi(page);
+    await registerAndOpen(page);
+  });
+
+  test("vague title shows lint chip; full assist chips are hidden", async ({
+    page,
+  }) => {
+    await page.locator("#todoInput").fill("do stuff");
+    await expect(page.locator(".ai-lint-chip")).toBeVisible();
+    await expect(page.locator(".ai-create-assist__chips")).toBeHidden();
+  });
+
+  test("short title (< 5 chars) shows title_too_short chip", async ({
+    page,
+  }) => {
+    await page.locator("#todoInput").fill("Fix");
+    await expect(
+      page.locator(".ai-lint-chip[data-lint-code='title_too_short']"),
+    ).toBeVisible();
+  });
+
+  test("urgency language without due date shows missing_due_date chip", async ({
+    page,
+  }) => {
+    await page.locator("#todoInput").fill("Submit the quarterly report today");
+    await expect(
+      page.locator(".ai-lint-chip[data-lint-code='missing_due_date']"),
+    ).toBeVisible();
+  });
+
+  test("clean specific title shows no lint chip and no assist row", async ({
+    page,
+  }) => {
+    await page
+      .locator("#todoInput")
+      .fill("Write quarterly report for finance team");
+    await expect(page.locator(".ai-lint-chip")).toBeHidden();
+    const row = page.locator("#aiOnCreateAssistRow");
+    // row should be either hidden or have empty content
+    const isHidden = await row.evaluate(
+      (el) => el.hidden || el.innerHTML.trim() === "",
+    );
+    expect(isHidden).toBe(true);
+  });
+
+  test("Fix button reveals full assist row", async ({ page }) => {
+    await page.locator("#todoInput").fill("do stuff");
+    await expect(page.locator(".ai-lint-chip")).toBeVisible();
+    await page
+      .locator(".ai-lint-chip__action[data-ai-lint-action='fix']")
+      .click();
+    // After Fix the lint chip should be gone and the assist header should appear
+    await expect(page.locator(".ai-lint-chip")).toBeHidden();
+    await expect(page.locator(".ai-create-assist__header")).toBeVisible();
+  });
+
+  test("Review button reveals full assist row", async ({ page }) => {
+    await page.locator("#todoInput").fill("handle things");
+    await expect(page.locator(".ai-lint-chip")).toBeVisible();
+    await page
+      .locator(".ai-lint-chip__action[data-ai-lint-action='review']")
+      .click();
+    await expect(page.locator(".ai-lint-chip")).toBeHidden();
+    await expect(page.locator(".ai-create-assist__header")).toBeVisible();
+  });
+
+  test("lint chip resets when input is cleared", async ({ page }) => {
+    await page.locator("#todoInput").fill("do stuff");
+    await expect(page.locator(".ai-lint-chip")).toBeVisible();
+    await page.locator("#todoInput").fill("");
+    await expect(page.locator(".ai-lint-chip")).toBeHidden();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Task drawer surface
+// ---------------------------------------------------------------------------
+
+test.describe("Lint-first task drawer chip", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockApi(page);
+    await registerAndOpen(page);
+  });
+
+  test("drawer shows lint chip for vague task title; full AI list hidden", async ({
+    page,
+  }) => {
+    // Create a todo with a vague title
+    await page.locator("#todoInput").fill("do stuff");
+    await page.locator("#todoInput").press("Enter");
+    // Wait for it to appear in the list
+    await expect(page.locator(".todo-item").first()).toBeVisible();
+    // Open drawer
+    await page.locator(".todo-item").first().click();
+    await expect(page.locator("#todoDetailsDrawer")).toBeVisible();
+    // Lint chip should be in the AI section
+    await expect(
+      page.locator("#todoDetailsDrawer .ai-lint-chip"),
+    ).toBeVisible();
+    // Full AI list should not be rendered
+    await expect(
+      page.locator("#todoDetailsDrawer .todo-drawer-ai-list"),
+    ).toBeHidden();
+  });
+
+  test("drawer shows no chip for a clean task title", async ({ page }) => {
+    await page
+      .locator("#todoInput")
+      .fill("Write quarterly report for finance team");
+    await page.locator("#todoInput").press("Enter");
+    await expect(page.locator(".todo-item").first()).toBeVisible();
+    await page.locator(".todo-item").first().click();
+    await expect(page.locator("#todoDetailsDrawer")).toBeVisible();
+    await expect(page.locator("#todoDetailsDrawer .ai-lint-chip")).toBeHidden();
+  });
+
+  test("Fix in drawer reveals full AI suggestions section", async ({
+    page,
+  }) => {
+    await page.locator("#todoInput").fill("handle things");
+    await page.locator("#todoInput").press("Enter");
+    await expect(page.locator(".todo-item").first()).toBeVisible();
+    await page.locator(".todo-item").first().click();
+    await expect(page.locator("#todoDetailsDrawer")).toBeVisible();
+    await expect(
+      page.locator("#todoDetailsDrawer .ai-lint-chip"),
+    ).toBeVisible();
+    await page
+      .locator(
+        "#todoDetailsDrawer .ai-lint-chip__action[data-ai-lint-action='fix']",
+      )
+      .click();
+    // Lint chip should be gone; the AI Suggestions section title should appear
+    await expect(page.locator("#todoDetailsDrawer .ai-lint-chip")).toBeHidden();
+    await expect(
+      page.locator("#todoDetailsDrawer .todo-drawer__section-title", {
+        hasText: "AI Suggestions",
+      }),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AI Plan not in nav (Task 102 already merged — verify here too)
+// ---------------------------------------------------------------------------
+
+test.describe("AI Plan excluded from nav surfaces", () => {
+  test.beforeEach(async ({ page }) => {
+    // Register the AI Plan todos override AFTER installMockApi so it runs
+    // FIRST (Playwright routes are LIFO). Use route.fallback() — not
+    // route.continue() — so unmatched requests fall through to installMockApi
+    // instead of going to the network.
+    await installMockApi(page);
+    await page.route("**/*", async (route) => {
+      const url = new URL(route.request().url());
+      if (
+        url.pathname === "/todos" &&
+        route.request().method() === "GET" &&
+        route.request().headers().authorization
+      ) {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            {
+              id: "todo-ai-plan-1",
+              title: "AI generated task",
+              completed: false,
+              category: "AI Plan",
+              dueDate: null,
+              priority: "medium",
+              notes: null,
+              createdAt: nowIso(),
+              updatedAt: nowIso(),
+            },
+          ]),
+        });
+      }
+      // Fall through to the installMockApi handler for all other routes.
+      await route.fallback();
+    });
+    await registerAndOpen(page);
+  });
+
+  test("AI Plan does not appear in the projects rail", async ({ page }) => {
+    await expect(page.locator("[data-project-key='AI Plan']")).toHaveCount(0);
+  });
+
+  test("AI Plan does not appear in categoryFilter dropdown", async ({
+    page,
+  }) => {
+    await expect(
+      page.locator("#categoryFilter option[value='AI Plan']"),
+    ).toHaveCount(0);
+  });
+
+  test("todo with AI Plan category is still visible under All Tasks", async ({
+    page,
+  }) => {
+    await expect(
+      page.locator(".todo-item", { hasText: "AI generated task" }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `lintTodoFields()` pure function and `renderLintChip()` renderer to surface exactly one deterministic hint per vague/incomplete title
- Gates `renderOnCreateAssistRow()` and `renderTaskDrawerAssistSection()` behind a `showFullAssist` flag — shows lint chip by default, reveals full AI panel only after Fix/Review click
- Auto-sets `showFullAssist=true` on todo creation (post-create live mode) and in `AI_DEBUG_ENABLED` mode (dev bypass)
- Context-aware vague-word detection: `LINT_VAGUE_WORDS_ON_CREATE` extends the base set for the on-create surface without affecting the drawer (avoids breaking existing drawer live tests)
- Removes today-plan auto-generate on first open; keeps fetch-only auto-load so previously generated plans restore across reloads
- Adds `.ai-lint-chip` CSS block in `public/styles.css`
- Adds 11 new Playwright tests in `tests/ui/lint-chip.spec.ts`
- Patches `tests/ui/ai-on-create-assist.spec.ts` with `revealOnCreateFullAssist()` helper so existing tests adapt to the new lint gate

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean  
- [x] `npm run lint:html` — clean
- [x] `npm run lint:css` — clean
- [x] `npm run test:unit` — 117/117 passed
- [x] `CI=1 npm run test:ui:fast` — 227 passed, 41 skipped (@visual), 0 failed

## Files changed

- `public/app.js` — lint utilities, showFullAssist gates, click delegation, today-plan auto-load fix
- `public/styles.css` — `.ai-lint-chip` styles
- `tests/ui/lint-chip.spec.ts` — new fast-suite spec (11 tests)
- `tests/ui/ai-on-create-assist.spec.ts` — `revealOnCreateFullAssist` adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)