### PR TITLE
refactor(api): harden todo ordering concurrency and optimize reorder efficiency (Task 107)

### DIFF
--- a/src/prismaTodoService.error.test.ts
+++ b/src/prismaTodoService.error.test.ts
@@ -78,4 +78,34 @@ describe("PrismaTodoService error handling", () => {
       "database unavailable",
     );
   });
+
+  it("reorder should return null for invalid UUID errors", async () => {
+    const service = createService({
+      findMany: jest.fn().mockRejectedValue({ code: "P2023" }),
+    });
+
+    await expect(
+      service.reorder("user-1", [{ id: "bad-id", order: 0 }]),
+    ).resolves.toBeNull();
+  });
+
+  it("reorder should return null when todo not found", async () => {
+    const service = createService({
+      findMany: jest.fn().mockResolvedValue([]),
+    });
+
+    await expect(
+      service.reorder("user-1", [{ id: "missing-id", order: 0 }]),
+    ).resolves.toBeNull();
+  });
+
+  it("reorder should rethrow unknown errors", async () => {
+    const service = createService({
+      findMany: jest.fn().mockRejectedValue(new Error("database unavailable")),
+    });
+
+    await expect(
+      service.reorder("user-1", [{ id: "todo-1", order: 0 }]),
+    ).rejects.toThrow("database unavailable");
+  });
 });

--- a/src/prismaTodoService.ts
+++ b/src/prismaTodoService.ts
@@ -55,6 +55,12 @@ export class PrismaTodoService implements ITodoService {
 
   async create(userId: string, dto: CreateTodoDto): Promise<Todo> {
     const todo = await this.prisma.$transaction(async (tx) => {
+      // Lock the user row so concurrent creates are serialized and cannot
+      // compute the same next order value (same pattern as createSubtask).
+      await tx.$queryRaw`
+        SELECT "id" FROM "users" WHERE "id" = ${userId} FOR UPDATE
+      `;
+
       // Calculate next order: max order + 1 for this user
       const maxOrderTodo = await tx.todo.findFirst({
         where: { userId },
@@ -250,13 +256,30 @@ export class PrismaTodoService implements ITodoService {
   ): Promise<Todo[] | null> {
     try {
       return await this.prisma.$transaction(async (tx) => {
+        // Fetch current orders in a single query to identify which items
+        // actually changed — avoids N writes when only a few moved.
+        const currentTodos = await tx.todo.findMany({
+          where: { userId },
+          select: { id: true, order: true },
+        });
+        const currentOrderMap = new Map(
+          currentTodos.map((t) => [t.id, t.order]),
+        );
+
+        // Validate all requested IDs exist before writing anything.
         for (const item of items) {
-          const updateResult = await tx.todo.updateMany({
-            where: { id: item.id, userId },
-            data: { order: item.order },
-          });
-          if (updateResult.count !== 1) {
+          if (!currentOrderMap.has(item.id)) {
             throw new Error(PrismaTodoService.NOT_FOUND_ERROR);
+          }
+        }
+
+        // Only update items whose order actually changed (delta-only).
+        for (const item of items) {
+          if (currentOrderMap.get(item.id) !== item.order) {
+            await tx.todo.updateMany({
+              where: { id: item.id, userId },
+              data: { order: item.order },
+            });
           }
         }
 


### PR DESCRIPTION
## Summary

- **Harden `create()` with FOR UPDATE locking** — Adds `SELECT ... FOR UPDATE` on the user row inside the transaction to serialize concurrent creates, preventing duplicate order values. Same proven pattern already used by `createSubtask()`.
- **Optimize `reorder()` with delta-only updates** — Fetches current orders in a single query, validates all requested IDs exist via Map lookup, and only issues UPDATE for items whose order actually changed. Turns the common "drag one item" case from N writes to ~2 writes.
- **Add 11 new tests** — 8 integration tests (ordering, concurrent creates, reorder behavior, delta-only verification, cross-user isolation) + 3 unit error tests (invalid UUID, not-found, rethrow).

### Deferred
- Schema-level `@@unique([userId, order])` constraint on todos: requires a Prisma migration and is a scope escalation trigger. The `FOR UPDATE` lock makes duplicates very unlikely in practice.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint:html` — clean
- [x] `npm run lint:css` — clean
- [x] `npm run test:unit` — 153 tests pass (150 existing + 3 new reorder error tests)
- [x] `CI=1 npm run test:ui:fast` — 227 passed, 41 skipped
- [ ] CI integration tests validate 8 new ordering/reorder integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)