### PR TITLE
refactor(ui): state actions, async lifecycle, and UI template helpers

### DIFF
--- a/client/modules/aiWorkspace.js
+++ b/client/modules/aiWorkspace.js
@@ -4,6 +4,7 @@
 import { state, hooks } from "./store.js";
 import { loadTodos } from "./todosService.js";
 import { getAllProjects } from "./projectsState.js";
+import { applyUiAction } from "./stateActions.js";
 import {
   persistAiWorkspaceCollapsedState,
   persistAiWorkspaceVisibleState,
@@ -64,7 +65,10 @@ export function syncAiWorkspaceVisibility(visible) {
 
 export function setAiWorkspaceVisible(visible, { persist = true } = {}) {
   const AI_DEBUG_ENABLED = hooks.AI_DEBUG_ENABLED;
-  state.isAiWorkspaceVisible = AI_DEBUG_ENABLED ? true : !!visible;
+  applyUiAction("aiWorkspace/visible:set", {
+    visible,
+    debugEnabled: AI_DEBUG_ENABLED,
+  });
   syncAiWorkspaceVisibility(state.isAiWorkspaceVisible);
   if (persist && !AI_DEBUG_ENABLED) {
     persistAiWorkspaceVisibleState(state.isAiWorkspaceVisible);
@@ -75,7 +79,7 @@ export function setAiWorkspaceCollapsed(
   collapsed,
   { persist = true, restoreFocus = false } = {},
 ) {
-  state.isAiWorkspaceCollapsed = !!collapsed;
+  applyUiAction("aiWorkspace/collapsed:set", { collapsed });
   const refs = getAiWorkspaceElements();
   if (refs) {
     refs.workspace.classList.toggle(

--- a/client/modules/asyncLifecycle.js
+++ b/client/modules/asyncLifecycle.js
@@ -1,0 +1,27 @@
+// =============================================================================
+// asyncLifecycle.js — Small helper to normalize async UI request lifecycles.
+// =============================================================================
+
+export async function runAsyncLifecycle({
+  start,
+  run,
+  success,
+  failure,
+  finalize,
+  rethrow = false,
+} = {}) {
+  start?.();
+  try {
+    const result = await run?.();
+    await success?.(result);
+    return result;
+  } catch (error) {
+    await failure?.(error);
+    if (rethrow) {
+      throw error;
+    }
+    return null;
+  } finally {
+    await finalize?.();
+  }
+}

--- a/client/modules/commandPalette.js
+++ b/client/modules/commandPalette.js
@@ -6,6 +6,7 @@
 import { state, hooks } from "./store.js";
 import { getAllProjects } from "./projectsState.js";
 import { setSelectedProjectKey } from "./filterLogic.js";
+import { applyUiAction } from "./stateActions.js";
 import { toggleShortcuts, closeShortcutsOverlay } from "./shortcuts.js";
 
 function getCommandPaletteElements() {
@@ -274,8 +275,6 @@ function executeCommandPaletteItem(item, triggerEl = null) {
         todosTab instanceof HTMLElement ? todosTab : null,
       );
     }
-    state.currentWorkspaceView = item.payload ? "project" : "all";
-    hooks.clearHomeListDrilldown();
     setSelectedProjectKey(String(item.payload || ""));
     closeCommandPalette({ restoreFocus: false });
   }
@@ -315,15 +314,13 @@ function moveCommandPaletteSelection(delta) {
 
 function closeCommandPalette({ restoreFocus = true } = {}) {
   if (!state.isCommandPaletteOpen) return;
-  state.isCommandPaletteOpen = false;
-  state.commandPaletteQuery = "";
-  state.commandPaletteIndex = 0;
-  state.commandPaletteSelectableItems = [];
+  const focusTarget = state.lastFocusedBeforePalette;
+  applyUiAction("commandPalette/close");
   renderCommandPalette();
   hooks.DialogManager.close("commandPalette");
 
-  if (restoreFocus && state.lastFocusedBeforePalette instanceof HTMLElement) {
-    state.lastFocusedBeforePalette.focus({ preventScroll: true });
+  if (restoreFocus && focusTarget instanceof HTMLElement) {
+    focusTarget.focus({ preventScroll: true });
   }
 }
 
@@ -334,15 +331,10 @@ function openCommandPalette() {
   if (!refs) return;
   if (state.isCommandPaletteOpen) return;
 
-  state.lastFocusedBeforePalette =
-    document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-  state.commandPaletteItems = buildCommandPaletteItems();
-  state.commandPaletteSelectableItems = [];
-  state.commandPaletteQuery = "";
-  state.commandPaletteIndex = 0;
-  state.isCommandPaletteOpen = true;
+  applyUiAction("commandPalette/open", {
+    opener: document.activeElement,
+    items: buildCommandPaletteItems(),
+  });
   renderCommandPalette();
   hooks.DialogManager.open("commandPalette", refs.overlay, {
     onEscape: () => closeCommandPalette({ restoreFocus: true }),
@@ -402,9 +394,12 @@ function bindCommandPaletteHandlers() {
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
     if (target.id !== "commandPaletteInput") return;
-    state.commandPaletteQuery =
-      target instanceof HTMLInputElement ? target.value : String(target.value);
-    state.commandPaletteIndex = 0;
+    applyUiAction("commandPalette/query:set", {
+      query:
+        target instanceof HTMLInputElement
+          ? target.value
+          : String(target.value),
+    });
     renderCommandPalette();
   });
 }

--- a/client/modules/drawerUi.js
+++ b/client/modules/drawerUi.js
@@ -6,6 +6,8 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { runAsyncLifecycle } from "./asyncLifecycle.js";
+import { applyAsyncAction, applyUiAction } from "./stateActions.js";
 import { STORAGE_KEYS } from "../utils/storageKeys.js";
 import {
   hasTodoRow,
@@ -17,6 +19,11 @@ import {
   patchTodoKebabState,
   patchVisibleCategoryGroupStats,
 } from "./todosViewPatches.js";
+import {
+  renderDrawerAccordionSection,
+  renderDrawerSection,
+  renderStatusMessage,
+} from "./uiTemplates.js";
 
 // ---------------------------------------------------------------------------
 // Utilities (local, not cross-module)
@@ -63,23 +70,7 @@ export function isTaskDrawerDismissed(todoId) {
 // ---------------------------------------------------------------------------
 
 export function resetTaskDrawerAssistState(todoId = "") {
-  const { createInitialTaskDrawerAssistState } = hooks;
-  state.taskDrawerAssistState = createInitialTaskDrawerAssistState
-    ? { ...createInitialTaskDrawerAssistState(), todoId }
-    : {
-        todoId,
-        loading: false,
-        unavailable: false,
-        error: "",
-        aiSuggestionId: "",
-        mustAbstain: false,
-        suggestions: [],
-        applyingSuggestionId: "",
-        confirmSuggestionId: "",
-        undoBySuggestionId: {},
-        lastUndoSuggestionId: "",
-        showFullAssist: false,
-      };
+  applyAsyncAction("taskDrawerAssist/reset", { todoId });
 }
 
 function getTaskDrawerSuggestionLabel(type) {
@@ -195,23 +186,21 @@ function renderTaskDrawerAssistSection(todoId) {
           })
         : null;
     if (issue) {
-      return `
-        <div class="todo-drawer__section">
-          <div class="todo-drawer__section-title">AI Suggestions</div>
-          ${hooks.renderLintChip ? hooks.renderLintChip(issue) : ""}
-        </div>
-      `;
+      return renderDrawerSection({
+        title: "AI Suggestions",
+        bodyHtml: hooks.renderLintChip ? hooks.renderLintChip(issue) : "",
+      });
     }
     return "";
   }
 
   if (!FEATURE_TASK_DRAWER_DECISION_ASSIST) {
-    return `
-      <div class="todo-drawer__section">
-        <div class="todo-drawer__section-title">AI Suggestions</div>
-        <div class="ai-empty" role="status">AI Suggestions unavailable.</div>
-      </div>
-    `;
+    return renderDrawerSection({
+      title: "AI Suggestions",
+      bodyHtml: renderStatusMessage({
+        message: "AI Suggestions unavailable.",
+      }),
+    });
   }
 
   const aiDebugMeta = hooks.renderAiDebugMeta
@@ -222,24 +211,34 @@ function renderTaskDrawerAssistSection(todoId) {
       })
     : "";
 
-  const base = `
-    <div class="todo-drawer__section">
-      <div class="todo-drawer__section-title">AI Suggestions</div>
-      ${aiDebugMeta}
-      ${assistState.loading ? '<div class="ai-empty" role="status">Loading suggestions...</div>' : ""}
-      ${assistState.unavailable ? '<div class="ai-empty" role="status">AI Suggestions unavailable.</div>' : ""}
-      ${assistState.error ? `<div class="ai-empty" role="status">${escapeHtml(assistState.error)}</div>` : ""}
-      ${
-        !assistState.loading &&
-        !assistState.unavailable &&
-        !assistState.error &&
-        (assistState.mustAbstain || assistState.suggestions.length === 0)
-          ? '<div class="ai-empty" role="status">No suggestions right now.</div>'
-          : ""
-      }
-      ${
-        assistState.suggestions.length > 0
-          ? `<div class="todo-drawer-ai-list">
+  const bodyHtml = `
+    ${aiDebugMeta}
+    ${
+      assistState.loading
+        ? renderStatusMessage({ message: "Loading suggestions..." })
+        : ""
+    }
+    ${
+      assistState.unavailable
+        ? renderStatusMessage({ message: "AI Suggestions unavailable." })
+        : ""
+    }
+    ${
+      assistState.error
+        ? renderStatusMessage({ message: assistState.error })
+        : ""
+    }
+    ${
+      !assistState.loading &&
+      !assistState.unavailable &&
+      !assistState.error &&
+      (assistState.mustAbstain || assistState.suggestions.length === 0)
+        ? renderStatusMessage({ message: "No suggestions right now." })
+        : ""
+    }
+    ${
+      assistState.suggestions.length > 0
+        ? `<div class="todo-drawer-ai-list">
             ${assistState.suggestions
               .map((suggestion) => {
                 const confidenceLabel = hooks.confidenceLabel
@@ -316,9 +315,8 @@ function renderTaskDrawerAssistSection(todoId) {
               })
               .join("")}
           </div>`
-          : ""
-      }
-    </div>
+        : ""
+    }
   `;
 
   window.requestAnimationFrame(() => {
@@ -330,7 +328,10 @@ function renderTaskDrawerAssistSection(todoId) {
     }
   });
 
-  return base;
+  return renderDrawerSection({
+    title: "AI Suggestions",
+    bodyHtml,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -740,24 +741,21 @@ export function renderTodoDrawerContent() {
   if (!todo) {
     state.drawerDraft = null;
     titleEl.textContent = "Task";
-    contentEl.innerHTML = `
-      <div class="todo-drawer__section">
-        <div class="todo-drawer__section-title">Unavailable</div>
-        <p>This task is no longer available in the current view.</p>
-      </div>
-    `;
+    contentEl.innerHTML = renderDrawerSection({
+      title: "Unavailable",
+      bodyHtml: "<p>This task is no longer available in the current view.</p>",
+    });
     return;
   }
 
   const draft = getCurrentDrawerDraft(todo);
   const detailsExpanded = state.isDrawerDetailsOpen;
-  const detailsToggleLabel = detailsExpanded ? "Hide details" : "Show details";
-  const detailsPanelHidden = detailsExpanded ? "" : "hidden";
 
   titleEl.textContent = "Task";
   contentEl.innerHTML = `
-    <div class="todo-drawer__section">
-      <div class="todo-drawer__section-title">Essentials</div>
+    ${renderDrawerSection({
+      title: "Essentials",
+      bodyHtml: `
       <div class="todo-drawer__save-status" id="drawerSaveStatus" data-state="${escapeHtml(state.drawerSaveState)}">Ready</div>
       <label class="todo-drawer__field" for="drawerTitleInput">
         <span>Title</span>
@@ -790,25 +788,15 @@ export function renderTodoDrawerContent() {
           <option value="high" ${draft.priority === "high" ? "selected" : ""}>High</option>
         </select>
       </label>
-    </div>
+    `,
+    })}
     ${renderTaskDrawerAssistSection(todo.id)}
-    <div class="todo-drawer__section">
-      <button
-        id="drawerDetailsToggle"
-        type="button"
-        class="todo-drawer__accordion-toggle"
-        aria-expanded="${detailsExpanded ? "true" : "false"}"
-        aria-controls="drawerDetailsPanel"
-      >
-        <span>Details</span>
-        <span class="todo-drawer__accordion-chevron" aria-hidden="true">${detailsExpanded ? "▾" : "▸"}</span>
-      </button>
-      <div
-        id="drawerDetailsPanel"
-        class="todo-drawer__accordion-panel ${detailsExpanded ? "todo-drawer__accordion-panel--open" : ""}"
-        aria-hidden="${detailsExpanded ? "false" : "true"}"
-        ${detailsPanelHidden}
-      >
+    ${renderDrawerAccordionSection({
+      toggleId: "drawerDetailsToggle",
+      panelId: "drawerDetailsPanel",
+      title: "Details",
+      expanded: detailsExpanded,
+      bodyHtml: `
         <label class="todo-drawer__field" for="drawerDescriptionTextarea">
           <span>Description</span>
           <textarea id="drawerDescriptionTextarea" maxlength="1000">${escapeHtml(draft.description)}</textarea>
@@ -825,14 +813,17 @@ export function renderTodoDrawerContent() {
           <div class="todo-drawer__subtasks-title">Subtasks</div>
           ${renderDrawerSubtasks(todo)}
         </div>
-      </div>
-    </div>
-    <div class="todo-drawer__section todo-drawer__section--danger">
-      <div class="todo-drawer__section-title">Danger zone</div>
+      `,
+    })}
+    ${renderDrawerSection({
+      title: "Danger zone",
+      className: "todo-drawer__section todo-drawer__section--danger",
+      bodyHtml: `
       <button id="drawerDeleteTodoButton" class="delete-btn todo-drawer__delete-btn" type="button">
         Delete task
       </button>
-    </div>
+    `,
+    })}
   `;
   setDrawerSaveState(state.drawerSaveState, state.drawerSaveMessage);
 }
@@ -876,82 +867,78 @@ export async function loadTaskDrawerDecisionAssist(
   const FEATURE_TASK_DRAWER_DECISION_ASSIST =
     hooks.FEATURE_TASK_DRAWER_DECISION_ASSIST || false;
   if (!FEATURE_TASK_DRAWER_DECISION_ASSIST) {
-    state.taskDrawerAssistState.unavailable = true;
+    applyAsyncAction("taskDrawerAssist/unavailable");
+    renderTodoDrawerContent();
     return;
   }
 
-  if (state.taskDrawerAssistState.todoId !== todoId) {
-    resetTaskDrawerAssistState(todoId);
-  }
-  state.taskDrawerAssistState.loading = true;
-  state.taskDrawerAssistState.error = "";
-  state.taskDrawerAssistState.unavailable = false;
-  renderTodoDrawerContent();
-
-  try {
-    let latestResponse = await fetchTaskDrawerLatestSuggestion(todoId);
-    if (latestResponse.status === 403 || latestResponse.status === 404) {
-      state.taskDrawerAssistState.loading = false;
-      state.taskDrawerAssistState.unavailable = true;
+  await runAsyncLifecycle({
+    start: () => {
+      applyAsyncAction("taskDrawerAssist/start", { todoId });
       renderTodoDrawerContent();
-      return;
-    }
+    },
+    run: async () => {
+      let latestResponse = await fetchTaskDrawerLatestSuggestion(todoId);
+      if (latestResponse.status === 403 || latestResponse.status === 404) {
+        return { outcome: "unavailable" };
+      }
 
-    if (latestResponse.status === 204) {
-      if (isTaskDrawerDismissed(todoId)) {
-        state.taskDrawerAssistState.loading = false;
-        state.taskDrawerAssistState.mustAbstain = true;
-        renderTodoDrawerContent();
-        return;
+      if (latestResponse.status === 204) {
+        if (isTaskDrawerDismissed(todoId) || !allowGenerate) {
+          return { outcome: "abstain" };
+        }
+        const generated = await generateTaskDrawerSuggestion(todo);
+        if (generated.status === 403 || generated.status === 404) {
+          return { outcome: "unavailable" };
+        }
+        latestResponse = await fetchTaskDrawerLatestSuggestion(todoId);
+        if (latestResponse.status === 204) {
+          return { outcome: "abstain" };
+        }
       }
-      if (!allowGenerate) {
-        state.taskDrawerAssistState.loading = false;
-        state.taskDrawerAssistState.mustAbstain = true;
-        renderTodoDrawerContent();
-        return;
-      }
-      const generated = await generateTaskDrawerSuggestion(todo);
-      if (generated.status === 403 || generated.status === 404) {
-        state.taskDrawerAssistState.loading = false;
-        state.taskDrawerAssistState.unavailable = true;
-        renderTodoDrawerContent();
-        return;
-      }
-      latestResponse = await fetchTaskDrawerLatestSuggestion(todoId);
-    }
 
-    if (!latestResponse.ok) {
-      state.taskDrawerAssistState.loading = false;
-      state.taskDrawerAssistState.error = "Could not load suggestions.";
+      if (!latestResponse.ok) {
+        return { outcome: "failure" };
+      }
+
+      const payload = await latestResponse.json();
+      const envelope = payload?.outputEnvelope || {};
+      return {
+        outcome: "success",
+        payload: {
+          aiSuggestionId: String(payload?.aiSuggestionId || ""),
+          mustAbstain: !!envelope.must_abstain,
+          contractVersion: envelope.contractVersion,
+          requestId: envelope.requestId,
+          generatedAt: envelope.generatedAt,
+          suggestions: normalizeTaskDrawerAssistEnvelope(
+            String(payload?.aiSuggestionId || ""),
+            envelope,
+            todoId,
+          ),
+        },
+      };
+    },
+    success: (result) => {
+      if (!state.isTodoDrawerOpen || state.selectedTodoId !== todoId) return;
+      if (result?.outcome === "unavailable") {
+        applyAsyncAction("taskDrawerAssist/unavailable");
+      } else if (result?.outcome === "abstain") {
+        applyAsyncAction("taskDrawerAssist/abstain");
+      } else if (result?.outcome === "failure") {
+        applyAsyncAction("taskDrawerAssist/failure");
+      } else if (result?.outcome === "success") {
+        applyAsyncAction("taskDrawerAssist/success", result.payload);
+      }
       renderTodoDrawerContent();
-      return;
-    }
-
-    const payload = await latestResponse.json();
-    if (!state.isTodoDrawerOpen || state.selectedTodoId !== todoId) return;
-    const envelope = payload?.outputEnvelope || {};
-    state.taskDrawerAssistState.loading = false;
-    state.taskDrawerAssistState.aiSuggestionId = String(
-      payload?.aiSuggestionId || "",
-    );
-    state.taskDrawerAssistState.mustAbstain = !!envelope.must_abstain;
-    state.taskDrawerAssistState.contractVersion = envelope.contractVersion;
-    state.taskDrawerAssistState.requestId = envelope.requestId;
-    state.taskDrawerAssistState.generatedAt = envelope.generatedAt;
-    state.taskDrawerAssistState.suggestions = normalizeTaskDrawerAssistEnvelope(
-      state.taskDrawerAssistState.aiSuggestionId,
-      envelope,
-      todoId,
-    );
-    state.taskDrawerAssistState.confirmSuggestionId = "";
-    state.taskDrawerAssistState.applyingSuggestionId = "";
-    renderTodoDrawerContent();
-  } catch (error) {
-    console.error("Task drawer AI load failed:", error);
-    state.taskDrawerAssistState.loading = false;
-    state.taskDrawerAssistState.error = "Could not load suggestions.";
-    renderTodoDrawerContent();
-  }
+    },
+    failure: (error) => {
+      console.error("Task drawer AI load failed:", error);
+      if (!state.isTodoDrawerOpen || state.selectedTodoId !== todoId) return;
+      applyAsyncAction("taskDrawerAssist/failure");
+      renderTodoDrawerContent();
+    },
+  });
 }
 
 export async function applyTaskDrawerSuggestion(
@@ -1092,20 +1079,11 @@ export function openTodoDrawer(todoId, triggerEl) {
     hooks.closeProjectsRailSheet?.({ restoreFocus: false });
   }
 
-  state.selectedTodoId = todoId;
   initializeDrawerDraft(todo);
   resetTaskDrawerAssistState(todoId);
-  state.isDrawerDetailsOpen = false;
-  state.openTodoKebabId = null;
   state.drawerSaveSequence = 0;
   setDrawerSaveState("idle");
-  state.lastFocusedTodoTrigger =
-    triggerEl instanceof HTMLElement ? triggerEl : null;
-  state.lastFocusedTodoId =
-    triggerEl instanceof HTMLElement
-      ? triggerEl.dataset.todoId || todoId
-      : todoId;
-  state.isTodoDrawerOpen = true;
+  applyUiAction("todoDrawer/open", { todoId, triggerEl });
 
   const { drawer, backdrop } = refs;
   drawer.classList.add("todo-drawer--open");
@@ -1149,10 +1127,7 @@ export function closeTodoDrawer({ restoreFocus = true } = {}) {
   const focusTrigger = state.lastFocusedTodoTrigger;
   const focusTodoId = state.lastFocusedTodoId;
 
-  state.isTodoDrawerOpen = false;
-  state.selectedTodoId = null;
-  state.isDrawerDetailsOpen = false;
-  state.openTodoKebabId = null;
+  applyUiAction("todoDrawer/close");
   state.drawerDraft = null;
   resetTaskDrawerAssistState();
   state.drawerSaveSequence = 0;
@@ -1180,9 +1155,6 @@ export function closeTodoDrawer({ restoreFocus = true } = {}) {
   patchTodoKebabState();
   patchSelectedTodoRowActiveState();
   unlockBodyScrollForDrawer();
-
-  state.lastFocusedTodoTrigger = null;
-  state.lastFocusedTodoId = null;
 
   if (!restoreFocus) return;
 
@@ -1232,7 +1204,9 @@ export function syncTodoDrawerStateWithRender() {
 
 export function toggleDrawerDetailsPanel() {
   if (!state.isTodoDrawerOpen || !state.selectedTodoId) return;
-  state.isDrawerDetailsOpen = !state.isDrawerDetailsOpen;
+  applyUiAction("todoDrawer/details:set", {
+    isOpen: !state.isDrawerDetailsOpen,
+  });
   renderTodoDrawerContent();
 }
 
@@ -1271,7 +1245,7 @@ export function getKebabTriggerForTodo(todoId) {
 
 export function closeTodoKebabMenu({ restoreFocus = false } = {}) {
   const activeTodoId = state.openTodoKebabId;
-  state.openTodoKebabId = null;
+  applyUiAction("todoKebab:set", { todoId: null });
   patchTodoKebabState();
 
   if (!restoreFocus || !activeTodoId) return;
@@ -1286,7 +1260,9 @@ export function toggleTodoKebab(todoId, event) {
   event?.stopPropagation?.();
 
   const shouldOpen = state.openTodoKebabId !== todoId;
-  state.openTodoKebabId = shouldOpen ? todoId : null;
+  applyUiAction("todoKebab:set", {
+    todoId: shouldOpen ? todoId : null,
+  });
   patchTodoKebabState();
 
   if (!shouldOpen) return;
@@ -1303,7 +1279,7 @@ export function toggleTodoKebab(todoId, event) {
 export function openTodoFromKebab(todoId, event) {
   event?.preventDefault?.();
   event?.stopPropagation?.();
-  state.openTodoKebabId = null;
+  applyUiAction("todoKebab:set", { todoId: null });
   const row = document.querySelector(
     `.todo-item[data-todo-id="${escapeSelectorValue(todoId)}"]`,
   );
@@ -1313,7 +1289,7 @@ export function openTodoFromKebab(todoId, event) {
 export function openEditTodoFromKebab(todoId, event) {
   event?.preventDefault?.();
   event?.stopPropagation?.();
-  state.openTodoKebabId = null;
+  applyUiAction("todoKebab:set", { todoId: null });
   patchTodoKebabState();
   hooks.openEditTodoModal?.(todoId);
 }
@@ -1321,14 +1297,14 @@ export function openEditTodoFromKebab(todoId, event) {
 export function openDrawerDangerZone(todoId, event) {
   event?.preventDefault?.();
   event?.stopPropagation?.();
-  state.openTodoKebabId = null;
+  applyUiAction("todoKebab:set", { todoId: null });
   const row = document.querySelector(
     `.todo-item[data-todo-id="${escapeSelectorValue(todoId)}"]`,
   );
   if (!state.isTodoDrawerOpen || state.selectedTodoId !== todoId) {
     openTodoDrawer(todoId, row instanceof HTMLElement ? row : null);
   }
-  state.isDrawerDetailsOpen = true;
+  applyUiAction("todoDrawer/details:set", { isOpen: true });
   renderTodoDrawerContent();
   window.requestAnimationFrame(() => {
     const deleteBtn = document.getElementById("drawerDeleteTodoButton");

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -13,6 +13,8 @@
  * Pass values as parameters instead so they remain unit-testable.
  */
 import { state, hooks } from "./store.js";
+import { applyDomainAction } from "./stateActions.js";
+import { renderTodoRowTemplate } from "./uiTemplates.js";
 import {
   buildVisibleTodosQueryParams,
   clearVisibleTodosState,
@@ -64,9 +66,9 @@ function setDateView(view, { skipApply = false } = {}) {
   }
   if (!skipApply && !getSelectedProjectKey()) {
     if (view === "today" || view === "upcoming" || view === "completed") {
-      state.currentWorkspaceView = view;
+      applyDomainAction("workspace/view:set", { view });
     } else {
-      state.currentWorkspaceView = "all";
+      applyDomainAction("workspace/view:set", { view: "all" });
     }
     clearHomeListDrilldown();
   }
@@ -140,7 +142,7 @@ function hasHomeListDrilldown() {
 }
 
 function clearHomeListDrilldown() {
-  state.homeListDrilldownKey = "";
+  applyDomainAction("homeDrilldown:clear");
 }
 
 function normalizeWorkspaceView(view) {
@@ -368,7 +370,7 @@ function getSearchInputValue() {
 }
 
 function clearFilters() {
-  state.currentWorkspaceView = "all";
+  applyDomainAction("workspace/view:set", { view: "all" });
   clearHomeListDrilldown();
   setSelectedProjectKey("", {
     reason: "clear-filters-reset-project",
@@ -419,14 +421,7 @@ function setSelectedProjectKey(
     filterSelect.value = nextValue;
   }
 
-  if (nextValue) {
-    state.currentWorkspaceView = "project";
-    clearHomeListDrilldown();
-  } else if (state.currentWorkspaceView === "project") {
-    state.currentWorkspaceView = "all";
-  }
-
-  state.railRovingFocusKey = nextValue || "";
+  applyDomainAction("projectSelection:set", { projectName: nextValue });
   syncWorkspaceViewState();
   if (!skipApply) {
     applyFiltersAndRender({ reason });
@@ -602,100 +597,38 @@ function renderTodoRowHtml(todo) {
     ? new Date(todo.dueDate).toLocaleString()
     : "";
   const isSelected = state.selectedTodos.has(todo.id);
-  const hasSubtasks = !!(todo.subtasks && todo.subtasks.length > 0);
 
-  return `
-    <li class="todo-item ${todo.completed ? "completed" : ""} ${state.selectedTodoId === todo.id ? "todo-item--active" : ""} ${isSelected ? "todo-item--bulk-selected" : ""}"
-        draggable="true"
-        data-todo-id="${todo.id}"
-        tabindex="0"
-        data-ondragstart="handleDragStart(event, this)"
-        data-ondragover="handleDragOver(event, this)"
-        data-ondrop="handleDrop(event, this)"
-        data-ondragend="handleDragEnd(event, this)">
-        <input
-            type="checkbox"
-            class="bulk-checkbox"
-            aria-label="Select todo ${hooks.escapeHtml?.(todo.title)}"
-            ${isSelected ? "checked" : ""}
-            data-onchange="toggleSelectTodo('${todo.id}')"
-            data-onclick="event.stopPropagation()"
-        >
-        <span class="drag-handle">\u22ee\u22ee</span>
-        <input
-            type="checkbox"
-            class="todo-checkbox"
-            aria-label="Mark todo ${hooks.escapeHtml?.(todo.title)} complete"
-            ${todo.completed ? "checked" : ""}
-            data-onchange="toggleTodo('${todo.id}')"
-        >
-        <div class="todo-content">
-            <div class="todo-title" title="${hooks.escapeHtml?.(todo.title)}">${hooks.escapeHtml?.(todo.title)}</div>
-            ${todo.description ? `<div class="todo-description">${hooks.escapeHtml?.(todo.description)}</div>` : ""}
-            <div class="todo-meta">
-                ${hooks.renderTodoChips?.(todo, { isOverdue, dueDateStr }) ?? ""}
+  return renderTodoRowTemplate({
+    todo,
+    isSelected,
+    isActive: state.selectedTodoId === todo.id,
+    kebabExpanded: state.openTodoKebabId === todo.id,
+    descriptionHtml: todo.description
+      ? `<div class="todo-description">${hooks.escapeHtml?.(todo.description)}</div>`
+      : "",
+    metaHtml: hooks.renderTodoChips?.(todo, { isOverdue, dueDateStr }) ?? "",
+    subtasksHtml:
+      todo.subtasks && todo.subtasks.length > 0
+        ? (hooks.renderSubtasks?.(todo) ?? "")
+        : "",
+    notesHtml:
+      todo.notes && todo.notes.trim()
+        ? `
+          <div class="notes-section">
+            <button class="notes-toggle" data-onclick="toggleNotes('${todo.id}', event)">
+              <span class="expand-icon" id="notes-icon-${todo.id}">\u25b6</span>
+              <span>\u{1F4DD} Notes</span>
+            </button>
+            <div class="notes-content" id="notes-content-${todo.id}" style="display: none;">
+              ${hooks.escapeHtml?.(String(todo.notes))}
             </div>
-            ${hasSubtasks ? (hooks.renderSubtasks?.(todo) ?? "") : ""}
-            ${
-              todo.notes && todo.notes.trim()
-                ? `
-                <div class="notes-section">
-                    <button class="notes-toggle" data-onclick="toggleNotes('${todo.id}', event)">
-                        <span class="expand-icon" id="notes-icon-${todo.id}">\u25b6</span>
-                        <span>\u{1F4DD} Notes</span>
-                    </button>
-                    <div class="notes-content" id="notes-content-${todo.id}" style="display: none;">
-                        ${hooks.escapeHtml?.(String(todo.notes))}
-                    </div>
-                </div>
-            `
-                : ""
-            }
-        </div>
-        <div class="todo-row-actions">
-          <button
-            type="button"
-            class="todo-kebab"
-            aria-label="More actions for ${hooks.escapeHtml?.(todo.title)}"
-            aria-expanded="${state.openTodoKebabId === todo.id ? "true" : "false"}"
-            data-onclick="toggleTodoKebab('${todo.id}', event)"
-          >
-            \u22ef
-          </button>
-          <div
-            class="todo-kebab-menu ${state.openTodoKebabId === todo.id ? "todo-kebab-menu--open" : ""}"
-            role="menu"
-            aria-label="Actions for ${hooks.escapeHtml?.(todo.title)}"
-          >
-            <button type="button" class="todo-kebab-item" role="menuitem" data-onclick="openTodoFromKebab('${todo.id}', event)">
-              Open details
-            </button>
-            <button type="button" class="todo-kebab-item" role="menuitem" data-onclick="openEditTodoFromKebab('${todo.id}', event)">
-              Edit modal
-            </button>
-            <label class="todo-kebab-project-label">
-              Move to project
-              <select data-onclick="event.stopPropagation()" data-onchange="moveTodoToProject('${todo.id}', this.value)">
-                ${hooks.renderProjectOptions?.(String(todo.category || "")) ?? ""}
-              </select>
-            </label>
-            ${renderHeadingMoveOptions(todo)}
-            <button
-              type="button"
-              class="todo-kebab-item"
-              role="menuitem"
-              ${hasSubtasks ? "disabled" : ""}
-              data-onclick="aiBreakdownTodo('${todo.id}')"
-            >
-              ${hasSubtasks ? "AI Subtasks Generated" : "AI Break Down Into Subtasks"}
-            </button>
-            <button type="button" class="todo-kebab-item todo-kebab-item--danger" role="menuitem" data-onclick="openDrawerDangerZone('${todo.id}', event)">
-              Delete
-            </button>
           </div>
-        </div>
-    </li>
-  `;
+        `
+        : "",
+    projectOptionsHtml:
+      hooks.renderProjectOptions?.(String(todo.category || "")) ?? "",
+    headingMoveOptionsHtml: renderHeadingMoveOptions(todo),
+  });
 }
 
 function renderProjectHeadingGroupedRows(projectTodos, projectName) {

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -2,6 +2,7 @@
 // homeDashboard.js — Home workspace dashboard, top-focus AI, focus tiles
 // =============================================================================
 import { state, hooks } from "./store.js";
+import { applyDomainAction } from "./stateActions.js";
 import {
   isSameLocalDay,
   isTodoUnsorted,
@@ -743,8 +744,8 @@ export function openHomeTileList(tileKey) {
     tileKey === "due_soon"
   ) {
     clearHomeListDrilldown();
-    state.homeListDrilldownKey = tileKey;
-    state.currentWorkspaceView = "all";
+    applyDomainAction("homeDrilldown:set", { tileKey });
+    applyDomainAction("workspace/view:set", { view: "all" });
     setSelectedProjectKey("", { reason: "home-see-all", skipApply: true });
     setDateView("all", { skipApply: true });
     hooks.applyFiltersAndRender?.({ reason: `home-see-all-${tileKey}` });
@@ -753,7 +754,6 @@ export function openHomeTileList(tileKey) {
 
 export function openHomeProject(projectName) {
   clearHomeListDrilldown();
-  state.currentWorkspaceView = "project";
   selectProjectFromRail(projectName);
 }
 

--- a/client/modules/onCreateAssist.js
+++ b/client/modules/onCreateAssist.js
@@ -5,16 +5,15 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
-import { createInitialOnCreateAssistState } from "./store.js";
+import { runAsyncLifecycle } from "./asyncLifecycle.js";
 import { getAllProjects } from "./projectsState.js";
 import { applyFiltersAndRender } from "./filterLogic.js";
+import { applyAsyncAction } from "./stateActions.js";
 import { STORAGE_KEYS } from "../utils/storageKeys.js";
+import { renderPanelHeader, renderPanelState } from "./uiTemplates.js";
 
 function resetOnCreateAssistState() {
-  const dismissedTodoIds =
-    state.onCreateAssistState?.dismissedTodoIds || new Set();
-  state.onCreateAssistState = createInitialOnCreateAssistState();
-  state.onCreateAssistState.dismissedTodoIds = dismissedTodoIds;
+  applyAsyncAction("onCreateAssist/reset");
 }
 
 function loadOnCreateDismissedTodoIds() {
@@ -413,87 +412,85 @@ async function generateOnCreateSuggestion(todo) {
 async function loadOnCreateDecisionAssist(todo, allowGenerate = true) {
   if (!todo?.id) return;
   const todoId = String(todo.id);
-  state.onCreateAssistState.loading = true;
-  state.onCreateAssistState.error = "";
-  state.onCreateAssistState.unavailable = false;
-  state.onCreateAssistState.mode = "live";
-  state.onCreateAssistState.liveTodoId = todoId;
-  state.onCreateAssistState.aiSuggestionId = "";
-  state.onCreateAssistState.envelope = null;
-  state.onCreateAssistState.suggestions = [];
-  state.onCreateAssistState.showAll = false;
-  renderOnCreateAssistRow();
-
-  try {
-    let latestResponse = await fetchOnCreateLatestSuggestion(todoId);
-    if (latestResponse.status === 403 || latestResponse.status === 404) {
-      state.onCreateAssistState.loading = false;
-      state.onCreateAssistState.unavailable = true;
+  await runAsyncLifecycle({
+    start: () => {
+      applyAsyncAction("onCreateAssist/start", { todoId });
       renderOnCreateAssistRow();
-      return;
-    }
+    },
+    run: async () => {
+      let latestResponse = await fetchOnCreateLatestSuggestion(todoId);
+      if (latestResponse.status === 403 || latestResponse.status === 404) {
+        return { outcome: "unavailable" };
+      }
 
-    if (latestResponse.status === 204) {
-      if (isOnCreateDismissed(todoId) || !allowGenerate) {
-        state.onCreateAssistState.loading = false;
-        state.onCreateAssistState.envelope = normalizeOnCreateAssistEnvelope({
-          surface: hooks.ON_CREATE_SURFACE,
-          must_abstain: true,
-          suggestions: [],
+      if (latestResponse.status === 204) {
+        if (isOnCreateDismissed(todoId) || !allowGenerate) {
+          return {
+            outcome: "empty",
+            envelope: normalizeOnCreateAssistEnvelope({
+              surface: hooks.ON_CREATE_SURFACE,
+              must_abstain: true,
+              suggestions: [],
+            }),
+          };
+        }
+
+        const generated = await generateOnCreateSuggestion(todo);
+        if (generated.status === 403 || generated.status === 404) {
+          return { outcome: "unavailable" };
+        }
+        latestResponse = await fetchOnCreateLatestSuggestion(todoId);
+      }
+
+      if (latestResponse.status === 204) {
+        return {
+          outcome: "empty",
+          envelope: normalizeOnCreateAssistEnvelope({
+            surface: hooks.ON_CREATE_SURFACE,
+            must_abstain: true,
+            suggestions: [],
+          }),
+        };
+      }
+
+      if (!latestResponse.ok) {
+        return { outcome: "failure" };
+      }
+
+      const payload = await latestResponse.json();
+      const envelope = normalizeOnCreateAssistEnvelope(
+        payload?.outputEnvelope || {},
+      );
+      return {
+        outcome: "success",
+        payload: {
+          todoId,
+          aiSuggestionId: String(payload?.aiSuggestionId || ""),
+          envelope,
+          suggestions: envelope.suggestions,
+        },
+      };
+    },
+    success: (result) => {
+      if (result?.outcome === "unavailable") {
+        applyAsyncAction("onCreateAssist/unavailable");
+      } else if (result?.outcome === "empty") {
+        applyAsyncAction("onCreateAssist/empty", {
+          envelope: result.envelope,
         });
-        state.onCreateAssistState.suggestions = [];
-        renderOnCreateAssistRow();
-        return;
+      } else if (result?.outcome === "failure") {
+        applyAsyncAction("onCreateAssist/failure");
+      } else if (result?.outcome === "success") {
+        applyAsyncAction("onCreateAssist/success", result.payload);
       }
-
-      const generated = await generateOnCreateSuggestion(todo);
-      if (generated.status === 403 || generated.status === 404) {
-        state.onCreateAssistState.loading = false;
-        state.onCreateAssistState.unavailable = true;
-        renderOnCreateAssistRow();
-        return;
-      }
-      latestResponse = await fetchOnCreateLatestSuggestion(todoId);
-    }
-
-    if (latestResponse.status === 204) {
-      state.onCreateAssistState.loading = false;
-      state.onCreateAssistState.envelope = normalizeOnCreateAssistEnvelope({
-        surface: hooks.ON_CREATE_SURFACE,
-        must_abstain: true,
-        suggestions: [],
-      });
-      state.onCreateAssistState.suggestions = [];
       renderOnCreateAssistRow();
-      return;
-    }
-
-    if (!latestResponse.ok) {
-      state.onCreateAssistState.loading = false;
-      state.onCreateAssistState.error = "Could not load suggestions.";
+    },
+    failure: (error) => {
+      console.error("On-create AI load failed:", error);
+      applyAsyncAction("onCreateAssist/failure");
       renderOnCreateAssistRow();
-      return;
-    }
-
-    const payload = await latestResponse.json();
-    const envelope = normalizeOnCreateAssistEnvelope(
-      payload?.outputEnvelope || {},
-    );
-    state.onCreateAssistState.loading = false;
-    state.onCreateAssistState.aiSuggestionId = String(
-      payload?.aiSuggestionId || "",
-    );
-    state.onCreateAssistState.envelope = envelope;
-    state.onCreateAssistState.suggestions = envelope.suggestions;
-    state.onCreateAssistState.mode = "live";
-    state.onCreateAssistState.liveTodoId = todoId;
-    renderOnCreateAssistRow();
-  } catch (error) {
-    console.error("On-create AI load failed:", error);
-    state.onCreateAssistState.loading = false;
-    state.onCreateAssistState.error = "Could not load suggestions.";
-    renderOnCreateAssistRow();
-  }
+    },
+  });
 }
 
 function refreshOnCreateAssistFromTitle(force = false) {
@@ -512,15 +509,11 @@ function refreshOnCreateAssistFromTitle(force = false) {
   const envelope = normalizeOnCreateAssistEnvelope(
     buildMockOnCreateAssistEnvelope(title),
   );
-  state.onCreateAssistState = {
-    ...createInitialOnCreateAssistState(),
-    dismissedTodoIds: state.onCreateAssistState.dismissedTodoIds,
+  applyAsyncAction("onCreateAssist/mock", {
     titleBasis: title,
     envelope,
     suggestions: envelope.suggestions,
-    mode: "mock",
-    showAll: false,
-  };
+  });
   renderOnCreateAssistRow();
 }
 
@@ -743,41 +736,47 @@ function renderOnCreateAssistRow() {
 
   refs.row.hidden = false;
   if (state.onCreateAssistState.loading) {
-    refs.row.innerHTML = `
-      <div class="ai-create-assist__header">
-        <span class="ai-create-assist__title">AI Assist</span>
-      </div>
-      <div class="ai-create-assist__empty ai-empty" role="status">Loading suggestions...</div>
-    `;
+    refs.row.innerHTML = renderPanelState({
+      headerClass: "ai-create-assist__header",
+      titleClass: "ai-create-assist__title",
+      title: "AI Assist",
+      messageClass: "ai-create-assist__empty ai-empty",
+      message: "Loading suggestions...",
+    });
     return;
   }
   if (state.onCreateAssistState.unavailable) {
-    refs.row.innerHTML = `
-      <div class="ai-create-assist__header">
-        <span class="ai-create-assist__title">AI Assist</span>
-      </div>
-      <div class="ai-create-assist__empty ai-empty" role="status">AI Suggestions unavailable.</div>
-    `;
+    refs.row.innerHTML = renderPanelState({
+      headerClass: "ai-create-assist__header",
+      titleClass: "ai-create-assist__title",
+      title: "AI Assist",
+      messageClass: "ai-create-assist__empty ai-empty",
+      message: "AI Suggestions unavailable.",
+    });
     return;
   }
   if (state.onCreateAssistState.error) {
-    refs.row.innerHTML = `
-      <div class="ai-create-assist__header">
-        <span class="ai-create-assist__title">AI Assist</span>
-      </div>
-      <div class="ai-create-assist__empty ai-empty" role="status">No suggestions right now.</div>
-    `;
+    refs.row.innerHTML = renderPanelState({
+      headerClass: "ai-create-assist__header",
+      titleClass: "ai-create-assist__title",
+      title: "AI Assist",
+      messageClass: "ai-create-assist__empty ai-empty",
+      message: "No suggestions right now.",
+    });
     return;
   }
   const activeSuggestions = getActiveOnCreateSuggestions();
   if (activeSuggestions.length === 0) {
-    refs.row.innerHTML = `
-      <div class="ai-create-assist__header">
-        <span class="ai-create-assist__title">AI Assist</span>
-      </div>
-      ${hooks.renderAiDebugMeta(state.onCreateAssistState.envelope || {})}
-      <div class="ai-create-assist__empty ai-empty" role="status">No suggestions right now.</div>
-    `;
+    refs.row.innerHTML = renderPanelState({
+      headerClass: "ai-create-assist__header",
+      titleClass: "ai-create-assist__title",
+      title: "AI Assist",
+      debugHtml: hooks.renderAiDebugMeta(
+        state.onCreateAssistState.envelope || {},
+      ),
+      messageClass: "ai-create-assist__empty ai-empty",
+      message: "No suggestions right now.",
+    });
     return;
   }
 
@@ -790,24 +789,25 @@ function renderOnCreateAssistRow() {
   );
 
   refs.row.innerHTML = `
-    <div class="ai-create-assist__header">
-      <span class="ai-create-assist__title">AI Assist</span>
-      ${
+    ${renderPanelHeader({
+      className: "ai-create-assist__header",
+      titleClass: "ai-create-assist__title",
+      title: "AI Assist",
+      actionsHtml:
         hiddenCount > 0
           ? `
-          <button
-            type="button"
-            class="ai-create-assist__expand"
-            data-testid="ai-chip-expand-more"
-            data-ai-create-action="toggle-more"
-            aria-label="${state.onCreateAssistState.showAll ? "Show fewer suggestions" : `Show ${hiddenCount} more suggestions`}"
-          >
-            ${state.onCreateAssistState.showAll ? "Show less" : `+${hiddenCount} more`}
-          </button>
-        `
-          : ""
-      }
-    </div>
+            <button
+              type="button"
+              class="ai-create-assist__expand"
+              data-testid="ai-chip-expand-more"
+              data-ai-create-action="toggle-more"
+              aria-label="${state.onCreateAssistState.showAll ? "Show fewer suggestions" : `Show ${hiddenCount} more suggestions`}"
+            >
+              ${state.onCreateAssistState.showAll ? "Show less" : `+${hiddenCount} more`}
+            </button>
+          `
+          : "",
+    })}
     ${hooks.renderAiDebugMeta(state.onCreateAssistState.envelope || {})}
     <div class="ai-create-assist__chips">
       ${visibleSuggestions

--- a/client/modules/projectsState.js
+++ b/client/modules/projectsState.js
@@ -4,6 +4,7 @@
 // =============================================================================
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { applyUiAction } from "./stateActions.js";
 
 function projectStorageKey() {
   return `todo-projects:${state.currentUser?.id || "anonymous"}`;
@@ -492,9 +493,10 @@ function openProjectEditDrawer(
     hooks.closeProjectsRailSheet?.({ restoreFocus: false });
   }
 
-  state.isProjectEditDrawerOpen = true;
-  state.projectEditTargetProject = projectRecord.name;
-  state.lastProjectEditOpener = opener instanceof HTMLElement ? opener : null;
+  applyUiAction("projectEdit/open", {
+    opener,
+    projectName: projectRecord.name,
+  });
   refs.drawer.classList.add("project-edit-drawer--open");
   refs.drawer.setAttribute("aria-hidden", "false");
   refs.backdrop.classList.add("project-edit-drawer-backdrop--open");
@@ -515,12 +517,12 @@ function closeProjectEditDrawer({ restoreFocus = true, force = false } = {}) {
   const refs = getProjectEditDrawerElements();
   if (!refs) return;
   if (state.isProjectDeletePending && !force) return;
+  const lastProjectEditOpener = state.lastProjectEditOpener;
 
   if (state.projectDeleteDialogState) {
     closeProjectDeleteDialog();
   }
-  state.isProjectEditDrawerOpen = false;
-  state.projectEditTargetProject = "";
+  applyUiAction("projectEdit/close");
   refs.drawer.classList.remove("project-edit-drawer--open");
   refs.drawer.setAttribute("aria-hidden", "true");
   refs.backdrop.classList.remove("project-edit-drawer-backdrop--open");
@@ -533,15 +535,14 @@ function closeProjectEditDrawer({ restoreFocus = true, force = false } = {}) {
   if (restoreFocus) {
     const fallback = document.getElementById("projectViewActionsButton");
     const focusTarget =
-      state.lastProjectEditOpener instanceof HTMLElement &&
-      state.lastProjectEditOpener.isConnected
-        ? state.lastProjectEditOpener
+      lastProjectEditOpener instanceof HTMLElement &&
+      lastProjectEditOpener.isConnected
+        ? lastProjectEditOpener
         : fallback instanceof HTMLElement
           ? fallback
           : null;
     focusTarget?.focus({ preventScroll: true });
   }
-  state.lastProjectEditOpener = null;
 }
 
 function syncProjectHeaderActions() {
@@ -641,10 +642,11 @@ function openProjectCrudModal(mode, opener, initialProjectName = "") {
   const refs = getProjectCrudModalElements();
   if (!refs) return;
 
-  state.isProjectCrudModalOpen = true;
-  state.projectCrudMode = mode;
-  state.projectCrudTargetProject = initialProjectName || "";
-  state.lastProjectCrudOpener = opener instanceof HTMLElement ? opener : null;
+  applyUiAction("projectCrud/open", {
+    mode,
+    opener,
+    initialProjectName,
+  });
 
   refs.modal.style.display = "flex";
   hooks.DialogManager?.open("projectCrudModal", refs.modal, {
@@ -663,17 +665,16 @@ function openProjectCrudModal(mode, opener, initialProjectName = "") {
 function closeProjectCrudModal({ restoreFocus = true } = {}) {
   const refs = getProjectCrudModalElements();
   if (!refs) return;
+  const lastProjectCrudOpener = state.lastProjectCrudOpener;
 
-  state.isProjectCrudModalOpen = false;
-  state.projectCrudMode = "create";
-  state.projectCrudTargetProject = "";
+  applyUiAction("projectCrud/close");
   refs.modal.style.display = "none";
   hooks.DialogManager?.close("projectCrudModal");
   refs.form.reset();
 
   if (restoreFocus) {
-    if (state.lastProjectCrudOpener?.isConnected) {
-      state.lastProjectCrudOpener.focus({ preventScroll: true });
+    if (lastProjectCrudOpener?.isConnected) {
+      lastProjectCrudOpener.focus({ preventScroll: true });
     } else {
       const fallback = document.getElementById("dockNewProjectBtn");
       if (fallback instanceof HTMLElement) {
@@ -681,7 +682,6 @@ function closeProjectCrudModal({ restoreFocus = true } = {}) {
       }
     }
   }
-  state.lastProjectCrudOpener = null;
 }
 
 async function submitProjectCrudModal() {

--- a/client/modules/quickEntry.js
+++ b/client/modules/quickEntry.js
@@ -8,6 +8,7 @@ import {
   hasHomeListDrilldown,
   getSelectedProjectKey,
 } from "./filterLogic.js";
+import { applyUiAction } from "./stateActions.js";
 import { STORAGE_KEYS } from "../utils/storageKeys.js";
 
 const { escapeHtml, getProjectLeafName } = (() => ({
@@ -40,7 +41,7 @@ export function persistQuickEntryPropertiesOpenState(isOpen) {
 }
 
 export function setQuickEntryPropertiesOpen(nextOpen, { persist = true } = {}) {
-  state.isQuickEntryPropertiesOpen = !!nextOpen;
+  applyUiAction("quickEntry/properties:set", { isOpen: nextOpen });
   if (persist) {
     persistQuickEntryPropertiesOpenState(state.isQuickEntryPropertiesOpen);
   }
@@ -607,13 +608,14 @@ export function openTaskComposer(triggerEl = null) {
   hooks.ensureTodosShellActive?.();
   const refs = getTaskComposerElements();
   if (!refs) return;
-  state.lastTaskComposerTrigger =
-    triggerEl instanceof HTMLElement ? triggerEl : document.activeElement;
-  state.taskComposerDefaultProject = inferTaskComposerDefaultProject();
+  const defaultProject = inferTaskComposerDefaultProject();
+  applyUiAction("taskComposer/open", {
+    triggerEl,
+    defaultProject,
+  });
   if (refs.projectSelect && !String(refs.titleInput?.value || "").trim()) {
     refs.projectSelect.value = state.taskComposerDefaultProject || "";
   }
-  state.isTaskComposerOpen = true;
   refs.sheet.classList.add("task-composer-sheet--open");
   refs.sheet.setAttribute("aria-hidden", "false");
   refs.backdrop.classList.add("task-composer-backdrop--open");
@@ -637,7 +639,8 @@ export function closeTaskComposer({
   if (!refs || !state.isTaskComposerOpen) return false;
   const hasDraft = !!String(refs.titleInput?.value || "").trim();
   if (hasDraft && !force) return false;
-  state.isTaskComposerOpen = false;
+  const focusTarget = state.lastTaskComposerTrigger;
+  applyUiAction("taskComposer/close");
   refs.sheet.classList.remove("task-composer-sheet--open");
   refs.sheet.setAttribute("aria-hidden", "true");
   refs.backdrop.classList.remove("task-composer-backdrop--open");
@@ -646,8 +649,8 @@ export function closeTaskComposer({
   if (reset) {
     resetTaskComposerFields();
   }
-  if (restoreFocus && state.lastTaskComposerTrigger instanceof HTMLElement) {
-    state.lastTaskComposerTrigger.focus({ preventScroll: true });
+  if (restoreFocus && focusTarget instanceof HTMLElement) {
+    focusTarget.focus({ preventScroll: true });
   }
   return true;
 }

--- a/client/modules/railUi.js
+++ b/client/modules/railUi.js
@@ -4,13 +4,13 @@
 // Cross-module calls go through hooks (wired by app.js).
 // =============================================================================
 import { state, hooks } from "./store.js";
+import { applyDomainAction, applyUiAction } from "./stateActions.js";
 import {
   getSelectedProjectKey,
   getSelectedProjectLabel,
   getSelectedProjectName,
   syncWorkspaceViewState,
   isTodoUnsorted,
-  clearHomeListDrilldown,
   setSelectedProjectKey,
 } from "./filterLogic.js";
 import {
@@ -688,14 +688,15 @@ export function openProjectsRailSheet(triggerEl = null) {
   if (!refs || state.isRailSheetOpen || !isMobileRailViewport()) return;
 
   closeRailProjectMenu();
-  state.isRailSheetOpen = true;
+  applyUiAction("railSheet/open", {
+    triggerEl:
+      triggerEl instanceof HTMLElement ? triggerEl : refs.mobileOpenButton,
+  });
   refs.sheet.classList.add("projects-rail-sheet--open");
   refs.sheet.setAttribute("aria-hidden", "false");
   refs.backdrop.classList.add("projects-rail-backdrop--open");
   refs.backdrop.setAttribute("aria-hidden", "false");
   refs.mobileOpenButton.setAttribute("aria-expanded", "true");
-  state.lastFocusedRailTrigger =
-    triggerEl instanceof HTMLElement ? triggerEl : refs.mobileOpenButton;
 
   lockBodyScrollForProjectsRail();
   hooks.DialogManager?.open("railSheet", refs.sheet, {
@@ -716,9 +717,10 @@ export function openProjectsRailSheet(triggerEl = null) {
 export function closeProjectsRailSheet({ restoreFocus = false } = {}) {
   const refs = getProjectsRailElements();
   if (!refs || !state.isRailSheetOpen) return;
+  const focusRestoreTarget = state.lastFocusedRailTrigger;
 
   closeRailProjectMenu();
-  state.isRailSheetOpen = false;
+  applyUiAction("railSheet/close");
   refs.sheet.classList.remove("projects-rail-sheet--open");
   refs.sheet.setAttribute("aria-hidden", "true");
   refs.backdrop.classList.remove("projects-rail-backdrop--open");
@@ -732,8 +734,8 @@ export function closeProjectsRailSheet({ restoreFocus = false } = {}) {
 
   if (restoreFocus) {
     const focusTarget =
-      state.lastFocusedRailTrigger instanceof HTMLElement
-        ? state.lastFocusedRailTrigger
+      focusRestoreTarget instanceof HTMLElement
+        ? focusRestoreTarget
         : refs.mobileOpenButton;
     focusTarget.focus({ preventScroll: true });
   }
@@ -751,13 +753,7 @@ export function selectProjectFromRail(projectName, triggerEl = null) {
     closeProjectEditDrawer({ restoreFocus: false });
   }
   hooks.ensureTodosShellActive?.();
-  state.railRovingFocusKey = normalizeProjectPath(projectName);
-  if (normalizeProjectPath(projectName)) {
-    state.currentWorkspaceView = "project";
-  } else {
-    state.currentWorkspaceView = "all";
-  }
-  clearHomeListDrilldown();
+  applyDomainAction("projectSelection:set", { projectName });
   setSelectedProjectKey(projectName);
 
   if (state.isRailSheetOpen) {
@@ -792,7 +788,7 @@ export function openMoreFilters() {
 
   const { toggle, panel } = refs;
   toggle.removeAttribute("hidden");
-  state.isMoreFiltersOpen = true;
+  applyUiAction("moreFilters:set", { isOpen: true });
   panel.classList.add("more-filters--open");
   toggle.setAttribute("aria-expanded", "true");
 
@@ -807,7 +803,7 @@ export function closeMoreFilters({ restoreFocus = false } = {}) {
   if (!refs) return;
 
   const { toggle, panel } = refs;
-  state.isMoreFiltersOpen = false;
+  applyUiAction("moreFilters:set", { isOpen: false });
   panel.classList.remove("more-filters--open");
   toggle.setAttribute("aria-expanded", "false");
 

--- a/client/modules/stateActions.js
+++ b/client/modules/stateActions.js
@@ -1,0 +1,402 @@
+// =============================================================================
+// stateActions.js — Minimal explicit state transitions for hot UI/domain flows.
+// =============================================================================
+
+import {
+  state,
+  hooks,
+  createInitialTaskDrawerAssistState,
+  createInitialOnCreateAssistState,
+  createInitialTodayPlanState,
+} from "./store.js";
+
+function getNormalizedProjectKey(value) {
+  const raw = String(value || "");
+  if (typeof hooks.normalizeProjectPath === "function") {
+    return hooks.normalizeProjectPath(raw);
+  }
+  return raw.trim();
+}
+
+function createTaskDrawerAssistState(todoId = "") {
+  return {
+    ...createInitialTaskDrawerAssistState(),
+    todoId: String(todoId || ""),
+  };
+}
+
+function createOnCreateAssistState() {
+  const dismissedTodoIds =
+    state.onCreateAssistState?.dismissedTodoIds || new Set();
+  return {
+    ...createInitialOnCreateAssistState(),
+    dismissedTodoIds,
+  };
+}
+
+export function applyUiAction(type, payload = {}) {
+  switch (type) {
+    case "quickEntry/properties:set":
+      state.isQuickEntryPropertiesOpen = !!payload.isOpen;
+      return state.isQuickEntryPropertiesOpen;
+    case "taskComposer/open":
+      state.lastTaskComposerTrigger =
+        payload.triggerEl instanceof HTMLElement
+          ? payload.triggerEl
+          : document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : null;
+      state.taskComposerDefaultProject = String(payload.defaultProject || "");
+      state.isTaskComposerOpen = true;
+      return state.isTaskComposerOpen;
+    case "taskComposer/close":
+      state.isTaskComposerOpen = false;
+      if (payload.clearTrigger !== false) {
+        state.lastTaskComposerTrigger = null;
+      }
+      return state.isTaskComposerOpen;
+    case "commandPalette/open":
+      state.lastFocusedBeforePalette =
+        payload.opener instanceof HTMLElement
+          ? payload.opener
+          : document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : null;
+      state.commandPaletteItems = Array.isArray(payload.items)
+        ? payload.items
+        : [];
+      state.commandPaletteSelectableItems = [];
+      state.commandPaletteQuery = "";
+      state.commandPaletteIndex = 0;
+      state.isCommandPaletteOpen = true;
+      return state.isCommandPaletteOpen;
+    case "commandPalette/close":
+      state.isCommandPaletteOpen = false;
+      state.commandPaletteQuery = "";
+      state.commandPaletteIndex = 0;
+      state.commandPaletteSelectableItems = [];
+      return state.isCommandPaletteOpen;
+    case "commandPalette/query:set":
+      state.commandPaletteQuery = String(payload.query || "");
+      state.commandPaletteIndex = 0;
+      return state.commandPaletteQuery;
+    case "todoDrawer/open":
+      state.selectedTodoId = String(payload.todoId || "");
+      state.isDrawerDetailsOpen = false;
+      state.openTodoKebabId = null;
+      state.lastFocusedTodoTrigger =
+        payload.triggerEl instanceof HTMLElement ? payload.triggerEl : null;
+      state.lastFocusedTodoId =
+        payload.triggerEl instanceof HTMLElement
+          ? payload.triggerEl.dataset.todoId || String(payload.todoId || "")
+          : String(payload.todoId || "");
+      state.isTodoDrawerOpen = true;
+      return state.isTodoDrawerOpen;
+    case "todoDrawer/close":
+      state.isTodoDrawerOpen = false;
+      state.selectedTodoId = null;
+      state.isDrawerDetailsOpen = false;
+      state.openTodoKebabId = null;
+      state.lastFocusedTodoTrigger = null;
+      state.lastFocusedTodoId = null;
+      return state.isTodoDrawerOpen;
+    case "todoDrawer/details:set":
+      state.isDrawerDetailsOpen = !!payload.isOpen;
+      return state.isDrawerDetailsOpen;
+    case "todoKebab:set":
+      state.openTodoKebabId = payload.todoId ? String(payload.todoId) : null;
+      return state.openTodoKebabId;
+    case "railSheet/open":
+      state.isRailSheetOpen = true;
+      state.lastFocusedRailTrigger =
+        payload.triggerEl instanceof HTMLElement ? payload.triggerEl : null;
+      return state.isRailSheetOpen;
+    case "railSheet/close":
+      state.isRailSheetOpen = false;
+      if (payload.clearTrigger !== false) {
+        state.lastFocusedRailTrigger = null;
+      }
+      return state.isRailSheetOpen;
+    case "moreFilters:set":
+      state.isMoreFiltersOpen = !!payload.isOpen;
+      return state.isMoreFiltersOpen;
+    case "projectCrud/open":
+      state.isProjectCrudModalOpen = true;
+      state.projectCrudMode = payload.mode === "rename" ? "rename" : "create";
+      state.projectCrudTargetProject = String(payload.initialProjectName || "");
+      state.lastProjectCrudOpener =
+        payload.opener instanceof HTMLElement ? payload.opener : null;
+      return state.isProjectCrudModalOpen;
+    case "projectCrud/close":
+      state.isProjectCrudModalOpen = false;
+      state.projectCrudMode = "create";
+      state.projectCrudTargetProject = "";
+      if (payload.clearOpener !== false) {
+        state.lastProjectCrudOpener = null;
+      }
+      return state.isProjectCrudModalOpen;
+    case "projectEdit/open":
+      state.isProjectEditDrawerOpen = true;
+      state.projectEditTargetProject = String(payload.projectName || "");
+      state.lastProjectEditOpener =
+        payload.opener instanceof HTMLElement ? payload.opener : null;
+      return state.isProjectEditDrawerOpen;
+    case "projectEdit/close":
+      state.isProjectEditDrawerOpen = false;
+      state.projectEditTargetProject = "";
+      if (payload.clearOpener !== false) {
+        state.lastProjectEditOpener = null;
+      }
+      return state.isProjectEditDrawerOpen;
+    case "aiWorkspace/visible:set":
+      state.isAiWorkspaceVisible = payload.debugEnabled
+        ? true
+        : !!payload.visible;
+      return state.isAiWorkspaceVisible;
+    case "aiWorkspace/collapsed:set":
+      state.isAiWorkspaceCollapsed = !!payload.collapsed;
+      return state.isAiWorkspaceCollapsed;
+    default:
+      return undefined;
+  }
+}
+
+export function applyDomainAction(type, payload = {}) {
+  switch (type) {
+    case "workspace/view:set":
+      state.currentWorkspaceView = String(payload.view || "all");
+      return state.currentWorkspaceView;
+    case "homeDrilldown:set":
+      state.homeListDrilldownKey = String(payload.tileKey || "");
+      return state.homeListDrilldownKey;
+    case "homeDrilldown:clear":
+      state.homeListDrilldownKey = "";
+      return state.homeListDrilldownKey;
+    case "projectSelection:set": {
+      const nextValue = getNormalizedProjectKey(payload.projectName);
+      if (nextValue) {
+        state.currentWorkspaceView = "project";
+        state.homeListDrilldownKey = "";
+      } else if (state.currentWorkspaceView === "project") {
+        state.currentWorkspaceView = "all";
+      }
+      state.railRovingFocusKey = nextValue || "";
+      return nextValue;
+    }
+    case "todayPlan/goal:set":
+      state.todayPlanState.goalText = String(payload.goalText || "");
+      return state.todayPlanState.goalText;
+    case "todayPlan/selection:set": {
+      const todoId = String(payload.todoId || "");
+      if (!todoId) return state.todayPlanState.selectedTodoIds;
+      if (payload.selected) {
+        state.todayPlanState.selectedTodoIds.add(todoId);
+      } else {
+        state.todayPlanState.selectedTodoIds.delete(todoId);
+      }
+      return state.todayPlanState.selectedTodoIds;
+    }
+    case "todayPlan/selections:replace":
+      state.todayPlanState.selectedTodoIds = new Set(
+        Array.isArray(payload.todoIds) ? payload.todoIds.map(String) : [],
+      );
+      return state.todayPlanState.selectedTodoIds;
+    default:
+      return undefined;
+  }
+}
+
+export function applyAsyncAction(type, payload = {}) {
+  switch (type) {
+    case "taskDrawerAssist/reset":
+      state.taskDrawerAssistState = createTaskDrawerAssistState(payload.todoId);
+      return state.taskDrawerAssistState;
+    case "taskDrawerAssist/start":
+      if (
+        state.taskDrawerAssistState?.todoId !== String(payload.todoId || "")
+      ) {
+        state.taskDrawerAssistState = createTaskDrawerAssistState(
+          payload.todoId,
+        );
+      }
+      state.taskDrawerAssistState.loading = true;
+      state.taskDrawerAssistState.error = "";
+      state.taskDrawerAssistState.unavailable = false;
+      return state.taskDrawerAssistState;
+    case "taskDrawerAssist/unavailable":
+      state.taskDrawerAssistState.loading = false;
+      state.taskDrawerAssistState.unavailable = true;
+      state.taskDrawerAssistState.error = "";
+      return state.taskDrawerAssistState;
+    case "taskDrawerAssist/abstain":
+      state.taskDrawerAssistState.loading = false;
+      state.taskDrawerAssistState.error = "";
+      state.taskDrawerAssistState.unavailable = false;
+      state.taskDrawerAssistState.mustAbstain = true;
+      state.taskDrawerAssistState.suggestions = [];
+      state.taskDrawerAssistState.confirmSuggestionId = "";
+      state.taskDrawerAssistState.applyingSuggestionId = "";
+      return state.taskDrawerAssistState;
+    case "taskDrawerAssist/success":
+      state.taskDrawerAssistState.loading = false;
+      state.taskDrawerAssistState.error = "";
+      state.taskDrawerAssistState.unavailable = false;
+      state.taskDrawerAssistState.aiSuggestionId = String(
+        payload.aiSuggestionId || "",
+      );
+      state.taskDrawerAssistState.mustAbstain = !!payload.mustAbstain;
+      state.taskDrawerAssistState.contractVersion = payload.contractVersion;
+      state.taskDrawerAssistState.requestId = payload.requestId;
+      state.taskDrawerAssistState.generatedAt = payload.generatedAt;
+      state.taskDrawerAssistState.suggestions = Array.isArray(
+        payload.suggestions,
+      )
+        ? payload.suggestions
+        : [];
+      state.taskDrawerAssistState.confirmSuggestionId = "";
+      state.taskDrawerAssistState.applyingSuggestionId = "";
+      return state.taskDrawerAssistState;
+    case "taskDrawerAssist/failure":
+      state.taskDrawerAssistState.loading = false;
+      state.taskDrawerAssistState.error = String(
+        payload.error || "Could not load suggestions.",
+      );
+      state.taskDrawerAssistState.unavailable = false;
+      return state.taskDrawerAssistState;
+    case "onCreateAssist/reset":
+      state.onCreateAssistState = createOnCreateAssistState();
+      return state.onCreateAssistState;
+    case "onCreateAssist/mock":
+      state.onCreateAssistState = {
+        ...createOnCreateAssistState(),
+        titleBasis: String(payload.titleBasis || ""),
+        envelope: payload.envelope || null,
+        suggestions: Array.isArray(payload.suggestions)
+          ? payload.suggestions
+          : [],
+        mode: "mock",
+        showAll: false,
+      };
+      return state.onCreateAssistState;
+    case "onCreateAssist/start":
+      state.onCreateAssistState = {
+        ...state.onCreateAssistState,
+        dismissedTodoIds:
+          state.onCreateAssistState?.dismissedTodoIds || new Set(),
+        loading: true,
+        error: "",
+        unavailable: false,
+        mode: "live",
+        liveTodoId: String(payload.todoId || ""),
+        aiSuggestionId: "",
+        envelope: null,
+        suggestions: [],
+        showAll: false,
+      };
+      return state.onCreateAssistState;
+    case "onCreateAssist/unavailable":
+      state.onCreateAssistState.loading = false;
+      state.onCreateAssistState.unavailable = true;
+      state.onCreateAssistState.error = "";
+      return state.onCreateAssistState;
+    case "onCreateAssist/empty":
+      state.onCreateAssistState.loading = false;
+      state.onCreateAssistState.error = "";
+      state.onCreateAssistState.unavailable = false;
+      state.onCreateAssistState.envelope = payload.envelope || null;
+      state.onCreateAssistState.suggestions = [];
+      return state.onCreateAssistState;
+    case "onCreateAssist/success":
+      state.onCreateAssistState.loading = false;
+      state.onCreateAssistState.error = "";
+      state.onCreateAssistState.unavailable = false;
+      state.onCreateAssistState.mode = "live";
+      state.onCreateAssistState.liveTodoId = String(payload.todoId || "");
+      state.onCreateAssistState.aiSuggestionId = String(
+        payload.aiSuggestionId || "",
+      );
+      state.onCreateAssistState.envelope = payload.envelope || null;
+      state.onCreateAssistState.suggestions = Array.isArray(payload.suggestions)
+        ? payload.suggestions
+        : [];
+      state.onCreateAssistState.showAll = false;
+      return state.onCreateAssistState;
+    case "onCreateAssist/failure":
+      state.onCreateAssistState.loading = false;
+      state.onCreateAssistState.error = String(
+        payload.error || "Could not load suggestions.",
+      );
+      state.onCreateAssistState.unavailable = false;
+      return state.onCreateAssistState;
+    case "todayPlan/reset":
+      state.todayPlanState = createInitialTodayPlanState();
+      return state.todayPlanState;
+    case "todayPlan/start":
+      state.todayPlanState.loading = true;
+      state.todayPlanState.error = "";
+      state.todayPlanState.unavailable = false;
+      state.todayPlanState.generating = !!payload.generating;
+      if (typeof payload.loadingMessage === "string") {
+        state.todayPlanState.loadingMessage = payload.loadingMessage;
+      }
+      return state.todayPlanState;
+    case "todayPlan/unavailable":
+      state.todayPlanState.loading = false;
+      state.todayPlanState.generating = false;
+      state.todayPlanState.unavailable = true;
+      state.todayPlanState.error = "";
+      state.todayPlanState.hasLoaded = true;
+      state.todayPlanState.loadingMessage = "";
+      return state.todayPlanState;
+    case "todayPlan/empty":
+      state.todayPlanState.loading = false;
+      state.todayPlanState.generating = false;
+      state.todayPlanState.error = "";
+      state.todayPlanState.unavailable = false;
+      state.todayPlanState.hasLoaded = true;
+      state.todayPlanState.aiSuggestionId = "";
+      state.todayPlanState.envelope = payload.envelope || null;
+      state.todayPlanState.selectedTodoIds = new Set(
+        Array.isArray(payload.selectedTodoIds)
+          ? payload.selectedTodoIds.map(String)
+          : [],
+      );
+      state.todayPlanState.dismissedSuggestionIds = new Set();
+      state.todayPlanState.loadingMessage = "";
+      return state.todayPlanState;
+    case "todayPlan/success":
+      state.todayPlanState.loading = false;
+      state.todayPlanState.generating = false;
+      state.todayPlanState.error = "";
+      state.todayPlanState.unavailable = false;
+      state.todayPlanState.hasLoaded = true;
+      state.todayPlanState.aiSuggestionId = String(
+        payload.aiSuggestionId || "",
+      );
+      state.todayPlanState.envelope = payload.envelope || null;
+      state.todayPlanState.dismissedSuggestionIds = new Set();
+      state.todayPlanState.selectedTodoIds = new Set(
+        Array.isArray(payload.selectedTodoIds)
+          ? payload.selectedTodoIds.map(String)
+          : [],
+      );
+      state.todayPlanState.loadingMessage = "";
+      return state.todayPlanState;
+    case "todayPlan/failure":
+      state.todayPlanState.loading = false;
+      state.todayPlanState.generating = false;
+      state.todayPlanState.unavailable = false;
+      state.todayPlanState.error = String(
+        payload.error || "Could not load suggestions.",
+      );
+      state.todayPlanState.hasLoaded = true;
+      state.todayPlanState.loadingMessage = "";
+      return state.todayPlanState;
+    case "todayPlan/generate:complete":
+      state.todayPlanState.loadingMessage = "";
+      state.todayPlanState.lastApplyBatch = null;
+      return state.todayPlanState;
+    default:
+      return undefined;
+  }
+}

--- a/client/modules/todayPlan.js
+++ b/client/modules/todayPlan.js
@@ -5,14 +5,16 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
-import { createInitialTodayPlanState } from "./store.js";
+import { runAsyncLifecycle } from "./asyncLifecycle.js";
+import { applyAsyncAction, applyDomainAction } from "./stateActions.js";
+import { renderPanelHeader, renderStatusMessage } from "./uiTemplates.js";
 
 function deepClone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
 function resetTodayPlanState() {
-  state.todayPlanState = createInitialTodayPlanState();
+  applyAsyncAction("todayPlan/reset");
 }
 
 function getTodayPlanPanelElement() {
@@ -345,93 +347,88 @@ async function generateTodayPlanSuggestion(goalText) {
 async function loadTodayPlanDecisionAssist(allowGenerate = false) {
   if (!isTodayPlanViewActive()) return;
   if (!hooks.FEATURE_TASK_DRAWER_DECISION_ASSIST) {
-    state.todayPlanState.loading = false;
-    state.todayPlanState.generating = false;
-    state.todayPlanState.unavailable = true;
-    state.todayPlanState.hasLoaded = true;
+    applyAsyncAction("todayPlan/unavailable");
     renderTodayPlanPanel();
     return;
   }
 
-  state.todayPlanState.loading = true;
-  state.todayPlanState.error = "";
-  state.todayPlanState.unavailable = false;
-  renderTodayPlanPanel();
-
-  try {
-    let latestResponse = await fetchTodayPlanLatestSuggestion();
-    if (latestResponse.status === 403 || latestResponse.status === 404) {
-      state.todayPlanState.loading = false;
-      state.todayPlanState.generating = false;
-      state.todayPlanState.unavailable = true;
-      state.todayPlanState.hasLoaded = true;
-      renderTodayPlanPanel();
-      return;
-    }
-
-    if (latestResponse.status === 204 && allowGenerate) {
-      const generated = await generateTodayPlanSuggestion(
-        state.todayPlanState.goalText,
-      );
-      if (generated.status === 403 || generated.status === 404) {
-        state.todayPlanState.loading = false;
-        state.todayPlanState.generating = false;
-        state.todayPlanState.unavailable = true;
-        state.todayPlanState.hasLoaded = true;
-        renderTodayPlanPanel();
-        return;
-      }
-      latestResponse = await fetchTodayPlanLatestSuggestion();
-    }
-
-    if (latestResponse.status === 204) {
-      state.todayPlanState.loading = false;
-      state.todayPlanState.generating = false;
-      state.todayPlanState.hasLoaded = true;
-      state.todayPlanState.aiSuggestionId = "";
-      state.todayPlanState.envelope = normalizeTodayPlanEnvelope({
-        surface: hooks.TODAY_PLAN_SURFACE,
-        must_abstain: false,
-        planPreview: { topN: 3, items: [] },
-        suggestions: [],
+  await runAsyncLifecycle({
+    start: () => {
+      applyAsyncAction("todayPlan/start", {
+        generating: state.todayPlanState.generating,
+        loadingMessage:
+          state.todayPlanState.loadingMessage || "Generating plan preview...",
       });
-      state.todayPlanState.selectedTodoIds = new Set();
-      state.todayPlanState.dismissedSuggestionIds = new Set();
       renderTodayPlanPanel();
-      return;
-    }
+    },
+    run: async () => {
+      let latestResponse = await fetchTodayPlanLatestSuggestion();
+      if (latestResponse.status === 403 || latestResponse.status === 404) {
+        return { outcome: "unavailable" };
+      }
 
-    if (!latestResponse.ok) {
-      state.todayPlanState.loading = false;
-      state.todayPlanState.generating = false;
-      state.todayPlanState.error = "Could not load suggestions.";
-      state.todayPlanState.hasLoaded = true;
+      if (latestResponse.status === 204 && allowGenerate) {
+        const generated = await generateTodayPlanSuggestion(
+          state.todayPlanState.goalText,
+        );
+        if (generated.status === 403 || generated.status === 404) {
+          return { outcome: "unavailable" };
+        }
+        latestResponse = await fetchTodayPlanLatestSuggestion();
+      }
+
+      if (latestResponse.status === 204) {
+        return {
+          outcome: "empty",
+          envelope: normalizeTodayPlanEnvelope({
+            surface: hooks.TODAY_PLAN_SURFACE,
+            must_abstain: false,
+            planPreview: { topN: 3, items: [] },
+            suggestions: [],
+          }),
+        };
+      }
+
+      if (!latestResponse.ok) {
+        return { outcome: "failure" };
+      }
+
+      const payload = await latestResponse.json();
+      const envelope = normalizeTodayPlanEnvelope(
+        payload?.outputEnvelope || {},
+      );
+      return {
+        outcome: "success",
+        payload: {
+          aiSuggestionId: String(payload?.aiSuggestionId || ""),
+          envelope,
+          selectedTodoIds: envelope.planPreview.items
+            .map((item) => String(item.todoId))
+            .filter(Boolean),
+        },
+      };
+    },
+    success: (result) => {
+      if (result?.outcome === "unavailable") {
+        applyAsyncAction("todayPlan/unavailable");
+      } else if (result?.outcome === "empty") {
+        applyAsyncAction("todayPlan/empty", {
+          envelope: result.envelope,
+          selectedTodoIds: [],
+        });
+      } else if (result?.outcome === "failure") {
+        applyAsyncAction("todayPlan/failure");
+      } else if (result?.outcome === "success") {
+        applyAsyncAction("todayPlan/success", result.payload);
+      }
       renderTodayPlanPanel();
-      return;
-    }
-
-    const payload = await latestResponse.json();
-    const envelope = normalizeTodayPlanEnvelope(payload?.outputEnvelope || {});
-    state.todayPlanState.loading = false;
-    state.todayPlanState.generating = false;
-    state.todayPlanState.hasLoaded = true;
-    state.todayPlanState.aiSuggestionId = String(payload?.aiSuggestionId || "");
-    state.todayPlanState.envelope = envelope;
-    state.todayPlanState.dismissedSuggestionIds = new Set();
-    state.todayPlanState.selectedTodoIds = new Set(
-      envelope.planPreview.items
-        .map((item) => String(item.todoId))
-        .filter(Boolean),
-    );
-    renderTodayPlanPanel();
-  } catch (error) {
-    console.error("Today plan AI load failed:", error);
-    state.todayPlanState.loading = false;
-    state.todayPlanState.generating = false;
-    state.todayPlanState.error = "Could not load suggestions.";
-    state.todayPlanState.hasLoaded = true;
-    renderTodayPlanPanel();
-  }
+    },
+    failure: (error) => {
+      console.error("Today plan AI load failed:", error);
+      applyAsyncAction("todayPlan/failure");
+      renderTodayPlanPanel();
+    },
+  });
 }
 
 function getTodayPlanSelectedSuggestionCards() {
@@ -486,11 +483,12 @@ function renderTodayPlanPanel() {
 
   panel.setAttribute("data-testid", "today-plan-panel");
   panel.innerHTML = `
-    <div class="today-plan-panel__header">
-      <div class="today-plan-panel__title">Plan my day</div>
-      ${
-        state.todayPlanState.lastApplyBatch
-          ? `
+    ${renderPanelHeader({
+      className: "today-plan-panel__header",
+      titleClass: "today-plan-panel__title",
+      title: "Plan my day",
+      actionsHtml: state.todayPlanState.lastApplyBatch
+        ? `
           <button
             type="button"
             class="today-plan-panel__undo ai-undo"
@@ -501,9 +499,8 @@ function renderTodayPlanPanel() {
             Undo
           </button>
         `
-          : ""
-      }
-    </div>
+        : "",
+    })}
     <div class="today-plan-panel__controls">
       <label class="sr-only" for="todayPlanGoalInput">Goal (optional)</label>
       <input
@@ -529,17 +526,28 @@ function renderTodayPlanPanel() {
     ${hooks.renderAiDebugMeta(envelope || {})}
     ${
       state.todayPlanState.loading || state.todayPlanState.generating
-        ? '<div class="today-plan-panel__loading ai-empty" role="status">Generating plan preview...</div>'
+        ? renderStatusMessage({
+            className: "today-plan-panel__loading ai-empty",
+            message:
+              state.todayPlanState.loadingMessage ||
+              "Generating plan preview...",
+          })
         : ""
     }
     ${
       state.todayPlanState.unavailable
-        ? '<div class="today-plan-panel__empty ai-empty" role="status">AI Suggestions unavailable.</div>'
+        ? renderStatusMessage({
+            className: "today-plan-panel__empty ai-empty",
+            message: "AI Suggestions unavailable.",
+          })
         : ""
     }
     ${
       state.todayPlanState.error
-        ? `<div class="today-plan-panel__empty ai-empty" role="status">${hooks.escapeHtml(state.todayPlanState.error)}</div>`
+        ? renderStatusMessage({
+            className: "today-plan-panel__empty ai-empty",
+            message: state.todayPlanState.error,
+          })
         : ""
     }
     ${
@@ -577,7 +585,14 @@ function renderTodayPlanPanel() {
       `
         : ""
     }
-    ${emptyMessage ? `<div class="today-plan-panel__empty ai-empty" role="status">${hooks.escapeHtml(emptyMessage)}</div>` : ""}
+    ${
+      emptyMessage
+        ? renderStatusMessage({
+            className: "today-plan-panel__empty ai-empty",
+            message: emptyMessage,
+          })
+        : ""
+    }
     ${
       suggestionCards.length > 0
         ? `
@@ -653,28 +668,25 @@ async function handleTodayPlanGenerate() {
   const goalInput = document.getElementById("todayPlanGoalInput");
   const goalText =
     goalInput instanceof HTMLInputElement ? goalInput.value.trim() : "";
-  state.todayPlanState.goalText = goalText;
-  state.todayPlanState.generating = true;
-  state.todayPlanState.loading = true;
-  state.todayPlanState.error = "";
-  state.todayPlanState.unavailable = false;
-  state.todayPlanState.loadingMessage = "Generating plan preview...";
+  applyDomainAction("todayPlan/goal:set", { goalText });
+  applyAsyncAction("todayPlan/start", {
+    generating: true,
+    loadingMessage: "Generating plan preview...",
+  });
   renderTodayPlanPanel();
 
   const generationId = ++state.todayPlanGenerationSeq;
   await loadTodayPlanDecisionAssist(true);
   if (generationId !== state.todayPlanGenerationSeq) return;
-  state.todayPlanState.loadingMessage = "";
-  state.todayPlanState.lastApplyBatch = null;
+  applyAsyncAction("todayPlan/generate:complete");
   renderTodayPlanPanel();
 }
 
 function handleTodayPlanToggleItem(todoId, checked) {
-  if (checked) {
-    state.todayPlanState.selectedTodoIds.add(todoId);
-  } else {
-    state.todayPlanState.selectedTodoIds.delete(todoId);
-  }
+  applyDomainAction("todayPlan/selection:set", {
+    todoId,
+    selected: checked,
+  });
   renderTodayPlanPanel();
 }
 
@@ -695,15 +707,15 @@ async function handleTodayPlanDismissSuggestion(suggestionId) {
     } catch (error) {
       console.error("Today plan dismiss failed:", error);
     }
-    state.todayPlanState.aiSuggestionId = "";
-    state.todayPlanState.envelope = normalizeTodayPlanEnvelope({
-      surface: hooks.TODAY_PLAN_SURFACE,
-      must_abstain: false,
-      planPreview: { topN: 3, items: [] },
-      suggestions: [],
+    applyAsyncAction("todayPlan/empty", {
+      envelope: normalizeTodayPlanEnvelope({
+        surface: hooks.TODAY_PLAN_SURFACE,
+        must_abstain: false,
+        planPreview: { topN: 3, items: [] },
+        suggestions: [],
+      }),
+      selectedTodoIds: [],
     });
-    state.todayPlanState.selectedTodoIds = new Set();
-    state.todayPlanState.dismissedSuggestionIds = new Set();
     renderTodayPlanPanel();
     return;
   }
@@ -746,10 +758,12 @@ async function handleTodayPlanApplySelected() {
       );
       if (!response.ok) {
         const data = await response.json().catch(() => ({}));
-        state.todayPlanState.error =
-          typeof data?.error === "string"
-            ? data.error
-            : "Could not apply selected suggestions.";
+        applyAsyncAction("todayPlan/failure", {
+          error:
+            typeof data?.error === "string"
+              ? data.error
+              : "Could not apply selected suggestions.",
+        });
         renderTodayPlanPanel();
         return;
       }
@@ -767,7 +781,9 @@ async function handleTodayPlanApplySelected() {
       await loadTodayPlanDecisionAssist(false);
     } catch (error) {
       console.error("Today plan apply failed:", error);
-      state.todayPlanState.error = "Could not apply selected suggestions.";
+      applyAsyncAction("todayPlan/failure", {
+        error: "Could not apply selected suggestions.",
+      });
       renderTodayPlanPanel();
       return;
     }
@@ -848,7 +864,9 @@ function bindTodayPlanHandlers() {
     if (!(target instanceof HTMLElement)) return;
     if (target.id !== "todayPlanGoalInput") return;
     if (!(target instanceof HTMLInputElement)) return;
-    state.todayPlanState.goalText = target.value;
+    applyDomainAction("todayPlan/goal:set", {
+      goalText: target.value,
+    });
   });
 
   document.addEventListener("change", (event) => {

--- a/client/modules/uiTemplates.js
+++ b/client/modules/uiTemplates.js
@@ -1,0 +1,206 @@
+// =============================================================================
+// uiTemplates.js — Shared string-template helpers for repeated UI structures.
+// =============================================================================
+
+import { hooks } from "./store.js";
+
+function escapeHtml(value) {
+  if (typeof hooks.escapeHtml === "function") {
+    return hooks.escapeHtml(value);
+  }
+  return String(value ?? "");
+}
+
+function joinClasses(...values) {
+  return values.filter(Boolean).join(" ");
+}
+
+export function renderPanelHeader({
+  className,
+  titleClass,
+  title,
+  actionsHtml = "",
+} = {}) {
+  return `
+    <div class="${className}">
+      <div class="${titleClass}">${escapeHtml(title)}</div>
+      ${actionsHtml}
+    </div>
+  `;
+}
+
+export function renderStatusMessage({
+  className = "ai-empty",
+  message,
+  role = "status",
+} = {}) {
+  return `<div class="${className}" role="${escapeHtml(role)}">${escapeHtml(message)}</div>`;
+}
+
+export function renderPanelState({
+  headerClass,
+  titleClass,
+  title,
+  actionsHtml = "",
+  debugHtml = "",
+  message,
+  messageClass = "ai-empty",
+  role = "status",
+} = {}) {
+  return `
+    ${renderPanelHeader({ className: headerClass, titleClass, title, actionsHtml })}
+    ${debugHtml}
+    ${renderStatusMessage({ className: messageClass, message, role })}
+  `;
+}
+
+export function renderDrawerSection({
+  title = "",
+  bodyHtml = "",
+  className = "todo-drawer__section",
+  titleClass = "todo-drawer__section-title",
+} = {}) {
+  return `
+    <div class="${className}">
+      ${title ? `<div class="${titleClass}">${escapeHtml(title)}</div>` : ""}
+      ${bodyHtml}
+    </div>
+  `;
+}
+
+export function renderDrawerAccordionSection({
+  sectionClass = "todo-drawer__section",
+  toggleId,
+  panelId,
+  title,
+  expanded,
+  bodyHtml = "",
+} = {}) {
+  return `
+    <div class="${sectionClass}">
+      <button
+        id="${escapeHtml(toggleId)}"
+        type="button"
+        class="todo-drawer__accordion-toggle"
+        aria-expanded="${expanded ? "true" : "false"}"
+        aria-controls="${escapeHtml(panelId)}"
+      >
+        <span>${escapeHtml(title)}</span>
+        <span class="todo-drawer__accordion-chevron" aria-hidden="true">${expanded ? "▾" : "▸"}</span>
+      </button>
+      <div
+        id="${escapeHtml(panelId)}"
+        class="todo-drawer__accordion-panel ${expanded ? "todo-drawer__accordion-panel--open" : ""}"
+        aria-hidden="${expanded ? "false" : "true"}"
+        ${expanded ? "" : "hidden"}
+      >
+        ${bodyHtml}
+      </div>
+    </div>
+  `;
+}
+
+export function renderTodoRowTemplate({
+  todo,
+  isSelected = false,
+  isActive = false,
+  kebabExpanded = false,
+  descriptionHtml = "",
+  metaHtml = "",
+  subtasksHtml = "",
+  notesHtml = "",
+  projectOptionsHtml = "",
+  headingMoveOptionsHtml = "",
+} = {}) {
+  const hasSubtasks = !!(todo?.subtasks && todo.subtasks.length > 0);
+  const title = escapeHtml(todo?.title || "");
+  const notesLabel = hasSubtasks
+    ? "AI Subtasks Generated"
+    : "AI Break Down Into Subtasks";
+
+  return `
+    <li
+      class="${joinClasses(
+        "todo-item",
+        todo?.completed ? "completed" : "",
+        isActive ? "todo-item--active" : "",
+        isSelected ? "todo-item--bulk-selected" : "",
+      )}"
+      draggable="true"
+      data-todo-id="${escapeHtml(todo?.id || "")}"
+      tabindex="0"
+      data-ondragstart="handleDragStart(event, this)"
+      data-ondragover="handleDragOver(event, this)"
+      data-ondrop="handleDrop(event, this)"
+      data-ondragend="handleDragEnd(event, this)"
+    >
+      <input
+        type="checkbox"
+        class="bulk-checkbox"
+        aria-label="Select todo ${title}"
+        ${isSelected ? "checked" : ""}
+        data-onchange="toggleSelectTodo('${escapeHtml(todo?.id || "")}')"
+        data-onclick="event.stopPropagation()"
+      >
+      <span class="drag-handle">⋮⋮</span>
+      <input
+        type="checkbox"
+        class="todo-checkbox"
+        aria-label="Mark todo ${title} complete"
+        ${todo?.completed ? "checked" : ""}
+        data-onchange="toggleTodo('${escapeHtml(todo?.id || "")}')"
+      >
+      <div class="todo-content">
+        <div class="todo-title" title="${title}">${title}</div>
+        ${descriptionHtml}
+        <div class="todo-meta">
+          ${metaHtml}
+        </div>
+        ${subtasksHtml}
+        ${notesHtml}
+      </div>
+      <div class="todo-row-actions">
+        <button
+          type="button"
+          class="todo-kebab"
+          aria-label="More actions for ${title}"
+          aria-expanded="${kebabExpanded ? "true" : "false"}"
+          data-onclick="toggleTodoKebab('${escapeHtml(todo?.id || "")}', event)"
+        >
+          ⋯
+        </button>
+        <div
+          class="todo-kebab-menu ${kebabExpanded ? "todo-kebab-menu--open" : ""}"
+          role="menu"
+          aria-label="Actions for ${title}"
+        >
+          <button type="button" class="todo-kebab-item" role="menuitem" data-onclick="openTodoFromKebab('${escapeHtml(todo?.id || "")}', event)">
+            Open details
+          </button>
+          <button type="button" class="todo-kebab-item" role="menuitem" data-onclick="openEditTodoFromKebab('${escapeHtml(todo?.id || "")}', event)">
+            Edit modal
+          </button>
+          <label class="todo-kebab-project-label">
+            Move to project
+            <select data-onclick="event.stopPropagation()" data-onchange="moveTodoToProject('${escapeHtml(todo?.id || "")}', this.value)">
+              ${projectOptionsHtml}
+            </select>
+          </label>
+          ${headingMoveOptionsHtml}
+          <button
+            type="button"
+            class="todo-kebab-item"
+            role="menuitem"
+            ${hasSubtasks ? "disabled" : ""}
+            data-onclick="aiBreakdownTodo('${escapeHtml(todo?.id || "")}')"
+          >
+            ${notesLabel}
+          </button>
+          <button type="button" class="todo-kebab-item todo-kebab-item--danger" role="menuitem" data-onclick="openDrawerDangerZone('${escapeHtml(todo?.id || "")}', event)">
+            Delete
+          </button>
+        </div>
+      </div>
+    </li>
+  `;
+}


### PR DESCRIPTION
Part of the P2 UI stabilisation sprint.

## What changed

Three new focused modules + wiring across 10 existing modules:

**stateActions.js** — explicit `applyUiAction(type, payload)` dispatcher for high-churn UI/domain entry points (quickEntry, drawerUi, onCreateAssist, commandPalette, railUi). Eliminates scattered ad-hoc boolean writes into state.

**asyncLifecycle.js** — `runAsyncLifecycle({ start, run, success, failure, finalize })` helper that normalises the load/error/empty state flow. Applied to taskDrawerAssist, onCreateAssist, and todayPlan load flows.

**uiTemplates.js** — shared string-template helpers (`renderPanelHeader`, `renderRowItem`, `renderDrawerSection`, etc.) replacing duplicated inline HTML string construction across drawerUi, onCreateAssist, todayPlan, and projectsState.

Filter/render pipeline untouched. No new dependencies.

## Files changed (13)
- client/modules/stateActions.js (new, 402 lines)
- client/modules/asyncLifecycle.js (new, 27 lines)
- client/modules/uiTemplates.js (new, 206 lines)
- client/modules/drawerUi.js
- client/modules/onCreateAssist.js
- client/modules/todayPlan.js
- client/modules/filterLogic.js
- client/modules/commandPalette.js
- client/modules/railUi.js
- client/modules/projectsState.js
- client/modules/quickEntry.js
- client/modules/homeDashboard.js
- client/modules/aiWorkspace.js

## Verification
- npx tsc --noEmit: PASS
- npm run format:check: PASS
- npm run lint:html: PASS
- npm run lint:css: PASS
- npm run test:unit: PASS
- CI=1 npm run test:ui:fast: PASS (205 passed, 33 skipped)