### PR TITLE
fix(ui): polish todos search and quick entry affordances

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -254,7 +254,7 @@
                     aria-label="Projects"
                   >
                     <div class="projects-rail__header">
-                      <h3>Projects</h3>
+                      <h3>Views & Projects</h3>
                       <button
                         id="projectsRailToggle"
                         type="button"
@@ -267,12 +267,9 @@
                       class="projects-rail__section projects-rail__section--workspace"
                     >
                       <div class="projects-rail__section-header">
-                        <span>Workspace</span>
+                        <span>Views</span>
                       </div>
-                      <nav
-                        class="projects-rail__primary"
-                        aria-label="Workspace views"
-                      >
+                      <nav class="projects-rail__primary" aria-label="Views">
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item projects-rail-item--active"
@@ -342,7 +339,7 @@
                     aria-label="Projects"
                   >
                     <div class="projects-rail__header">
-                      <h3>Projects</h3>
+                      <h3>Views & Projects</h3>
                       <button
                         id="projectsRailMobileClose"
                         type="button"
@@ -356,12 +353,9 @@
                       class="projects-rail__section projects-rail__section--workspace"
                     >
                       <div class="projects-rail__section-header">
-                        <span>Workspace</span>
+                        <span>Views</span>
                       </div>
-                      <nav
-                        class="projects-rail__primary"
-                        aria-label="Workspace views"
-                      >
+                      <nav class="projects-rail__primary" aria-label="Views">
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item projects-rail-item--active"
@@ -591,7 +585,7 @@
                             type="text"
                             id="searchInput"
                             class="search-input"
-                            placeholder="Search todos... (Ctrl/Cmd+F)"
+                            placeholder="Search… (/)"
                             data-oninput="filterTodos()"
                           />
                           <span class="search-icon">🔍</span>
@@ -744,6 +738,13 @@
                           >
                             Properties
                           </button>
+                          <div
+                            id="quickEntryPropertiesSummary"
+                            class="quick-entry-properties-summary"
+                            aria-live="polite"
+                          >
+                            No project • No due date • Priority: Medium
+                          </div>
                         </div>
                         <div
                           id="aiOnCreateAssistRow"
@@ -801,6 +802,8 @@
                             <input
                               type="datetime-local"
                               id="todoDueDateInput"
+                              title="Due date (optional)"
+                              aria-label="Due date (optional)"
                             />
                           </div>
                           <div class="action-row">
@@ -1213,7 +1216,8 @@
     <button
       class="keyboard-shortcuts-btn"
       data-onclick="toggleShortcuts()"
-      title="Keyboard Shortcuts (?)"
+      title="Shortcuts"
+      aria-label="Keyboard shortcuts"
     >
       ⌨️
     </button>
@@ -1272,7 +1276,7 @@
         </div>
         <div class="shortcut-item">
           <span class="shortcut-desc">Search Todos</span>
-          <kbd class="shortcut-key">Ctrl/Cmd + F</kbd>
+          <kbd class="shortcut-key">/</kbd>
         </div>
         <div class="shortcut-item">
           <span class="shortcut-desc">Clear Search</span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -5197,3 +5197,160 @@ body.is-todos-view .projects-rail-item__count {
   background: color-mix(in oklab, var(--surface) 90%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 45%, transparent);
 }
+
+/* M13: feedback polish (search hint, hierarchy, quick-entry framing, row clarity) */
+#todosView .todos-top-bar-actions .top-add-btn {
+  box-shadow: 0 6px 14px rgb(15 23 42 / 12%);
+}
+
+#todosView .todos-top-bar-actions .more-filters-toggle {
+  background: color-mix(in oklab, var(--surface) 94%, transparent);
+  color: var(--text-secondary);
+  border: 1px solid color-mix(in oklab, var(--border-color) 85%, transparent);
+  box-shadow: none;
+}
+
+#todosView .todos-top-bar-actions .more-filters-toggle:hover,
+#todosView .todos-top-bar-actions .more-filters-toggle[aria-expanded="true"] {
+  background: color-mix(in oklab, var(--surface-2) 88%, var(--surface));
+  color: var(--text-primary);
+  border-color: color-mix(in oklab, var(--border-color) 100%, transparent);
+}
+
+body.is-todos-view .add-todo.quick-entry {
+  border: 1px solid color-mix(in oklab, var(--border-color) 88%, transparent);
+  border-radius: 12px;
+  padding: 10px;
+  background: color-mix(in oklab, var(--surface) 96%, var(--surface-2));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%);
+}
+
+body.is-todos-view .quick-entry-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 0;
+  min-height: 0;
+}
+
+body.is-todos-view .quick-entry-properties-summary {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1 1 220px;
+}
+
+body.is-todos-view .quick-entry-properties-summary[hidden] {
+  display: none !important;
+}
+
+body.is-todos-view .quick-entry-properties-panel {
+  border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
+  background: color-mix(in oklab, var(--surface-2) 55%, transparent);
+  border-radius: 10px;
+}
+
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"] {
+  color: var(--text-secondary);
+}
+
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"]:focus,
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"]:not(:placeholder-shown) {
+  color: var(--text-primary);
+}
+
+body.is-todos-view .priority-selector {
+  border-radius: 10px;
+}
+
+body.is-todos-view .priority-btn {
+  border-width: 1px;
+  border-color: color-mix(in oklab, var(--border-color) 80%, transparent);
+  color: var(--text-secondary);
+  background: color-mix(in oklab, var(--surface) 98%, transparent);
+}
+
+body.is-todos-view .priority-btn.active {
+  border-width: 2px;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 22%) inset;
+}
+
+body.is-todos-view .priority-btn.low.active {
+  border-color: color-mix(in oklab, var(--accent-2) 82%, white);
+  background: color-mix(in oklab, var(--accent-2) 88%, black 8%);
+}
+
+body.is-todos-view .priority-btn.medium.active {
+  border-color: #c98900;
+  background: color-mix(in oklab, #c98900 90%, black 8%);
+}
+
+body.is-todos-view .priority-btn.high.active {
+  border-color: color-mix(in oklab, var(--danger) 86%, white);
+  background: color-mix(in oklab, var(--danger) 90%, black 8%);
+}
+
+body.is-todos-view .priority-btn.active::before {
+  content: "●";
+  font-size: 0.7em;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  #todosView .todo-item .bulk-checkbox {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 120ms ease;
+  }
+
+  #todosView .todo-item:hover .bulk-checkbox,
+  #todosView .todo-item:focus-within .bulk-checkbox,
+  #todosView .todo-item .bulk-checkbox:checked,
+  #todosView .todo-item.todo-item--bulk-selected .bulk-checkbox {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+}
+
+.keyboard-shortcuts-btn {
+  position: fixed;
+}
+
+.keyboard-shortcuts-btn::after {
+  content: attr(aria-label);
+  position: absolute;
+  right: 58px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgb(15 23 42 / 92%);
+  color: #fff;
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease;
+}
+
+.keyboard-shortcuts-btn:hover::after,
+.keyboard-shortcuts-btn:focus-visible::after {
+  opacity: 1;
+}


### PR DESCRIPTION
Files Changed

[index.html](app://-/index.html#)
[app.js](app://-/index.html#)
[styles.css](app://-/index.html#)
Implemented

Fixed misleading search hint to Search… (/) and wired / to focus app search.
Reduced top-row CTA competition by styling More filters as secondary/ghost.
Tightened quick entry presentation with unified framing and a collapsed properties summary line.
Kept quick-entry property summary synced to project/due/priority changes and reset on add.
Clarified due date as optional via label/title (without changing datetime-local behavior).
Strengthened priority chip selected state (fill/border + indicator dot).
Reduced row clutter by hiding bulk-select checkbox on hover-capable devices until hover/focus/selected.
Clarified left rail naming (Views vs Projects, Views & Projects header).
Added a visible tooltip label for the floating shortcuts button and clarified button title.
Removed top-header Not Verified badge display (status still visible in Profile / verification banner).