### PR TITLE
feat(ui): add Lucide icons, polish sidebar nav, and restore Logout button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1524,8 +1524,19 @@ async function hydrateHomeTopFocusIfNeeded() {
   }
 }
 
+const HOME_BADGE_ICONS = {
+  Overdue: `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>`,
+  Today: `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"/><line x1="16" x2="16" y1="2" y2="6"/><line x1="8" x2="8" y1="2" y2="6"/><line x1="3" x2="21" y1="10" y2="10"/><path d="M8 14h.01"/><path d="M12 14h.01"/></svg>`,
+  Tomorrow: `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`,
+};
+
 function renderHomeTaskRow(todo, { reason = "" } = {}) {
   const dueBadge = formatHomeDueBadge(todo);
+  const badgeIcon =
+    HOME_BADGE_ICONS[dueBadge] ??
+    (dueBadge
+      ? `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
+      : "");
   return `
     <div class="home-task-row" data-home-todo-id="${escapeHtml(String(todo.id))}">
       <input
@@ -1543,7 +1554,7 @@ function renderHomeTaskRow(todo, { reason = "" } = {}) {
       >
         ${escapeHtml(String(todo.title || "Untitled task"))}
       </button>
-      ${dueBadge ? `<span class="home-task-row__badge ${dueBadge === "Overdue" ? "home-task-row__badge--overdue" : ""}">${escapeHtml(dueBadge)}</span>` : ""}
+      ${dueBadge ? `<span class="home-task-row__badge ${dueBadge === "Overdue" ? "home-task-row__badge--overdue" : ""}">${badgeIcon}${escapeHtml(dueBadge)}</span>` : ""}
       ${reason ? `<div class="home-task-row__reason">${escapeHtml(reason)}</div>` : ""}
     </div>
   `;
@@ -1591,11 +1602,16 @@ function renderHomeTaskTile({
             )
             .join("")
       : `<div class="home-tile__empty">${escapeHtml(emptyText)}</div>`;
+  const TILE_ICON_SVG = {
+    top_focus: `<svg class="home-tile__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>`,
+    due_soon: `<svg class="home-tile__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16.5 12"/></svg>`,
+  };
+  const tileIcon = TILE_ICON_SVG[key] ?? "";
   return `
     <section class="home-tile" data-home-tile="${escapeHtml(key)}">
       <div class="home-tile__header">
-        <div>
-          <h3 class="home-tile__title">${escapeHtml(title)}</h3>
+        <div class="home-tile__title-row">
+          ${tileIcon}<h3 class="home-tile__title">${escapeHtml(title)}</h3>
           ${subtitle ? `<p class="home-tile__subtitle">${escapeHtml(subtitle)}</p>` : ""}
         </div>
         ${showSeeAll ? `<button type="button" class="mini-btn home-tile__see-all" data-onclick="openHomeTileList('${escapeHtml(key)}')">${escapeHtml(seeAllLabel)}</button>` : ""}
@@ -1613,10 +1629,14 @@ function renderHomeTaskTile({
 }
 
 function renderProjectsToNudgeTile(items = []) {
+  const folderIcon = `<svg class="home-project-row__icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>`;
   return `
     <section class="home-tile" data-home-tile="projects_to_nudge">
       <div class="home-tile__header">
-        <h3 class="home-tile__title">Projects to Nudge</h3>
+        <div class="home-tile__title-row">
+          <svg class="home-tile__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+          <h3 class="home-tile__title">Projects to Nudge</h3>
+        </div>
       </div>
       <div class="home-tile__body">
         ${
@@ -1629,7 +1649,7 @@ function renderProjectsToNudgeTile(items = []) {
                     class="home-project-row"
                     data-onclick="openHomeProject('${escapeHtml(project.projectName)}')"
                   >
-                    <span class="home-project-row__name">${escapeHtml(getProjectLeafName(project.projectName))}</span>
+                    <span class="home-project-row__header">${folderIcon}<span class="home-project-row__name">${escapeHtml(getProjectLeafName(project.projectName))}</span></span>
                     <span class="home-project-row__meta">${project.openCount} open${project.overdueCount ? ` · ${project.overdueCount} overdue` : ""}${project.dueSoonCount ? ` · ${project.dueSoonCount} due soon` : ""}</span>
                   </button>
                 `,
@@ -6136,6 +6156,7 @@ function renderProjectsRailListHtml({ projects, selectedProject }) {
             data-project-key="${escapeHtml(projectName)}"
             ${isActive ? 'aria-current="page"' : ""}
           >
+            <svg class="nav-icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
             <span class="projects-rail-item__label" title="${escapeHtml(getProjectLeafName(projectName))}">${escapeHtml(getProjectLeafName(projectName))}</span>
             <span class="projects-rail-item__count">${count}</span>
           </button>

--- a/public/index.html
+++ b/public/index.html
@@ -257,11 +257,22 @@
                         aria-label="Collapse sidebar"
                         aria-expanded="true"
                       >
-                        <span
+                        <svg
                           class="sidebar-toggle-btn__icon"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
                           aria-hidden="true"
-                          >☰</span
                         >
+                          <rect width="18" height="18" x="3" y="3" rx="2" />
+                          <path d="M9 3v18" />
+                        </svg>
                       </button>
                     </div>
                     <div class="rail-search-container" id="railSearchContainer">
@@ -269,6 +280,21 @@
                         <label for="searchInput" class="sr-only"
                           >Search todos</label
                         >
+                        <span class="search-icon" aria-hidden="true"
+                          ><svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <circle cx="11" cy="11" r="8" />
+                            <path d="m21 21-4.3-4.3" /></svg
+                        ></span>
                         <input
                           type="text"
                           id="searchInput"
@@ -277,7 +303,6 @@
                           autocomplete="off"
                           data-oninput="filterTodos()"
                         />
-                        <span class="search-icon" aria-hidden="true">🔍</span>
                       </div>
                       <button
                         id="moreFiltersToggle"
@@ -363,14 +388,52 @@
                           data-workspace-view="home"
                           aria-current="page"
                         >
-                          <span>Home</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+                            />
+                            <polyline points="9 22 9 12 15 12 15 22" />
+                          </svg>
+                          <span class="nav-label">Home</span>
                         </button>
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="unsorted"
                         >
-                          <span>Unsorted</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <polyline
+                              points="22 12 16 12 14 15 10 15 8 12 2 12"
+                            />
+                            <path
+                              d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                            />
+                          </svg>
+                          <span class="nav-label">Unsorted</span>
                           <span class="projects-rail-item__count">0</span>
                         </button>
                         <button
@@ -378,7 +441,26 @@
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="all"
                         >
-                          <span>All tasks</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect x="3" y="5" width="6" height="6" rx="1" />
+                            <path d="m3 17 2 2 4-4" />
+                            <path d="M13 6h8" />
+                            <path d="M13 12h8" />
+                            <path d="M13 18h8" />
+                          </svg>
+                          <span class="nav-label">All tasks</span>
                           <span class="projects-rail-item__count">0</span>
                         </button>
                         <button
@@ -386,27 +468,92 @@
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="today"
                         >
-                          <span>Today</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect
+                              width="18"
+                              height="18"
+                              x="3"
+                              y="4"
+                              rx="2"
+                              ry="2"
+                            />
+                            <line x1="16" x2="16" y1="2" y2="6" />
+                            <line x1="8" x2="8" y1="2" y2="6" />
+                            <line x1="3" x2="21" y1="10" y2="10" />
+                            <path d="M8 14h.01" />
+                            <path d="M12 14h.01" />
+                            <path d="M16 14h.01" />
+                            <path d="M8 18h.01" />
+                            <path d="M12 18h.01" />
+                            <path d="M16 18h.01" />
+                          </svg>
+                          <span class="nav-label">Today</span>
                         </button>
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="upcoming"
                         >
-                          <span>Upcoming</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <polyline points="12 6 12 12 16.5 12" />
+                          </svg>
+                          <span class="nav-label">Upcoming</span>
                         </button>
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="completed"
                         >
-                          <span>Completed</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <path d="m9 12 2 2 4-4" />
+                          </svg>
+                          <span class="nav-label">Completed</span>
                         </button>
                       </nav>
                     </div>
                     <div class="projects-rail__section">
                       <div class="projects-rail__section-header">
-                        <span>Projects</span>
+                        <span class="projects-rail__section-label"
+                          >Projects</span
+                        >
                         <button
                           id="projectsRailCreateButton"
                           type="button"
@@ -432,13 +579,29 @@
                         class="projects-rail-item"
                         data-onclick="switchView('settings', this)"
                       >
-                        <span class="projects-rail-item__label"
-                          >⚙ Settings</span
+                        <svg
+                          class="nav-icon"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="15"
+                          height="15"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
                         >
+                          <path
+                            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                          />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                        <span class="projects-rail-item__label">Settings</span>
                       </button>
                       <button
                         type="button"
-                        class="projects-rail-item"
+                        class="projects-rail-item projects-rail-item--logout"
                         data-onclick="logout()"
                       >
                         <span class="projects-rail-item__label">Logout</span>
@@ -448,7 +611,7 @@
                         class="projects-rail-item admin-rail-btn"
                         data-onclick="switchView('admin', this)"
                       >
-                        <span class="projects-rail-item__label">⭐ Admin</span>
+                        <span class="projects-rail-item__label">Admin</span>
                       </button>
                     </div>
                   </aside>
@@ -484,14 +647,52 @@
                           data-workspace-view="home"
                           aria-current="page"
                         >
-                          <span>Home</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+                            />
+                            <polyline points="9 22 9 12 15 12 15 22" />
+                          </svg>
+                          <span class="nav-label">Home</span>
                         </button>
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="unsorted"
                         >
-                          <span>Unsorted</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <polyline
+                              points="22 12 16 12 14 15 10 15 8 12 2 12"
+                            />
+                            <path
+                              d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                            />
+                          </svg>
+                          <span class="nav-label">Unsorted</span>
                           <span class="projects-rail-item__count">0</span>
                         </button>
                         <button
@@ -499,7 +700,26 @@
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="all"
                         >
-                          <span>All tasks</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect x="3" y="5" width="6" height="6" rx="1" />
+                            <path d="m3 17 2 2 4-4" />
+                            <path d="M13 6h8" />
+                            <path d="M13 12h8" />
+                            <path d="M13 18h8" />
+                          </svg>
+                          <span class="nav-label">All tasks</span>
                           <span class="projects-rail-item__count">0</span>
                         </button>
                         <button
@@ -507,21 +727,84 @@
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="today"
                         >
-                          <span>Today</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect
+                              width="18"
+                              height="18"
+                              x="3"
+                              y="4"
+                              rx="2"
+                              ry="2"
+                            />
+                            <line x1="16" x2="16" y1="2" y2="6" />
+                            <line x1="8" x2="8" y1="2" y2="6" />
+                            <line x1="3" x2="21" y1="10" y2="10" />
+                            <path d="M8 14h.01" />
+                            <path d="M12 14h.01" />
+                            <path d="M16 14h.01" />
+                            <path d="M8 18h.01" />
+                            <path d="M12 18h.01" />
+                            <path d="M16 18h.01" />
+                          </svg>
+                          <span class="nav-label">Today</span>
                         </button>
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="upcoming"
                         >
-                          <span>Upcoming</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <polyline points="12 6 12 12 16.5 12" />
+                          </svg>
+                          <span class="nav-label">Upcoming</span>
                         </button>
                         <button
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="completed"
                         >
-                          <span>Completed</span>
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <path d="m9 12 2 2 4-4" />
+                          </svg>
+                          <span class="nav-label">Completed</span>
                         </button>
                       </nav>
                     </div>
@@ -533,6 +816,21 @@
                         <label for="searchInputSheet" class="sr-only"
                           >Search todos</label
                         >
+                        <span class="search-icon" aria-hidden="true"
+                          ><svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                          >
+                            <circle cx="11" cy="11" r="8" />
+                            <path d="m21 21-4.3-4.3" /></svg
+                        ></span>
                         <input
                           type="text"
                           id="searchInputSheet"
@@ -541,7 +839,6 @@
                           autocomplete="off"
                           data-oninput="syncSheetSearch()"
                         />
-                        <span class="search-icon" aria-hidden="true">🔍</span>
                       </div>
                       <div
                         id="moreFiltersPanelSheet"
@@ -610,7 +907,9 @@
                     </div>
                     <div class="projects-rail__section">
                       <div class="projects-rail__section-header">
-                        <span>Projects</span>
+                        <span class="projects-rail__section-label"
+                          >Projects</span
+                        >
                         <button
                           id="projectsRailSheetCreateButton"
                           type="button"
@@ -633,13 +932,29 @@
                         class="projects-rail-item"
                         data-onclick="switchView('settings', this)"
                       >
-                        <span class="projects-rail-item__label"
-                          >⚙ Settings</span
+                        <svg
+                          class="nav-icon"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="15"
+                          height="15"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
                         >
+                          <path
+                            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                          />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                        <span class="projects-rail-item__label">Settings</span>
                       </button>
                       <button
                         type="button"
-                        class="projects-rail-item"
+                        class="projects-rail-item projects-rail-item--logout"
                         data-onclick="logout()"
                       >
                         <span class="projects-rail-item__label">Logout</span>
@@ -649,7 +964,7 @@
                         class="projects-rail-item admin-rail-btn"
                         data-onclick="switchView('admin', this)"
                       >
-                        <span class="projects-rail-item__label">⭐ Admin</span>
+                        <span class="projects-rail-item__label">Admin</span>
                       </button>
                     </div>
                   </aside>

--- a/public/styles.css
+++ b/public/styles.css
@@ -6145,3 +6145,195 @@ body.is-todos-view
 body.is-todos-view #todosView .todos-top-bar[hidden] {
   display: none !important;
 }
+
+/* ── Icon & nav polish ────────────────────────────────────────────────────── */
+
+/* Nav icons: shared outline SVG style inside sidebar rows */
+.nav-icon {
+  flex-shrink: 0;
+  display: block;
+  opacity: 0.55;
+  transition: opacity 120ms ease;
+  color: currentColor;
+}
+
+.projects-rail-item:hover .nav-icon,
+.projects-rail-item--active .nav-icon,
+.projects-rail-item[aria-selected="true"] .nav-icon {
+  opacity: 0.85;
+}
+
+/* Nav labels: flex-grow text in sidebar rows */
+.nav-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Sidebar rows: flex-start layout so icon + label are left-aligned,
+   count floats right via margin-left:auto */
+body.is-todos-view .projects-rail-item {
+  justify-content: flex-start;
+}
+
+body.is-todos-view .projects-rail-item__label {
+  flex: 1 1 auto;
+}
+
+body.is-todos-view .projects-rail-item__count {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Remove the old > span:first-child overflow rule — nav-label handles it */
+body.is-todos-view .projects-rail-item > span:first-child {
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
+}
+
+/* Collapsed sidebar: icons lead, labels stay in DOM but constrained by existing
+   overflow rules so they remain accessible (visible to a11y / tests). */
+body.is-todos-view .projects-rail.projects-rail--collapsed .nav-icon {
+  opacity: 0.65;
+}
+
+/* Toggle button: SVG replaces the old __icon span (no size change needed) */
+.sidebar-toggle-btn__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Search: leading icon ─────────────────────────────────────────────────── */
+
+body.is-todos-view .search-bar .search-icon {
+  left: 9px;
+  right: auto;
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+}
+
+body.is-todos-view .search-input {
+  padding: 8px 12px 8px 30px;
+}
+
+/* ── Projects section header: quieter ────────────────────────────────────── */
+
+body.is-todos-view .projects-rail__section-label {
+  font-size: 10px;
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--text-muted) 80%, transparent);
+}
+
+body.is-todos-view .projects-rail-create-btn {
+  min-width: 22px;
+  min-height: 22px;
+  padding: 0 5px;
+  font-size: 0.9rem;
+  opacity: 0.55;
+  transition: opacity 120ms ease;
+}
+
+body.is-todos-view .projects-rail-create-btn:hover {
+  opacity: 1;
+}
+
+/* ── Home tile hierarchy ──────────────────────────────────────────────────── */
+
+/* Focus: visual hero — strongest surface, more padding, bolder title */
+body.is-todos-view .home-tile[data-home-tile="top_focus"] {
+  background: var(--surface);
+  border-color: color-mix(in oklab, var(--border-color) 75%, transparent);
+  box-shadow:
+    0 1px 4px rgb(15 23 42 / 6%),
+    0 4px 16px rgb(15 23 42 / 5%);
+  padding: 20px;
+}
+
+body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__title {
+  font-size: 22px;
+}
+
+/* Up Next: standard secondary */
+body.is-todos-view .home-tile[data-home-tile="due_soon"] {
+  background: color-mix(in oklab, var(--surface) 97%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 55%, transparent);
+}
+
+/* Projects to Nudge: lightest — no card frame, just a quiet list */
+body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 4px 4px 0;
+}
+
+body.is-todos-view
+  .home-tile[data-home-tile="projects_to_nudge"]
+  .home-tile__title {
+  font-size: 16px;
+  font-weight: var(--fw-semibold);
+  color: var(--text-secondary);
+}
+
+/* Section title row: icon + h3 side by side */
+.home-tile__title-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.home-tile__icon {
+  flex-shrink: 0;
+  opacity: 0.5;
+  color: currentColor;
+}
+
+body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__icon {
+  opacity: 0.65;
+}
+
+/* ── Task badge: icon + label inline ─────────────────────────────────────── */
+
+.home-task-row__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+/* ── Home project row: icon + name header ────────────────────────────────── */
+
+.home-project-row__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.home-project-row__icon {
+  flex-shrink: 0;
+  opacity: 0.5;
+  color: var(--text-secondary);
+}
+
+.home-project-row__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.projects-rail-item--logout {
+  opacity: 0.55;
+  font-size: 0.8125rem;
+}
+
+.projects-rail-item--logout:hover {
+  opacity: 0.8;
+}


### PR DESCRIPTION
## Summary

- Add inline Lucide SVGs to all six workspace-view buttons (House, Inbox, ListTodo, CalendarDays, Clock3, CheckCircle2), sidebar toggle (PanelLeft), and Settings gear in footer
- Move search icon to leading (left) position with matching input padding
- Restore de-emphasised Logout button after Settings in both desktop and mobile sidebar footers
- Add Folder icon to dynamically-rendered project rail items
- Add section icons (Target, Clock3, Folder) to home dashboard tile headers
- Add metadata icons to home task-row due badges (AlertCircle/Overdue, CalendarDays/Today, ArrowRight/Tomorrow+upcoming)
- Quiet Projects section header (10px uppercase muted label)
- Home tile visual hierarchy: Focus = hero surface, Up Next = secondary, Projects to Nudge = transparent/borderless
- CSS: `nav-icon`/`nav-label` layout, `flex-start` rail rows, collapsed icon opacity

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run format:check` — Prettier clean
- [x] `npm run lint:html` — HTML valid
- [x] `npm run lint:css` — CSS clean
- [x] `CI=1 npm run test:ui:fast` — 195 passed, 33 skipped (mobile/desktop split), 0 failed
- [x] Sidebar footer contains Settings → Logout (de-emphasised) → Admin in both desktop and mobile rails
- [x] `app-smoke` logout tests pass (previously broken when Logout was removed)
- [x] `topbar-no-cta-clipping` and `layout-invariants` pass (collapsed label visibility preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)