### PR TITLE
refactor(api): decompose AI router into service modules (Task 106)

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -10,5 +10,7 @@ module.exports = {
     "**/src/aiContracts.test.ts",
     "**/src/prismaTodoService.error.test.ts",
     "**/src/api.contract.test.ts",
+    "**/src/aiQuotaService.test.ts",
+    "**/src/aiApplyService.test.ts",
   ],
 };

--- a/src/aiApplyService.test.ts
+++ b/src/aiApplyService.test.ts
@@ -1,0 +1,466 @@
+import {
+  applyTodoBoundSuggestion,
+  applyTodayPlanSuggestions,
+  ApplyTodoBoundResult,
+  ApplyTodayPlanResult,
+} from "./aiApplyService";
+import { ITodoService } from "./interfaces/ITodoService";
+import { IProjectService } from "./interfaces/IProjectService";
+import {
+  NormalizedTodoBoundSuggestion,
+  NormalizedTodayPlanSuggestion,
+} from "./aiNormalizationService";
+
+// ── Helpers ──
+
+const USER_ID = "user-1";
+const TODO_ID = "todo-1";
+
+function makeTodo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TODO_ID,
+    userId: USER_ID,
+    title: "Buy groceries",
+    completed: false,
+    priority: "medium" as const,
+    notes: undefined as string | undefined,
+    category: undefined as string | undefined,
+    dueDate: undefined as Date | undefined,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    order: 0,
+    ...overrides,
+  };
+}
+
+function buildMockTodoService(
+  overrides: Partial<ITodoService> = {},
+): ITodoService {
+  const baseTodo = makeTodo();
+  return {
+    findAll: jest.fn().mockResolvedValue([baseTodo]),
+    findById: jest.fn().mockResolvedValue(baseTodo),
+    create: jest.fn().mockResolvedValue(baseTodo),
+    update: jest.fn().mockImplementation(async (_userId, _id, dto) => ({
+      ...baseTodo,
+      ...dto,
+    })),
+    delete: jest.fn().mockResolvedValue(true),
+    reorder: jest.fn().mockResolvedValue([baseTodo]),
+    createSubtask: jest.fn().mockResolvedValue({
+      id: "sub-1",
+      title: "Subtask",
+      completed: false,
+      order: 1,
+      todoId: baseTodo.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
+    updateSubtask: jest.fn().mockResolvedValue(null),
+    deleteSubtask: jest.fn().mockResolvedValue(true),
+    findSubtasks: jest.fn().mockResolvedValue([]),
+    clear: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function buildMockProjectService(
+  overrides: Partial<IProjectService> = {},
+): IProjectService {
+  return {
+    findAll: jest.fn().mockResolvedValue([]),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    ...overrides,
+  };
+}
+
+function makeSuggestion(
+  type: string,
+  payload: Record<string, unknown>,
+  overrides: Partial<NormalizedTodoBoundSuggestion> = {},
+): NormalizedTodoBoundSuggestion {
+  return {
+    type: type as NormalizedTodoBoundSuggestion["type"],
+    confidence: 0.85,
+    rationale: "Test rationale",
+    payload,
+    suggestionId: "sug-1",
+    requiresConfirmation: false,
+    ...overrides,
+  };
+}
+
+// ── applyTodoBoundSuggestion ──
+
+describe("applyTodoBoundSuggestion", () => {
+  it("applies rewrite_title and returns updated todo", async () => {
+    const todoService = buildMockTodoService();
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("rewrite_title", {
+        title: "Buy organic groceries",
+      }),
+      todoService,
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.updatedTodo.title).toBe("Buy organic groceries");
+    }
+    expect(todoService.update).toHaveBeenCalledWith(
+      USER_ID,
+      TODO_ID,
+      expect.objectContaining({ title: "Buy organic groceries" }),
+    );
+  });
+
+  it("rejects empty rewrite title", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("rewrite_title", { title: "   " }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.error).toContain("Invalid rewrite title");
+    }
+  });
+
+  it("applies set_due_date with valid future date", async () => {
+    const futureDate = new Date(Date.now() + 86_400_000).toISOString();
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_due_date", { dueDateISO: futureDate }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects past due date without confirmation", async () => {
+    const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_due_date", { dueDateISO: pastDate }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(
+        "Past due dates require explicit confirmation",
+      );
+    }
+  });
+
+  it("accepts past due date with confirmation", async () => {
+    const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_due_date", { dueDateISO: pastDate }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+      confirmed: true,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("applies set_priority for valid priority", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_priority", { priority: "low" }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires confirmation for high priority", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_priority", { priority: "high" }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(
+        "High priority changes require explicit confirmation",
+      );
+    }
+  });
+
+  it("applies set_category with valid category", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_category", { category: "Errands" }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("resolves projectId via project service for set_project", async () => {
+    const projectService = buildMockProjectService({
+      findAll: jest.fn().mockResolvedValue([
+        {
+          id: "proj-1",
+          name: "Work",
+          userId: USER_ID,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ]),
+    });
+    const todoService = buildMockTodoService();
+
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("set_project", { projectId: "proj-1" }),
+      todoService,
+      projectService,
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(todoService.update).toHaveBeenCalledWith(
+      USER_ID,
+      TODO_ID,
+      expect.objectContaining({ category: "Work" }),
+    );
+  });
+
+  it("applies split_subtasks with valid subtasks", async () => {
+    const todoService = buildMockTodoService();
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("split_subtasks", {
+        subtasks: [
+          { title: "Sub A", order: 1 },
+          { title: "Sub B", order: 2 },
+        ],
+      }),
+      todoService,
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(todoService.createSubtask).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects split_subtasks with more than 5", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("split_subtasks", {
+        subtasks: [
+          { title: "A", order: 1 },
+          { title: "B", order: 2 },
+          { title: "C", order: 3 },
+          { title: "D", order: 4 },
+          { title: "E", order: 5 },
+          { title: "F", order: 6 },
+        ],
+      }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("split_subtasks requires 1-5 subtasks");
+    }
+  });
+
+  it("applies propose_next_action to notes", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("propose_next_action", {
+        text: "Check prices online",
+      }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects ask_clarification for apply", async () => {
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("ask_clarification", { question: "When?" }),
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not supported for apply");
+    }
+  });
+
+  it("returns 404 when todo is not found during update", async () => {
+    const todoService = buildMockTodoService({
+      update: jest.fn().mockResolvedValue(null),
+    });
+    const result = await applyTodoBoundSuggestion({
+      selected: makeSuggestion("rewrite_title", { title: "Valid title" }),
+      todoService,
+      userId: USER_ID,
+      inputTodoId: TODO_ID,
+      todo: makeTodo(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(404);
+    }
+  });
+});
+
+// ── applyTodayPlanSuggestions ──
+
+describe("applyTodayPlanSuggestions", () => {
+  it("applies multiple suggestions across different todos", async () => {
+    const todoA = makeTodo({ id: "todo-a" });
+    const todoB = makeTodo({ id: "todo-b" });
+
+    const todoService = buildMockTodoService({
+      findById: jest
+        .fn()
+        .mockImplementation(async (_uid: string, id: string) => {
+          if (id === "todo-a") return todoA;
+          if (id === "todo-b") return todoB;
+          return null;
+        }),
+      update: jest
+        .fn()
+        .mockImplementation(async (_uid: string, id: string, dto: unknown) => ({
+          ...(id === "todo-a" ? todoA : todoB),
+          ...(dto as Record<string, unknown>),
+        })),
+    });
+
+    const suggestions: NormalizedTodayPlanSuggestion[] = [
+      {
+        type: "set_priority",
+        confidence: 0.8,
+        rationale: "Critical task",
+        payload: { todoId: "todo-a", priority: "medium" },
+        suggestionId: "sug-1",
+        requiresConfirmation: false,
+      },
+      {
+        type: "set_due_date",
+        confidence: 0.7,
+        rationale: "Needs deadline",
+        payload: {
+          todoId: "todo-b",
+          dueDateISO: new Date(Date.now() + 86_400_000).toISOString(),
+        },
+        suggestionId: "sug-2",
+        requiresConfirmation: false,
+      },
+    ];
+
+    const result = await applyTodayPlanSuggestions({
+      applicableSuggestions: suggestions,
+      todoService,
+      userId: USER_ID,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.appliedTodoIds).toHaveLength(2);
+      expect(result.appliedTodoIds).toContain("todo-a");
+      expect(result.appliedTodoIds).toContain("todo-b");
+    }
+  });
+
+  it("skips suggestions with empty todoId", async () => {
+    const todoService = buildMockTodoService();
+    const suggestions: NormalizedTodayPlanSuggestion[] = [
+      {
+        type: "set_priority",
+        confidence: 0.8,
+        rationale: "Test",
+        payload: { todoId: "", priority: "low" },
+        suggestionId: "sug-1",
+        requiresConfirmation: false,
+      },
+    ];
+
+    const result = await applyTodayPlanSuggestions({
+      applicableSuggestions: suggestions,
+      todoService,
+      userId: USER_ID,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.appliedTodoIds).toHaveLength(0);
+    }
+  });
+
+  it("requires confirmation when suggestion has requiresConfirmation", async () => {
+    const suggestions: NormalizedTodayPlanSuggestion[] = [
+      {
+        type: "set_priority",
+        confidence: 0.8,
+        rationale: "Test",
+        payload: { todoId: TODO_ID, priority: "low" },
+        suggestionId: "sug-1",
+        requiresConfirmation: true,
+      },
+    ];
+
+    const result = await applyTodayPlanSuggestions({
+      applicableSuggestions: suggestions,
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("Confirmation is required");
+    }
+  });
+
+  it("returns empty result when no suggestions", async () => {
+    const result = await applyTodayPlanSuggestions({
+      applicableSuggestions: [],
+      todoService: buildMockTodoService(),
+      userId: USER_ID,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.updatedTodos).toHaveLength(0);
+      expect(result.appliedTodoIds).toHaveLength(0);
+    }
+  });
+});

--- a/src/aiApplyService.ts
+++ b/src/aiApplyService.ts
@@ -1,0 +1,350 @@
+import { ITodoService } from "./interfaces/ITodoService";
+import { IProjectService } from "./interfaces/IProjectService";
+import { Priority } from "./types";
+import {
+  NormalizedTodoBoundSuggestion,
+  NormalizedTodayPlanSuggestion,
+} from "./aiNormalizationService";
+
+// ── Result types ──
+
+export type ApplyTodoBoundResult =
+  | {
+      ok: true;
+      updatedTodo: NonNullable<Awaited<ReturnType<ITodoService["findById"]>>>;
+    }
+  | { ok: false; status: number; error: string };
+
+export type ApplyTodayPlanResult =
+  | {
+      ok: true;
+      updatedTodos: NonNullable<
+        Awaited<ReturnType<ITodoService["findById"]>>
+      >[];
+      appliedTodoIds: string[];
+    }
+  | { ok: false; status: number; error: string };
+
+// ── Todo-bound apply ──
+
+export async function applyTodoBoundSuggestion(params: {
+  selected: NormalizedTodoBoundSuggestion;
+  todoService: ITodoService;
+  projectService?: IProjectService;
+  userId: string;
+  inputTodoId: string;
+  todo: NonNullable<Awaited<ReturnType<ITodoService["findById"]>>>;
+  confirmed?: boolean;
+}): Promise<ApplyTodoBoundResult> {
+  const {
+    selected,
+    todoService,
+    projectService,
+    userId,
+    inputTodoId,
+    todo,
+    confirmed,
+  } = params;
+  const payload = selected.payload || {};
+  const now = Date.now();
+  let updatedTodo = todo;
+
+  switch (selected.type) {
+    case "rewrite_title": {
+      const nextTitle =
+        typeof payload.title === "string" ? payload.title.trim() : "";
+      if (!nextTitle || nextTitle.length > 200) {
+        return { ok: false, status: 400, error: "Invalid rewrite title" };
+      }
+      const updated = await todoService.update(userId, inputTodoId, {
+        title: nextTitle,
+      });
+      if (!updated) {
+        return { ok: false, status: 404, error: "Todo not found" };
+      }
+      updatedTodo = updated;
+      break;
+    }
+    case "set_due_date": {
+      const dueDateISO =
+        typeof payload.dueDateISO === "string" ? payload.dueDateISO : "";
+      const parsed = new Date(dueDateISO);
+      if (Number.isNaN(parsed.getTime())) {
+        return { ok: false, status: 400, error: "Invalid due date" };
+      }
+      if (parsed.getTime() < now && confirmed !== true) {
+        return {
+          ok: false,
+          status: 400,
+          error: "Past due dates require explicit confirmation",
+        };
+      }
+      const updated = await todoService.update(userId, inputTodoId, {
+        dueDate: parsed,
+      });
+      if (!updated) {
+        return { ok: false, status: 404, error: "Todo not found" };
+      }
+      updatedTodo = updated;
+      break;
+    }
+    case "set_priority": {
+      const priority = String(payload.priority || "").toLowerCase();
+      if (!["low", "medium", "high"].includes(priority)) {
+        return { ok: false, status: 400, error: "Invalid priority value" };
+      }
+      if (priority === "high" && confirmed !== true) {
+        return {
+          ok: false,
+          status: 400,
+          error: "High priority changes require explicit confirmation",
+        };
+      }
+      const updated = await todoService.update(userId, inputTodoId, {
+        priority: priority as Priority,
+      });
+      if (!updated) {
+        return { ok: false, status: 404, error: "Todo not found" };
+      }
+      updatedTodo = updated;
+      break;
+    }
+    case "set_category":
+    case "set_project": {
+      let nextCategory =
+        typeof payload.category === "string" ? payload.category.trim() : "";
+      const projectName =
+        typeof payload.projectName === "string"
+          ? payload.projectName.trim()
+          : "";
+      const projectId =
+        typeof payload.projectId === "string" ? payload.projectId.trim() : "";
+
+      if (!nextCategory && projectName) {
+        nextCategory = projectName;
+      }
+
+      if (projectId && projectService) {
+        const projects = await projectService.findAll(userId);
+        const byId = projects.find((item) => item.id === projectId);
+        if (byId) {
+          nextCategory = byId.name;
+        }
+      } else if (projectName && projectService) {
+        const projects = await projectService.findAll(userId);
+        const byName = projects.find(
+          (item) => item.name.toLowerCase() === projectName.toLowerCase(),
+        );
+        if (byName) {
+          nextCategory = byName.name;
+        }
+      }
+
+      if (!nextCategory || nextCategory.length > 50) {
+        return {
+          ok: false,
+          status: 400,
+          error: "Invalid category/project value",
+        };
+      }
+
+      const updated = await todoService.update(userId, inputTodoId, {
+        category: nextCategory,
+      });
+      if (!updated) {
+        return { ok: false, status: 404, error: "Todo not found" };
+      }
+      updatedTodo = updated;
+      break;
+    }
+    case "split_subtasks": {
+      const subtasksRaw = Array.isArray(payload.subtasks)
+        ? payload.subtasks
+        : [];
+      if (subtasksRaw.length < 1 || subtasksRaw.length > 5) {
+        return {
+          ok: false,
+          status: 400,
+          error: "split_subtasks requires 1-5 subtasks",
+        };
+      }
+      for (const item of subtasksRaw.slice(0, 5)) {
+        const title =
+          item && typeof item === "object" && typeof item.title === "string"
+            ? item.title.trim()
+            : "";
+        if (!title || title.length > 200) {
+          return { ok: false, status: 400, error: "Invalid subtask title" };
+        }
+        const created = await todoService.createSubtask(userId, inputTodoId, {
+          title,
+        });
+        if (!created) {
+          return { ok: false, status: 404, error: "Todo not found" };
+        }
+      }
+      updatedTodo = (await todoService.findById(userId, inputTodoId)) || todo;
+      break;
+    }
+    case "propose_next_action": {
+      const textCandidate =
+        typeof payload.text === "string"
+          ? payload.text
+          : typeof payload.title === "string"
+            ? payload.title
+            : "";
+      const nextAction = textCandidate.trim();
+      if (!nextAction || nextAction.length > 200) {
+        return { ok: false, status: 400, error: "Invalid next action text" };
+      }
+      const prefix = "Next action: ";
+      const nextNotes = updatedTodo.notes
+        ? `${updatedTodo.notes}\n${prefix}${nextAction}`
+        : `${prefix}${nextAction}`;
+      const updated = await todoService.update(userId, inputTodoId, {
+        notes: nextNotes,
+      });
+      if (!updated) {
+        return { ok: false, status: 404, error: "Todo not found" };
+      }
+      updatedTodo = updated;
+      break;
+    }
+    case "ask_clarification":
+    case "defer_task":
+    default: {
+      return {
+        ok: false,
+        status: 400,
+        error: `Suggestion type "${selected.type}" is not supported for apply`,
+      };
+    }
+  }
+
+  return { ok: true, updatedTodo };
+}
+
+// ── Today-plan apply ──
+
+export async function applyTodayPlanSuggestions(params: {
+  applicableSuggestions: NormalizedTodayPlanSuggestion[];
+  todoService: ITodoService;
+  userId: string;
+  confirmed?: boolean;
+}): Promise<ApplyTodayPlanResult> {
+  const { applicableSuggestions, todoService, userId, confirmed } = params;
+
+  const updatedTodosMap = new Map<
+    string,
+    NonNullable<Awaited<ReturnType<ITodoService["findById"]>>>
+  >();
+
+  for (const selected of applicableSuggestions) {
+    const payload = selected.payload || {};
+    const todoId = typeof payload.todoId === "string" ? payload.todoId : "";
+    if (!todoId) continue;
+
+    const currentTodo =
+      updatedTodosMap.get(todoId) ||
+      (await todoService.findById(userId, todoId));
+    if (!currentTodo) continue;
+
+    if (selected.requiresConfirmation && confirmed !== true) {
+      return {
+        ok: false,
+        status: 400,
+        error: "Confirmation is required for this suggestion",
+      };
+    }
+
+    if (selected.type === "set_priority") {
+      const priority = String(payload.priority || "").toLowerCase();
+      if (!["low", "medium", "high"].includes(priority)) {
+        return { ok: false, status: 400, error: "Invalid priority value" };
+      }
+      if (priority === "high" && confirmed !== true) {
+        return {
+          ok: false,
+          status: 400,
+          error: "High priority changes require explicit confirmation",
+        };
+      }
+      const updated = await todoService.update(userId, todoId, {
+        priority: priority as Priority,
+      });
+      if (updated) updatedTodosMap.set(todoId, updated);
+      continue;
+    }
+
+    if (selected.type === "set_due_date") {
+      const dueDateISO =
+        typeof payload.dueDateISO === "string" ? payload.dueDateISO : "";
+      const parsed = new Date(dueDateISO);
+      if (Number.isNaN(parsed.getTime())) {
+        return { ok: false, status: 400, error: "Invalid due date" };
+      }
+      if (parsed.getTime() < Date.now() && confirmed !== true) {
+        return {
+          ok: false,
+          status: 400,
+          error: "Past due dates require explicit confirmation",
+        };
+      }
+      const updated = await todoService.update(userId, todoId, {
+        dueDate: parsed,
+      });
+      if (updated) updatedTodosMap.set(todoId, updated);
+      continue;
+    }
+
+    if (selected.type === "split_subtasks") {
+      const subtasksRaw = Array.isArray(payload.subtasks)
+        ? payload.subtasks
+        : [];
+      if (subtasksRaw.length < 1 || subtasksRaw.length > 5) {
+        return {
+          ok: false,
+          status: 400,
+          error: "split_subtasks requires 1-5 subtasks",
+        };
+      }
+      for (const item of subtasksRaw.slice(0, 5)) {
+        const title =
+          item && typeof item === "object" && typeof item.title === "string"
+            ? item.title.trim()
+            : "";
+        if (!title || title.length > 200) {
+          return { ok: false, status: 400, error: "Invalid subtask title" };
+        }
+        await todoService.createSubtask(userId, todoId, { title });
+      }
+      const refreshed = await todoService.findById(userId, todoId);
+      if (refreshed) updatedTodosMap.set(todoId, refreshed);
+      continue;
+    }
+
+    if (selected.type === "propose_next_action") {
+      const textCandidate =
+        typeof payload.text === "string"
+          ? payload.text
+          : typeof payload.title === "string"
+            ? payload.title
+            : "";
+      const nextAction = textCandidate.trim();
+      if (!nextAction || nextAction.length > 200) {
+        return { ok: false, status: 400, error: "Invalid next action text" };
+      }
+      const nextNotes = currentTodo.notes
+        ? `${currentTodo.notes}\nNext action: ${nextAction}`
+        : `Next action: ${nextAction}`;
+      const updated = await todoService.update(userId, todoId, {
+        notes: nextNotes,
+      });
+      if (updated) updatedTodosMap.set(todoId, updated);
+    }
+  }
+
+  const updatedTodos = Array.from(updatedTodosMap.values());
+  const appliedTodoIds = updatedTodos.map((todo) => todo.id);
+  return { ok: true, updatedTodos, appliedTodoIds };
+}

--- a/src/aiDismissService.ts
+++ b/src/aiDismissService.ts
@@ -1,0 +1,55 @@
+import { DecisionAssistSurface } from "./aiContracts";
+import { AiSuggestionRecord } from "./aiSuggestionStore";
+import {
+  TODO_BOUND_TYPE,
+  TODO_BOUND_SURFACES,
+  TODAY_PLAN_SURFACE,
+} from "./aiNormalizationService";
+
+export type DismissValidationResult =
+  | { ok: true; surface: DecisionAssistSurface }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Validates whether a suggestion record is eligible for dismiss.
+ * Returns the resolved surface on success, or an error on failure.
+ */
+export function validateDismissable(
+  suggestion: AiSuggestionRecord,
+): DismissValidationResult {
+  const isTodoBoundSuggestion = suggestion.type === TODO_BOUND_TYPE;
+  const isTodayPlanSuggestion =
+    suggestion.type === "plan_from_goal" &&
+    suggestion.input &&
+    typeof suggestion.input.surface === "string" &&
+    suggestion.input.surface === TODAY_PLAN_SURFACE;
+
+  if (!isTodoBoundSuggestion && !isTodayPlanSuggestion) {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        "Only on_create/task_drawer/today_plan suggestions can be dismissed",
+    };
+  }
+
+  const inputSurfaceRaw =
+    typeof suggestion.input?.surface === "string"
+      ? suggestion.input.surface
+      : "";
+  const inputSurface = inputSurfaceRaw as DecisionAssistSurface;
+
+  if (
+    !TODO_BOUND_SURFACES.has(inputSurface) &&
+    inputSurface !== TODAY_PLAN_SURFACE
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error:
+        "Only on_create/task_drawer/today_plan suggestions can be dismissed",
+    };
+  }
+
+  return { ok: true, surface: inputSurface };
+}

--- a/src/aiNormalizationService.ts
+++ b/src/aiNormalizationService.ts
@@ -1,0 +1,300 @@
+import {
+  DecisionAssistOutput,
+  DecisionAssistSuggestion,
+  DecisionAssistSuggestionType,
+  DecisionAssistSurface,
+  validateDecisionAssistOutput,
+} from "./aiContracts";
+import { IAiSuggestionStore, AiSuggestionRecord } from "./aiSuggestionStore";
+import { CreateTodoDto, Priority } from "./types";
+
+// ── Surface and type constants ──
+
+export const TASK_DRAWER_SURFACE: DecisionAssistSurface = "task_drawer";
+export const ON_CREATE_SURFACE: DecisionAssistSurface = "on_create";
+export const TODAY_PLAN_SURFACE: DecisionAssistSurface = "today_plan";
+export const TODO_BOUND_TYPE: "task_critic" = "task_critic";
+
+export const TODO_BOUND_SURFACES = new Set<DecisionAssistSurface>([
+  TASK_DRAWER_SURFACE,
+  ON_CREATE_SURFACE,
+]);
+
+export const TODAY_PLAN_ALLOWED_TYPES = new Set<DecisionAssistSuggestionType>([
+  "set_due_date",
+  "set_priority",
+  "split_subtasks",
+  "propose_next_action",
+]);
+
+export const TODO_BOUND_ALLOWED_TYPES: Record<
+  "task_drawer" | "on_create",
+  Set<DecisionAssistSuggestionType>
+> = {
+  task_drawer: new Set<DecisionAssistSuggestionType>([
+    "rewrite_title",
+    "split_subtasks",
+    "propose_next_action",
+    "set_due_date",
+    "set_priority",
+    "set_project",
+    "set_category",
+    "ask_clarification",
+    "defer_task",
+  ]),
+  on_create: new Set<DecisionAssistSuggestionType>([
+    "rewrite_title",
+    "set_due_date",
+    "set_priority",
+    "set_project",
+    "set_category",
+    "ask_clarification",
+  ]),
+};
+
+// ── Normalized types ──
+
+export type NormalizedTodoBoundSuggestion = DecisionAssistSuggestion & {
+  suggestionId: string;
+  requiresConfirmation: boolean;
+  payload: Record<string, unknown>;
+};
+
+export type NormalizedTodoBoundEnvelope = DecisionAssistOutput & {
+  suggestions: NormalizedTodoBoundSuggestion[];
+};
+
+export type NormalizedTodayPlanSuggestion = DecisionAssistSuggestion & {
+  suggestionId: string;
+  requiresConfirmation: boolean;
+  payload: Record<string, unknown>;
+};
+
+export type NormalizedTodayPlanEnvelope = DecisionAssistOutput & {
+  suggestions: NormalizedTodayPlanSuggestion[];
+};
+
+// ── Small helpers ──
+
+export function parseBool(value: unknown): boolean {
+  return value === true;
+}
+
+export function parseOptionalTopN(value: unknown): 3 | 5 | undefined {
+  return value === 3 || value === 5 ? value : undefined;
+}
+
+// ── Envelope normalization ──
+
+export function normalizeTodoBoundEnvelope(
+  rawOutput: Record<string, unknown>,
+  todoId: string,
+  surface: DecisionAssistSurface,
+): NormalizedTodoBoundEnvelope {
+  const validated = validateDecisionAssistOutput(rawOutput);
+  if (validated.surface !== surface) {
+    throw new Error("Suggestion envelope surface mismatch");
+  }
+  const allowedTypes =
+    TODO_BOUND_ALLOWED_TYPES[surface as "task_drawer" | "on_create"];
+
+  const normalizedSuggestions = validated.suggestions
+    .map((item, index): NormalizedTodoBoundSuggestion => {
+      const rawItem =
+        Array.isArray(rawOutput.suggestions) &&
+        rawOutput.suggestions[index] &&
+        typeof rawOutput.suggestions[index] === "object"
+          ? (rawOutput.suggestions[index] as Record<string, unknown>)
+          : {};
+      const suggestionIdRaw =
+        typeof rawItem.suggestionId === "string"
+          ? rawItem.suggestionId.trim()
+          : "";
+      const suggestionId = suggestionIdRaw || `task-drawer-${index + 1}`;
+      const payload = {
+        ...(item.payload || {}),
+        todoId:
+          typeof (item.payload || {}).todoId === "string"
+            ? (item.payload as Record<string, unknown>).todoId
+            : todoId,
+      };
+      return {
+        ...item,
+        payload,
+        suggestionId,
+        requiresConfirmation: parseBool(rawItem.requiresConfirmation),
+      };
+    })
+    .filter((item) => allowedTypes.has(item.type));
+
+  return {
+    ...validated,
+    suggestions: normalizedSuggestions,
+  };
+}
+
+export function normalizeTodayPlanEnvelope(
+  rawOutput: Record<string, unknown>,
+): NormalizedTodayPlanEnvelope {
+  const validated = validateDecisionAssistOutput(rawOutput);
+  if (validated.surface !== TODAY_PLAN_SURFACE) {
+    throw new Error("Suggestion envelope surface mismatch");
+  }
+  const previewTodoIds = new Set(
+    (validated.planPreview?.items || [])
+      .map((item) => (typeof item.todoId === "string" ? item.todoId : ""))
+      .filter(Boolean),
+  );
+  const normalizedSuggestions = validated.suggestions.reduce<
+    NormalizedTodayPlanSuggestion[]
+  >((acc, item, index) => {
+    const rawItem =
+      Array.isArray(rawOutput.suggestions) &&
+      rawOutput.suggestions[index] &&
+      typeof rawOutput.suggestions[index] === "object"
+        ? (rawOutput.suggestions[index] as Record<string, unknown>)
+        : {};
+    const suggestionIdRaw =
+      typeof rawItem.suggestionId === "string"
+        ? rawItem.suggestionId.trim()
+        : "";
+    const suggestionId = suggestionIdRaw || `today-plan-${index + 1}`;
+    const payload =
+      item.payload && typeof item.payload === "object"
+        ? ({ ...item.payload } as Record<string, unknown>)
+        : {};
+    const payloadTodoId =
+      typeof payload.todoId === "string" ? payload.todoId.trim() : "";
+    if (!payloadTodoId || !previewTodoIds.has(payloadTodoId)) {
+      return acc;
+    }
+    const normalized: NormalizedTodayPlanSuggestion = {
+      ...item,
+      suggestionId,
+      requiresConfirmation: parseBool(rawItem.requiresConfirmation),
+      payload: {
+        ...payload,
+        todoId: payloadTodoId,
+      },
+    };
+    if (TODAY_PLAN_ALLOWED_TYPES.has(normalized.type)) {
+      acc.push(normalized);
+    }
+    return acc;
+  }, []);
+
+  return {
+    ...validated,
+    suggestions: normalizedSuggestions,
+  };
+}
+
+// ── Plan task parsing ──
+
+export function parsePlanTasks(
+  output: Record<string, unknown>,
+): CreateTodoDto[] {
+  const rawTasks = output.tasks;
+  if (!Array.isArray(rawTasks)) {
+    return [];
+  }
+
+  const priorities: Priority[] = ["low", "medium", "high"];
+  return rawTasks
+    .map((task): CreateTodoDto | null => {
+      if (!task || typeof task !== "object") {
+        return null;
+      }
+      const item = task as Record<string, unknown>;
+      const title = typeof item.title === "string" ? item.title.trim() : "";
+      if (!title) {
+        return null;
+      }
+
+      const description =
+        typeof item.description === "string"
+          ? item.description.trim()
+          : undefined;
+      const priority = priorities.includes(item.priority as Priority)
+        ? (item.priority as Priority)
+        : "medium";
+
+      let dueDate: Date | undefined;
+      if (
+        typeof item.dueDate === "string" &&
+        !Number.isNaN(Date.parse(item.dueDate))
+      ) {
+        dueDate = new Date(item.dueDate);
+      }
+
+      return {
+        title,
+        description,
+        priority,
+        dueDate,
+        category: "AI Plan",
+      };
+    })
+    .filter((task): task is CreateTodoDto => !!task);
+}
+
+// ── Throttle abstain envelope ──
+
+export function buildThrottleAbstainEnvelope(
+  surface: DecisionAssistSurface,
+  preferredTopN?: 3 | 5,
+): DecisionAssistOutput {
+  return {
+    requestId: `throttle-${surface}-${Date.now()}`,
+    surface,
+    must_abstain: true,
+    planPreview:
+      surface === TODAY_PLAN_SURFACE
+        ? {
+            topN: preferredTopN || 3,
+            items: [],
+          }
+        : undefined,
+    suggestions: [],
+  };
+}
+
+// ── Latest suggestion finders ──
+
+export async function findLatestPendingDecisionAssistSuggestion(
+  suggestionStore: IAiSuggestionStore,
+  userId: string,
+  todoId: string,
+  surface: DecisionAssistSurface,
+): Promise<AiSuggestionRecord | null> {
+  const records = await suggestionStore.listByUser(userId, 100);
+  return (
+    records.find((record) => {
+      if (record.status !== "pending") return false;
+      if (record.type !== TODO_BOUND_TYPE) return false;
+      const inputSurface =
+        typeof record.input?.surface === "string" ? record.input.surface : "";
+      const inputTodoId =
+        typeof record.input?.todoId === "string" ? record.input.todoId : "";
+      return inputSurface === surface && inputTodoId === todoId;
+    }) || null
+  );
+}
+
+export async function findLatestPendingTodayPlanSuggestion(
+  suggestionStore: IAiSuggestionStore,
+  userId: string,
+): Promise<AiSuggestionRecord | null> {
+  const records = await suggestionStore.listByUser(userId, 100);
+  return (
+    records.find((record) => {
+      if (record.status !== "pending") return false;
+      if (record.type !== "plan_from_goal") return false;
+      const inputSurface =
+        typeof record.input?.surface === "string" ? record.input.surface : "";
+      const inputTodoId =
+        typeof record.input?.todoId === "string" ? record.input.todoId : "";
+      return inputSurface === TODAY_PLAN_SURFACE && !inputTodoId;
+    }) || null
+  );
+}

--- a/src/aiQuotaService.test.ts
+++ b/src/aiQuotaService.test.ts
@@ -1,0 +1,227 @@
+import {
+  AiQuotaService,
+  buildInsightsRecommendation,
+  buildLimitsByPlan,
+  getCurrentUtcDayStart,
+  getNextUtcDayStart,
+  UserPlan,
+} from "./aiQuotaService";
+import { IAiSuggestionStore, AiFeedbackSummary } from "./aiSuggestionStore";
+
+// ── Helpers ──
+
+function buildMockStore(
+  overrides: Partial<IAiSuggestionStore> = {},
+): IAiSuggestionStore {
+  return {
+    create: jest.fn(),
+    listByUser: jest.fn(),
+    getById: jest.fn(),
+    countByUserSince: jest.fn().mockResolvedValue(0),
+    summarizeFeedbackByUserSince: jest.fn().mockResolvedValue({
+      acceptedCount: 0,
+      rejectedCount: 0,
+      acceptedReasons: [],
+      rejectedReasons: [],
+    } satisfies AiFeedbackSummary),
+    markApplied: jest.fn(),
+    updateStatus: jest.fn(),
+    ...overrides,
+  };
+}
+
+const DEFAULT_LIMITS: Record<UserPlan, number> = {
+  free: 10,
+  pro: 50,
+  team: 100,
+};
+
+// ── Date helpers ──
+
+describe("getCurrentUtcDayStart / getNextUtcDayStart", () => {
+  it("returns midnight UTC for the current day", () => {
+    const dayStart = getCurrentUtcDayStart();
+    expect(dayStart.getUTCHours()).toBe(0);
+    expect(dayStart.getUTCMinutes()).toBe(0);
+    expect(dayStart.getUTCSeconds()).toBe(0);
+    expect(dayStart.getUTCMilliseconds()).toBe(0);
+  });
+
+  it("next day start is exactly 24h after day start", () => {
+    const dayStart = getCurrentUtcDayStart();
+    const nextDay = getNextUtcDayStart();
+    expect(nextDay.getTime() - dayStart.getTime()).toBe(86_400_000);
+  });
+});
+
+// ── AiQuotaService ──
+
+describe("AiQuotaService", () => {
+  describe("getUserPlan", () => {
+    it("defaults to free when no resolver is provided", async () => {
+      const svc = new AiQuotaService({
+        suggestionStore: buildMockStore(),
+        limitsByPlan: DEFAULT_LIMITS,
+      });
+      expect(await svc.getUserPlan("user-1")).toBe("free");
+    });
+
+    it("delegates to resolver when provided", async () => {
+      const resolver = jest.fn().mockResolvedValue("pro" as UserPlan);
+      const svc = new AiQuotaService({
+        suggestionStore: buildMockStore(),
+        limitsByPlan: DEFAULT_LIMITS,
+        resolveUserPlan: resolver,
+      });
+      expect(await svc.getUserPlan("user-1")).toBe("pro");
+      expect(resolver).toHaveBeenCalledWith("user-1");
+    });
+  });
+
+  describe("getUsage", () => {
+    it("computes remaining from limit minus used", async () => {
+      const store = buildMockStore({
+        countByUserSince: jest.fn().mockResolvedValue(7),
+      });
+      const svc = new AiQuotaService({
+        suggestionStore: store,
+        limitsByPlan: DEFAULT_LIMITS,
+      });
+
+      const usage = await svc.getUsage("user-1");
+
+      expect(usage.plan).toBe("free");
+      expect(usage.limit).toBe(10);
+      expect(usage.used).toBe(7);
+      expect(usage.remaining).toBe(3);
+      expect(typeof usage.resetAt).toBe("string");
+    });
+
+    it("clamps remaining to zero when over limit", async () => {
+      const store = buildMockStore({
+        countByUserSince: jest.fn().mockResolvedValue(15),
+      });
+      const svc = new AiQuotaService({
+        suggestionStore: store,
+        limitsByPlan: DEFAULT_LIMITS,
+      });
+
+      const usage = await svc.getUsage("user-1");
+      expect(usage.remaining).toBe(0);
+    });
+  });
+
+  describe("checkQuota", () => {
+    it("returns null when under quota", async () => {
+      const store = buildMockStore({
+        countByUserSince: jest.fn().mockResolvedValue(5),
+      });
+      const svc = new AiQuotaService({
+        suggestionStore: store,
+        limitsByPlan: DEFAULT_LIMITS,
+      });
+
+      expect(await svc.checkQuota("user-1")).toBeNull();
+    });
+
+    it("returns usage when quota exceeded", async () => {
+      const store = buildMockStore({
+        countByUserSince: jest.fn().mockResolvedValue(10),
+      });
+      const svc = new AiQuotaService({
+        suggestionStore: store,
+        limitsByPlan: DEFAULT_LIMITS,
+      });
+
+      const result = await svc.checkQuota("user-1");
+      expect(result).not.toBeNull();
+      expect(result!.remaining).toBe(0);
+    });
+  });
+
+  describe("getFeedbackContext", () => {
+    it("maps store summary to rejection and acceptance signals", async () => {
+      const store = buildMockStore({
+        summarizeFeedbackByUserSince: jest.fn().mockResolvedValue({
+          acceptedCount: 5,
+          rejectedCount: 2,
+          acceptedReasons: [{ reason: "helpful", count: 5 }],
+          rejectedReasons: [{ reason: "too generic", count: 2 }],
+        } satisfies AiFeedbackSummary),
+      });
+      const svc = new AiQuotaService({
+        suggestionStore: store,
+        limitsByPlan: DEFAULT_LIMITS,
+      });
+
+      const ctx = await svc.getFeedbackContext("user-1");
+      expect(ctx.acceptanceSignals).toEqual(["helpful"]);
+      expect(ctx.rejectionSignals).toEqual(["too generic"]);
+    });
+  });
+});
+
+// ── buildInsightsRecommendation ──
+
+describe("buildInsightsRecommendation", () => {
+  it("recommends upgrade when free plan is near cap", () => {
+    const result = buildInsightsRecommendation({
+      plan: "free",
+      usageRemaining: 1,
+      usageLimit: 10,
+      generatedCount: 10,
+    });
+    expect(result).toContain("Upgrade to Pro");
+  });
+
+  it("recommends constraints when rejections are generic", () => {
+    const result = buildInsightsRecommendation({
+      plan: "pro",
+      usageRemaining: 40,
+      usageLimit: 50,
+      generatedCount: 20,
+      topRejectedReason: "Too generic output",
+    });
+    expect(result).toContain("generic");
+  });
+
+  it("recommends more generation when count is low", () => {
+    const result = buildInsightsRecommendation({
+      plan: "pro",
+      usageRemaining: 40,
+      usageLimit: 50,
+      generatedCount: 1,
+    });
+    expect(result).toContain("Generate a few more");
+  });
+
+  it("falls back to rating advice", () => {
+    const result = buildInsightsRecommendation({
+      plan: "pro",
+      usageRemaining: 40,
+      usageLimit: 50,
+      generatedCount: 10,
+    });
+    expect(result).toContain("Keep rating");
+  });
+});
+
+// ── buildLimitsByPlan ──
+
+describe("buildLimitsByPlan", () => {
+  it("uses per-plan overrides when provided", () => {
+    const limits = buildLimitsByPlan({
+      aiDailySuggestionLimitByPlan: { free: 5, pro: 25, team: 75 },
+    });
+    expect(limits.free).toBe(5);
+    expect(limits.pro).toBe(25);
+    expect(limits.team).toBe(75);
+  });
+
+  it("uses global override for free when per-plan not set", () => {
+    const limits = buildLimitsByPlan({
+      aiDailySuggestionLimit: 20,
+    });
+    expect(limits.free).toBe(20);
+  });
+});

--- a/src/aiQuotaService.ts
+++ b/src/aiQuotaService.ts
@@ -1,0 +1,145 @@
+import { IAiSuggestionStore } from "./aiSuggestionStore";
+import { config } from "./config";
+
+export type UserPlan = "free" | "pro" | "team";
+
+export interface AiUsage {
+  plan: UserPlan;
+  used: number;
+  remaining: number;
+  limit: number;
+  resetAt: string;
+}
+
+export interface AiFeedbackContext {
+  rejectionSignals: string[];
+  acceptanceSignals: string[];
+}
+
+export function getCurrentUtcDayStart(): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+}
+
+export function getNextUtcDayStart(): Date {
+  const dayStart = getCurrentUtcDayStart();
+  return new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
+}
+
+export function buildInsightsRecommendation(params: {
+  plan: UserPlan;
+  usageRemaining: number;
+  usageLimit: number;
+  generatedCount: number;
+  topRejectedReason?: string;
+}): string {
+  const usageThreshold = Math.max(1, Math.ceil(params.usageLimit * 0.1));
+  if (params.plan === "free" && params.usageRemaining <= usageThreshold) {
+    return "You are near your daily AI cap. Upgrade to Pro for higher limits and uninterrupted planning.";
+  }
+  const reason = (params.topRejectedReason || "").toLowerCase();
+  if (
+    reason.includes("generic") ||
+    reason.includes("vague") ||
+    reason.includes("specific")
+  ) {
+    return "Recent rejections suggest outputs are too generic. Add constraints like owner, metric, and due date to get stronger suggestions.";
+  }
+  if (params.generatedCount < 3) {
+    return "Generate a few more AI suggestions this week to improve personalization and quality tracking.";
+  }
+  return "Keep rating suggestions after each run to continuously improve output quality.";
+}
+
+export class AiQuotaService {
+  private readonly suggestionStore: IAiSuggestionStore;
+  private readonly limitsByPlan: Record<UserPlan, number>;
+  private readonly resolveUserPlan?: (userId: string) => Promise<UserPlan>;
+
+  constructor(params: {
+    suggestionStore: IAiSuggestionStore;
+    limitsByPlan: Record<UserPlan, number>;
+    resolveUserPlan?: (userId: string) => Promise<UserPlan>;
+  }) {
+    this.suggestionStore = params.suggestionStore;
+    this.limitsByPlan = params.limitsByPlan;
+    this.resolveUserPlan = params.resolveUserPlan;
+  }
+
+  async getUserPlan(userId: string): Promise<UserPlan> {
+    if (!this.resolveUserPlan) {
+      return "free";
+    }
+    return this.resolveUserPlan(userId);
+  }
+
+  async getUsage(userId: string): Promise<AiUsage> {
+    const plan = await this.getUserPlan(userId);
+    const dailyLimit = this.limitsByPlan[plan] || this.limitsByPlan.free;
+    const dayStart = getCurrentUtcDayStart();
+    const used = await this.suggestionStore.countByUserSince(userId, dayStart);
+    const remaining = Math.max(dailyLimit - used, 0);
+    return {
+      plan,
+      used,
+      remaining,
+      limit: dailyLimit,
+      resetAt: getNextUtcDayStart().toISOString(),
+    };
+  }
+
+  async checkQuota(userId: string): Promise<AiUsage | null> {
+    const usage = await this.getUsage(userId);
+    if (usage.remaining <= 0) {
+      return usage;
+    }
+    return null;
+  }
+
+  async getFeedbackContext(userId: string): Promise<AiFeedbackContext> {
+    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const summary = await this.suggestionStore.summarizeFeedbackByUserSince(
+      userId,
+      since,
+      3,
+    );
+    return {
+      rejectionSignals: summary.rejectedReasons.map((item) => item.reason),
+      acceptanceSignals: summary.acceptedReasons.map((item) => item.reason),
+    };
+  }
+}
+
+export function buildLimitsByPlan(params: {
+  aiDailySuggestionLimit?: number;
+  aiDailySuggestionLimitByPlan?: Partial<Record<UserPlan, number>>;
+}): Record<UserPlan, number> {
+  const defaultLimits: Record<UserPlan, number> = {
+    free: config.aiDailySuggestionLimitByPlan.free,
+    pro: config.aiDailySuggestionLimitByPlan.pro,
+    team: config.aiDailySuggestionLimitByPlan.team,
+  };
+  const globalOverride =
+    params.aiDailySuggestionLimit && params.aiDailySuggestionLimit > 0
+      ? params.aiDailySuggestionLimit
+      : undefined;
+  return {
+    free:
+      params.aiDailySuggestionLimitByPlan?.free &&
+      params.aiDailySuggestionLimitByPlan.free > 0
+        ? params.aiDailySuggestionLimitByPlan.free
+        : globalOverride || defaultLimits.free || config.aiDailySuggestionLimit,
+    pro:
+      params.aiDailySuggestionLimitByPlan?.pro &&
+      params.aiDailySuggestionLimitByPlan.pro > 0
+        ? params.aiDailySuggestionLimitByPlan.pro
+        : defaultLimits.pro || config.aiDailySuggestionLimit,
+    team:
+      params.aiDailySuggestionLimitByPlan?.team &&
+      params.aiDailySuggestionLimitByPlan.team > 0
+        ? params.aiDailySuggestionLimitByPlan.team
+        : defaultLimits.team || config.aiDailySuggestionLimit,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted four application-layer services from the 1,737-line `aiRouter.ts`, reducing it to ~1,024 lines of HTTP-only logic
- **aiQuotaService.ts**: plan resolution, usage counting, daily quota enforcement, insights recommendation
- **aiNormalizationService.ts**: envelope normalization, surface constants/types, suggestion finders
- **aiApplyService.ts**: todo-bound and today-plan apply orchestration with discriminated union result types
- **aiDismissService.ts**: dismiss eligibility validation predicate
- Added 33 focused unit tests for quota and apply services (150 total, up from 117)
- All 227 UI tests pass unchanged — zero behavioral drift

## Test plan
- [x] `npx tsc --noEmit` — clean compilation
- [x] `npm run format:check` — passes
- [x] `npm run lint:html` / `npm run lint:css` — passes
- [x] `npm run test:unit` — 150 tests pass (117 existing + 33 new)
- [x] `CI=1 npm run test:ui:fast` — 227 tests pass, 0 failures
- [x] Existing integration tests (`ai.api.integration.test.ts`) validate endpoint contracts end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)