### PR TITLE
feat(ui): fixed sidebar/topbar with scrollable main pane

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -205,6 +205,9 @@ body.is-todos-view #appSidebar {
 
 .app-sidebar__settings {
   width: 100%;
+body.is-todos-view {
+  padding: 0;
+  overflow: hidden;
 }
 
 h1,
@@ -446,6 +449,7 @@ body.is-todos-view .container {
   max-width: none;
   margin: 0;
   flex: 1 1 auto;
+  border-radius: 0;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -456,8 +460,13 @@ body.is-todos-view .content {
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+body.is-todos-view #todosView.view.active {
+  flex: 1 1 auto;
 }
 
 .auth-container {
@@ -1720,7 +1729,10 @@ textarea:focus-visible,
   position: sticky;
   top: var(--s-4);
   min-height: 0;
+  height: 100%;
+  max-height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .projects-rail.projects-rail--collapsed {
@@ -2855,6 +2867,11 @@ button.projects-rail-item {
     padding: 10px;
   }
 
+  body.is-todos-view {
+    padding: 10px;
+    overflow: auto;
+  }
+
   .container {
     border-radius: var(--r-md);
     max-width: 100%;
@@ -2883,8 +2900,9 @@ button.projects-rail-item {
   }
 
   body.is-todos-view .container {
-    height: 100%;
-    max-height: 100%;
+    height: calc(100dvh - 20px);
+    max-height: calc(100dvh - 20px);
+    border-radius: var(--r-md);
   }
 
   .todos-top-bar {

--- a/public/styles.css
+++ b/public/styles.css
@@ -205,6 +205,8 @@ body.is-todos-view #appSidebar {
 
 .app-sidebar__settings {
   width: 100%;
+}
+
 body.is-todos-view {
   padding: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary\n- apply a Notion-style fixed app shell in Todos view using CSS-only layout changes\n- keep sidebar and topbar pinned while moving vertical scrolling to the main content pane\n- preserve mobile behavior by restoring body/container scrolling rules under the existing mobile breakpoint\n\n## Verification\n- npx tsc --noEmit\n- npm run format:check\n- npm run lint:html\n- npm run lint:css\n- npm run test:unit\n- npm run test:integration\n- CI=1 npm run test:ui:fast\n\nNo tests were modified.