### PR TITLE
fix(ui): polish collapsed desktop rail layout and access

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -5763,6 +5763,35 @@ function getProjectsRailElements() {
   };
 }
 
+function openProjectsFromCollapsedRail(triggerEl = null) {
+  if (!isRailCollapsed) return;
+  setProjectsRailCollapsed(false);
+  renderProjectsRail();
+  window.requestAnimationFrame(() => {
+    const refs = getProjectsRailElements();
+    if (!refs) return;
+    const selected = refs.desktopRail.querySelector(
+      `.projects-rail-item[data-project-key="${escapeSelectorValue(getSelectedProjectKey())}"]`,
+    );
+    const firstProject = refs.desktopRail.querySelector(
+      ".projects-rail-item[data-project-key]",
+    );
+    const fallbackTarget =
+      (selected instanceof HTMLElement && selected) ||
+      (firstProject instanceof HTMLElement && firstProject) ||
+      refs.createButton;
+
+    if (fallbackTarget instanceof HTMLElement) {
+      fallbackTarget.focus({ preventScroll: true });
+      return;
+    }
+
+    if (triggerEl instanceof HTMLElement) {
+      triggerEl.focus({ preventScroll: true });
+    }
+  });
+}
+
 function isMobileRailViewport() {
   if (typeof window.matchMedia !== "function") return false;
   return window.matchMedia(MOBILE_DRAWER_MEDIA_QUERY).matches;
@@ -12121,6 +12150,16 @@ function bindProjectsRailHandlers() {
       event.preventDefault();
       event.stopPropagation();
       selectWorkspaceView(view, workspaceViewButton);
+      return;
+    }
+
+    const collapsedProjectsButton = target.closest(
+      "#projectsRailCollapsedProjectsButton",
+    );
+    if (collapsedProjectsButton instanceof HTMLElement) {
+      event.preventDefault();
+      event.stopPropagation();
+      openProjectsFromCollapsedRail(collapsedProjectsButton);
       return;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -553,6 +553,35 @@
                           </svg>
                           <span class="nav-label">Completed</span>
                         </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item projects-rail-projects-access"
+                          id="projectsRailCollapsedProjectsButton"
+                          title="Projects"
+                          aria-label="Projects"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M20 7h-9a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2Z"
+                            />
+                            <path
+                              d="M4 15h4a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2Z"
+                            />
+                          </svg>
+                          <span class="nav-label">Projects</span>
+                        </button>
                       </nav>
                     </div>
                     <div class="projects-rail__section">
@@ -569,6 +598,92 @@
                           <span>Sample Project</span>
                           <span class="projects-rail-item__count">0</span>
                         </div>
+                      </div>
+                    </div>
+                    <div class="projects-rail__spacer" aria-hidden="true"></div>
+                    <div
+                      class="projects-rail__section projects-rail__section--utilities"
+                    >
+                      <div class="projects-rail__utility-list">
+                        <button
+                          type="button"
+                          class="projects-rail-item projects-rail-utility-item sidebar-nav-item"
+                          data-sidebar-view="settings"
+                          data-onclick="switchView('settings', this)"
+                          title="Settings"
+                          aria-label="Settings"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                            />
+                            <circle cx="12" cy="12" r="3" />
+                          </svg>
+                          <span class="projects-rail-item__label"
+                            >Settings</span
+                          >
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item projects-rail-utility-item"
+                          data-onclick="toggleTheme()"
+                          title="Toggle dark mode"
+                          aria-label="Toggle dark mode"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+                          </svg>
+                          <span class="projects-rail-item__label">Theme</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item projects-rail-utility-item"
+                          data-onclick="toggleProfilePanel()"
+                          title="Profile"
+                          aria-label="Profile"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="8" r="4" />
+                            <path d="M6 20a6 6 0 0 1 12 0" />
+                          </svg>
+                          <span class="projects-rail-item__label">Profile</span>
+                        </button>
                       </div>
                     </div>
                     <div

--- a/public/styles.css
+++ b/public/styles.css
@@ -6375,6 +6375,30 @@ body.is-todos-view.is-projects-rail-collapsed #appSidebar {
   padding-left: 0;
   padding-right: 0;
 }
+
+body.is-todos-view .projects-rail {
+  display: flex;
+  flex-direction: column;
+}
+
+body.is-todos-view .projects-rail__spacer {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+body.is-todos-view .projects-rail__utility-list {
+  display: grid;
+  gap: 6px;
+}
+
+body.is-todos-view .projects-rail__section--utilities {
+  display: none;
+}
+
+body.is-todos-view .projects-rail-projects-access {
+  display: none;
+}
+
 body.is-todos-view .projects-rail.projects-rail--collapsed .nav-label,
 body.is-todos-view
   .projects-rail.projects-rail--collapsed
@@ -6387,14 +6411,51 @@ body.is-todos-view
 
 body.is-todos-view
   .projects-rail.projects-rail--collapsed
-  .projects-rail__section:not(.projects-rail__section--workspace),
+  .projects-rail__section:not(.projects-rail__section--workspace):not(
+    .projects-rail__section--utilities
+  ),
 body.is-todos-view .projects-rail.projects-rail--collapsed #projectsRailList {
   display: none;
 }
 
 body.is-todos-view
   .projects-rail.projects-rail--collapsed
-  .workspace-view-item {
+  .projects-rail__footer--admin-only {
+  display: none;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__header {
+  justify-content: center;
+  padding-bottom: 8px;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__section--workspace {
+  margin-top: 0;
+  padding-top: 8px;
+  border-top: 0;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__primary {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+}
+
+body.is-todos-view .projects-rail.projects-rail--collapsed .workspace-view-item,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-utility-item {
+  width: 46px;
+  min-width: 46px;
   justify-content: center;
   align-items: center;
   min-height: 46px;
@@ -6404,7 +6465,21 @@ body.is-todos-view
 
 body.is-todos-view
   .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access {
+  display: flex;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
   .workspace-view-item
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-utility-item
   .nav-icon {
   width: 18px;
   height: 18px;
@@ -6418,6 +6493,14 @@ body.is-todos-view
 body.is-todos-view
   .projects-rail.projects-rail--collapsed
   .workspace-view-item.projects-rail-item--active
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access:hover
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-utility-item:hover
   .nav-icon {
   opacity: 0.92;
 }
@@ -6426,6 +6509,23 @@ body.is-todos-view
   .projects-rail.projects-rail--collapsed
   .workspace-view-item.projects-rail-item--active {
   border-radius: 10px;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__section--utilities {
+  display: block;
+  margin-top: auto;
+  padding-top: 10px;
+  border-top: 1px solid
+    color-mix(in oklab, var(--border-color) 70%, transparent);
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__utility-list {
+  justify-items: center;
+  gap: 8px;
 }
 
 /* Toggle button: SVG replaces the old __icon span (no size change needed) */


### PR DESCRIPTION
Implemented on branch codex/collapsed-rail-polish (commit c306ae7).

Key updates:

Collapsed rail now uses a true top/bottom layout: toggle + primary nav at top, spacer in middle, utilities at bottom (no vertical centering of primary nav).
Added collapsed-only Projects icon in the primary nav. Current behavior uses your allowed fallback: clicking it expands the rail and focuses project selection so projects remain accessible.
Added collapsed utility stack (Settings/Theme/Profile) as vertical icon buttons with matching 46px hit areas and tooltips.
Kept collapsed rail icon-only behavior (no full project text list shown in collapsed state).
Changed files:

[public/index.html](app://-/index.html?hostId=local#)
[public/app.js](app://-/index.html?hostId=local#)
[public/styles.css](app://-/index.html?hostId=local#)