### PR TITLE
docs(memory): compact brief and promote sidebar/AI rules

### DIFF
--- a/docs/memory/archive/2026-02-21-brief-pre-sidebar-nav-polish.md
+++ b/docs/memory/archive/2026-02-21-brief-pre-sidebar-nav-polish.md
@@ -1,0 +1,43 @@
+# Brief Archive — pre sidebar-nav polish
+
+Archived on: 2026-02-21
+Reason: Superseded by recent UI sidebar/nav decisions and memory audit follow-up.
+
+## Snapshot
+
+# Brief — Current Project Context
+
+Target: ≤2 pages. When this grows beyond 2 pages, compact:
+extract new rules → Canon, archive old sections → Archive, reset Brief.
+
+## What This Project Is
+
+Full-stack todo application. Express + Prisma + PostgreSQL backend, vanilla JS frontend (single-page app, no framework, no bundler). Deployed on Railway.
+
+## Current State
+
+- UI revamp completed through milestones M1, M2, M4 (M3 skipped).
+- AI workspace feature in progress (calm mode / collapsed shell).
+- Dual-agent workflow (Codex builder / Claude reviewer) operational.
+- v2 operating model being integrated (Green/Yellow/Red classification).
+
+## Active Architecture Patterns
+
+- Event delegation on container elements (never on dynamic children).
+- `filterTodos()` is the single filter entry point.
+- `setSelectedProjectKey()` is the only project selection API.
+- `waitForTodosViewIdle()` for DOM-ready detection in tests.
+
+## Key Risks
+
+- Snapshot drift between macOS (local) and Linux (CI).
+- Port 4173 conflicts from interrupted test runs.
+- Spec file leakage across branches without worktree isolation.
+
+## Recent Decisions
+
+- (append decisions here as they happen)
+
+---
+
+*Last updated: session start*

--- a/docs/memory/brief/BRIEF.md
+++ b/docs/memory/brief/BRIEF.md
@@ -1,7 +1,7 @@
 # Brief — Current Project Context
 
-Target: ≤2 pages. When this grows beyond 2 pages, compact:
-extract new rules → Canon, archive old sections → Archive, reset Brief.
+Target: <=2 pages. When this grows beyond 2 pages, compact:
+extract new rules -> Canon, archive old sections -> Archive, reset Brief.
 
 ## What This Project Is
 
@@ -9,28 +9,31 @@ Full-stack todo application. Express + Prisma + PostgreSQL backend, vanilla JS f
 
 ## Current State
 
-- UI revamp completed through milestones M1, M2, M4 (M3 skipped).
-- AI workspace feature in progress (calm mode / collapsed shell).
-- Dual-agent workflow (Codex builder / Claude reviewer) operational.
-- v2 operating model being integrated (Green/Yellow/Red classification).
+- Notion-style shell is active: pinned sidebar + pinned topbar, main pane scroll.
+- Sidebar remains the primary navigation surface for workspace flows.
+- Settings is available from the sidebar bottom and renders in the Todos shell.
+- AI internal category handling is hardened; `AI Plan` is hidden from nav/filter surfaces.
 
 ## Active Architecture Patterns
 
 - Event delegation on container elements (never on dynamic children).
 - `filterTodos()` is the single filter entry point.
 - `setSelectedProjectKey()` is the only project selection API.
-- `waitForTodosViewIdle()` for DOM-ready detection in tests.
+- `waitForTodosViewIdle()` for deterministic UI readiness in tests.
 
-## Key Risks
+## Active Constraints
 
-- Snapshot drift between macOS (local) and Linux (CI).
-- Port 4173 conflicts from interrupted test runs.
-- Spec file leakage across branches without worktree isolation.
+- Keep legacy top tabs while Playwright depends on them.
+- Do not break `Profile` test path until tests are migrated to Settings-only navigation.
+- Internal categories are data-visible under `All tasks` but excluded from navigation/selectors.
 
-## Recent Decisions
+## Recent Decisions (2026-02-21)
 
-- (append decisions here as they happen)
+- Settings is pinned to sidebar bottom as the stable account/settings entry point.
+- Sidebar should not disappear when entering settings/profile-related workflows.
+- `AI Plan` remains internal-only and must be excluded from projects/category UI surfaces.
+- Memory compaction follow-up required because PRs #124-#128 shipped UX decisions without memory updates.
 
 ---
 
-*Last updated: session start*
+*Last updated: 2026-02-21*

--- a/docs/memory/canon/CANON.md
+++ b/docs/memory/canon/CANON.md
@@ -23,6 +23,17 @@ A rule enters Canon when:
 ### Process
 - Never weaken a test to make CI pass. Fix the code.
 - Do not commit untracked `docs/` content unless the task explicitly allows it.
+- When a UI/task PR changes navigation IA or persistent UX behavior, update `docs/memory/canon/CANON.md` + `docs/memory/brief/BRIEF.md` in the same PR (or immediate docs-only follow-up PR).
+
+### UI Navigation & IA
+- Sidebar is the single primary navigation surface in Todos mode; top tabs remain compatibility affordances only while tests still depend on them.
+- Sidebar bottom contains the stable account entry point: `Settings`.
+- `Profile` is presented as Settings content, not as a standalone sidebar nav item.
+- Entering Settings must not collapse or remove the sidebar shell.
+
+### Internal Categories
+- `AI Plan` is an internal category and must never appear in user navigation surfaces (projects rail, category dropdown, create/edit project pickers).
+- If persisted selection resolves to an internal category, client selection must fall back to `All tasks` (`setSelectedProjectKey("")` path).
 
 ---
 

--- a/docs/memory/index/INDEX.md
+++ b/docs/memory/index/INDEX.md
@@ -34,6 +34,7 @@ Quick-reference to find things. Keep this flat and current.
 | Current context (brief) | `docs/memory/brief/BRIEF.md`               |
 | This index              | `docs/memory/index/INDEX.md`               |
 | Archived briefs         | `docs/memory/archive/`                      |
+| Latest archive snapshot | `docs/memory/archive/2026-02-21-brief-pre-sidebar-nav-polish.md` |
 
 ## Feature Specs
 


### PR DESCRIPTION
Memory Status Report

Compaction policy located
Policy source: [WORKFLOW.md](app://-/index.html#) (section: Memory Compaction).
Canonical memory paths:
Canon: [CANON.md](app://-/index.html#)
Brief: [BRIEF.md](app://-/index.html#)
Archive: /private/tmp/todos-api-memory-compaction-audit/docs/memory/archive/
Index: [INDEX.md](app://-/index.html#)
Rule trigger and actions:
When Brief exceeds ~2 pages: promote stable rules to Canon, archive old Brief, write fresh Brief, update Index pointers.
Required format/sections observed:
Canon: How Rules Get Promoted, Rules grouped by headings.
Brief: What This Project Is, Current State, Active Architecture Patterns, risk/decision context.
Index: pointer table for Canon/Brief/Index/Archive.
Audit of last 5 relevant merged PRs
Audited PR commits: #128, #127, #126, #125, #124 (UI sidebar/nav series).
Result: none included memory updates (docs/memory/* untouched in all five).
Compaction updates applied now
Promoted stable decisions into Canon:
sidebar-first nav in Todos mode
Settings pinned to sidebar bottom
Profile as settings content model
sidebar persists in settings/profile flows
AI Plan internal-category exclusion + fallback behavior
Refreshed Brief with current state/constraints.
Archived superseded pre-polish brief snapshot.
Updated Index with latest archive pointer.
Changed files (docs-only)

[CANON.md](app://-/index.html#)
[BRIEF.md](app://-/index.html#)
[INDEX.md](app://-/index.html#)
[2026-02-21-brief-pre-sidebar-nav-polish.md](app://-/index.html#)