### PR TITLE
feat(ui): unify sidebar nav and keep settings in todos shell

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -183,6 +183,10 @@ const PROJECTS_RAIL_COLLAPSED_STORAGE_KEY = "todos:projects-rail-collapsed";
 const AI_WORKSPACE_COLLAPSED_STORAGE_KEY = "todos:ai-collapsed";
 const AI_WORKSPACE_VISIBLE_STORAGE_KEY = "todos:ai-visible";
 const AI_ON_CREATE_DISMISSED_STORAGE_KEY = "todos:ai-on-create-dismissed";
+const SIDEBAR_NAV_ITEMS = [
+  { view: "todos", label: "Todos" },
+  { view: "settings", label: "Settings" },
+];
 let isAiWorkspaceCollapsed = true;
 let isAiWorkspaceVisible = AI_DEBUG_ENABLED;
 let onCreateAssistState = createInitialOnCreateAssistState();
@@ -271,6 +275,41 @@ function syncProjectsRailHost() {
     projectsRailHost instanceof HTMLElement &&
       projectsRail.parentElement === projectsRailHost,
   );
+}
+
+function renderSidebarNavigation() {
+  const navTargets = document.querySelectorAll("[data-sidebar-nav-target]");
+  if (!navTargets.length) return;
+
+  const navMarkup = SIDEBAR_NAV_ITEMS.map(
+    ({ view, label }) => `
+      <button
+        type="button"
+        class="projects-rail-item sidebar-nav-item"
+        data-sidebar-view="${escapeHtml(view)}"
+        data-onclick="switchView('${escapeHtml(view)}')"
+      >
+        <span>${escapeHtml(label)}</span>
+      </button>
+    `,
+  ).join("");
+
+  navTargets.forEach((target) => {
+    if (!(target instanceof HTMLElement)) return;
+    if (target.innerHTML === navMarkup) return;
+    target.innerHTML = navMarkup;
+  });
+}
+
+function setSettingsPaneVisible(isVisible) {
+  const settingsPane = document.getElementById("settingsPane");
+  const todosView = document.getElementById("todosView");
+  if (!(settingsPane instanceof HTMLElement)) return;
+
+  settingsPane.hidden = !isVisible;
+  if (todosView instanceof HTMLElement) {
+    todosView.classList.toggle("todos-view--settings-active", isVisible);
+  }
 }
 
 function setTodosViewBodyState(isTodosView) {
@@ -543,6 +582,7 @@ async function ensureProjectExists(projectName) {
 
 // Initialize app
 function init() {
+  renderSidebarNavigation();
   bindCriticalHandlers();
   bindTodoDrawerHandlers();
   bindProjectsRailHandlers();
@@ -8806,17 +8846,21 @@ async function deleteUser(userId) {
 }
 
 function syncSidebarNavState(activeView) {
+  const normalizedView = activeView === "profile" ? "settings" : activeView;
   document
     .querySelectorAll(".sidebar-nav-item[data-sidebar-view]")
     .forEach((el) => {
       if (!(el instanceof HTMLElement)) return;
-      const isActive = el.getAttribute("data-sidebar-view") === activeView;
+      const isActive = el.getAttribute("data-sidebar-view") === normalizedView;
       el.classList.toggle("projects-rail-item--active", isActive);
     });
 }
 
 // Switch view
 function switchView(view, triggerEl = null) {
+  const isSettingsView = view === "settings";
+  const primaryView = isSettingsView ? "todos" : view;
+
   document
     .querySelectorAll(".view")
     .forEach((v) => v.classList.remove("active"));
@@ -8824,25 +8868,38 @@ function switchView(view, triggerEl = null) {
     .querySelectorAll(".nav-tab")
     .forEach((t) => t.classList.remove("active"));
 
-  document.getElementById(view + "View").classList.add("active");
+  const targetView = document.getElementById(primaryView + "View");
+  if (!(targetView instanceof HTMLElement)) {
+    return;
+  }
+  targetView.classList.add("active");
   if (triggerEl) {
     triggerEl.classList.add("active");
   }
   if (
-    !(triggerEl instanceof HTMLElement) ||
-    !triggerEl.classList.contains("nav-tab")
+    !isSettingsView &&
+    (!(triggerEl instanceof HTMLElement) ||
+      !triggerEl.classList.contains("nav-tab"))
   ) {
     const matchingTab = document.querySelector(
-      `.nav-tab[data-onclick*="switchView('${view}'"]`,
+      `.nav-tab[data-onclick*="switchView('${primaryView}'"]`,
     );
     if (matchingTab instanceof HTMLElement) {
       matchingTab.classList.add("active");
     }
   }
-  setTodosViewBodyState(view === "todos");
+  setTodosViewBodyState(primaryView === "todos");
+  setSettingsPaneVisible(isSettingsView);
   syncSidebarNavState(view);
 
-  if (view === "todos") {
+  if (isSettingsView) {
+    closeCommandPalette({ restoreFocus: false });
+    closeProjectCrudModal({ restoreFocus: false });
+    closeMoreFilters();
+    closeProjectsRailSheet({ restoreFocus: false });
+    closeTodoDrawer({ restoreFocus: false });
+    updateUserDisplay();
+  } else if (view === "todos") {
     closeCommandPalette({ restoreFocus: false });
     closeProjectCrudModal({ restoreFocus: false });
     closeMoreFilters();
@@ -9403,6 +9460,7 @@ async function logout() {
 // Show app view
 function showAppView() {
   setTodosViewBodyState(true);
+  setSettingsPaneVisible(false);
   document.getElementById("authView").classList.remove("active");
   document.getElementById("todosView").classList.add("active");
   document.getElementById("navTabs").style.display = "flex";
@@ -9448,6 +9506,7 @@ function showAppView() {
 // Show auth view
 function showAuthView() {
   setTodosViewBodyState(false);
+  setSettingsPaneVisible(false);
   document.getElementById("authView").classList.add("active");
   document.getElementById("todosView").classList.remove("active");
   document.getElementById("profileView").classList.remove("active");

--- a/public/index.html
+++ b/public/index.html
@@ -14,16 +14,7 @@
           <div class="app-sidebar__brand">Workspace</div>
           <div id="projectsRailHost" aria-live="polite"></div>
         </div>
-        <div class="app-sidebar__bottom">
-          <button
-            id="appSidebarSettingsButton"
-            type="button"
-            class="mini-btn app-sidebar__settings"
-            data-onclick="switchView('profile')"
-          >
-            Settings
-          </button>
-        </div>
+        <div class="app-sidebar__bottom"></div>
       </aside>
       <main id="appMain">
         <div id="appMainScroll">
@@ -291,24 +282,10 @@
                         <span>Navigation</span>
                       </div>
                       <nav
-                        class="projects-rail__list"
+                        class="projects-rail__list sidebar-nav-list"
                         aria-label="View navigation"
-                      >
-                        <div
-                          class="projects-rail-item sidebar-nav-item projects-rail-item--active"
-                          data-sidebar-view="todos"
-                          data-onclick="switchView('todos')"
-                        >
-                          <span>Todos</span>
-                        </div>
-                        <div
-                          class="projects-rail-item sidebar-nav-item"
-                          data-sidebar-view="profile"
-                          data-onclick="switchView('profile')"
-                        >
-                          <span>Profile</span>
-                        </div>
-                      </nav>
+                        data-sidebar-nav-target
+                      ></nav>
                     </div>
                     <div class="projects-rail__section">
                       <div class="projects-rail__section-header">
@@ -370,24 +347,10 @@
                         <span>Navigation</span>
                       </div>
                       <nav
-                        class="projects-rail__list"
+                        class="projects-rail__list sidebar-nav-list"
                         aria-label="View navigation"
-                      >
-                        <div
-                          class="projects-rail-item sidebar-nav-item projects-rail-item--active"
-                          data-sidebar-view="todos"
-                          data-onclick="switchView('todos')"
-                        >
-                          <span>Todos</span>
-                        </div>
-                        <div
-                          class="projects-rail-item sidebar-nav-item"
-                          data-sidebar-view="profile"
-                          data-onclick="switchView('profile')"
-                        >
-                          <span>Profile</span>
-                        </div>
-                      </nav>
+                        data-sidebar-nav-target
+                      ></nav>
                     </div>
                     <div class="projects-rail__section">
                       <div class="projects-rail__section-header">
@@ -410,6 +373,16 @@
                   </aside>
 
                   <div class="todos-main-zone">
+                    <section id="settingsPane" class="settings-pane" hidden>
+                      <h2>Settings</h2>
+                      <div class="settings-pane__section">
+                        <h3>Profile</h3>
+                        <p>
+                          Manage your profile from this panel while keeping the
+                          workspace sidebar visible.
+                        </p>
+                      </div>
+                    </section>
                     <div class="todos-top-bar">
                       <div class="todos-top-bar-left">
                         <button

--- a/public/styles.css
+++ b/public/styles.css
@@ -1658,6 +1658,32 @@ textarea:focus-visible,
   overflow: hidden;
 }
 
+.settings-pane {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+}
+
+.settings-pane__section {
+  margin-top: var(--s-3);
+  padding-top: var(--s-3);
+  border-top: 1px solid var(--border-color);
+}
+
+#todosView.todos-view--settings-active .settings-pane {
+  display: block;
+}
+
+#todosView.todos-view--settings-active .todos-top-bar,
+#todosView.todos-view--settings-active #todosScrollRegion {
+  display: none;
+}
+
 .todos-list-header {
   position: sticky;
   top: 0;


### PR DESCRIPTION
Summary: remove duplicated hardcoded sidebar nav entries from desktop rail + mobile sheet and render both from one shared nav source in app.js; replace sidebar Profile entry with Settings; add an in-shell settings pane in the todos main pane so opening settings keeps the fixed sidebar layout; keep existing top nav tabs and event delegation intact. Verification: npx tsc --noEmit; npm run format:check; npm run lint:html; npm run lint:css; npm run test:unit; npm run test:integration; CI=1 npm run test:ui:fast.