### PR TITLE
feat(ui): add bottom action dock, clean up sidebar footer

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4482,7 +4482,7 @@ function closeProjectCrudModal({ restoreFocus = true } = {}) {
     if (lastProjectCrudOpener?.isConnected) {
       lastProjectCrudOpener.focus({ preventScroll: true });
     } else {
-      const fallback = document.getElementById("projectsRailCreateButton");
+      const fallback = document.getElementById("dockNewProjectBtn");
       if (fallback instanceof HTMLElement) {
         fallback.focus({ preventScroll: true });
       }
@@ -5279,7 +5279,6 @@ function getProjectsRailElements() {
   if (!(unsortedButton instanceof HTMLElement)) return null;
   if (!(mobileOpenButton instanceof HTMLElement)) return null;
   if (!(mobileCloseButton instanceof HTMLElement)) return null;
-  if (!(createButton instanceof HTMLElement)) return null;
   if (!(sheetCreateButton instanceof HTMLElement)) return null;
   if (!(sheet instanceof HTMLElement)) return null;
   if (!(sheetList instanceof HTMLElement)) return null;

--- a/public/index.html
+++ b/public/index.html
@@ -554,14 +554,6 @@
                         <span class="projects-rail__section-label"
                           >Projects</span
                         >
-                        <button
-                          id="projectsRailCreateButton"
-                          type="button"
-                          class="mini-btn projects-rail-create-btn"
-                          aria-label="Create project"
-                        >
-                          +
-                        </button>
                       </div>
                       <div id="projectsRailList" class="projects-rail__list">
                         <div
@@ -573,39 +565,9 @@
                         </div>
                       </div>
                     </div>
-                    <div class="projects-rail__footer">
-                      <button
-                        type="button"
-                        class="projects-rail-item"
-                        data-onclick="switchView('settings', this)"
-                      >
-                        <svg
-                          class="nav-icon"
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="15"
-                          height="15"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path
-                            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
-                          />
-                          <circle cx="12" cy="12" r="3" />
-                        </svg>
-                        <span class="projects-rail-item__label">Settings</span>
-                      </button>
-                      <button
-                        type="button"
-                        class="projects-rail-item projects-rail-item--logout"
-                        data-onclick="logout()"
-                      >
-                        <span class="projects-rail-item__label">Logout</span>
-                      </button>
+                    <div
+                      class="projects-rail__footer projects-rail__footer--admin-only"
+                    >
                       <button
                         type="button"
                         class="projects-rail-item admin-rail-btn"
@@ -926,39 +888,9 @@
                         </div>
                       </div>
                     </div>
-                    <div class="projects-rail__footer">
-                      <button
-                        type="button"
-                        class="projects-rail-item"
-                        data-onclick="switchView('settings', this)"
-                      >
-                        <svg
-                          class="nav-icon"
-                          xmlns="http://www.w3.org/2000/svg"
-                          width="15"
-                          height="15"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path
-                            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
-                          />
-                          <circle cx="12" cy="12" r="3" />
-                        </svg>
-                        <span class="projects-rail-item__label">Settings</span>
-                      </button>
-                      <button
-                        type="button"
-                        class="projects-rail-item projects-rail-item--logout"
-                        data-onclick="logout()"
-                      >
-                        <span class="projects-rail-item__label">Logout</span>
-                      </button>
+                    <div
+                      class="projects-rail__footer projects-rail__footer--admin-only"
+                    >
                       <button
                         type="button"
                         class="projects-rail-item admin-rail-btn"
@@ -1743,6 +1675,165 @@
         </div>
       </main>
     </div>
+
+    <!-- Bottom Action Dock -->
+    <div
+      id="bottomActionDock"
+      class="bottom-action-dock"
+      role="toolbar"
+      aria-label="Global actions"
+    >
+      <div class="dock__group dock__group--left">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          data-onclick="switchView('settings', this)"
+          aria-label="Settings"
+          title="Settings"
+        >
+          <svg
+            class="dock-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path
+              d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+            />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="dock-icon-btn"
+          data-onclick="toggleTheme()"
+          aria-label="Toggle dark mode"
+          title="Toggle dark mode"
+        >
+          <svg
+            class="dock-icon dock-icon--moon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+          </svg>
+          <svg
+            class="dock-icon dock-icon--sun"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path
+              d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
+            />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="dock-icon-btn"
+          data-onclick="logout()"
+          aria-label="Logout"
+          title="Logout"
+        >
+          <svg
+            class="dock-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+        </button>
+      </div>
+      <div class="dock__group dock__group--right">
+        <button
+          id="dockNewProjectBtn"
+          type="button"
+          class="dock-action-btn dock-action-btn--secondary"
+          data-onclick="createProject()"
+          aria-label="New project"
+        >
+          <svg
+            class="dock-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path
+              d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+            />
+            <line x1="12" y1="11" x2="12" y2="17" />
+            <line x1="9" y1="14" x2="15" y2="14" />
+          </svg>
+          New Project
+        </button>
+        <button
+          type="button"
+          class="dock-action-btn dock-action-btn--primary"
+          data-onclick="openTaskComposer()"
+          aria-label="New task"
+        >
+          <svg
+            class="dock-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="16" />
+            <line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+          New Task
+        </button>
+      </div>
+    </div>
+
     <script src="/state.js" defer></script>
     <script src="/apiClient.js" defer></script>
     <script src="/utils.js" defer></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -6337,3 +6337,131 @@ body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__icon {
 .projects-rail-item--logout:hover {
   opacity: 0.8;
 }
+
+/* ========== BOTTOM ACTION DOCK ========== */
+.bottom-action-dock {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  height: 56px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--s-5);
+  background: var(--surface-2);
+  border-top: 1px solid var(--border-color);
+  gap: var(--s-3);
+}
+
+body.is-todos-view .bottom-action-dock {
+  display: flex;
+}
+
+@media (max-width: 768px) {
+  .bottom-action-dock {
+    display: none !important;
+  }
+}
+
+.dock__group {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.dock-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.dock-icon-btn:hover {
+  background: var(--card-hover);
+  color: var(--text);
+}
+
+.dock-icon-btn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.dock-icon--sun {
+  display: none;
+}
+
+body.dark-mode .dock-icon--moon {
+  display: none;
+}
+
+body.dark-mode .dock-icon--sun {
+  display: block;
+}
+
+.dock-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-1);
+  height: 36px;
+  padding: 0 var(--s-4);
+  border-radius: var(--r-sm);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.dock-action-btn:hover {
+  opacity: 0.88;
+}
+
+.dock-action-btn:focus-visible {
+  box-shadow: var(--focus-ring);
+  outline: none;
+}
+
+.dock-action-btn--primary {
+  border: none;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+}
+
+.dock-action-btn--secondary {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--muted);
+}
+
+.dock-action-btn--secondary:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+#todosScrollRegion {
+  padding-bottom: 72px;
+}
+
+#projectsRail {
+  padding-bottom: 72px;
+}
+
+.projects-rail__footer--admin-only {
+  display: none;
+}
+
+body.is-admin-user .projects-rail__footer--admin-only {
+  display: flex;
+}

--- a/tests/ui/project-crud.spec.ts
+++ b/tests/ui/project-crud.spec.ts
@@ -355,7 +355,7 @@ test.describe("Projects rail CRUD", () => {
   }) => {
     test.skip(isMobile, "Desktop-focused CRUD rail interactions");
 
-    await page.locator("#projectsRailCreateButton").click();
+    await page.locator("#dockNewProjectBtn").click();
     await expect(page.locator("#projectCrudModal")).toBeVisible();
     await page.locator("#projectCrudNameInput").fill("Errands");
     await page.locator("#projectCrudSubmitButton").click();
@@ -456,12 +456,12 @@ test.describe("Projects rail CRUD", () => {
   }) => {
     test.skip(isMobile, "Desktop-focused CRUD rail interactions");
 
-    await page.locator("#projectsRailCreateButton").click();
+    await page.locator("#dockNewProjectBtn").click();
     await page.locator("#projectCrudNameInput").fill("Chores");
     await page.locator("#projectCrudSubmitButton").click();
     await expect(page.locator("#projectCrudModal")).toBeHidden();
 
-    await page.locator("#projectsRailCreateButton").click();
+    await page.locator("#dockNewProjectBtn").click();
     await page.locator("#projectCrudNameInput").fill("Chores");
     await page.locator("#projectCrudSubmitButton").click();
 


### PR DESCRIPTION
## Summary

- Adds a persistent fixed bottom dock (56px, desktop-only) with a left zone of icon-only utility buttons (Settings, theme toggle, Logout) and a right zone of labelled creation buttons (New Project secondary, New Task primary)
- Sidebar footer stripped to admin-only row; Settings and Logout rows removed from both desktop and mobile sheet rail instances
- Desktop `#projectsRailCreateButton` removed; its null-guard dropped from `getProjectsRailElements()` so the rail function no longer hard-depends on it
- Adds 72px `padding-bottom` to `#todosScrollRegion` and `#projectsRail` to prevent content hiding behind the dock
- Theme toggle uses CSS-only Moon↔Sun icon swap (`body.dark-mode` class) — no JS changes needed
- Updates 3 `project-crud.spec.ts` selectors from `#projectsRailCreateButton` → `#dockNewProjectBtn`

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint:html` — clean
- [x] `npm run lint:css` — clean
- [x] `npm run test:unit` — 200/200 passed
- [x] `CI=1 npm run test:ui:fast` — 195 passed, 33 skipped (pre-existing mobile skips), 0 failed
- [ ] Visual: dock renders at bottom with correct layout, hidden on mobile, theme icon swaps correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)