### PR TITLE
feat(ui): icon-only collapsed sidebar rail at 64px

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -387,6 +387,7 @@
                           class="projects-rail-item workspace-view-item projects-rail-item--active"
                           data-workspace-view="home"
                           aria-current="page"
+                          title="Home"
                         >
                           <svg
                             class="nav-icon"
@@ -412,6 +413,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="unsorted"
+                          title="Unsorted"
                         >
                           <svg
                             class="nav-icon"
@@ -440,6 +442,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="all"
+                          title="All tasks"
                         >
                           <svg
                             class="nav-icon"
@@ -467,6 +470,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="today"
+                          title="Today"
                         >
                           <svg
                             class="nav-icon"
@@ -505,6 +509,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="upcoming"
+                          title="Upcoming"
                         >
                           <svg
                             class="nav-icon"
@@ -528,6 +533,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="completed"
+                          title="Completed"
                         >
                           <svg
                             class="nav-icon"
@@ -608,6 +614,7 @@
                           class="projects-rail-item workspace-view-item projects-rail-item--active"
                           data-workspace-view="home"
                           aria-current="page"
+                          title="Home"
                         >
                           <svg
                             class="nav-icon"
@@ -633,6 +640,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="unsorted"
+                          title="Unsorted"
                         >
                           <svg
                             class="nav-icon"
@@ -661,6 +669,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="all"
+                          title="All tasks"
                         >
                           <svg
                             class="nav-icon"
@@ -688,6 +697,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="today"
+                          title="Today"
                         >
                           <svg
                             class="nav-icon"
@@ -726,6 +736,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="upcoming"
+                          title="Upcoming"
                         >
                           <svg
                             class="nav-icon"
@@ -749,6 +760,7 @@
                           type="button"
                           class="projects-rail-item workspace-view-item"
                           data-workspace-view="completed"
+                          title="Completed"
                         >
                           <svg
                             class="nav-icon"

--- a/public/styles.css
+++ b/public/styles.css
@@ -1727,7 +1727,7 @@ textarea:focus-visible,
 }
 
 .todos-layout--rail-collapsed {
-  grid-template-columns: 84px minmax(0, 1fr);
+  grid-template-columns: 64px minmax(0, 1fr);
 }
 
 .todos-layout--sidebar-mounted {
@@ -1914,9 +1914,9 @@ textarea:focus-visible,
 }
 
 .projects-rail.projects-rail--collapsed {
-  width: 84px;
-  padding-left: var(--s-2);
-  padding-right: var(--s-2);
+  width: 64px;
+  padding-left: var(--s-1);
+  padding-right: var(--s-1);
 }
 
 .projects-rail.projects-rail--collapsed .projects-rail__header {
@@ -6195,6 +6195,73 @@ body.is-todos-view .projects-rail-item > span:first-child {
   overflow: visible;
   text-overflow: unset;
   white-space: normal;
+}
+
+/* ── Collapsed sidebar: true icon-only rail ───────────────────────────────── */
+
+/* Nav labels (Home/Unsorted/All tasks/Today/Upcoming/Completed) disappear;
+   icons become the sole visual affordance. Use [title] on the button for
+   native browser tooltips (no JS required). */
+body.is-todos-view .projects-rail.projects-rail--collapsed .nav-label {
+  display: none;
+}
+
+/* Center each workspace nav icon in the 64 px column. */
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+  min-height: 40px;
+}
+
+/* Scale icon up slightly so it reads clearly at the smaller rail width. */
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item
+  .nav-icon {
+  width: 18px;
+  height: 18px;
+  opacity: 0.7;
+}
+
+/* Boost icon opacity on hover / active so state is still obvious. */
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item:hover
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item.projects-rail-item--active
+  .nav-icon {
+  opacity: 0.9;
+}
+
+/* Active pill: keep the subtle accent background; it reads as a centred chip
+   around the icon because the label is gone. */
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item.projects-rail-item--active {
+  border-radius: 10px;
+}
+
+/* Tighten the workspace section's bottom gap so the projects list below
+   doesn't have excess breathing room at 64 px. */
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__section--workspace {
+  margin-bottom: 0;
+}
+
+/* Projects list items: keep them in DOM (test constraint — tests assert
+   .projects-rail-item__label is visible and text-overflow is nowrap), but
+   push them to a compact strip. Count badges are already hidden globally. */
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-item:not(.workspace-view-item) {
+  min-height: 28px;
+  padding: 3px 4px;
 }
 
 /* Collapsed sidebar: icons lead, labels stay in DOM but constrained by existing


### PR DESCRIPTION
## Summary

- **Shrinks collapsed rail from 84 px → 64 px** — tighter, less wasted space
- **Hides `.nav-label` text in collapsed state** — Home/Unsorted/All tasks/Today/Upcoming/Completed become pure icon buttons
- **Centers workspace nav icons** with `justify-content: center`, 40 px min-height hit area, and 18×18 px icon scale-up
- **Native browser tooltips** via `title=` on all workspace nav buttons (no JS, no extra DOM)
- **Compact project list** at the bottom stays in DOM (tests assert label visibility + text-overflow in collapsed state), restyled to 28 px rows at the narrow width
- **Active pill** retains accent background; border-radius tightened to 10 px so it reads as a centred chip around the icon

## What did NOT change

- No JS changes — `setProjectsRailCollapsed()`, `updateTopbarProjectsButton()`, event delegation, and rail toggle all untouched
- Collapsed topbar (`#projectsRailMobileOpen`) behaviour unchanged — still visible when rail is collapsed so the existing desktop test passes
- Mobile layout untouched — `title=` on mobile sheet buttons is inert (no hover on touch)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean (auto-fixed CSS multiline selector formatting with `prettier --write`)
- [x] `npm run lint:html` — clean
- [x] `npm run lint:css` — clean
- [x] `npm run test:unit` — 200/200 passed
- [x] `CI=1 npm run test:ui:fast` — **195 passed, 33 skipped (@visual / isMobile), 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)