### PR TITLE
feat(ui): UI polish pass — profile panel, active-state fix, heading refinements

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -189,6 +189,7 @@ let projectCrudTargetProject = "";
 let lastProjectCrudOpener = null;
 let isCommandPaletteOpen = false;
 let commandPaletteQuery = "";
+let isProfilePanelOpen = false;
 let commandPaletteIndex = 0;
 let commandPaletteItems = [];
 let commandPaletteSelectableItems = [];
@@ -1675,13 +1676,6 @@ function renderHomeDashboard() {
     <section class="home-dashboard" data-testid="home-dashboard">
       <div class="home-dashboard__header">
         <h2 class="home-dashboard__title">Home</h2>
-        <button
-          type="button"
-          class="add-btn home-dashboard__new-task"
-          data-onclick="openTaskComposer()"
-        >
-          + New Task
-        </button>
       </div>
       ${renderHomeTaskTile({
         key: "top_focus",
@@ -2202,6 +2196,7 @@ function init() {
   bindProjectsRailHandlers();
   bindCommandPaletteHandlers();
   bindTaskComposerHandlers();
+  bindDockHandlers();
   bindOnCreateAssistHandlers();
   bindTodayPlanHandlers();
   bindQuickEntryNaturalDateHandlers();
@@ -4988,6 +4983,10 @@ function syncWorkspaceViewState() {
       const view = item.getAttribute("data-workspace-view") || "all";
       const isActive = matchesWorkspaceView(view);
       item.classList.toggle("projects-rail-item--active", isActive);
+      // Clear the project-option aria-selected so the CSS rule
+      // [role="option"][aria-selected="true"] doesn't double-highlight
+      // workspace items when a matching project is selected.
+      item.setAttribute("aria-selected", "false");
       if (isActive) {
         item.setAttribute("aria-current", "page");
       } else {
@@ -11098,6 +11097,12 @@ document.addEventListener("keydown", function (e) {
     return;
   }
 
+  if (e.key === "Escape" && isProfilePanelOpen) {
+    e.preventDefault();
+    closeProfilePanel({ restoreFocus: true });
+    return;
+  }
+
   if (e.key === "Escape" && openTodoKebabId) {
     e.preventDefault();
     closeTodoKebabMenu({ restoreFocus: true });
@@ -11926,6 +11931,54 @@ function bindCriticalHandlers() {
     });
     resendBtn.dataset.bound = "true";
   }
+}
+
+// Profile panel (dock)
+function toggleProfilePanel() {
+  if (isProfilePanelOpen) {
+    closeProfilePanel({ restoreFocus: true });
+  } else {
+    const panel = document.getElementById("dockProfilePanel");
+    if (!(panel instanceof HTMLElement)) return;
+    const emailEl = document.getElementById("dockProfileEmail");
+    if (emailEl instanceof HTMLElement) {
+      emailEl.textContent = currentUser?.email ?? "";
+    }
+    panel.hidden = false;
+    isProfilePanelOpen = true;
+  }
+}
+
+function closeProfilePanel({ restoreFocus = false } = {}) {
+  const panel = document.getElementById("dockProfilePanel");
+  if (panel instanceof HTMLElement) {
+    panel.hidden = true;
+  }
+  isProfilePanelOpen = false;
+  if (restoreFocus) {
+    const trigger = document.getElementById("dockProfileBtn");
+    if (trigger instanceof HTMLElement) trigger.focus();
+  }
+}
+
+function bindDockHandlers() {
+  if (window.__dockHandlersBound) return;
+  window.__dockHandlersBound = true;
+
+  document.addEventListener("click", (event) => {
+    if (!isProfilePanelOpen) return;
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const panel = document.getElementById("dockProfilePanel");
+    const trigger = document.getElementById("dockProfileBtn");
+    if (
+      (panel instanceof HTMLElement && panel.contains(target)) ||
+      (trigger instanceof HTMLElement && trigger.contains(target))
+    ) {
+      return;
+    }
+    closeProfilePanel({ restoreFocus: false });
+  });
 }
 
 // Logout

--- a/public/index.html
+++ b/public/index.html
@@ -1752,11 +1752,13 @@
           </svg>
         </button>
         <button
+          id="dockProfileBtn"
           type="button"
           class="dock-icon-btn"
-          data-onclick="logout()"
-          aria-label="Logout"
-          title="Logout"
+          data-onclick="toggleProfilePanel()"
+          aria-label="Profile"
+          aria-haspopup="true"
+          title="Profile"
         >
           <svg
             class="dock-icon"
@@ -1771,9 +1773,9 @@
             stroke-linejoin="round"
             aria-hidden="true"
           >
-            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-            <polyline points="16 17 21 12 16 7" />
-            <line x1="21" y1="12" x2="9" y2="12" />
+            <circle cx="12" cy="12" r="10" />
+            <circle cx="12" cy="10" r="3" />
+            <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662" />
           </svg>
         </button>
       </div>
@@ -1832,6 +1834,25 @@
           New Task
         </button>
       </div>
+    </div>
+
+    <!-- Profile panel (anchored above dock Profile button) -->
+    <div
+      id="dockProfilePanel"
+      class="dock-profile-panel"
+      hidden
+      role="dialog"
+      aria-label="Profile"
+    >
+      <span id="dockProfileEmail" class="dock-profile-panel__email"></span>
+      <button
+        type="button"
+        class="dock-profile-panel__logout"
+        data-onclick="logout()"
+        aria-label="Logout"
+      >
+        Logout
+      </button>
     </div>
 
     <script src="/state.js" defer></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -5604,12 +5604,15 @@ body.is-todos-view .projects-rail-item__count {
   border: 1px solid color-mix(in oklab, var(--border-color) 60%, transparent);
   background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
   color: var(--text-primary);
-  border-radius: 12px;
-  padding: 9px 10px;
+  border-radius: 10px;
+  padding: 10px 12px;
   text-align: left;
   cursor: pointer;
   display: grid;
-  gap: 3px;
+  gap: 4px;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease;
 }
 
 .home-project-row:hover {
@@ -6224,11 +6227,10 @@ body.is-todos-view .search-input {
 /* ── Projects section header: quieter ────────────────────────────────────── */
 
 body.is-todos-view .projects-rail__section-label {
-  font-size: 10px;
-  font-weight: var(--fw-semibold);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: color-mix(in oklab, var(--text-muted) 80%, transparent);
+  font-size: 11px;
+  font-weight: var(--fw-medium);
+  letter-spacing: 0.02em;
+  color: color-mix(in oklab, var(--text-muted) 75%, transparent);
 }
 
 body.is-todos-view .projects-rail-create-btn {
@@ -6271,7 +6273,14 @@ body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
   background: transparent;
   border: none;
   box-shadow: none;
-  padding: 4px 4px 0;
+  padding: 8px 4px 0;
+}
+
+body.is-todos-view
+  .home-tile[data-home-tile="projects_to_nudge"]
+  .home-tile__body {
+  display: grid;
+  gap: 6px;
 }
 
 body.is-todos-view
@@ -6464,4 +6473,70 @@ body.dark-mode .dock-icon--sun {
 
 body.is-admin-user .projects-rail__footer--admin-only {
   display: flex;
+}
+
+/* ========== PROFILE PANEL (dock) ========== */
+
+.dock-profile-panel {
+  position: fixed;
+  bottom: 64px;
+  left: var(--s-5);
+  z-index: 55;
+  width: 220px;
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  box-shadow:
+    0 4px 12px rgb(0 0 0 / 8%),
+    0 1px 4px rgb(0 0 0 / 5%);
+  padding: var(--s-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+}
+
+/* Author CSS overrides UA [hidden]{display:none} — restore it explicitly. */
+.dock-profile-panel[hidden] {
+  display: none;
+}
+
+.dock-profile-panel__email {
+  display: block;
+  padding: 2px var(--s-2);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dock-profile-panel__logout {
+  width: 100%;
+  padding: 6px var(--s-2);
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.dock-profile-panel__logout:hover {
+  background: var(--card-hover);
+  color: var(--text);
+}
+
+.dock-profile-panel__logout:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+@media (max-width: 768px) {
+  .dock-profile-panel {
+    display: none !important;
+  }
 }

--- a/tests/ui/app-smoke.spec.ts
+++ b/tests/ui/app-smoke.spec.ts
@@ -4,6 +4,19 @@ import {
   openTaskComposerSheet,
 } from "./helpers/todos-view";
 
+/**
+ * Clicks logout regardless of viewport. On desktop the logout option lives
+ * inside the Profile panel (dock); on mobile it's a direct button in the
+ * header bar. Opens the panel first when it's visible.
+ */
+async function clickLogout(page: Page) {
+  const profileBtn = page.locator("#dockProfileBtn");
+  if (await profileBtn.isVisible()) {
+    await profileBtn.click();
+  }
+  await page.getByRole("button", { name: "Logout" }).click();
+}
+
 type UserRecord = {
   id: string;
   email: string;
@@ -271,7 +284,7 @@ test.describe("App smoke flows", () => {
     await ensureAllTasksListActive(page);
     await expect(page.locator(".todo-item .todo-title")).toHaveCount(0);
 
-    await page.getByRole("button", { name: "Logout" }).click();
+    await clickLogout(page);
     await expect(page.locator("#authView")).toHaveClass(/active/);
 
     await page.getByRole("button", { name: "Register" }).click();
@@ -304,7 +317,7 @@ test.describe("App smoke flows", () => {
     );
     await expect(page.locator("#dateViewSomeday")).toHaveClass(/active/);
 
-    await page.getByRole("button", { name: "Logout" }).click();
+    await clickLogout(page);
     await expect(page.locator("#authView")).toHaveClass(/active/);
 
     await page.getByRole("button", { name: "Register" }).click();


### PR DESCRIPTION
## Summary

- **Profile panel**: Replaces dock logout icon with a CircleUser Profile button that opens a small popover showing the user's email and a "Logout" action; includes outside-click and ESC dismissal
- **Active-state bug fix**: `syncWorkspaceViewState()` now sets `aria-selected="false"` on workspace-view items, preventing the project-option CSS rule from double-highlighting them when a project is selected
- **Home dashboard cleanup**: Removes the duplicate "New Task" button from the home header — the dock's primary action button is the canonical entry point
- **Visual refinements**: Softer "Projects" section label (no uppercase, lighter weight), more breathing room in Projects-to-Nudge rows, tighter home-project-row padding and transitions
- **Test update**: `clickLogout()` helper in smoke tests handles the two-step flow on desktop (open panel → click Logout) while mobile header path remains unchanged

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run lint:html` — clean
- [x] `npm run lint:css` — clean
- [x] `npm run test:unit` — 200/200
- [x] `CI=1 npm run test:ui:fast` — 195 passed, 33 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)