### PR TITLE
fix(ui): keep admin todos tab visible

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -425,6 +425,10 @@ body.is-todos-view.is-admin-user #adminNavTab {
   display: inline-flex !important;
 }
 
+body.is-todos-view.is-admin-user .nav-tab[data-onclick*="switchView('todos'"] {
+  display: inline-flex !important;
+}
+
 body.is-todos-view .nav-tab {
   flex: 0 0 auto;
   border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- restore a visible admin path back to Todos after entering Settings
- keep sidebar bottom nav as Settings-only
- fix regression by overriding admin-only top-tab hiding to keep the legacy `Todos` tab visible

## Context
PR #132 removed the sidebar bottom `Todos` button. Admin-specific CSS still hid non-admin top tabs in Todos mode, which removed the last visible control to invoke `switchView('todos')` after entering Settings.

## Files changed
- `public/styles.css`

## Notes
- Follow-up to merged PR #132.
- Local `npm run lint:css` was not runnable in this fresh follow-up worktree because `stylelint` was unavailable (no dependency install in this worktree).