### PR TITLE
feat(ui): persist compact quick-entry properties

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -197,6 +197,8 @@ const PROJECTS_RAIL_COLLAPSED_STORAGE_KEY = "todos:projects-rail-collapsed";
 const AI_WORKSPACE_COLLAPSED_STORAGE_KEY = "todos:ai-collapsed";
 const AI_WORKSPACE_VISIBLE_STORAGE_KEY = "todos:ai-visible";
 const AI_ON_CREATE_DISMISSED_STORAGE_KEY = "todos:ai-on-create-dismissed";
+const QUICK_ENTRY_PROPERTIES_OPEN_STORAGE_KEY =
+  "todos:quick-entry-properties-open";
 const SIDEBAR_NAV_ITEMS = [{ view: "settings", label: "Settings" }];
 let isAiWorkspaceCollapsed = true;
 let isAiWorkspaceVisible = AI_DEBUG_ENABLED;
@@ -397,8 +399,33 @@ function persistAiWorkspaceVisibleState(isVisible) {
   }
 }
 
-function setQuickEntryPropertiesOpen(nextOpen) {
+function readStoredQuickEntryPropertiesOpenState() {
+  try {
+    return (
+      window.localStorage.getItem(QUICK_ENTRY_PROPERTIES_OPEN_STORAGE_KEY) ===
+      "1"
+    );
+  } catch (error) {
+    return false;
+  }
+}
+
+function persistQuickEntryPropertiesOpenState(isOpen) {
+  try {
+    window.localStorage.setItem(
+      QUICK_ENTRY_PROPERTIES_OPEN_STORAGE_KEY,
+      isOpen ? "1" : "0",
+    );
+  } catch (error) {
+    // Ignore storage failures.
+  }
+}
+
+function setQuickEntryPropertiesOpen(nextOpen, { persist = true } = {}) {
   isQuickEntryPropertiesOpen = !!nextOpen;
+  if (persist) {
+    persistQuickEntryPropertiesOpenState(isQuickEntryPropertiesOpen);
+  }
   const panel = document.getElementById("quickEntryPropertiesPanel");
   const toggle = document.getElementById("quickEntryPropertiesToggle");
   if (panel instanceof HTMLElement) {
@@ -669,7 +696,9 @@ function init() {
     setAuthState(AUTH_STATE.UNAUTHENTICATED);
   }
   renderOnCreateAssistRow();
-  setQuickEntryPropertiesOpen(false);
+  setQuickEntryPropertiesOpen(readStoredQuickEntryPropertiesOpenState(), {
+    persist: false,
+  });
   syncQuickEntryProjectActions();
   handleVerificationStatusFromUrl();
 }
@@ -2653,7 +2682,7 @@ async function addTodo() {
       projectSelect.value = "";
       dueDateInput.value = "";
       notesInput.value = "";
-      setQuickEntryPropertiesOpen(false);
+      setQuickEntryPropertiesOpen(false, { persist: false });
       syncQuickEntryProjectActions();
 
       // Reset priority to medium
@@ -9671,7 +9700,9 @@ function showAppView() {
   resetTodayPlanState();
   renderOnCreateAssistRow();
   renderTodayPlanPanel();
-  setQuickEntryPropertiesOpen(false);
+  setQuickEntryPropertiesOpen(readStoredQuickEntryPropertiesOpenState(), {
+    persist: false,
+  });
   syncQuickEntryProjectActions();
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -5040,3 +5040,69 @@ body.is-todos-view .priority-btn:hover {
     grid-template-columns: 1fr;
   }
 }
+
+/* M11: Quick-entry accordion density pass (reduce pre-list stack height) */
+body.is-todos-view .add-todo.quick-entry {
+  gap: 4px;
+}
+
+body.is-todos-view .quick-entry > input {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+body.is-todos-view .quick-entry-toolbar {
+  margin-top: -6px;
+  min-height: 28px;
+}
+
+body.is-todos-view .quick-entry-properties-toggle {
+  padding: 4px 8px;
+  font-size: 12px;
+  min-height: 28px;
+}
+
+body.is-todos-view .quick-entry-properties-panel {
+  gap: 6px;
+  padding: 6px 8px;
+  margin-top: 0;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row,
+body.is-todos-view .quick-entry-properties-panel .action-row {
+  gap: 6px;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row input,
+body.is-todos-view .quick-entry-properties-panel .field-row select,
+body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+  min-height: 34px;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+  padding: 6px 9px !important;
+  font-size: 11px;
+}
+
+body.is-todos-view .action-label {
+  font-size: 11px;
+}
+
+body.is-todos-view .priority-selector {
+  gap: 4px;
+}
+
+body.is-todos-view .priority-btn {
+  padding: 4px 8px;
+  font-size: 0.76em;
+}
+
+body.is-todos-view .expand-section {
+  margin-top: 4px;
+  padding: 4px 6px;
+  font-size: 0.8em;
+}
+
+body.is-todos-view .notes-textarea {
+  margin-top: 4px !important;
+}


### PR DESCRIPTION
## Summary
- makes Quick Entry Properties a real accordion with persisted state via localStorage (default closed)
- remembers the user’s open/closed preference across app reloads and Todos view re-entry
- keeps auto-close after creating a todo as a temporary close without overwriting the saved preference
- reduces vertical paddings/gaps in the quick-entry / properties / notes stack to bring the todo list higher

## Files changed
- public/app.js
- public/styles.css

## Verification (focused)
- node -c public/app.js ✅ PASS
- npm run format:check ✅ PASS
- npm run lint:css ✅ PASS
- CI=1 npm run test:ui:fast -- tests/ui/topbar-cta-invariants.spec.ts tests/ui/composition-spacing.spec.ts tests/ui/more-filters.spec.ts tests/ui/list-header.spec.ts ✅ PASS (25 passed, 3 skipped)

## Notes
- No markup or test changes.
- Accordion state key: todos:quick-entry-properties-open