### PR TITLE
docs(tasks): mark task 112 done and archive

### DIFF
--- a/docs/agent-queue/tasks/done/112-sidebar-nav-polish-v3.md
+++ b/docs/agent-queue/tasks/done/112-sidebar-nav-polish-v3.md
@@ -1,7 +1,7 @@
 # TASK 112: sidebar-nav-polish-v3
 
 type: Yellow
-status: REVIEW
+status: DONE
 mode: implement
 builder: claude
 reviewer: user


### PR DESCRIPTION
## Summary
- Move task 112 (sidebar-nav-polish-v3) from `yellow/` to `done/` and update status from REVIEW to DONE.
- PR #130 and follow-up PRs #131-#137 already merged; this archives the task spec.

## Test plan
- Docs-only change — no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)