### PR TITLE
docs(tasks): add P3 task entries 161-171

### DIFF
--- a/docs/agent-queue/tasks/yellow/161-ui-stability-sweep-filter-pipeline.md
+++ b/docs/agent-queue/tasks/yellow/161-ui-stability-sweep-filter-pipeline.md
@@ -1,0 +1,31 @@
+# TASK 161: ui-stability-sweep-filter-pipeline
+
+type: Yellow
+status: PENDING_REVIEW
+mode: test + fix
+builder: codex
+reviewer: claude
+branch: codex/ui-stability-sweep-filter-pipeline
+pr: (not yet created)
+sha: 88475e4
+
+## Problem
+The filter pipeline (filterTodos → applyFiltersAndRender) lacked regression test
+coverage. A targeted sweep was needed to verify the pipeline is stable and catch
+any latent bugs before M1/M4 UI work lands on top.
+
+## What Changed
+- Added `tests/ui/filter-pipeline-regression.spec.ts` (491 lines) covering the
+  canonical filter pipeline end-to-end
+- Minor fixes to `public/app.js` (34 line delta) to address any latent issues
+  found during the sweep
+
+## Files Changed (2)
+- public/app.js
+- tests/ui/filter-pipeline-regression.spec.ts (new)
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/162-ui-stability-sweep-project-filter.md
+++ b/docs/agent-queue/tasks/yellow/162-ui-stability-sweep-project-filter.md
@@ -1,0 +1,31 @@
+# TASK 162: ui-stability-sweep-project-filter
+
+type: Yellow
+status: PENDING_REVIEW
+mode: test + fix
+builder: codex
+reviewer: claude
+branch: codex/ui-stability-sweep-project-filter
+pr: (not yet created)
+sha: 8c3e1c1
+
+## Problem
+Project filter/header sync had no regression coverage. When a project is selected
+the list header and filter state must stay in sync — this was untested and had at
+least one latent bug.
+
+## What Changed
+- Fixed project filter/header sync bug in `public/app.js` (119 line delta with
+  54 deletions — meaningful logic correction)
+- Added `tests/ui/project-filter-regression.spec.ts` (626 lines) covering
+  project selection, header sync, and filter state transitions
+
+## Files Changed (2)
+- public/app.js
+- tests/ui/project-filter-regression.spec.ts (new)
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/163-ui-m1-topbar-more-filters-html-css.md
+++ b/docs/agent-queue/tasks/yellow/163-ui-m1-topbar-more-filters-html-css.md
@@ -1,0 +1,39 @@
+# TASK 163: ui-m1-topbar-more-filters-html-css
+
+type: Yellow
+status: PENDING_REVIEW
+mode: feature
+builder: codex
+reviewer: claude
+branch: codex/ui-m1-pr1-topbar-more-filters
+pr: (not yet created)
+sha: 94401af (includes 2 commits: HTML/CSS + selector updates)
+
+## Problem
+The top bar lacked a "More filters" disclosure panel. Filter controls (date range,
+priority, tag) were either absent or buried. The top bar layout needed restructuring
+to accommodate an expandable panel without breaking existing smoke tests.
+
+## What Changed
+- `public/index.html`: restructured top bar markup to include More filters button
+  and collapsible panel (121 line delta, 68 deletions — significant restructure)
+- `public/styles.css`: added More filters panel styles and top bar layout
+  adjustments (141 line additions)
+- `tests/ui/app-smoke.spec.ts`: selector updates for new top bar structure (+17)
+- `tests/ui/ics-export.spec.ts`: selector updates for new top bar structure (+17)
+
+## Files Changed (4)
+- public/index.html
+- public/styles.css
+- tests/ui/app-smoke.spec.ts
+- tests/ui/ics-export.spec.ts
+
+## Note
+This is PR1 of 3 for the M1 More filters feature. PR2 wires the toggle behavior
+(Task 164), PR3 adds dedicated tests (Task 165).
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/164-ui-m1-more-filters-wiring.md
+++ b/docs/agent-queue/tasks/yellow/164-ui-m1-more-filters-wiring.md
@@ -1,0 +1,30 @@
+# TASK 164: ui-m1-more-filters-wiring
+
+type: Yellow
+status: PENDING_REVIEW
+mode: feature
+builder: codex
+reviewer: claude
+branch: codex/ui-m1-pr2-more-filters-wiring
+pr: (not yet created)
+sha: 02e15d2
+
+## Problem
+The More filters panel markup (Task 163) needed JS wiring: toggle open/close,
+accessible focus management on open, and Escape key dismissal.
+
+## What Changed
+- `public/app.js`: wired More filters toggle with accessible focus handling and
+  Escape dismissal (75 line addition — pure new behavior)
+
+## Files Changed (1)
+- public/app.js
+
+## Dependencies
+Requires Task 163 (HTML/CSS) to be merged first.
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/165-ui-m1-more-filters-tests.md
+++ b/docs/agent-queue/tasks/yellow/165-ui-m1-more-filters-tests.md
@@ -1,0 +1,31 @@
+# TASK 165: ui-m1-more-filters-tests
+
+type: Yellow
+status: PENDING_REVIEW
+mode: test
+builder: codex
+reviewer: claude
+branch: codex/ui-m1-pr3-more-filters-tests
+pr: (not yet created)
+sha: ee8ffa6
+
+## Problem
+The More filters disclosure behavior (Tasks 163 + 164) needed dedicated Playwright
+coverage: panel opens/closes, focus is trapped correctly, Escape dismisses,
+relocated controls are reachable.
+
+## What Changed
+- `tests/ui/more-filters.spec.ts` (new, 258 lines): covers More filters disclosure
+  behavior, relocated filter controls, accessibility invariants
+
+## Files Changed (1)
+- tests/ui/more-filters.spec.ts (new)
+
+## Dependencies
+Requires Tasks 163 and 164 to be merged first.
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/166-ui-m4-topbar-cleanup-projects-rail.md
+++ b/docs/agent-queue/tasks/yellow/166-ui-m4-topbar-cleanup-projects-rail.md
@@ -1,0 +1,37 @@
+# TASK 166: ui-m4-topbar-cleanup-projects-rail
+
+type: Yellow
+status: PENDING_REVIEW
+mode: feature
+builder: codex
+reviewer: claude
+branch: codex/ui-m4-pr4-topbar-cleanup
+pr: (not yet created)
+sha: 34bc7c2
+
+## Problem
+The top bar had residual projects-rail coordination issues after the M1 restructure.
+The projects button and rail toggle needed cleanup to work correctly together, and
+the interaction had no test coverage.
+
+## What Changed
+- `public/app.js`: projects rail / top bar coordination logic (+81 lines)
+- `public/index.html`: markup cleanup for projects button area (-8 line delta)
+- `public/styles.css`: projects rail top bar styles (+26 lines)
+- `tests/ui/topbar-projects.spec.ts` (new, 283 lines): top bar + projects rail
+  interaction coverage
+
+## Files Changed (4)
+- public/app.js
+- public/index.html
+- public/styles.css
+- tests/ui/topbar-projects.spec.ts (new)
+
+## Note
+This is PR4 of the M4 series. Pairs with PR5 (list header polish, Task 167).
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/167-ui-m4-list-header-polish.md
+++ b/docs/agent-queue/tasks/yellow/167-ui-m4-list-header-polish.md
@@ -1,0 +1,37 @@
+# TASK 167: ui-m4-list-header-polish
+
+type: Yellow
+status: PENDING_REVIEW
+mode: feature
+builder: codex
+reviewer: claude
+branch: codex/ui-m4-pr5-list-header-polish
+pr: (not yet created)
+sha: e0e26f9
+
+## Problem
+The sticky list header needed polish and correct rail/list coordination. The header
+should stay visible on scroll and correctly reflect the active view/project context.
+No test coverage existed for this behavior.
+
+## What Changed
+- `public/app.js`: list header + rail coordination logic (+52 lines)
+- `public/index.html`: list header markup additions (+9 lines)
+- `public/styles.css`: sticky list header styles (+36 lines)
+- `tests/ui/list-header.spec.ts` (new, 348 lines): sticky header behavior,
+  rail/list coordination, view context reflection
+
+## Files Changed (4)
+- public/app.js
+- public/index.html
+- public/styles.css
+- tests/ui/list-header.spec.ts (new)
+
+## Note
+PR5 of the M4 series. Depends on PR4 (Task 166).
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/168-ui-m4-overflow-hardening.md
+++ b/docs/agent-queue/tasks/yellow/168-ui-m4-overflow-hardening.md
@@ -1,0 +1,33 @@
+# TASK 168: ui-m4-overflow-hardening
+
+type: Yellow
+status: PENDING_REVIEW
+mode: fix
+builder: codex
+reviewer: claude
+branch: codex/ui-m4-pr6a-overflow-hardening
+pr: (not yet created)
+sha: 129f4b6
+
+## Problem
+The todos panel was susceptible to horizontal overflow in edge cases (long task
+titles, narrow viewports, certain filter combinations). This caused layout breakage
+with no test coverage to catch regressions.
+
+## What Changed
+- `public/styles.css`: overflow containment rules for todos panel (+28 lines)
+- `tests/ui/layout-overflow.spec.ts` (new, 204 lines): horizontal overflow
+  regression coverage for todos panel at various viewport widths
+
+## Files Changed (2)
+- public/styles.css
+- tests/ui/layout-overflow.spec.ts (new)
+
+## Note
+PR6a of M4. Pairs with PR6d (ellipsis fixes, Task 169).
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/169-ui-m4-topbar-rail-ellipsis-fixes.md
+++ b/docs/agent-queue/tasks/yellow/169-ui-m4-topbar-rail-ellipsis-fixes.md
@@ -1,0 +1,36 @@
+# TASK 169: ui-m4-topbar-rail-ellipsis-fixes
+
+type: Yellow
+status: PENDING_REVIEW
+mode: fix
+builder: codex
+reviewer: claude
+branch: codex/ui-m4-pr6d-topbar-rail-ellipsis-fixes
+pr: (not yet created)
+sha: 4a50b93
+
+## Problem
+Top bar CTA buttons and rail nav labels were clipping rather than truncating with
+ellipsis on narrow viewports. A hardening pass was needed to enforce correct
+text-overflow behavior across both surfaces.
+
+## What Changed
+- `public/app.js`: minor fix for topbar/rail label clipping logic (+2/-1 lines)
+- `public/styles.css`: text-overflow/ellipsis hardening for topbar and rail
+  label elements (+50 lines)
+- `tests/ui/topbar-no-cta-clipping.spec.ts` (new, 266 lines): verifies no
+  clipping occurs on CTA buttons and rail labels at narrow widths
+
+## Files Changed (3)
+- public/app.js
+- public/styles.css
+- tests/ui/topbar-no-cta-clipping.spec.ts (new)
+
+## Note
+PR6d of M4. Pairs with PR6a (overflow hardening, Task 168).
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/170-ui-m7-inputs-buttons-calm.md
+++ b/docs/agent-queue/tasks/yellow/170-ui-m7-inputs-buttons-calm.md
@@ -1,0 +1,34 @@
+# TASK 170: ui-m7-inputs-buttons-calm
+
+type: Yellow
+status: PENDING_REVIEW
+mode: feature
+builder: codex
+reviewer: claude
+branch: codex/ui-m7-inputs-buttons-calm
+pr: (not yet created)
+sha: b661561
+
+## Problem
+Input fields and buttons across the UI had inconsistent visual weight, focus rings,
+and hover states. The top bar CTA had no enforced invariants. A calm, systematic
+treatment was needed to unify the input/button design language.
+
+## What Changed
+- `public/styles.css`: calm input/button system — consistent sizing, focus rings,
+  hover states, disabled states (+184 lines); top bar CTA invariants enforced
+- `tests/ui/topbar-cta-invariants.spec.ts` (new, 263 lines): verifies CTA
+  button invariants (size, focus, hover, disabled) across surfaces
+
+## Files Changed (2)
+- public/styles.css
+- tests/ui/topbar-cta-invariants.spec.ts (new)
+
+## Note
+M7 milestone. Followed by post-M7 layout hardening (Task 171).
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)

--- a/docs/agent-queue/tasks/yellow/171-ui-post-m7-layout-hardening.md
+++ b/docs/agent-queue/tasks/yellow/171-ui-post-m7-layout-hardening.md
@@ -1,0 +1,36 @@
+# TASK 171: ui-post-m7-layout-hardening
+
+type: Yellow
+status: PENDING_REVIEW
+mode: fix
+builder: codex
+reviewer: claude
+branch: codex/ui-post-m7-layout-hardening
+pr: (not yet created)
+sha: 39ddebe
+
+## Problem
+After the M7 calm polish pass, a final layout hardening sweep was needed to catch
+any remaining spacing/sizing inconsistencies and extend overflow + CTA test coverage.
+
+## What Changed
+- `public/styles.css`: layout hardening and calm polish invariants (+103 lines)
+- `tests/ui/layout-overflow.spec.ts`: extended with additional viewport/overflow
+  cases (+37 lines)
+- `tests/ui/topbar-cta-invariants.spec.ts`: extended with additional CTA cases
+  (+10 lines)
+
+## Files Changed (3)
+- public/styles.css
+- tests/ui/layout-overflow.spec.ts
+- tests/ui/topbar-cta-invariants.spec.ts
+
+## Note
+Post-M7 cleanup. Depends on Task 170 (M7 inputs/buttons calm) and Task 168
+(overflow hardening) for the test files it extends.
+
+## Verification
+(to be confirmed on review/merge)
+
+## Outcome
+(to be filled after merge)


### PR DESCRIPTION
Retrospective task documentation for all 11 P3 branches.

## Stability sweeps (161-162)
- Task 161: filter pipeline regression tests + fixes
- Task 162: project filter/header sync fix + regression tests

## M1 — More filters (163-165, sequential)
- Task 163: topbar + More filters panel HTML/CSS
- Task 164: More filters toggle wiring (JS)
- Task 165: More filters dedicated tests

## M4 — Topbar/header/overflow (166-169)
- Task 166: topbar cleanup + projects rail coordination + tests
- Task 167: sticky list header polish + tests
- Task 168: todos panel overflow hardening + tests
- Task 169: topbar/rail ellipsis clipping fixes + tests

## M7 + post (170-171)
- Task 170: calm input/button system + CTA invariants + tests
- Task 171: post-M7 layout hardening + test extensions

All branches pushed to origin, PRs not yet created (review later).