### PR TITLE
fix(ui): remove redundant sidebar headings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -254,7 +254,6 @@
                     aria-label="Projects"
                   >
                     <div class="projects-rail__header">
-                      <h3>Views & Projects</h3>
                       <button
                         id="projectsRailToggle"
                         type="button"
@@ -355,9 +354,6 @@
                     <div
                       class="projects-rail__section projects-rail__section--workspace"
                     >
-                      <div class="projects-rail__section-header">
-                        <span>Views</span>
-                      </div>
                       <nav class="projects-rail__primary" aria-label="Views">
                         <button
                           type="button"
@@ -460,7 +456,6 @@
                     aria-label="Projects"
                   >
                     <div class="projects-rail__header">
-                      <h3>Views & Projects</h3>
                       <button
                         id="projectsRailMobileClose"
                         type="button"
@@ -473,9 +468,6 @@
                     <div
                       class="projects-rail__section projects-rail__section--workspace"
                     >
-                      <div class="projects-rail__section-header">
-                        <span>Views</span>
-                      </div>
                       <nav class="projects-rail__primary" aria-label="Views">
                         <button
                           type="button"

--- a/public/styles.css
+++ b/public/styles.css
@@ -1927,7 +1927,6 @@ textarea:focus-visible,
   justify-content: center;
 }
 
-.projects-rail.projects-rail--collapsed .projects-rail__header h3,
 .projects-rail.projects-rail--collapsed .projects-rail__section-header,
 .projects-rail.projects-rail--collapsed .projects-rail__footer,
 .projects-rail.projects-rail--collapsed #railSearchContainer {
@@ -1959,16 +1958,8 @@ textarea:focus-visible,
 .projects-rail__header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: var(--s-2);
-}
-
-.projects-rail__header h3 {
-  margin: 0;
-  font-size: var(--fs-sm);
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 .projects-rail__primary,
@@ -4979,11 +4970,6 @@ body.is-todos-view .projects-rail__header {
   padding: 0 6px 6px;
   border-bottom: 1px solid
     color-mix(in oklab, var(--border-color) 70%, transparent);
-}
-
-body.is-todos-view .projects-rail__header h3 {
-  font-size: 12px;
-  letter-spacing: 0.06em;
 }
 
 body.is-todos-view .projects-rail__section {


### PR DESCRIPTION
## Summary

- Removes `<h3>Views & Projects</h3>` from both the desktop rail and mobile sheet headers — was visually loud, uppercase, added no information not already conveyed by the nav items below it
- Removes the `<span>Views</span>` section-label div from both sidebars — equally redundant
- Retains the muted **Projects** label above the project list (orientation anchor per spec)
- Fixes `justify-content` on `.projects-rail__header`: `space-between` → `flex-end` so the Collapse/× button stays right-aligned now that there's no h3 counterpart on the left
- Removes 3 now-dead CSS selectors targeting `.projects-rail__header h3`

Net: −23 lines, 0 new lines. Pure chrome reduction.

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint:html` passes
- [x] `npm run lint:css` passes
- [x] 10/10 home UI tests pass (desktop + mobile, Chromium)
- [ ] Confirm Collapse button sits at right edge of desktop rail header
- [ ] Confirm × Close button sits at right edge of mobile sheet header

🤖 Generated with [Claude Code](https://claude.com/claude-code)