### PR TITLE
feat(ui): debounce input-event filter triggers (task 146)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,24 @@ const API_URL =
     ? "http://localhost:3000"
     : window.location.origin;
 
+// Debounce utility — no external dependency.
+// Fires on the leading edge (immediate on first call) and again on the
+// trailing edge (ms after the last call), so single-event triggers (e.g.
+// Playwright fill()) respond instantly while rapid keystrokes are batched.
+const DEBOUNCE_MS = 250;
+const debounce = (fn, ms) => {
+  let t;
+  return (...args) => {
+    const leading = !t;
+    clearTimeout(t);
+    t = setTimeout(() => {
+      t = null;
+      if (!leading) fn(...args);
+    }, ms);
+    if (leading) fn(...args);
+  };
+};
+
 // ---------------------------------------------------------------------------
 // Module consumption — extracted pure-function modules loaded before app.js
 // via <script defer> in index.html (see state.js, apiClient.js pattern).
@@ -13201,6 +13219,10 @@ function bindDeclarativeHandlers() {
   }
   window.__declarativeHandlersBound = true;
 
+  // Per-expression debounce cache: input events are debounced so that rapid
+  // keystrokes (e.g. typing into #searchInput) do not re-render on every key.
+  const inputDebouncedInvokers = new Map();
+
   const events = [
     "click",
     "submit",
@@ -13245,7 +13267,19 @@ function bindDeclarativeHandlers() {
       if (!element) return;
       const expression = element.dataset[attribute];
       if (!expression) return;
-      invokeBoundExpression(expression, event, element);
+      if (eventType === "input") {
+        let fn = inputDebouncedInvokers.get(expression);
+        if (!fn) {
+          fn = debounce(
+            (expr, ev, el) => invokeBoundExpression(expr, ev, el),
+            DEBOUNCE_MS,
+          );
+          inputDebouncedInvokers.set(expression, fn);
+        }
+        fn(expression, event, element);
+      } else {
+        invokeBoundExpression(expression, event, element);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary

- Adds a leading+trailing `debounce` utility (~10 lines, no deps) and `DEBOUNCE_MS = 250`
- Wires it into `bindDeclarativeHandlers` via a per-expression `inputDebouncedInvokers` Map, so only `data-oninput` events are debounced — `data-onchange` (e.g. `#categoryFilter`) remains synchronous
- **Leading edge** fires immediately on the first call, keeping single-event triggers (Playwright `fill()`) synchronous and test-transparent
- **Trailing edge** fires 250ms after the last rapid keystroke, preventing re-render thrashing during human typing

## Call sites debounced

| Source | Expression | Event type |
|---|---|---|
| `#searchInput` | `data-oninput="filterTodos()"` | `input` |
| `#searchInputSheet` | `data-oninput="syncSheetSearch()"` | `input` |

## Test plan

- [x] `npx tsc --noEmit` — pass
- [x] `npm run format:check` — pass (unchanged)
- [x] `npm run lint:html` — pass
- [x] `npm run lint:css` — pass
- [x] `npm run test:unit` — 207/207 pass
- [x] `CI=1 npm run test:ui:fast` — 204/204 pass (32 skipped @visual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)