### PR TITLE
docs(tasks): mark tasks 100 and 110 done and archive

### DIFF
--- a/docs/agent-queue/tasks/done/100-ai-eval-harness-mvp.md
+++ b/docs/agent-queue/tasks/done/100-ai-eval-harness-mvp.md
@@ -1,7 +1,7 @@
 # TASK 100: ai-eval-harness-mvp
 
 type: Yellow
-status: REVIEW
+status: DONE
 mode: implement
 builder: codex
 reviewer: claude

--- a/docs/agent-queue/tasks/done/110-docs-refresh-current-architecture-and-testing-truth.md
+++ b/docs/agent-queue/tasks/done/110-docs-refresh-current-architecture-and-testing-truth.md
@@ -1,7 +1,7 @@
 # TASK 110: docs-refresh-current-architecture-and-testing-truth
 
 type: Green
-status: REVIEW
+status: DONE
 mode: refactor
 builder: codex
 reviewer: claude


### PR DESCRIPTION
Docs-only update: moved completed tasks 100 and 110 from active queues to done and set status to DONE.\n\nNo runtime, API, or behavior changes.