### PR TITLE
fix(ui): leave settings pane on rail selection

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3366,6 +3366,21 @@ function syncWorkspaceViewState() {
     });
 }
 
+function ensureTodosShellActive() {
+  const todosView = document.getElementById("todosView");
+  const shouldSwitchToTodos =
+    !(todosView instanceof HTMLElement) ||
+    !todosView.classList.contains("active") ||
+    todosView.classList.contains("todos-view--settings-active");
+
+  if (!shouldSwitchToTodos) return;
+
+  const todosTab = document.querySelector(
+    ".nav-tab[data-onclick*=\"switchView('todos'\"]",
+  );
+  switchView("todos", todosTab instanceof HTMLElement ? todosTab : null);
+}
+
 function selectWorkspaceView(view, triggerEl = null) {
   const normalizedView = String(view || "all").toLowerCase();
   const nextView =
@@ -3377,6 +3392,7 @@ function selectWorkspaceView(view, triggerEl = null) {
   if (triggerEl instanceof HTMLElement) {
     triggerEl.blur();
   }
+  ensureTodosShellActive();
   setSelectedProjectKey("", { reason: "workspace-view", skipApply: true });
   setDateView(nextView, { skipApply: false });
 }
@@ -4482,6 +4498,7 @@ function selectProjectFromRail(projectName, triggerEl = null) {
   if (openRailProjectMenuKey) {
     openRailProjectMenuKey = null;
   }
+  ensureTodosShellActive();
   railRovingFocusKey = normalizeProjectPath(projectName);
   setSelectedProjectKey(projectName);
 


### PR DESCRIPTION
Fixes a settings-pane navigation regression: clicking workspace/project items in the rail while Settings is open now switches back to Todos before applying the selection. File changed: public/app.js. Local focused UI verification was blocked in this worktree because Playwright was unavailable on PATH after npm ci; JS syntax check passed via node -c public/app.js.