### PR TITLE
feat(ui): hide ai entrypoints by default (Task 111)

### DIFF
--- a/docs/agent-queue/tasks/yellow/111-hide-ai-entrypoints-by-default.md
+++ b/docs/agent-queue/tasks/yellow/111-hide-ai-entrypoints-by-default.md
@@ -1,0 +1,79 @@
+# TASK 111: hide-ai-entrypoints-by-default
+
+type: Yellow
+status: REVIEW
+mode: implement
+builder: codex
+reviewer: claude
+branch: codex/task-111-hide-ai-entrypoints-by-default
+base: master
+
+## Intent *
+Hide AI assistant surfaces and AI-facing call-to-action controls by default so users only see AI UI after explicit opt-in actions.
+
+## Scope
+- Update frontend behavior so these are hidden by default on todos view load:
+  - AI workspace panel shell/header
+  - prominent AI action buttons that advertise assistant features
+  - task drawer full AI suggestions list when no lint issue is present
+- Preserve lint-first behavior for on-create and drawer flows:
+  - show lint chip only when deterministic lint rule fires
+  - only reveal full AI panel after explicit user action (Fix/Review or equivalent opt-in action)
+- Remove automatic today-plan suggestion fetch/render on first panel open unless explicitly user-triggered.
+- Keep debug/dev override behavior (`ai_debug=1`) for developer visibility.
+
+## Out of Scope
+- Backend endpoint contract changes.
+- Prisma schema changes.
+- New dependencies.
+- AI model/provider prompt changes.
+
+## Files Allowed
+- public/app.js
+- public/index.html
+- public/styles.css
+- tests/ui/**
+
+## Acceptance Criteria *
+- [x] Loading the todos view does not show AI assistant panel shell or AI CTA controls by default.
+- [x] On-create surface shows no AI UI by default unless lint triggers; when lint triggers, only lint chip appears.
+- [x] Task drawer does not show full AI suggestions by default; only lint chip appears when applicable.
+- [x] Full AI suggestions panel is shown only after explicit user action.
+- [x] Today plan does not auto-fetch suggestions on first open/load.
+- [x] `ai_debug=1` continues to expose AI panels for debugging.
+- [x] Required checks pass: `npx tsc --noEmit`, `npm run format:check`, `npm run lint:html`, `npm run lint:css`, `npm run test:unit`, `CI=1 npm run test:ui:fast`.
+
+## Constraints
+- Preserve event delegation architecture (no direct listeners on dynamic children).
+- Preserve `filterTodos()` and `setSelectedProjectKey(...)` behavior.
+- Keep telemetry emission paths intact for explicit AI interactions.
+
+## MIC-Lite (Yellow/Red)
+
+### Motivation
+Current UX still exposes AI controls by default, which conflicts with the intended lint-first, opt-in assistant behavior and creates perceived interface noise.
+
+### Impact
+Frontend behavior changes are user-visible; risk is accidentally hiding legitimate explicit AI entry paths.
+
+### Checkpoints
+- [x] Verify no AI shell/button appears on initial todos view load.
+- [x] Verify lint chip still appears for vague titles and still opens full panel on Fix/Review.
+- [x] Verify explicit actions still reach existing `/ai/*` endpoints successfully.
+
+## Scope Escalation Triggers
+If any of these occur, set status to BLOCKED and request re-approval:
+- Change touches >10 files
+- Introduces a new architectural pattern
+- Adds a new dependency
+- Changes cross-module behavior contracts
+- Modifies data model (Prisma schema)
+
+## Deliverable
+- PR URL
+- Commit SHA(s)
+- Files changed
+- PASS/FAIL matrix
+
+## Outcome *
+Implemented hidden-by-default AI entry points by introducing explicit AI workspace visibility state (`todos:ai-visible`, default hidden; debug override still forces visible), hiding the AI workspace shell and critique CTA on load, and preserving lint-first behavior for on-create and task drawer flows. Task drawer no longer falls through to full panel on clean titles; full panel is shown after explicit lint actions. Today plan no longer auto-fetches suggestions when entering Today view. Updated fast-suite tests to lock these behaviors and keep existing AI flows reachable through explicit/debug paths.

--- a/public/index.html
+++ b/public/index.html
@@ -562,6 +562,7 @@
                       id="critiqueDraftButton"
                       class="add-btn"
                       data-onclick="critiqueDraftWithAi()"
+                      hidden
                       style="background: #334155; width: auto"
                     >
                       Critique Draft (AI)
@@ -590,6 +591,7 @@
                 <section
                   id="aiWorkspace"
                   class="ai-workspace ai-workspace--collapsed"
+                  hidden
                 >
                   <div id="aiWorkspaceHeader" class="ai-workspace-header">
                     <button

--- a/tests/ui/ai-brain-dump.spec.ts
+++ b/tests/ui/ai-brain-dump.spec.ts
@@ -216,7 +216,7 @@ async function installBrainDumpMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
+  await page.goto("/?ai_debug=1");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Brain Dump User");
   await page.locator("#registerEmail").fill("brain-dump@example.com");

--- a/tests/ui/ai-critic-panel.spec.ts
+++ b/tests/ui/ai-critic-panel.spec.ts
@@ -186,7 +186,7 @@ async function installCriticMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
+  await page.goto("/?ai_debug=1");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Critic User");
   await page.locator("#registerEmail").fill("critic@example.com");

--- a/tests/ui/ai-plan-draft.spec.ts
+++ b/tests/ui/ai-plan-draft.spec.ts
@@ -228,7 +228,7 @@ async function installAiPlanMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
+  await page.goto("/?ai_debug=1");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Plan User");
   await page.locator("#registerEmail").fill("plan@example.com");

--- a/tests/ui/ai-task-drawer-live.spec.ts
+++ b/tests/ui/ai-task-drawer-live.spec.ts
@@ -395,15 +395,17 @@ test.describe("AI task drawer decision assist live flow", () => {
   test("renders server-backed drawer suggestions, applies rewrite title, and persists after reload", async ({
     page,
   }) => {
-    await page.locator("#todoInput").fill("launch checklist");
+    await page.locator("#todoInput").fill("do thing");
     await page.getByRole("button", { name: "Add Task" }).click();
 
     const row = page.locator(".todo-item").first();
     await row.click();
 
-    await expect(page.locator("#todoDetailsDrawer")).toContainText(
-      "AI Suggestions",
-    );
+    await page
+      .locator(
+        "#todoDetailsDrawer .ai-lint-chip__action[data-ai-lint-action='fix']",
+      )
+      .click();
     await expect(
       page.locator('[data-testid^="task-drawer-ai-card-"]'),
     ).toHaveCount(1);
@@ -414,23 +416,28 @@ test.describe("AI task drawer decision assist live flow", () => {
       .click();
 
     await expect(page.locator(".todo-item .todo-title").first()).toContainText(
-      "Draft launch checklist",
+      "Draft do thing",
     );
 
     await page.reload();
     await expect(page.locator(".todo-item .todo-title").first()).toContainText(
-      "Draft launch checklist",
+      "Draft do thing",
     );
   });
 
   test("dismiss hides suggestions and keeps drawer empty after reload", async ({
     page,
   }) => {
-    await page.locator("#todoInput").fill("follow up stakeholders");
+    await page.locator("#todoInput").fill("do follow up");
     await page.getByRole("button", { name: "Add Task" }).click();
 
     const row = page.locator(".todo-item").first();
     await row.click();
+    await page
+      .locator(
+        "#todoDetailsDrawer .ai-lint-chip__action[data-ai-lint-action='fix']",
+      )
+      .click();
     await expect(
       page.locator('[data-testid^="task-drawer-ai-card-"]'),
     ).toHaveCount(1);
@@ -445,6 +452,11 @@ test.describe("AI task drawer decision assist live flow", () => {
 
     await page.reload();
     await page.locator(".todo-item").first().click();
+    await page
+      .locator(
+        "#todoDetailsDrawer .ai-lint-chip__action[data-ai-lint-action='fix']",
+      )
+      .click();
     await expect(page.locator("#todoDetailsDrawer")).toContainText(
       "No suggestions right now.",
     );

--- a/tests/ui/ai-workspace-collapsed.spec.ts
+++ b/tests/ui/ai-workspace-collapsed.spec.ts
@@ -155,7 +155,7 @@ async function installAiWorkspaceMockApi(page: Page) {
   });
 }
 
-async function openTodos(page: Page) {
+async function openTodos(page: Page, { showWorkspace = false } = {}) {
   await page.addInitScript(() => {
     window.localStorage.removeItem("todos:ai-collapsed");
   });
@@ -163,13 +163,25 @@ async function openTodos(page: Page) {
     name: "AI Workspace User",
     email: "ai-workspace-user@example.com",
   });
+  if (showWorkspace) {
+    await page.goto("/?ai_debug=1");
+  }
   await expect(page.locator("#todosView")).toHaveClass(/active/);
 }
+
+test.describe("AI workspace visibility defaults", () => {
+  test("is hidden by default on Todos load", async ({ page }) => {
+    await installAiWorkspaceMockApi(page);
+    await openTodos(page);
+    await expect(page.locator("#aiWorkspace")).toBeHidden();
+    await expect(page.locator("#critiqueDraftButton")).toBeHidden();
+  });
+});
 
 test.describe("AI workspace calm mode", () => {
   test.beforeEach(async ({ page }) => {
     await installAiWorkspaceMockApi(page);
-    await openTodos(page);
+    await openTodos(page, { showWorkspace: true });
   });
 
   test("defaults to collapsed on Todos load", async ({ page }) => {

--- a/tests/ui/lint-chip.spec.ts
+++ b/tests/ui/lint-chip.spec.ts
@@ -310,6 +310,9 @@ test.describe("Lint-first task drawer chip", () => {
     await page.locator(".todo-item").first().click();
     await expect(page.locator("#todoDetailsDrawer")).toBeVisible();
     await expect(page.locator("#todoDetailsDrawer .ai-lint-chip")).toBeHidden();
+    await expect(
+      page.locator("#todoDetailsDrawer .todo-drawer-ai-list"),
+    ).toHaveCount(0);
   });
 
   test("Fix in drawer reveals full AI suggestions section", async ({

--- a/tests/ui/topbar-cta-invariants.spec.ts
+++ b/tests/ui/topbar-cta-invariants.spec.ts
@@ -172,6 +172,9 @@ test.describe("Topbar CTA invariants", () => {
     ]);
 
     await page.setViewportSize({ width: 1280, height: 880 });
+    await page.addInitScript(() => {
+      window.localStorage.setItem("todos:ai-visible", "1");
+    });
     await registerAndOpenTodosView(page, {
       name: "Topbar Invariants",
       email: "topbar-invariants@example.com",


### PR DESCRIPTION
## Summary

- Hide AI workspace panel, critique CTA, and task drawer full AI panel by default on todos view load
- Introduce `todos:ai-visible` localStorage key (default: hidden; `?ai_debug=1` forces visible)
- Task drawer lint-first gate no longer falls through to full AI panel on clean titles — `return ""` instead
- Task drawer `loadTaskDrawerDecisionAssist` auto-fetch gated behind `AI_DEBUG_ENABLED`
- Today plan removes auto-fetch of suggestions on first panel open
- Explicit user actions (brain dump, goal plan, lint Fix/Review) opt-in to AI surfaces and persist visibility

## Files changed (11)

| File | Change |
|------|--------|
| `public/app.js` | New visibility state, sync, persist, lint-first gate fix |
| `public/index.html` | `hidden` attribute on `#aiWorkspace` and `#critiqueDraftButton` |
| `tests/ui/ai-brain-dump.spec.ts` | Use `?ai_debug=1` |
| `tests/ui/ai-critic-panel.spec.ts` | Use `?ai_debug=1` |
| `tests/ui/ai-plan-draft.spec.ts` | Use `?ai_debug=1` |
| `tests/ui/ai-task-drawer-live.spec.ts` | Adapt to lint-first gate (click Fix action) |
| `tests/ui/ai-today-plan.spec.ts` | Add no-auto-fetch test + adapt persistence test |
| `tests/ui/ai-workspace-collapsed.spec.ts` | Add default-hidden test + `showWorkspace` param |
| `tests/ui/lint-chip.spec.ts` | Assert no full panel on clean titles |
| `tests/ui/topbar-cta-invariants.spec.ts` | Set `todos:ai-visible` for rail-expanded test |
| `docs/agent-queue/tasks/yellow/111-...` | Task spec |

## Test plan

- [x] `npx tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run lint:html` — pass
- [x] `npm run lint:css` — pass
- [x] `npm run test:unit` — 200 passed
- [x] `CI=1 npm run test:ui:fast` — 232 passed, 42 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)