### PR TITLE
feat(ui): UI chrome cleanup – move search up, remove redundant chrome

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1656,10 +1656,7 @@ function renderHomeDashboard() {
   return `
     <section class="home-dashboard" data-testid="home-dashboard">
       <div class="home-dashboard__hero">
-        <div>
-          <h2 class="home-dashboard__title">Home</h2>
-          <p class="home-dashboard__subtitle">Where should you pay attention today?</p>
-        </div>
+        <p class="home-dashboard__subtitle">Where should you pay attention today?</p>
         <button
           type="button"
           class="add-btn home-dashboard__new-task"

--- a/public/index.html
+++ b/public/index.html
@@ -263,60 +263,6 @@
                         Collapse
                       </button>
                     </div>
-                    <div
-                      class="projects-rail__section projects-rail__section--workspace"
-                    >
-                      <div class="projects-rail__section-header">
-                        <span>Views</span>
-                      </div>
-                      <nav class="projects-rail__primary" aria-label="Views">
-                        <button
-                          type="button"
-                          class="projects-rail-item workspace-view-item projects-rail-item--active"
-                          data-workspace-view="home"
-                          aria-current="page"
-                        >
-                          <span>Home</span>
-                        </button>
-                        <button
-                          type="button"
-                          class="projects-rail-item workspace-view-item"
-                          data-workspace-view="unsorted"
-                        >
-                          <span>Unsorted</span>
-                          <span class="projects-rail-item__count">0</span>
-                        </button>
-                        <button
-                          type="button"
-                          class="projects-rail-item workspace-view-item"
-                          data-workspace-view="all"
-                        >
-                          <span>All tasks</span>
-                          <span class="projects-rail-item__count">0</span>
-                        </button>
-                        <button
-                          type="button"
-                          class="projects-rail-item workspace-view-item"
-                          data-workspace-view="today"
-                        >
-                          <span>Today</span>
-                        </button>
-                        <button
-                          type="button"
-                          class="projects-rail-item workspace-view-item"
-                          data-workspace-view="upcoming"
-                        >
-                          <span>Upcoming</span>
-                        </button>
-                        <button
-                          type="button"
-                          class="projects-rail-item workspace-view-item"
-                          data-workspace-view="completed"
-                        >
-                          <span>Completed</span>
-                        </button>
-                      </nav>
-                    </div>
                     <div class="rail-search-container" id="railSearchContainer">
                       <div class="search-bar">
                         <label for="searchInput" class="sr-only"
@@ -405,6 +351,60 @@
                           Exports currently filtered due-dated tasks.
                         </div>
                       </div>
+                    </div>
+                    <div
+                      class="projects-rail__section projects-rail__section--workspace"
+                    >
+                      <div class="projects-rail__section-header">
+                        <span>Views</span>
+                      </div>
+                      <nav class="projects-rail__primary" aria-label="Views">
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item projects-rail-item--active"
+                          data-workspace-view="home"
+                          aria-current="page"
+                        >
+                          <span>Home</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="unsorted"
+                        >
+                          <span>Unsorted</span>
+                          <span class="projects-rail-item__count">0</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="all"
+                        >
+                          <span>All tasks</span>
+                          <span class="projects-rail-item__count">0</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="today"
+                        >
+                          <span>Today</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="upcoming"
+                        >
+                          <span>Upcoming</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="completed"
+                        >
+                          <span>Completed</span>
+                        </button>
+                      </nav>
                     </div>
                     <div class="projects-rail__section">
                       <div class="projects-rail__section-header">
@@ -1437,16 +1437,6 @@
     <script src="/theme.js" defer></script>
     <script src="/aiSuggestionUtils.js" defer></script>
     <script src="/app.js" defer></script>
-
-    <!-- Keyboard Shortcuts Button -->
-    <button
-      class="keyboard-shortcuts-btn"
-      data-onclick="toggleShortcuts()"
-      title="Shortcuts"
-      aria-label="Keyboard shortcuts"
-    >
-      ⌨️
-    </button>
 
     <!-- Undo/Redo Toast -->
     <div id="undoToast" class="undo-toast">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1984,14 +1984,16 @@ body.is-admin-user button.admin-rail-btn {
 }
 
 .rail-search-container {
-  padding: 8px 10px 4px;
+  padding: 4px 8px 6px;
   display: flex;
   flex-direction: column;
   gap: 4px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 2px;
 }
 
 .projects-rail__section--workspace {
-  border-top: 1px solid var(--border-color);
+  border-top: none;
 }
 
 .projects-rail__section-header {
@@ -2252,11 +2254,30 @@ button.projects-rail-item {
   display: none !important;
 }
 
-/* Top bar hidden on desktop; stays visible on mobile for hamburger button */
+/* Top bar hidden on desktop (body.is-todos-view raises specificity to 0,2,0
+   so it beats the base .todos-top-bar{display:grid} rule at 0,1,0).
+   Exception: when the rail is collapsed the topbar re-appears so that
+   #projectsRailMobileOpen (the expand button) and the project label remain
+   accessible. JS toggles .todos-layout--rail-collapsed on .todos-layout. */
 @media (min-width: 769px) {
-  .todos-top-bar {
+  body.is-todos-view .todos-top-bar {
     display: none;
   }
+  body.is-todos-view .todos-layout--rail-collapsed .todos-top-bar {
+    display: grid;
+  }
+}
+
+/* Floating New Task CTA hidden on desktop — the dashboard hero button serves that role */
+@media (min-width: 769px) {
+  .floating-new-task-cta {
+    display: none !important;
+  }
+}
+
+/* Hide context list-header when the home dashboard is rendered in #todosContent */
+#todosScrollRegion:has(#todosContent > .home-dashboard) #todosListHeader {
+  display: none;
 }
 
 .todos-top-bar {
@@ -2590,31 +2611,6 @@ body.is-todos-view .floating-new-task-cta {
 .bulk-count {
   margin-left: auto;
   font-size: 0.9em;
-}
-
-.keyboard-shortcuts-btn {
-  position: fixed;
-  bottom: 80px;
-  right: auto;
-  left: 20px;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  background: var(--accent);
-  color: white;
-  border: none;
-  font-size: 1.3em;
-  cursor: pointer;
-  box-shadow: var(--shadow-1);
-  transition:
-    transform 0.3s,
-    background 0.3s;
-  z-index: 1000;
-}
-
-.keyboard-shortcuts-btn:hover {
-  background: var(--accent-2);
-  transform: scale(1.1);
 }
 
 .shortcuts-overlay {
@@ -3348,15 +3344,6 @@ body.is-todos-view .floating-new-task-cta {
   .bulk-count {
     margin-left: 0;
     margin-top: 8px;
-  }
-
-  .keyboard-shortcuts-btn {
-    bottom: 76px;
-    right: auto;
-    left: 15px;
-    width: 45px;
-    height: 45px;
-    font-size: 1.1em;
   }
 
   .shortcuts-content {
@@ -5486,7 +5473,7 @@ body.is-todos-view .projects-rail-item__count {
 }
 
 .home-dashboard__subtitle {
-  margin: 4px 0 0;
+  margin: 0;
   color: var(--text-secondary);
   font-size: 0.9rem;
 }

--- a/tests/ui/helpers/todos-view.ts
+++ b/tests/ui/helpers/todos-view.ts
@@ -63,7 +63,11 @@ export async function ensureAllTasksListActive(page: Page) {
 }
 
 export async function openTaskComposerSheet(page: Page) {
-  await page.locator("#floatingNewTaskCta").click();
+  // Use global openTaskComposer() — floating CTA hidden on desktop since the
+  // home dashboard hero button serves that role.
+  await page.evaluate(() =>
+    (window as unknown as Record<string, () => void>).openTaskComposer(),
+  );
   await expect(page.locator("#taskComposerSheet")).toHaveAttribute(
     "aria-hidden",
     "false",

--- a/tests/ui/layout-invariants.spec.ts
+++ b/tests/ui/layout-invariants.spec.ts
@@ -196,28 +196,16 @@ test.describe("Todos layout invariants", () => {
       await expect(rail).not.toHaveClass(/projects-rail--collapsed/);
     }
 
-    const topbar = page.locator(".todos-top-bar");
-    const addBtn = page.locator("#floatingNewTaskCta");
+    // Topbar hidden on desktop; floating CTA and shortcuts btn removed.
+    await expect(page.locator(".todos-top-bar")).toBeHidden();
     await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
-    await expect(addBtn).toBeVisible();
-    await expect(topbar).toBeVisible();
+    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
+    await expect(page.locator(".keyboard-shortcuts-btn")).toHaveCount(0);
 
-    const topbarMetrics = await topbar.evaluate((el) => ({
-      scrollWidth: el.scrollWidth,
-      clientWidth: el.clientWidth,
-    }));
-    expect(topbarMetrics.scrollWidth).toBeLessThanOrEqual(
-      topbarMetrics.clientWidth + 1,
-    );
-
-    const addBox = await addBtn.boundingBox();
-    const viewport = page.viewportSize();
-    expect(addBox).not.toBeNull();
-    if (addBox) {
-      expect(addBox.x + addBox.width).toBeLessThanOrEqual(
-        (viewport?.width || 1280) - 1,
-      );
-    }
+    // Sidebar search must be accessible on desktop.
+    await expect(
+      page.locator("#railSearchContainer #searchInput"),
+    ).toBeVisible();
 
     await page
       .locator(

--- a/tests/ui/layout-overflow.spec.ts
+++ b/tests/ui/layout-overflow.spec.ts
@@ -181,30 +181,10 @@ test.describe("Todos layout overflow hardening", () => {
       )
       .click();
 
-    const addButton = page.locator("#floatingNewTaskCta");
-    const searchInput = page.locator("#searchInput");
+    // Floating CTA removed on desktop; search lives in the sidebar rail.
+    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
     await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
-    await expect(addButton).toBeVisible();
-    await expect(searchInput).toBeVisible();
-
-    const topbarOverlap = await page.evaluate(() => {
-      const add = document.querySelector(
-        "#floatingNewTaskCta",
-      ) as HTMLElement | null;
-      const search = document.querySelector(
-        "#searchInput",
-      ) as HTMLElement | null;
-      if (!add || !search) return false;
-      const addBox = add.getBoundingClientRect();
-      const searchBox = search.getBoundingClientRect();
-      return (
-        addBox.x < searchBox.x + searchBox.width &&
-        addBox.x + addBox.width > searchBox.x &&
-        addBox.y < searchBox.y + searchBox.height &&
-        addBox.y + addBox.height > searchBox.y
-      );
-    });
-    expect(topbarOverlap).toBe(false);
+    await expect(page.locator("#searchInput")).toBeVisible();
 
     const scrollRegion = page.locator("#todosScrollRegion");
     const regionDimensions = await scrollRegion.evaluate((el) => ({

--- a/tests/ui/more-filters.spec.ts
+++ b/tests/ui/more-filters.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test, type Page, type Route } from "@playwright/test";
-import { openTodosViewWithStorageState } from "./helpers/todos-view";
+import {
+  openTodosViewWithStorageState,
+  selectWorkspaceView,
+} from "./helpers/todos-view";
 
 type TodoSeed = {
   id: string;
@@ -279,9 +282,20 @@ test.describe("More filters disclosure", () => {
     );
   });
 
-  test("floating New Task CTA opens task composer", async ({ page }) => {
-    await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
-    await page.locator("#floatingNewTaskCta").click();
+  test("home dashboard new task button opens task composer", async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(
+      isMobile,
+      "home-dashboard__new-task only visible on desktop home view",
+    );
+    // Navigate to the Home view where the dashboard hero button lives.
+    await selectWorkspaceView(page, "home");
+    // Floating CTA removed on desktop; home dashboard hero button takes that role.
+    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
+    await expect(page.locator(".home-dashboard__new-task")).toBeVisible();
+    await page.locator(".home-dashboard__new-task").click();
     await expect(page.locator("#taskComposerSheet")).toHaveAttribute(
       "aria-hidden",
       "false",

--- a/tests/ui/topbar-no-cta-clipping.spec.ts
+++ b/tests/ui/topbar-no-cta-clipping.spec.ts
@@ -192,26 +192,18 @@ test.describe("Top bar and rail ellipsis hardening", () => {
       await expect(rail).not.toHaveClass(/projects-rail--collapsed/);
     }
 
-    const addBtn = page.locator("#floatingNewTaskCta");
-    // Search moved from top-bar (.todos-top-bar-search) into the desktop rail.
-    const searchArea = page.locator("#railSearchContainer .search-bar");
+    // Floating CTA removed on desktop; search is now in the sidebar rail.
+    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
     await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
-    await expect(addBtn).toBeVisible();
+    const searchArea = page.locator("#railSearchContainer .search-bar");
     await expect(searchArea).toBeVisible();
 
-    const addBox = await addBtn.boundingBox();
+    // Search area must be fully within the viewport.
     const searchBox = await searchArea.boundingBox();
     const viewport = page.viewportSize();
-    expect(addBox).not.toBeNull();
     expect(searchBox).not.toBeNull();
-    if (addBox && searchBox) {
-      const overlap =
-        addBox.x < searchBox.x + searchBox.width &&
-        addBox.x + addBox.width > searchBox.x &&
-        addBox.y < searchBox.y + searchBox.height &&
-        addBox.y + addBox.height > searchBox.y;
-      expect(overlap).toBe(false);
-      expect(addBox.x + addBox.width).toBeLessThanOrEqual(
+    if (searchBox) {
+      expect(searchBox.x + searchBox.width).toBeLessThanOrEqual(
         (viewport?.width || 1280) - 1,
       );
     }

--- a/tests/ui/topbar-projects.spec.ts
+++ b/tests/ui/topbar-projects.spec.ts
@@ -202,7 +202,9 @@ test.describe("Top bar projects cleanup", () => {
       page.locator("#railSearchContainer #searchInput"),
     ).toBeVisible();
     await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
-    await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
+    // Floating CTA removed on desktop; home dashboard hero button takes that role.
+    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
+    await expect(page.locator(".keyboard-shortcuts-btn")).toHaveCount(0);
     // #moreFiltersToggle is in the rail and hidden by default; it reveals on search focus.
     await expect(page.locator("#moreFiltersToggle")).toBeHidden();
     await page.locator("#searchInput").focus();


### PR DESCRIPTION
## Summary

- **Move sidebar search higher**: `#railSearchContainer` relocated above workspace views so search is the first control in the rail (was buried between Views and Projects)
- **Remove duplicate "Home" heading**: deleted `<h2 class="home-dashboard__title">Home</h2>` from `renderHomeDashboard()` — the sticky list header and workspace view label already provide context; added `:has()` CSS to hide `#todosListHeader` when the home dashboard is active, eliminating the duplicate row
- **Remove floating keyboard-shortcuts FAB**: deleted `.keyboard-shortcuts-btn` element and all associated CSS — shortcuts overlay dialog is still accessible via keyboard
- **Hide desktop floating CTA**: `#floatingNewTaskCta` hidden on desktop (≥769px) via CSS; home dashboard hero's New Task button serves that role; floating CTA stays on mobile
- **Fix blank toolbar strip**: the `@media` rule hiding `.todos-top-bar` on desktop was overridden by the base `display:grid` rule (equal specificity, later source position wins); fixed by raising to `body.is-todos-view` specificity (0,2,0); added exception for `.todos-layout--rail-collapsed` so `#projectsRailMobileOpen` (expand button) remains accessible when the rail is collapsed
- **Tighten rail search styling**: compact padding, bottom border separator replacing the redundant border-top on the views section below

## Test updates

6 previously-failing tests are now green (253 passed, 6 pre-existing `quick-entry-natural-date` failures unchanged):
- `topbar-cta-invariants.spec.ts`: rewritten for home dashboard hero button; adds `selectWorkspaceView("home")` + `waitForTodosViewIdle()` to guard against double-render flakiness
- `more-filters.spec.ts`, `topbar-projects.spec.ts`, `topbar-no-cta-clipping.spec.ts`, `layout-invariants.spec.ts`, `layout-overflow.spec.ts`: updated assertions to match new element visibility
- `helpers/todos-view.ts`: `openTaskComposerSheet()` now calls `openTaskComposer()` via `page.evaluate()` since `#floatingNewTaskCta` is hidden on desktop

## Test plan

- [x] `npm run format:check` — passes
- [x] `npm run lint:html` — passes
- [x] `npm run lint:css` — passes
- [x] `CI=1 npm run test:ui:fast` — 253 passed, 6 pre-existing failures, 47 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)