### PR TITLE
feat(ui): redesign home dashboard and sidebar chrome

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1616,10 +1616,7 @@ function renderProjectsToNudgeTile(items = []) {
   return `
     <section class="home-tile" data-home-tile="projects_to_nudge">
       <div class="home-tile__header">
-        <div>
-          <h3 class="home-tile__title">Projects to Nudge</h3>
-          <p class="home-tile__subtitle">Projects that could use a light touch.</p>
-        </div>
+        <h3 class="home-tile__title">Projects to Nudge</h3>
       </div>
       <div class="home-tile__body">
         ${
@@ -1656,42 +1653,32 @@ function renderHomeDashboard() {
 
   return `
     <section class="home-dashboard" data-testid="home-dashboard">
-      <div class="home-dashboard__toolbar">
+      <div class="home-dashboard__header">
+        <h2 class="home-dashboard__title">Home</h2>
         <button
           type="button"
           class="add-btn home-dashboard__new-task"
           data-onclick="openTaskComposer()"
         >
-          New Task
+          + New Task
         </button>
       </div>
-      <div class="home-dashboard__grid">
-        ${renderHomeTaskTile({
-          key: "top_focus",
-          title: "Top Focus",
-          subtitle: "The tasks most worth your attention.",
-          items: topFocusItems,
-          emptyText: "Nothing urgent right now.",
-          showReasons: true,
-          showSeeAll: false,
-        })}
-        ${renderHomeTaskTile({
-          key: "due_soon",
-          title: "Due Soon",
-          subtitle: "What needs attention in the next few days.",
-          items: model.dueSoon,
-          groupedItems: model.dueSoonGroups,
-          emptyText: "No due-soon tasks.",
-        })}
-        ${renderHomeTaskTile({
-          key: "quick_wins",
-          title: "Quick Wins",
-          subtitle: "Short tasks you can clear without much drag.",
-          items: model.quickWins,
-          emptyText: "No quick wins right now.",
-        })}
-        ${renderProjectsToNudgeTile(model.projectsToNudge)}
-      </div>
+      ${renderHomeTaskTile({
+        key: "top_focus",
+        title: "Focus",
+        items: topFocusItems,
+        emptyText: "Nothing urgent right now.",
+        showReasons: true,
+        showSeeAll: false,
+      })}
+      ${renderHomeTaskTile({
+        key: "due_soon",
+        title: "Up Next",
+        items: model.dueSoon,
+        groupedItems: model.dueSoonGroups,
+        emptyText: "Nothing coming up.",
+      })}
+      ${renderProjectsToNudgeTile(model.projectsToNudge)}
     </section>
   `;
 }
@@ -1723,7 +1710,7 @@ function openTodoFromHomeTile(todoId) {
 
 function getHomeDrilldownLabel() {
   const labels = {
-    due_soon: "Due Soon",
+    due_soon: "Up Next",
     stale_risks: "Stale Risks",
     quick_wins: "Quick Wins",
   };
@@ -6352,7 +6339,10 @@ function setProjectsRailCollapsed(nextCollapsed) {
     isRailCollapsed,
   );
   refs.collapseToggle.setAttribute("aria-expanded", String(!isRailCollapsed));
-  refs.collapseToggle.textContent = isRailCollapsed ? "Expand" : "Collapse";
+  refs.collapseToggle.setAttribute(
+    "aria-label",
+    isRailCollapsed ? "Expand sidebar" : "Collapse sidebar",
+  );
   updateTopbarProjectsButton(getSelectedProjectName());
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -13,25 +13,6 @@
         <div class="app-sidebar__top">
           <div id="projectsRailHost" aria-live="polite"></div>
         </div>
-        <div class="app-sidebar__bottom">
-          <div class="app-sidebar__actions">
-            <button
-              type="button"
-              class="projects-rail-item"
-              data-onclick="toggleTheme()"
-              title="Toggle dark mode"
-            >
-              <span class="app-sidebar__theme-label">🌙 Theme</span>
-            </button>
-            <button
-              type="button"
-              class="projects-rail-item"
-              data-onclick="logout()"
-            >
-              <span class="projects-rail-item__label">Logout</span>
-            </button>
-          </div>
-        </div>
       </aside>
       <main id="appMain">
         <div id="appMainScroll">
@@ -272,9 +253,15 @@
                       <button
                         id="projectsRailToggle"
                         type="button"
-                        class="mini-btn"
+                        class="sidebar-toggle-btn"
+                        aria-label="Collapse sidebar"
+                        aria-expanded="true"
                       >
-                        Collapse
+                        <span
+                          class="sidebar-toggle-btn__icon"
+                          aria-hidden="true"
+                          >☰</span
+                        >
                       </button>
                     </div>
                     <div class="rail-search-container" id="railSearchContainer">
@@ -448,6 +435,13 @@
                         <span class="projects-rail-item__label"
                           >⚙ Settings</span
                         >
+                      </button>
+                      <button
+                        type="button"
+                        class="projects-rail-item"
+                        data-onclick="logout()"
+                      >
+                        <span class="projects-rail-item__label">Logout</span>
                       </button>
                       <button
                         type="button"
@@ -642,6 +636,13 @@
                         <span class="projects-rail-item__label"
                           >⚙ Settings</span
                         >
+                      </button>
+                      <button
+                        type="button"
+                        class="projects-rail-item"
+                        data-onclick="logout()"
+                      >
+                        <span class="projects-rail-item__label">Logout</span>
                       </button>
                       <button
                         type="button"

--- a/public/styles.css
+++ b/public/styles.css
@@ -5957,6 +5957,157 @@ body.is-todos-view .priority-btn.active::before {
   opacity: 1;
 }
 
+/* Spec: calm workspace polish */
+
+/* 1. Remove blue body-gradient bleed around main content in todos view */
+body.is-todos-view #appMainScroll {
+  padding: 0;
+}
+
+/* 2. Sidebar toggle: icon-only hamburger button */
+.sidebar-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+  flex-shrink: 0;
+}
+
+.sidebar-toggle-btn:hover {
+  background: color-mix(in oklab, var(--surface) 82%, var(--surface-2));
+  color: var(--text-primary);
+}
+
+.sidebar-toggle-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.sidebar-toggle-btn__icon {
+  font-size: 16px;
+  line-height: 1;
+  user-select: none;
+}
+
+/* 3. Sidebar header: 48px height, flex row with toggle on left */
+body.is-todos-view .projects-rail__header {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 4px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--border-color) 60%, transparent);
+  flex-shrink: 0;
+}
+
+/* 4. Home dashboard: single-column layout with header row */
+.home-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  max-width: 880px;
+  padding: 24px 32px 40px;
+}
+
+.home-dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: -8px;
+}
+
+.home-dashboard__title {
+  font-size: 28px;
+  font-weight: 650;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.home-dashboard__new-task {
+  flex-shrink: 0;
+  height: 36px;
+  padding: 0 16px;
+  font-size: 0.875rem;
+  font-weight: var(--fw-semibold);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.home-dashboard__new-task:hover {
+  filter: saturate(1.05) brightness(1.03);
+}
+
+/* Override old grid-based layout */
+.home-dashboard__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+/* Home tile: section-style for single-column layout */
+body.is-todos-view .home-tile {
+  border-radius: 16px;
+  padding: 16px;
+  gap: 12px;
+}
+
+body.is-todos-view .home-tile__header {
+  margin-bottom: 0;
+}
+
+body.is-todos-view .home-tile__title {
+  font-size: 20px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+/* Focus tile: slightly more prominent surface */
+body.is-todos-view .home-tile[data-home-tile="top_focus"] {
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 60%, transparent);
+}
+
+/* Up Next / Due Soon tile: lighter surface */
+body.is-todos-view .home-tile[data-home-tile="due_soon"],
+body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
+  background: color-mix(in oklab, var(--surface) 98%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 40%, transparent);
+}
+
+/* Remove old toolbar spacing */
+.home-dashboard__toolbar {
+  display: none;
+}
+
+/* Remove app-sidebar__bottom styles (no longer used) */
+.app-sidebar__bottom {
+  display: none;
+}
+
+/* Override home-dashboard grid on mobile */
+@media (max-width: 900px) {
+  .home-dashboard {
+    padding: 20px 20px 32px;
+    gap: 24px;
+  }
+}
+
 /* Things-inspired surface refinement: final override layer */
 body.is-todos-view #todosView[data-surface-mode="list"] .todos-list-header {
   padding: 6px 2px 12px;

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -477,13 +477,13 @@ test.describe("Home focus dashboard + sheet composer", () => {
 
     await expect(page.locator('[data-home-tile="top_focus"]')).toBeVisible();
     await expect(page.locator('[data-home-tile="top_focus"]')).toContainText(
-      "Top Focus",
+      "Focus",
     );
     await expect(page.locator('[data-home-tile="top_focus"]')).toContainText(
-      /Your 3 most important items right now|Nothing urgent right now|Send overdue invoice/,
+      /Nothing urgent right now|Send overdue invoice/,
     );
     await expect(page.locator('[data-home-tile="due_soon"]')).toContainText(
-      /Due Soon|Prepare launch checklist|No tasks/,
+      /Up Next|Prepare launch checklist|No tasks/,
     );
   });
 
@@ -531,18 +531,10 @@ test.describe("Home focus dashboard + sheet composer", () => {
     ).toBeVisible();
   });
 
-  test("See all navigates for Due Soon and Quick Wins", async ({ page }) => {
-    const dueSoonTile = page.locator('[data-home-tile="due_soon"]');
-    await dueSoonTile.getByRole("button", { name: "See all" }).click();
-    await expect(page.locator("#todosListHeaderTitle")).toHaveText("Due Soon");
-    await expectListOrEmptyState(page);
-
-    await clickWorkspaceView(page, "home");
-    const quickWinsTile = page.locator('[data-home-tile="quick_wins"]');
-    await quickWinsTile.getByRole("button", { name: "See all" }).click();
-    await expect(page.locator("#todosListHeaderTitle")).toHaveText(
-      "Quick Wins",
-    );
+  test("See all navigates for Up Next", async ({ page }) => {
+    const upNextTile = page.locator('[data-home-tile="due_soon"]');
+    await upNextTile.getByRole("button", { name: "See all" }).click();
+    await expect(page.locator("#todosListHeaderTitle")).toHaveText("Up Next");
     await expectListOrEmptyState(page);
   });
 });


### PR DESCRIPTION
## Summary

- Replace sidebar "Collapse" text button with icon-only hamburger toggle (☰); `aria-label` updates dynamically on collapse/expand
- Remove `app-sidebar__bottom` (Theme + Logout buttons); move Logout into `projects-rail__footer` for both desktop rail and mobile sheet
- Home dashboard: single-column layout replacing 2×2 grid; add "Home" title + "+ New Task" header row
- Rename tiles: "Top Focus" → "Focus", "Due Soon" → "Up Next"; remove Quick Wins tile and all descriptive subcopy
- Remove blue body-gradient bleed around main content (`appMainScroll padding: 0`)

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run format:check` — passes
- [x] `npm run lint:html` — passes
- [x] `npm run lint:css` — passes
- [x] `npm run test:unit` — 200 passed
- [x] `CI=1 npm run test:ui:fast` — 195 passed, 33 skipped
- [x] `home-focus-dashboard.spec.ts` — 10 passed
- [x] Visual verification: hamburger toggle, single-column home, Focus/Up Next/Projects to Nudge tiles, Logout in rail footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)