### PR TITLE
feat(api): add MCP OAuth linking and scoped auth

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Navigation map for this directory.
 | `SAFETY_GUARDRAILS.md`   | Operational safety rules for all agents                                       |
 | `agent-accessibility.md` | First-pass server contract and safety model for machine agents                |
 | `assistant-mcp.md`       | Remote MCP adapter for assistant clients                                      |
+| `remote-mcp-auth.md`     | Account linking, auth, scopes, and local testing for the remote MCP surface   |
 | `ops/`                   | Repo operations runbooks and GitHub project setup notes                       |
 | `agent-ops/`             | Dual-agent protocol (state machine, review contract)                          |
 | `agent-queue/`           | Legacy markdown task archive and historical prompts                           |

--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -17,7 +17,7 @@ This is intentionally a thin layer over the existing Express routers and service
 
 The initial machine-readable contract lives in `src/agent/agent-manifest.json` and is exposed at runtime through `GET /agent/manifest`.
 
-The remote assistant-facing MCP adapter that builds on this internal layer is documented in `docs/assistant-mcp.md`.
+The remote assistant-facing MCP adapter that builds on this internal layer is documented in `docs/assistant-mcp.md`, with auth and scope details in `docs/remote-mcp-auth.md`.
 Supported actions:
 
 - `list_tasks`

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -10,30 +10,16 @@ Thin remote MCP layer for connecting registered todos app users from ChatGPT-, C
 
 ## Auth Model
 
-This first pass uses app-minted bearer tokens rather than OAuth.
+The remote MCP surface now expects a user-linked bearer token minted through the app-authenticated OAuth-style linking flow:
 
 1. The user signs in through the normal app auth flow and gets a standard app access token.
-2. The user calls `POST /auth/mcp/token` with that app token.
-3. The server returns a scoped MCP token.
-4. The assistant client uses that MCP token as `Authorization: Bearer <token>` when calling `/mcp`.
+2. The signed-in app starts assistant linking with `POST /auth/mcp/oauth/authorize`.
+3. The assistant exchanges the short-lived authorization code at `POST /auth/mcp/oauth/token`.
+4. The assistant calls `POST /mcp` with `Authorization: Bearer <accessToken>`.
 
-Current limitation:
+Detailed auth flow, scope mapping, and local development notes live in `docs/remote-mcp-auth.md`.
 
-- MCP tokens are minted manually through the API.
-- There is no OAuth discovery, consent screen, or token refresh flow for assistant clients yet.
-
-## Scopes
-
-Supported scopes are intentionally simple:
-
-- `read`
-- `write`
-
-Rules:
-
-- `read` allows read-only tools.
-- `write` allows mutating tools.
-- write tokens are normalized to include `read` as well.
+For local development only, `POST /auth/mcp/token` still exists as a direct token mint shortcut behind normal app auth.
 
 ## Supported Tools
 
@@ -48,7 +34,7 @@ Initial tools:
 - `list_projects`
 - `create_project`
 
-Tool discovery happens through standard MCP `tools/list`.
+Tool discovery happens through standard MCP `tools/list`, and each listed tool includes explicit auth metadata for required scopes and error expectations.
 
 ## Protocol Shape
 
@@ -72,7 +58,14 @@ Tool-level failures return:
 - `result.isError = true`
 - `result.structuredContent` carrying structured machine-usable error details
 
-The structured error shape includes stable codes, human-readable messages, retryability, and hints when the next step is clear.
+Auth and scope failures use stable codes such as:
+
+- `MCP_UNAUTHENTICATED`
+- `MCP_INVALID_TOKEN`
+- `MCP_AUTH_EXPIRED`
+- `MCP_INVALID_SESSION`
+- `MCP_INSUFFICIENT_SCOPE`
+- `RESOURCE_NOT_FOUND_OR_FORBIDDEN`
 
 ## Auditability
 
@@ -81,7 +74,8 @@ Assistant-triggered MCP calls emit lightweight structured logs with:
 - request ID
 - user ID
 - assistant identity
-- scopes
+- granted scopes
+- auth outcome
 - MCP method
 - tool name
 - outcome / error code
@@ -90,7 +84,7 @@ The delegated internal agent execution also logs its own action trace with `surf
 
 ## Idempotency
 
-First-pass idempotency is implemented for MCP `create_task` via an optional `idempotencyKey` argument.
+First-pass idempotency remains implemented for MCP `create_task` via an optional `idempotencyKey` argument.
 
 Current behavior:
 
@@ -103,7 +97,8 @@ Current limitation:
 
 ## Limitations / Follow-Up
 
-- add OAuth-based MCP auth for production-ready assistant connection flows
-- extend idempotency beyond `create_task` if assistant retry behavior needs it
-- decide whether `/mcp` should support SSE streaming once a concrete client requires it
-- add persisted audit storage if log-only tracing stops being enough
+- the OAuth-style linking flow is JSON API based and does not yet expose provider-facing discovery or consent UI
+- access tokens do not yet have refresh-token rotation for assistant clients
+- idempotency is only implemented for `create_task`
+- auditability is log-based only; there is no persisted audit store yet
+- add SSE support only if a concrete MCP client requires it

--- a/docs/memory/index/INDEX.md
+++ b/docs/memory/index/INDEX.md
@@ -53,6 +53,7 @@ Quick-reference to find things. Keep this flat and current.
 | ------------------- | ------------------------------ |
 | Agent accessibility | `docs/agent-accessibility.md`  |
 | Assistant MCP       | `docs/assistant-mcp.md`        |
+| Remote MCP auth     | `docs/remote-mcp-auth.md`      |
 | Codex task prompts  | `docs/codex-prompts.md`        |
 | Codex task config   | `.codex/tasks/ui-testing.md`   |
 | Dual-agent runner   | `scripts/dual-agent-runner.sh` |

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -1,0 +1,195 @@
+# Remote MCP Auth
+
+This doc covers the current account-linking, authentication, and scope model for the remote MCP server.
+
+## What "Account Linking" Means Here
+
+At this stage, assistant linking is an OAuth-style PKCE handshake over JSON API endpoints. It reuses the app's existing user auth and JWT primitives instead of introducing a second identity system.
+
+The current flow is:
+
+1. User signs in to the app and gets a normal app access token.
+2. The signed-in app calls `POST /auth/mcp/oauth/authorize`.
+3. The server binds a short-lived authorization code to:
+   - the authenticated user
+   - requested scopes
+   - assistant/client identity
+   - redirect URI
+   - PKCE code challenge
+4. The assistant exchanges that code at `POST /auth/mcp/oauth/token`.
+5. The assistant receives a scoped MCP access token and uses it on `POST /mcp`.
+
+This is intentionally thin. It is meant to be compatible with a future browser redirect / OIDC onboarding path, not to be a fully polished provider integration on its own.
+
+## Endpoints
+
+### `POST /auth/mcp/oauth/authorize`
+
+Starts assistant linking for a signed-in app user.
+
+Auth:
+
+- required
+- expects the normal app bearer token, not an MCP token
+
+Input:
+
+- `clientId`
+- `redirectUri`
+- `scopes`
+- `assistantName` (optional)
+- `state` (optional)
+- `codeChallenge`
+- `codeChallengeMethod` = `S256`
+
+Response:
+
+- `authorizationCode`
+- `expiresAt`
+- `redirectUri`
+- `scopes`
+- `assistantName` (if provided)
+- `state` (if provided)
+- `tokenEndpoint`
+
+### `POST /auth/mcp/oauth/token`
+
+Exchanges an authorization code for an MCP access token.
+
+Input:
+
+- `grantType` = `authorization_code`
+- `code`
+- `clientId`
+- `redirectUri`
+- `codeVerifier`
+
+Response:
+
+- `accessToken`
+- `tokenType`
+- `expiresAt`
+- `expiresIn`
+- `scope`
+- `scopes`
+- `assistantName` (if present)
+- `clientId` (if present)
+
+### `POST /auth/mcp/token`
+
+Local development shortcut only.
+
+This bypasses the authorization-code exchange and mints an MCP token directly from a signed-in app user session. It should not be the preferred path for production assistant connectors.
+
+## MCP Request Authentication
+
+Every `POST /mcp` request must include:
+
+- `Authorization: Bearer <mcp-access-token>`
+
+The server then:
+
+1. verifies token signature and expiry
+2. checks token type is `mcp`
+3. validates granted scopes
+4. resolves the token to a concrete app user with `getUserById`
+5. denies the request if the user session is no longer valid
+
+No MCP tool trusts a client-provided user ID.
+
+## Supported Scopes
+
+Initial assistant-facing scopes:
+
+- `tasks.read`
+- `tasks.write`
+- `projects.read`
+- `projects.write`
+
+The legacy `read` / `write` aliases are still accepted by the validation layer and expand to the explicit scopes above, but new docs and tooling should use the explicit scope names.
+
+## Tool to Scope Mapping
+
+| Tool             | Read only | Required scopes   |
+| ---------------- | --------- | ----------------- |
+| `list_tasks`     | Yes       | `tasks.read`      |
+| `search_tasks`   | Yes       | `tasks.read`      |
+| `get_task`       | Yes       | `tasks.read`      |
+| `create_task`    | No        | `tasks.write`     |
+| `update_task`    | No        | `tasks.write`     |
+| `complete_task`  | No        | `tasks.write`     |
+| `list_projects`  | Yes       | `projects.read`   |
+| `create_project` | No        | `projects.write`  |
+
+`tools/list` only returns tools that the current token is allowed to use.
+
+## Auth-Related Errors
+
+Auth and authorization failures return structured machine-usable errors with:
+
+- `code`
+- `message`
+- `retryable`
+- `hint` when the next step is clear
+
+Important auth codes:
+
+- `MCP_UNAUTHENTICATED`
+- `MCP_INVALID_AUTHORIZATION`
+- `MCP_INVALID_TOKEN`
+- `MCP_AUTH_EXPIRED`
+- `MCP_INVALID_SESSION`
+- `MCP_INSUFFICIENT_SCOPE`
+- `MCP_LINK_UNAUTHENTICATED`
+- `MCP_LINK_INVALID_TOKEN`
+- `MCP_LINK_AUTH_EXPIRED`
+- `MCP_AUTH_CODE_INVALID`
+- `MCP_AUTH_CODE_EXPIRED`
+- `MCP_INVALID_CODE_VERIFIER`
+- `RESOURCE_NOT_FOUND_OR_FORBIDDEN`
+
+For resource lookups, the server intentionally avoids trusting caller identity claims beyond the bearer token and user resolution step. The todo/project services still enforce user scoping.
+
+## Audit / Traceability
+
+The server logs lightweight structured events for:
+
+- assistant link authorization success/failure
+- token exchange success/failure
+- MCP auth success/failure
+- scope denials
+- tool calls with user ID, request ID, and tool name
+
+This is currently log-based traceability only.
+
+## Local Development
+
+Typical local flow:
+
+1. Sign in through `/auth/login` or the app UI and get a normal app token.
+2. Call `POST /auth/mcp/oauth/authorize` with:
+   - app bearer token
+   - desired scopes
+   - `clientId`
+   - `redirectUri`
+   - PKCE `codeChallenge`
+3. Exchange the returned `authorizationCode` at `POST /auth/mcp/oauth/token`.
+4. Use the returned MCP access token against `POST /mcp`.
+
+For quick manual testing only, `POST /auth/mcp/token` still mints a scoped token directly from the signed-in app user session.
+
+## Current Limitations
+
+- no provider-facing OAuth discovery document yet
+- no redirect/callback UI yet
+- no assistant refresh-token flow yet
+- authorization codes are in-memory and process-local
+- MCP access tokens are JWTs and are not yet individually revocable
+- audit data is not persisted outside logs
+
+## Follow-Up Direction
+
+- add provider-ready OAuth/OIDC discovery and consent UX when a specific assistant integration is ready
+- decide whether assistant refresh tokens should reuse or extend the app refresh-token model
+- persist link/session state if per-token revocation becomes necessary
+- broaden scopes only when more tools exist and concrete separation is needed

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -223,7 +223,7 @@ function toAgentError(error: unknown): {
     return {
       status: 404,
       error: {
-        code: "NOT_FOUND",
+        code: "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
         message: mapped.message,
         retryable: false,
         hint: "Verify the referenced resource ID belongs to the authenticated user.",
@@ -326,7 +326,7 @@ export class AgentExecutor {
           if (!task) {
             throw new AgentExecutionError(
               404,
-              "TASK_NOT_FOUND",
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
               "Task not found",
               false,
               "Verify the task ID belongs to the authenticated user.",
@@ -348,7 +348,7 @@ export class AgentExecutor {
           if (!task) {
             throw new AgentExecutionError(
               404,
-              "TASK_NOT_FOUND",
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
               "Task not found",
               false,
               "Verify the task ID belongs to the authenticated user.",
@@ -366,7 +366,7 @@ export class AgentExecutor {
           if (!task) {
             throw new AgentExecutionError(
               404,
-              "TASK_NOT_FOUND",
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
               "Task not found",
               false,
               "Verify the task ID belongs to the authenticated user.",

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import { createProjectsRouter } from "./routes/projectsRouter";
 import { IProjectService } from "./interfaces/IProjectService";
 import { IHeadingService } from "./interfaces/IHeadingService";
 import { AgentExecutor } from "./agent/agentExecutor";
+import { McpOAuthService } from "./services/mcpOAuthService";
 import {
   authLimiter,
   emailActionLimiter,
@@ -44,6 +45,7 @@ export function createApp(
 ) {
   const app = express();
   const agentExecutor = new AgentExecutor({ todoService, projectService });
+  const mcpOAuthService = new McpOAuthService();
 
   const resolveTodoUserId = (req: Request, res: Response): string | null => {
     if (authService) {
@@ -170,6 +172,7 @@ export function createApp(
     "/auth",
     createAuthRouter({
       authService,
+      mcpOAuthService,
       authLimiter,
       emailActionLimiter,
       requireAuthIfConfigured,

--- a/src/mcp/mcpAuth.ts
+++ b/src/mcp/mcpAuth.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "crypto";
+import { Request } from "express";
+import { AuthService, McpTokenPayload } from "../services/authService";
+import { McpScope } from "../types";
+import { buildStructuredMcpError } from "./mcpErrors";
+import { hasAllMcpScopes } from "./mcpScopes";
+
+type JsonRpcId = number | string | null;
+
+export interface ResolvedMcpAuthContext {
+  session: McpTokenPayload;
+  user: {
+    id: string;
+    email: string;
+    name: string | null;
+    isVerified: boolean;
+    role: string;
+    plan: string;
+  };
+  requestId: string;
+  actor: string;
+}
+
+function readHeader(req: Request, name: string): string | undefined {
+  const value = req.header(name);
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+export function buildMcpRequestId(req: Request, requestId?: JsonRpcId): string {
+  const headerId = readHeader(req, "x-mcp-request-id");
+  if (headerId) {
+    return headerId;
+  }
+  if (typeof requestId === "string" || typeof requestId === "number") {
+    return `mcp-${requestId}`;
+  }
+  return randomUUID();
+}
+
+export function buildMcpActor(
+  req: Request,
+  session?: Pick<McpTokenPayload, "assistantName" | "clientId">,
+): string {
+  const headerActor = readHeader(req, "x-assistant-name");
+  if (headerActor) {
+    return headerActor;
+  }
+  if (session?.assistantName) {
+    return session.assistantName;
+  }
+  if (session?.clientId) {
+    return session.clientId;
+  }
+  return readHeader(req, "user-agent") || "unknown-assistant";
+}
+
+export async function resolveMcpAuthContext(input: {
+  req: Request;
+  authService?: AuthService;
+  requestId: string;
+}): Promise<{
+  httpStatus: number;
+  context?: ResolvedMcpAuthContext;
+  error?: ReturnType<typeof buildStructuredMcpError>;
+}> {
+  if (!input.authService) {
+    return {
+      httpStatus: 501,
+      error: buildStructuredMcpError({
+        code: "MCP_NOT_CONFIGURED",
+        message: "MCP authentication is not configured",
+        retryable: false,
+        hint: "Enable application authentication before using the remote MCP surface.",
+      }),
+    };
+  }
+
+  const authHeader = readHeader(input.req, "authorization");
+  if (!authHeader) {
+    return {
+      httpStatus: 401,
+      error: buildStructuredMcpError({
+        code: "MCP_UNAUTHENTICATED",
+        message: "Authorization header missing",
+        retryable: false,
+        hint: "Complete the MCP account-link flow and send Authorization: Bearer <token>.",
+      }),
+    };
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer") {
+    return {
+      httpStatus: 401,
+      error: buildStructuredMcpError({
+        code: "MCP_INVALID_AUTHORIZATION",
+        message: "Invalid authorization format. Expected: Bearer <token>",
+        retryable: false,
+        hint: "Send the MCP access token as a bearer token.",
+      }),
+    };
+  }
+
+  let session: McpTokenPayload;
+  try {
+    session = input.authService.verifyMcpToken(parts[1]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message === "Token expired") {
+      return {
+        httpStatus: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_AUTH_EXPIRED",
+          message: "MCP access token expired",
+          retryable: false,
+          hint: "Repeat the MCP OAuth link flow to mint a fresh token.",
+        }),
+      };
+    }
+
+    return {
+      httpStatus: 401,
+      error: buildStructuredMcpError({
+        code: "MCP_INVALID_TOKEN",
+        message: "Invalid MCP access token",
+        retryable: false,
+        hint: "Use a token minted through the MCP OAuth exchange or local dev mint endpoint.",
+      }),
+    };
+  }
+
+  const user = await input.authService.getUserById(session.userId);
+  if (!user) {
+    return {
+      httpStatus: 401,
+      error: buildStructuredMcpError({
+        code: "MCP_INVALID_SESSION",
+        message: "MCP token no longer maps to an active user session",
+        retryable: false,
+        hint: "Re-link the user account to mint a fresh token.",
+      }),
+    };
+  }
+
+  return {
+    httpStatus: 200,
+    context: {
+      session,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        isVerified: user.isVerified,
+        role: user.role,
+        plan: user.plan,
+      },
+      requestId: input.requestId,
+      actor: buildMcpActor(input.req, session),
+    },
+  };
+}
+
+export function buildScopeError(input: {
+  toolName: string;
+  requiredScopes: McpScope[];
+}) {
+  return buildStructuredMcpError({
+    code: "MCP_INSUFFICIENT_SCOPE",
+    message: `Tool "${input.toolName}" requires scopes: ${input.requiredScopes.join(", ")}`,
+    retryable: false,
+    hint: "Re-link the account with the missing scopes and retry.",
+    details: {
+      requiredScopes: input.requiredScopes,
+    },
+  });
+}
+
+export function hasRequiredToolScopes(
+  availableScopes: McpScope[],
+  requiredScopes: McpScope[],
+) {
+  return hasAllMcpScopes(availableScopes, requiredScopes);
+}

--- a/src/mcp/mcpErrors.ts
+++ b/src/mcp/mcpErrors.ts
@@ -1,0 +1,120 @@
+import { mapError } from "../errorHandling";
+
+export interface StructuredMcpError {
+  code: string;
+  message: string;
+  retryable: boolean;
+  hint?: string;
+  details?: Record<string, unknown>;
+}
+
+export function buildStructuredMcpError(input: StructuredMcpError) {
+  return {
+    code: input.code,
+    message: input.message,
+    retryable: input.retryable,
+    ...(input.hint ? { hint: input.hint } : {}),
+    ...(input.details ? { details: input.details } : {}),
+  };
+}
+
+export function mapAgentFacingError(error: unknown): {
+  status: number;
+  error: StructuredMcpError;
+} {
+  const mapped = mapError(error);
+
+  if (mapped.status === 400) {
+    return {
+      status: 400,
+      error: buildStructuredMcpError({
+        code: "MCP_INVALID_REQUEST",
+        message: mapped.message,
+        retryable: false,
+        hint: "Review the request payload against the documented MCP auth or tool contract and retry.",
+      }),
+    };
+  }
+
+  if (mapped.status === 401) {
+    const code =
+      mapped.message === "Token expired"
+        ? "MCP_AUTH_EXPIRED"
+        : mapped.message === "Invalid token"
+          ? "MCP_INVALID_TOKEN"
+          : "MCP_UNAUTHENTICATED";
+    const hint =
+      code === "MCP_AUTH_EXPIRED"
+        ? "Repeat the account-link flow to mint a fresh MCP access token."
+        : code === "MCP_INVALID_TOKEN"
+          ? "Use a valid assistant token minted through the MCP OAuth exchange."
+          : "Authenticate the user account and retry.";
+    return {
+      status: 401,
+      error: buildStructuredMcpError({
+        code,
+        message: mapped.message,
+        retryable: false,
+        hint,
+      }),
+    };
+  }
+
+  if (mapped.status === 403) {
+    return {
+      status: 403,
+      error: buildStructuredMcpError({
+        code: "MCP_FORBIDDEN",
+        message: mapped.message,
+        retryable: false,
+        hint: "Use a token that was granted access to the requested action or resource.",
+      }),
+    };
+  }
+
+  if (mapped.status === 404) {
+    return {
+      status: 404,
+      error: buildStructuredMcpError({
+        code: "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+        message: mapped.message,
+        retryable: false,
+        hint: "Verify the resource ID belongs to the authenticated user and is still available.",
+      }),
+    };
+  }
+
+  if (mapped.status === 409) {
+    return {
+      status: 409,
+      error: buildStructuredMcpError({
+        code: "MCP_CONFLICT",
+        message: mapped.message,
+        retryable: false,
+        hint: "Fetch current state and retry with updated input if needed.",
+      }),
+    };
+  }
+
+  if (mapped.status === 501) {
+    return {
+      status: 501,
+      error: buildStructuredMcpError({
+        code: "MCP_NOT_CONFIGURED",
+        message: mapped.message,
+        retryable: false,
+        hint: "Enable the required server capability before calling this surface.",
+      }),
+    };
+  }
+
+  return {
+    status: 500,
+    error: buildStructuredMcpError({
+      code: "MCP_INTERNAL_ERROR",
+      message: "Internal server error",
+      retryable: true,
+      hint: "Retry the request. If it keeps failing, inspect the server logs using the request ID.",
+    }),
+  };
+}

--- a/src/mcp/mcpScopes.ts
+++ b/src/mcp/mcpScopes.ts
@@ -1,0 +1,88 @@
+import { McpScope } from "../types";
+import { ValidationError } from "../validation/validation";
+
+export type McpScopeAlias = "read" | "write";
+
+export const TASK_READ_SCOPE: McpScope = "tasks.read";
+export const TASK_WRITE_SCOPE: McpScope = "tasks.write";
+export const PROJECT_READ_SCOPE: McpScope = "projects.read";
+export const PROJECT_WRITE_SCOPE: McpScope = "projects.write";
+
+export const ALL_MCP_SCOPES: McpScope[] = [
+  TASK_READ_SCOPE,
+  TASK_WRITE_SCOPE,
+  PROJECT_READ_SCOPE,
+  PROJECT_WRITE_SCOPE,
+];
+
+export const DEFAULT_MCP_SCOPES: McpScope[] = [
+  TASK_READ_SCOPE,
+  PROJECT_READ_SCOPE,
+];
+
+const LEGACY_SCOPE_ALIASES: Record<McpScopeAlias, McpScope[]> = {
+  read: [...DEFAULT_MCP_SCOPES],
+  write: [...ALL_MCP_SCOPES],
+};
+
+function isExplicitMcpScope(value: string): value is McpScope {
+  return ALL_MCP_SCOPES.includes(value as McpScope);
+}
+
+export function normalizeMcpScopes(
+  value: unknown,
+  options?: { defaultScopes?: McpScope[]; requireNonEmpty?: boolean },
+): McpScope[] {
+  if (value === undefined) {
+    const defaults = options?.defaultScopes || DEFAULT_MCP_SCOPES;
+    return [...defaults];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new ValidationError("scopes must be an array");
+  }
+
+  const expandedScopes = value.flatMap((entry) => {
+    if (typeof entry !== "string") {
+      throw new ValidationError("scopes entries must be strings");
+    }
+
+    const normalized = entry.trim().toLowerCase();
+    if (!normalized) {
+      throw new ValidationError("scopes entries cannot be empty");
+    }
+
+    if (normalized in LEGACY_SCOPE_ALIASES) {
+      return LEGACY_SCOPE_ALIASES[normalized as McpScopeAlias];
+    }
+
+    if (!isExplicitMcpScope(normalized)) {
+      throw new ValidationError(
+        `Unsupported scope "${entry}". Use explicit scopes like tasks.read or projects.write.`,
+      );
+    }
+
+    return [normalized];
+  });
+
+  const uniqueScopes = Array.from(new Set(expandedScopes)).sort((left, right) =>
+    left.localeCompare(right),
+  ) as McpScope[];
+
+  if ((options?.requireNonEmpty ?? true) && uniqueScopes.length === 0) {
+    throw new ValidationError("scopes cannot be empty");
+  }
+
+  return uniqueScopes;
+}
+
+export function hasAllMcpScopes(
+  availableScopes: McpScope[],
+  requiredScopes: McpScope[],
+): boolean {
+  return requiredScopes.every((scope) => availableScopes.includes(scope));
+}
+
+export function formatMcpScopes(scopes: McpScope[]): string {
+  return [...scopes].sort((left, right) => left.localeCompare(right)).join(" ");
+}

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -1,6 +1,12 @@
 import agentManifest from "../agent/agent-manifest.json";
 import { AgentActionName } from "../agent/agentExecutor";
 import { McpScope } from "../types";
+import {
+  PROJECT_READ_SCOPE,
+  PROJECT_WRITE_SCOPE,
+  TASK_READ_SCOPE,
+  TASK_WRITE_SCOPE,
+} from "./mcpScopes";
 import { hasMcpScope } from "../validation/mcpValidation";
 
 export const MCP_PROTOCOL_VERSION = "2025-11-25";
@@ -10,12 +16,29 @@ type ToolCatalogEntry = {
   description: string;
   inputSchema: Record<string, unknown>;
   readOnly: boolean;
-  requiredScope: McpScope;
+  requiredScopes: McpScope[];
   requiresProjectService: boolean;
 };
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function requiredScopesForAction(actionName: AgentActionName): McpScope[] {
+  switch (actionName) {
+    case "list_tasks":
+    case "search_tasks":
+    case "get_task":
+      return [TASK_READ_SCOPE];
+    case "create_task":
+    case "update_task":
+    case "complete_task":
+      return [TASK_WRITE_SCOPE];
+    case "list_projects":
+      return [PROJECT_READ_SCOPE];
+    case "create_project":
+      return [PROJECT_WRITE_SCOPE];
+  }
 }
 
 function buildCatalog(): ToolCatalogEntry[] {
@@ -43,7 +66,7 @@ function buildCatalog(): ToolCatalogEntry[] {
       description: action.description,
       inputSchema,
       readOnly: action.readOnly,
-      requiredScope: action.readOnly ? "read" : "write",
+      requiredScopes: requiredScopesForAction(action.name as AgentActionName),
       requiresProjectService: Boolean(
         action.availability?.requires?.includes("project_service"),
       ),
@@ -61,7 +84,7 @@ export function listMcpTools(input: {
     if (tool.requiresProjectService && !input.projectServiceEnabled) {
       return false;
     }
-    return hasMcpScope(input.scopes, tool.requiredScope);
+    return hasMcpScope(input.scopes, tool.requiredScopes);
   }).map((tool) => ({
     name: tool.name,
     description: tool.description,
@@ -71,6 +94,18 @@ export function listMcpTools(input: {
       destructiveHint: false,
       idempotentHint: tool.name === "create_task",
       openWorldHint: false,
+    },
+    auth: {
+      required: true,
+      requiredScopes: [...tool.requiredScopes],
+      readOnly: tool.readOnly,
+      errors: [
+        "MCP_UNAUTHENTICATED",
+        "MCP_INVALID_TOKEN",
+        "MCP_AUTH_EXPIRED",
+        "MCP_INSUFFICIENT_SCOPE",
+        "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+      ],
     },
   }));
 }

--- a/src/mcpRouter.test.ts
+++ b/src/mcpRouter.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import request from "supertest";
 import type { Express } from "express";
 import { createApp } from "./app";
@@ -26,40 +27,79 @@ function createProjectServiceMock(): jest.Mocked<IProjectService> {
   };
 }
 
-function buildMcpSession(scopes: McpScope[]) {
+function buildMcpSession(
+  userId: string,
+  scopes: McpScope[],
+  assistantName = "ChatGPT",
+) {
   return {
-    userId: "user-1",
-    email: "user@example.com",
+    userId,
+    email: `${userId}@example.com`,
     tokenType: "mcp" as const,
     scopes,
-    assistantName: "ChatGPT",
+    assistantName,
+    clientId: "chatgpt-client",
   };
 }
 
-describe("Remote MCP router", () => {
+function createPkcePair(verifier: string) {
+  const challenge = createHash("sha256")
+    .update(verifier, "utf8")
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  return { verifier, challenge };
+}
+
+describe("Remote MCP router auth and scopes", () => {
   let app: Express;
   let todoService: TodoService;
   let projectService: jest.Mocked<IProjectService>;
+  let currentSession: ReturnType<typeof buildMcpSession>;
   let mockAuthService: {
     verifyToken: jest.Mock;
     createMcpToken: jest.Mock;
     verifyMcpToken: jest.Mock;
+    getUserById: jest.Mock;
   };
 
   beforeEach(() => {
     todoService = new TodoService();
     projectService = createProjectServiceMock();
+    currentSession = buildMcpSession("user-1", ["projects.read", "tasks.read"]);
+
     mockAuthService = {
       verifyToken: jest
         .fn()
-        .mockReturnValue({ userId: "user-1", email: "user@example.com" }),
-      createMcpToken: jest.fn().mockReturnValue({
-        token: "mcp-token-1",
-        scopes: ["read", "write"],
-        expiresAt: "2026-04-09T00:00:00.000Z",
-        assistantName: "ChatGPT",
+        .mockReturnValue({ userId: "user-1", email: "user-1@example.com" }),
+      createMcpToken: jest.fn().mockImplementation((input) => ({
+        token: `mcp-token-${input.userId}`,
+        tokenType: "Bearer",
+        scope: [...input.scopes].sort().join(" "),
+        scopes: [...input.scopes].sort(),
+        expiresAt: "2026-04-10T00:00:00.000Z",
+        expiresIn: 2592000,
+        assistantName: input.assistantName,
+        clientId: input.clientId,
+      })),
+      verifyMcpToken: jest.fn().mockImplementation(() => currentSession),
+      getUserById: jest.fn().mockImplementation(async (userId: string) => {
+        if (userId === "missing-user") {
+          return null;
+        }
+
+        return {
+          id: userId,
+          email: `${userId}@example.com`,
+          name: userId,
+          isVerified: true,
+          role: "user",
+          plan: "free",
+          createdAt: new Date("2026-03-11T00:00:00.000Z"),
+          updatedAt: new Date("2026-03-11T00:00:00.000Z"),
+        };
       }),
-      verifyMcpToken: jest.fn().mockReturnValue(buildMcpSession(["read"])),
     };
 
     app = createApp(
@@ -73,57 +113,197 @@ describe("Remote MCP router", () => {
     );
   });
 
-  it("issues scoped MCP tokens for authenticated users", async () => {
+  it("issues scoped MCP tokens directly for local development", async () => {
     const response = await request(app)
       .post("/auth/mcp/token")
       .set("Authorization", "Bearer app-access-token")
-      .send({ scopes: ["write"], assistantName: "ChatGPT" })
+      .send({
+        scopes: ["tasks.write"],
+        assistantName: "ChatGPT",
+        clientId: "chatgpt-client",
+      })
       .expect(201);
 
     expect(mockAuthService.createMcpToken).toHaveBeenCalledWith({
       userId: "user-1",
-      email: "user@example.com",
-      scopes: ["read", "write"],
+      email: "user-1@example.com",
+      scopes: ["tasks.write"],
       assistantName: "ChatGPT",
+      clientId: "chatgpt-client",
     });
     expect(response.body).toEqual({
-      token: "mcp-token-1",
-      scopes: ["read", "write"],
-      expiresAt: "2026-04-09T00:00:00.000Z",
+      token: "mcp-token-user-1",
+      tokenType: "Bearer",
+      scope: "tasks.write",
+      scopes: ["tasks.write"],
+      expiresAt: "2026-04-10T00:00:00.000Z",
+      expiresIn: 2592000,
       assistantName: "ChatGPT",
+      clientId: "chatgpt-client",
     });
   });
 
-  it("initializes the stateless MCP surface for an authenticated user", async () => {
+  it("starts OAuth-style assistant linking for an authenticated app user", async () => {
+    const pkce = createPkcePair(
+      "verifier-value-0000000000000000000000000000000000000",
+    );
+
+    const response = await request(app)
+      .post("/auth/mcp/oauth/authorize")
+      .set("Authorization", "Bearer app-access-token")
+      .send({
+        clientId: "chatgpt-client",
+        redirectUri: "https://chat.openai.com/aip/callback",
+        scopes: ["tasks.read", "projects.read"],
+        assistantName: "ChatGPT",
+        state: "opaque-state",
+        codeChallenge: pkce.challenge,
+        codeChallengeMethod: "S256",
+      })
+      .expect(201);
+
+    expect(response.body.authorizationCode).toEqual(expect.any(String));
+    expect(response.body.tokenEndpoint).toBe("/auth/mcp/oauth/token");
+    expect(response.body.scopes).toEqual(["projects.read", "tasks.read"]);
+    expect(response.body.state).toBe("opaque-state");
+  });
+
+  it("exchanges an authorization code for a scoped MCP access token", async () => {
+    const pkce = createPkcePair(
+      "oauth-verifier-111111111111111111111111111111111111111",
+    );
+
+    const authorize = await request(app)
+      .post("/auth/mcp/oauth/authorize")
+      .set("Authorization", "Bearer app-access-token")
+      .send({
+        clientId: "chatgpt-client",
+        redirectUri: "https://chat.openai.com/aip/callback",
+        scopes: ["tasks.read", "tasks.write"],
+        assistantName: "ChatGPT",
+        codeChallenge: pkce.challenge,
+        codeChallengeMethod: "S256",
+      })
+      .expect(201);
+
+    const exchange = await request(app)
+      .post("/auth/mcp/oauth/token")
+      .send({
+        grantType: "authorization_code",
+        code: authorize.body.authorizationCode,
+        clientId: "chatgpt-client",
+        redirectUri: "https://chat.openai.com/aip/callback",
+        codeVerifier: pkce.verifier,
+      })
+      .expect(200);
+
+    expect(mockAuthService.createMcpToken).toHaveBeenCalledWith({
+      userId: "user-1",
+      email: "user-1@example.com",
+      scopes: ["tasks.read", "tasks.write"],
+      assistantName: "ChatGPT",
+      clientId: "chatgpt-client",
+    });
+    expect(exchange.body).toEqual({
+      accessToken: "mcp-token-user-1",
+      tokenType: "Bearer",
+      expiresAt: "2026-04-10T00:00:00.000Z",
+      expiresIn: 2592000,
+      scope: "tasks.read tasks.write",
+      scopes: ["tasks.read", "tasks.write"],
+      assistantName: "ChatGPT",
+      clientId: "chatgpt-client",
+    });
+  });
+
+  it("returns structured errors when the PKCE verifier is wrong", async () => {
+    const pkce = createPkcePair(
+      "oauth-verifier-222222222222222222222222222222222222222",
+    );
+
+    const authorize = await request(app)
+      .post("/auth/mcp/oauth/authorize")
+      .set("Authorization", "Bearer app-access-token")
+      .send({
+        clientId: "claude-client",
+        redirectUri: "https://claude.ai/oauth/callback",
+        scopes: ["tasks.read"],
+        assistantName: "Claude",
+        codeChallenge: pkce.challenge,
+        codeChallengeMethod: "S256",
+      })
+      .expect(201);
+
+    const exchange = await request(app)
+      .post("/auth/mcp/oauth/token")
+      .send({
+        grantType: "authorization_code",
+        code: authorize.body.authorizationCode,
+        clientId: "claude-client",
+        redirectUri: "https://claude.ai/oauth/callback",
+        codeVerifier: "wrong-verifier-333333333333333333333333333333333333333",
+      })
+      .expect(401);
+
+    expect(exchange.body.error.code).toBe("MCP_INVALID_CODE_VERIFIER");
+  });
+
+  it("rejects missing MCP auth with a structured protocol error", async () => {
     const response = await request(app)
       .post("/mcp")
-      .set("Authorization", "Bearer mcp-token-1")
       .send({
         jsonrpc: "2.0",
         id: 1,
         method: "initialize",
-        params: {
-          protocolVersion: "2025-11-25",
-          capabilities: {},
-          clientInfo: { name: "ChatGPT", version: "1.0" },
-        },
       })
-      .expect(200);
+      .expect(401);
 
-    expect(response.body.result.protocolVersion).toBe("2025-11-25");
-    expect(response.body.result.capabilities.tools.listChanged).toBe(false);
-    expect(response.body.result.serverInfo.name).toBe("todos-api-mcp");
+    expect(response.body.error.data.code).toBe("MCP_UNAUTHENTICATED");
   });
 
-  it("lists only read tools for read-scoped MCP tokens", async () => {
-    mockAuthService.verifyMcpToken.mockReturnValue(buildMcpSession(["read"]));
+  it("rejects expired MCP access tokens", async () => {
+    mockAuthService.verifyMcpToken.mockImplementation(() => {
+      throw new Error("Token expired");
+    });
 
     const response = await request(app)
       .post("/mcp")
-      .set("Authorization", "Bearer mcp-token-1")
+      .set("Authorization", "Bearer expired-token")
       .send({
         jsonrpc: "2.0",
         id: 2,
+        method: "ping",
+      })
+      .expect(401);
+
+    expect(response.body.error.data.code).toBe("MCP_AUTH_EXPIRED");
+  });
+
+  it("rejects MCP tokens that no longer resolve to a user", async () => {
+    currentSession = buildMcpSession("missing-user", ["tasks.read"]);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer orphaned-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "ping",
+      })
+      .expect(401);
+
+    expect(response.body.error.data.code).toBe("MCP_INVALID_SESSION");
+  });
+
+  it("lists only tools allowed by the current scopes and exposes auth metadata", async () => {
+    currentSession = buildMcpSession("user-1", ["projects.read", "tasks.read"]);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer scoped-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 4,
         method: "tools/list",
       })
       .expect(200);
@@ -135,17 +315,33 @@ describe("Remote MCP router", () => {
     expect(toolNames).toContain("list_projects");
     expect(toolNames).not.toContain("create_task");
     expect(toolNames).not.toContain("create_project");
+
+    const listTasksTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "list_tasks",
+    );
+    expect(listTasksTool.auth).toEqual({
+      required: true,
+      requiredScopes: ["tasks.read"],
+      readOnly: true,
+      errors: [
+        "MCP_UNAUTHENTICATED",
+        "MCP_INVALID_TOKEN",
+        "MCP_AUTH_EXPIRED",
+        "MCP_INSUFFICIENT_SCOPE",
+        "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+      ],
+    });
   });
 
-  it("rejects write tools for read-scoped MCP tokens with structured errors", async () => {
-    mockAuthService.verifyMcpToken.mockReturnValue(buildMcpSession(["read"]));
+  it("rejects write tools when write scope is missing", async () => {
+    currentSession = buildMcpSession("user-1", ["tasks.read"]);
 
     const response = await request(app)
       .post("/mcp")
-      .set("Authorization", "Bearer mcp-token-1")
+      .set("Authorization", "Bearer readonly-token")
       .send({
         jsonrpc: "2.0",
-        id: 3,
+        id: 5,
         method: "tools/call",
         params: {
           name: "create_task",
@@ -156,14 +352,41 @@ describe("Remote MCP router", () => {
 
     expect(response.body.result.isError).toBe(true);
     expect(response.body.result.structuredContent.error.code).toBe(
-      "MCP_SCOPE_REQUIRED",
+      "MCP_INSUFFICIENT_SCOPE",
+    );
+    expect(
+      response.body.result.structuredContent.error.details.requiredScopes,
+    ).toEqual(["tasks.write"]);
+  });
+
+  it("blocks cross-user task access through the MCP surface", async () => {
+    const todo = await todoService.create("user-1", {
+      title: "User 1 private task",
+    });
+    currentSession = buildMcpSession("user-2", ["tasks.read"]);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer user-2-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: {
+          name: "get_task",
+          arguments: { id: todo.id },
+        },
+      })
+      .expect(200);
+
+    expect(response.body.result.isError).toBe(true);
+    expect(response.body.result.structuredContent.error.code).toBe(
+      "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
     );
   });
 
-  it("reuses the internal agent layer for create_task with MCP idempotency and logging", async () => {
-    mockAuthService.verifyMcpToken.mockReturnValue(
-      buildMcpSession(["read", "write"]),
-    );
+  it("reuses the internal agent layer for create_task with idempotency and audit logging", async () => {
+    currentSession = buildMcpSession("user-1", ["tasks.read", "tasks.write"]);
     const logSpy = jest.spyOn(console, "info").mockImplementation(() => {});
 
     const firstResponse = await request(app)
@@ -171,7 +394,7 @@ describe("Remote MCP router", () => {
       .set("Authorization", "Bearer mcp-token-1")
       .send({
         jsonrpc: "2.0",
-        id: 4,
+        id: 7,
         method: "tools/call",
         params: {
           name: "create_task",
@@ -188,7 +411,7 @@ describe("Remote MCP router", () => {
       .set("Authorization", "Bearer mcp-token-1")
       .send({
         jsonrpc: "2.0",
-        id: 5,
+        id: 8,
         method: "tools/call",
         params: {
           name: "create_task",
@@ -211,6 +434,9 @@ describe("Remote MCP router", () => {
     );
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining('"type":"assistant_mcp_call"'),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"authOutcome":"authenticated"'),
     );
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining('"toolName":"create_task"'),

--- a/src/routes/authRouter.ts
+++ b/src/routes/authRouter.ts
@@ -5,20 +5,231 @@ import {
   NextFunction,
   RequestHandler,
 } from "express";
+import { randomUUID } from "crypto";
 import { AuthService } from "../services/authService";
+import { McpOAuthService } from "../services/mcpOAuthService";
 import { validateRegister, validateLogin } from "../validation/authValidation";
 import { HttpError } from "../errorHandling";
-import { validateCreateMcpTokenInput } from "../validation/mcpValidation";
+import { buildStructuredMcpError, mapAgentFacingError } from "../mcp/mcpErrors";
+import {
+  validateCreateMcpAuthorizationCodeInput,
+  validateCreateMcpTokenInput,
+  validateExchangeMcpAuthorizationCodeInput,
+} from "../validation/mcpValidation";
 
 interface AuthRouterDeps {
   authService?: AuthService;
+  mcpOAuthService: McpOAuthService;
   authLimiter: RequestHandler;
   emailActionLimiter: RequestHandler;
   requireAuthIfConfigured: RequestHandler;
 }
 
+function buildLinkRequestId(req: Request): string {
+  const headerId =
+    req.header("x-mcp-request-id") || req.header("x-agent-request-id");
+  return typeof headerId === "string" && headerId.trim()
+    ? headerId.trim()
+    : randomUUID();
+}
+
+function logMcpLinkEvent(input: {
+  requestId: string;
+  event:
+    | "authorize_success"
+    | "authorize_error"
+    | "token_exchange_success"
+    | "token_exchange_error"
+    | "legacy_token_success"
+    | "legacy_token_error";
+  userId?: string;
+  clientId?: string;
+  assistantName?: string;
+  scopes?: string[];
+  errorCode?: string;
+}) {
+  console.info(
+    JSON.stringify({
+      type: "assistant_mcp_auth",
+      requestId: input.requestId,
+      event: input.event,
+      userId: input.userId,
+      clientId: input.clientId,
+      assistantName: input.assistantName,
+      scopes: input.scopes,
+      errorCode: input.errorCode,
+      ts: new Date().toISOString(),
+    }),
+  );
+}
+
+function sendStructuredError(
+  res: Response,
+  status: number,
+  error: ReturnType<typeof buildStructuredMcpError>,
+) {
+  return res.status(status).json({ error });
+}
+
+async function resolveAppUserForMcpLink(
+  req: Request,
+  authService?: AuthService,
+): Promise<
+  | {
+      user: {
+        id: string;
+        email: string;
+        name: string | null;
+        isVerified: boolean;
+      };
+    }
+  | { httpStatus: number; error: ReturnType<typeof buildStructuredMcpError> }
+> {
+  if (!authService) {
+    return {
+      httpStatus: 501,
+      error: buildStructuredMcpError({
+        code: "MCP_NOT_CONFIGURED",
+        message: "Authentication not configured",
+        retryable: false,
+        hint: "Enable application authentication before linking an assistant.",
+      }),
+    };
+  }
+
+  const authHeader = req.header("authorization");
+  if (!authHeader) {
+    return {
+      httpStatus: 401,
+      error: buildStructuredMcpError({
+        code: "MCP_LINK_UNAUTHENTICATED",
+        message: "Authorization header missing",
+        retryable: false,
+        hint: "Sign in to the app and send the app bearer token when starting account linking.",
+      }),
+    };
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer") {
+    return {
+      httpStatus: 401,
+      error: buildStructuredMcpError({
+        code: "MCP_LINK_INVALID_AUTHORIZATION",
+        message: "Invalid authorization format. Expected: Bearer <token>",
+        retryable: false,
+        hint: "Send the app access token as a bearer token.",
+      }),
+    };
+  }
+
+  try {
+    const payload = authService.verifyToken(parts[1]);
+    const user = await authService.getUserById(payload.userId);
+    if (!user) {
+      return {
+        httpStatus: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_LINK_INVALID_SESSION",
+          message: "App session no longer maps to a valid user",
+          retryable: false,
+          hint: "Sign in again before linking an assistant.",
+        }),
+      };
+    }
+
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        isVerified: user.isVerified,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    const mapped =
+      message === "Token expired"
+        ? buildStructuredMcpError({
+            code: "MCP_LINK_AUTH_EXPIRED",
+            message: "App access token expired",
+            retryable: false,
+            hint: "Refresh the app session or sign in again before linking an assistant.",
+          })
+        : buildStructuredMcpError({
+            code: "MCP_LINK_INVALID_TOKEN",
+            message: "Invalid app access token",
+            retryable: false,
+            hint: "Use a valid app access token when starting the account-link flow.",
+          });
+    return {
+      httpStatus: 401,
+      error: mapped,
+    };
+  }
+}
+
+function mapAuthorizationCodeError(error: unknown) {
+  const message = error instanceof Error ? error.message : "";
+  switch (message) {
+    case "Invalid authorization code":
+      return {
+        status: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_AUTH_CODE_INVALID",
+          message: "Authorization code is invalid",
+          retryable: false,
+          hint: "Restart the assistant linking flow to mint a fresh code.",
+        }),
+      };
+    case "Authorization code expired":
+      return {
+        status: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_AUTH_CODE_EXPIRED",
+          message: "Authorization code expired",
+          retryable: false,
+          hint: "Restart the assistant linking flow and exchange the new code promptly.",
+        }),
+      };
+    case "Authorization code already used":
+      return {
+        status: 409,
+        error: buildStructuredMcpError({
+          code: "MCP_AUTH_CODE_ALREADY_USED",
+          message: "Authorization code already used",
+          retryable: false,
+          hint: "Start a new assistant linking flow to mint a fresh code.",
+        }),
+      };
+    case "Authorization code binding mismatch":
+      return {
+        status: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_AUTH_CODE_BINDING_MISMATCH",
+          message: "Authorization code client binding mismatch",
+          retryable: false,
+          hint: "Retry the exchange with the same clientId and redirectUri used during authorization.",
+        }),
+      };
+    case "Invalid code verifier":
+      return {
+        status: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_INVALID_CODE_VERIFIER",
+          message: "Code verifier did not match the authorization challenge",
+          retryable: false,
+          hint: "Use the original PKCE verifier that matches the code challenge.",
+        }),
+      };
+    default:
+      return mapAgentFacingError(error);
+  }
+}
+
 export function createAuthRouter({
   authService,
+  mcpOAuthService,
   authLimiter,
   emailActionLimiter,
   requireAuthIfConfigured,
@@ -189,30 +400,201 @@ export function createAuthRouter({
   router.post(
     "/mcp/token",
     authLimiter,
-    requireAuthIfConfigured,
     async (req: Request, res: Response, next: NextFunction) => {
-      if (!authService) {
-        return res.status(501).json({ error: "Authentication not configured" });
-      }
-
       try {
-        const userId = req.user?.userId;
-        const email = req.user?.email;
-        if (!userId || !email) {
-          return res.status(401).json({ error: "Unauthorized" });
+        const requestId = buildLinkRequestId(req);
+        const resolvedUser = await resolveAppUserForMcpLink(req, authService);
+        if ("error" in resolvedUser) {
+          logMcpLinkEvent({
+            requestId,
+            event: "legacy_token_error",
+            errorCode: resolvedUser.error.code,
+          });
+          return sendStructuredError(
+            res,
+            resolvedUser.httpStatus,
+            resolvedUser.error,
+          );
         }
 
         const input = validateCreateMcpTokenInput(req.body);
-        const token = authService.createMcpToken({
-          userId,
-          email,
+        const token = authService!.createMcpToken({
+          userId: resolvedUser.user.id,
+          email: resolvedUser.user.email,
           scopes: input.scopes,
           assistantName: input.assistantName,
+          clientId: input.clientId,
         });
 
+        logMcpLinkEvent({
+          requestId,
+          event: "legacy_token_success",
+          userId: resolvedUser.user.id,
+          clientId: input.clientId,
+          assistantName: input.assistantName,
+          scopes: input.scopes,
+        });
         res.status(201).json(token);
       } catch (error) {
-        next(error);
+        const requestId = buildLinkRequestId(req);
+        const mapped = mapAgentFacingError(error);
+        logMcpLinkEvent({
+          requestId,
+          event: "legacy_token_error",
+          errorCode: mapped.error.code,
+        });
+        sendStructuredError(res, mapped.status, mapped.error);
+      }
+    },
+  );
+
+  router.post(
+    "/mcp/oauth/authorize",
+    authLimiter,
+    async (req: Request, res: Response) => {
+      const requestId = buildLinkRequestId(req);
+
+      try {
+        const resolvedUser = await resolveAppUserForMcpLink(req, authService);
+        if ("error" in resolvedUser) {
+          logMcpLinkEvent({
+            requestId,
+            event: "authorize_error",
+            errorCode: resolvedUser.error.code,
+          });
+          return sendStructuredError(
+            res,
+            resolvedUser.httpStatus,
+            resolvedUser.error,
+          );
+        }
+
+        const input = validateCreateMcpAuthorizationCodeInput(req.body);
+        const authCode = mcpOAuthService.createAuthorizationCode({
+          userId: resolvedUser.user.id,
+          email: resolvedUser.user.email,
+          clientId: input.clientId,
+          redirectUri: input.redirectUri,
+          scopes: input.scopes,
+          assistantName: input.assistantName,
+          state: input.state,
+          codeChallenge: input.codeChallenge,
+          codeChallengeMethod: input.codeChallengeMethod,
+        });
+
+        logMcpLinkEvent({
+          requestId,
+          event: "authorize_success",
+          userId: resolvedUser.user.id,
+          clientId: input.clientId,
+          assistantName: input.assistantName,
+          scopes: input.scopes,
+        });
+        res.status(201).json({
+          authorizationCode: authCode.code,
+          expiresAt: authCode.expiresAt,
+          redirectUri: authCode.redirectUri,
+          scopes: authCode.scopes,
+          ...(authCode.assistantName
+            ? { assistantName: authCode.assistantName }
+            : {}),
+          ...(authCode.state ? { state: authCode.state } : {}),
+          tokenEndpoint: "/auth/mcp/oauth/token",
+        });
+      } catch (error) {
+        const mapped = mapAgentFacingError(error);
+        logMcpLinkEvent({
+          requestId,
+          event: "authorize_error",
+          errorCode: mapped.error.code,
+        });
+        sendStructuredError(res, mapped.status, mapped.error);
+      }
+    },
+  );
+
+  router.post(
+    "/mcp/oauth/token",
+    authLimiter,
+    async (req: Request, res: Response) => {
+      const requestId = buildLinkRequestId(req);
+
+      try {
+        if (!authService) {
+          const error = buildStructuredMcpError({
+            code: "MCP_NOT_CONFIGURED",
+            message: "Authentication not configured",
+            retryable: false,
+            hint: "Enable application authentication before linking an assistant.",
+          });
+          logMcpLinkEvent({
+            requestId,
+            event: "token_exchange_error",
+            errorCode: error.code,
+          });
+          return sendStructuredError(res, 501, error);
+        }
+
+        const input = validateExchangeMcpAuthorizationCodeInput(req.body);
+        const exchange = mcpOAuthService.exchangeAuthorizationCode({
+          code: input.code,
+          clientId: input.clientId,
+          redirectUri: input.redirectUri,
+          codeVerifier: input.codeVerifier,
+        });
+        const user = await authService.getUserById(exchange.userId);
+        if (!user) {
+          const error = buildStructuredMcpError({
+            code: "MCP_INVALID_SESSION",
+            message: "Linked user account no longer exists",
+            retryable: false,
+            hint: "Link the assistant again from an active app user account.",
+          });
+          logMcpLinkEvent({
+            requestId,
+            event: "token_exchange_error",
+            clientId: input.clientId,
+            errorCode: error.code,
+          });
+          return sendStructuredError(res, 401, error);
+        }
+
+        const token = authService.createMcpToken({
+          userId: exchange.userId,
+          email: exchange.email,
+          scopes: exchange.scopes,
+          assistantName: exchange.assistantName,
+          clientId: exchange.clientId,
+        });
+
+        logMcpLinkEvent({
+          requestId,
+          event: "token_exchange_success",
+          userId: exchange.userId,
+          clientId: exchange.clientId,
+          assistantName: exchange.assistantName,
+          scopes: exchange.scopes,
+        });
+        res.status(200).json({
+          accessToken: token.token,
+          tokenType: token.tokenType,
+          expiresAt: token.expiresAt,
+          expiresIn: token.expiresIn,
+          scope: token.scope,
+          scopes: token.scopes,
+          ...(token.assistantName
+            ? { assistantName: token.assistantName }
+            : {}),
+          ...(token.clientId ? { clientId: token.clientId } : {}),
+        });
+      } catch (error) {
+        const mapped = mapAuthorizationCodeError(error);
+        logMcpLinkEvent({
+          requestId,
+          event: "token_exchange_error",
+          errorCode: mapped.error.code,
+        });
+        sendStructuredError(res, mapped.status, mapped.error);
       }
     },
   );

--- a/src/routes/mcpRouter.ts
+++ b/src/routes/mcpRouter.ts
@@ -1,16 +1,21 @@
-import { randomUUID } from "crypto";
 import { Request, Response, Router } from "express";
 import packageJson from "../../package.json";
 import { AgentActionName, AgentExecutor } from "../agent/agentExecutor";
 import { config } from "../config";
-import { AuthService, McpTokenPayload } from "../services/authService";
-import { McpScope } from "../types";
+import {
+  buildMcpRequestId,
+  buildScopeError,
+  hasRequiredToolScopes,
+  resolveMcpAuthContext,
+} from "../mcp/mcpAuth";
+import { buildStructuredMcpError } from "../mcp/mcpErrors";
 import {
   getMcpToolDefinition,
   listMcpTools,
   MCP_PROTOCOL_VERSION,
 } from "../mcp/mcpToolCatalog";
-import { hasMcpScope } from "../validation/mcpValidation";
+import { AuthService } from "../services/authService";
+import { McpScope } from "../types";
 
 type JsonRpcId = number | string | null;
 
@@ -24,50 +29,6 @@ interface JsonRpcRequest {
 interface McpRouterDeps {
   agentExecutor: AgentExecutor;
   authService?: AuthService;
-}
-
-type McpSession = McpTokenPayload;
-
-function buildMcpRequestId(req: Request, requestId?: JsonRpcId): string {
-  const headerId = req.header("x-mcp-request-id");
-  if (typeof headerId === "string" && headerId.trim()) {
-    return headerId.trim();
-  }
-  if (typeof requestId === "string" || typeof requestId === "number") {
-    return `mcp-${requestId}`;
-  }
-  return randomUUID();
-}
-
-function buildActor(req: Request, session: McpSession): string {
-  const assistantHeader = req.header("x-assistant-name");
-  if (typeof assistantHeader === "string" && assistantHeader.trim()) {
-    return assistantHeader.trim();
-  }
-  if (session.assistantName) {
-    return session.assistantName;
-  }
-  const userAgent = req.header("user-agent");
-  if (typeof userAgent === "string" && userAgent.trim()) {
-    return userAgent.trim();
-  }
-  return "unknown-assistant";
-}
-
-function buildStructuredError(input: {
-  code: string;
-  message: string;
-  retryable: boolean;
-  hint?: string;
-  details?: Record<string, unknown>;
-}) {
-  return {
-    code: input.code,
-    message: input.message,
-    retryable: input.retryable,
-    ...(input.hint ? { hint: input.hint } : {}),
-    ...(input.details ? { details: input.details } : {}),
-  };
 }
 
 function jsonRpcSuccess(id: JsonRpcId, result: Record<string, unknown>) {
@@ -120,32 +81,6 @@ function parseRequest(body: unknown): JsonRpcRequest | null {
   };
 }
 
-function logMcpRequest(input: {
-  requestId: string;
-  userId?: string;
-  actor?: string;
-  scopes?: McpScope[];
-  method: string;
-  outcome: "success" | "error";
-  toolName?: string;
-  errorCode?: string;
-}) {
-  console.info(
-    JSON.stringify({
-      type: "assistant_mcp_call",
-      requestId: input.requestId,
-      userId: input.userId,
-      actor: input.actor,
-      scopes: input.scopes,
-      method: input.method,
-      toolName: input.toolName,
-      outcome: input.outcome,
-      errorCode: input.errorCode,
-      ts: new Date().toISOString(),
-    }),
-  );
-}
-
 function buildToolErrorResult(message: string, error: Record<string, unknown>) {
   return {
     content: [{ type: "text", text: message }],
@@ -154,108 +89,15 @@ function buildToolErrorResult(message: string, error: Record<string, unknown>) {
   };
 }
 
-function rejectUnexpectedOrigin(req: Request): Record<string, unknown> | null {
-  const origin = req.header("origin");
-  if (!origin) {
-    return null;
-  }
-  if (config.corsOrigins.includes(origin)) {
-    return null;
-  }
-  return buildStructuredError({
-    code: "MCP_ORIGIN_NOT_ALLOWED",
-    message: "Origin not allowed for MCP requests",
-    retryable: false,
-    hint: "Use a non-browser MCP client or configure the origin in CORS_ORIGINS.",
-  });
-}
-
-function authenticateMcpRequest(
-  req: Request,
-  authService?: AuthService,
-): {
-  session?: McpSession;
-  error?: Record<string, unknown>;
-  httpStatus: number;
-} {
-  if (!authService) {
-    return {
-      httpStatus: 501,
-      error: buildStructuredError({
-        code: "MCP_NOT_CONFIGURED",
-        message: "MCP is not configured",
-        retryable: false,
-        hint: "Enable application authentication before using the remote MCP surface.",
-      }),
-    };
-  }
-
-  const authHeader = req.header("authorization");
-  if (!authHeader) {
-    return {
-      httpStatus: 401,
-      error: buildStructuredError({
-        code: "MCP_AUTH_REQUIRED",
-        message: "Authorization header missing",
-        retryable: false,
-        hint: "Provide Authorization: Bearer <mcp-token>.",
-      }),
-    };
-  }
-
-  const parts = authHeader.split(" ");
-  if (parts.length !== 2 || parts[0] !== "Bearer") {
-    return {
-      httpStatus: 401,
-      error: buildStructuredError({
-        code: "MCP_INVALID_AUTHORIZATION_FORMAT",
-        message: "Invalid authorization format. Expected: Bearer <token>",
-        retryable: false,
-        hint: "Send a bearer MCP token using the Authorization header.",
-      }),
-    };
-  }
-
-  try {
-    return {
-      httpStatus: 200,
-      session: authService.verifyMcpToken(parts[1]),
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "";
-    if (message === "Token expired") {
-      return {
-        httpStatus: 401,
-        error: buildStructuredError({
-          code: "MCP_TOKEN_EXPIRED",
-          message: "Token expired",
-          retryable: false,
-          hint: "Mint a new MCP token via /auth/mcp/token and retry.",
-        }),
-      };
-    }
-
-    return {
-      httpStatus: 401,
-      error: buildStructuredError({
-        code: "MCP_INVALID_TOKEN",
-        message: "Invalid MCP token",
-        retryable: false,
-        hint: "Use a valid MCP token minted via /auth/mcp/token.",
-      }),
-    };
-  }
-}
-
 function normalizeToolArguments(params: unknown): {
   name?: string;
   args: Record<string, unknown>;
-  error?: Record<string, unknown>;
+  error?: ReturnType<typeof buildStructuredMcpError>;
 } {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return {
       args: {},
-      error: buildStructuredError({
+      error: buildStructuredMcpError({
         code: "MCP_INVALID_PARAMS",
         message: "tools/call params must be an object",
         retryable: false,
@@ -268,7 +110,7 @@ function normalizeToolArguments(params: unknown): {
   if (typeof rawParams.name !== "string" || !rawParams.name.trim()) {
     return {
       args: {},
-      error: buildStructuredError({
+      error: buildStructuredMcpError({
         code: "MCP_TOOL_NAME_REQUIRED",
         message: "Tool name is required",
         retryable: false,
@@ -285,7 +127,7 @@ function normalizeToolArguments(params: unknown): {
     return {
       name: rawParams.name.trim(),
       args: {},
-      error: buildStructuredError({
+      error: buildStructuredMcpError({
         code: "MCP_INVALID_TOOL_ARGUMENTS",
         message: "Tool arguments must be an object",
         retryable: false,
@@ -298,6 +140,55 @@ function normalizeToolArguments(params: unknown): {
     name: rawParams.name.trim(),
     args: (rawParams.arguments as Record<string, unknown>) || {},
   };
+}
+
+function rejectUnexpectedOrigin(req: Request) {
+  const origin = req.header("origin");
+  if (!origin || config.corsOrigins.includes(origin)) {
+    return null;
+  }
+  return buildStructuredMcpError({
+    code: "MCP_ORIGIN_NOT_ALLOWED",
+    message: "Origin not allowed for MCP requests",
+    retryable: false,
+    hint: "Use a non-browser MCP client or configure the origin in CORS_ORIGINS.",
+  });
+}
+
+function logMcpRequest(input: {
+  requestId: string;
+  userId?: string;
+  actor?: string;
+  scopes?: McpScope[];
+  method: string;
+  outcome: "success" | "error";
+  toolName?: string;
+  errorCode?: string;
+  authOutcome?:
+    | "authenticated"
+    | "missing"
+    | "invalid"
+    | "expired"
+    | "session_invalid"
+    | "scope_denied";
+  requiredScopes?: McpScope[];
+}) {
+  console.info(
+    JSON.stringify({
+      type: "assistant_mcp_call",
+      requestId: input.requestId,
+      userId: input.userId,
+      actor: input.actor,
+      scopes: input.scopes,
+      method: input.method,
+      toolName: input.toolName,
+      outcome: input.outcome,
+      authOutcome: input.authOutcome,
+      requiredScopes: input.requiredScopes,
+      errorCode: input.errorCode,
+      ts: new Date().toISOString(),
+    }),
+  );
 }
 
 export function createMcpRouter({
@@ -332,7 +223,7 @@ export function createMcpRouter({
           id: null,
           code: -32600,
           message: "Invalid Request",
-          data: buildStructuredError({
+          data: buildStructuredMcpError({
             code: "MCP_INVALID_REQUEST",
             message: "Request must be a JSON-RPC 2.0 object",
             retryable: false,
@@ -349,7 +240,7 @@ export function createMcpRouter({
         requestId,
         method: parsedRequest.method,
         outcome: "error",
-        errorCode: originError.code as string,
+        errorCode: originError.code,
       });
       res.status(403).json(
         jsonRpcError({
@@ -362,33 +253,37 @@ export function createMcpRouter({
       return;
     }
 
-    if (parsedRequest.method === "notifications/initialized") {
-      logMcpRequest({
-        requestId,
-        method: parsedRequest.method,
-        outcome: "success",
-      });
-      res.status(202).end();
-      return;
-    }
-
-    const auth = authenticateMcpRequest(req, authService);
-    if (!auth.session || auth.error) {
+    const auth = await resolveMcpAuthContext({
+      req,
+      authService,
+      requestId,
+    });
+    if (!auth.context || auth.error) {
+      const errorCode = auth.error?.code;
+      const authOutcome =
+        errorCode === "MCP_UNAUTHENTICATED"
+          ? "missing"
+          : errorCode === "MCP_AUTH_EXPIRED"
+            ? "expired"
+            : errorCode === "MCP_INVALID_SESSION"
+              ? "session_invalid"
+              : "invalid";
       logMcpRequest({
         requestId,
         method: parsedRequest.method,
         outcome: "error",
-        errorCode: auth.error?.code as string | undefined,
+        authOutcome,
+        errorCode,
       });
       res.status(auth.httpStatus).json(
         jsonRpcError({
           id: parsedRequest.id ?? null,
           code: -32001,
-          message: auth.error?.message as string,
+          message: auth.error?.message || "Authentication failed",
           data:
             auth.error ||
-            buildStructuredError({
-              code: "MCP_AUTH_FAILED",
+            buildStructuredMcpError({
+              code: "MCP_UNAUTHENTICATED",
               message: "Authentication failed",
               retryable: false,
             }),
@@ -397,8 +292,8 @@ export function createMcpRouter({
       return;
     }
 
-    const session = auth.session;
-    const actor = buildActor(req, session);
+    const { context } = auth;
+    const { session, actor, user } = context;
 
     switch (parsedRequest.method) {
       case "initialize": {
@@ -406,9 +301,10 @@ export function createMcpRouter({
           requestId,
           method: parsedRequest.method,
           outcome: "success",
-          userId: session.userId,
+          userId: user.id,
           actor,
           scopes: session.scopes,
+          authOutcome: "authenticated",
         });
         res.status(200).json(
           jsonRpcSuccess(parsedRequest.id ?? null, {
@@ -423,7 +319,7 @@ export function createMcpRouter({
               version: packageJson.version,
             },
             instructions:
-              "Use tools/list to discover your scoped tools. This server is stateless, user-scoped, and expects a bearer MCP token minted through /auth/mcp/token.",
+              "Use tools/list to discover your scoped tools. Link an app user account through /auth/mcp/oauth/authorize and /auth/mcp/oauth/token to mint a scoped bearer token. /auth/mcp/token remains available for local development.",
           }),
         );
         return;
@@ -433,11 +329,25 @@ export function createMcpRouter({
           requestId,
           method: parsedRequest.method,
           outcome: "success",
-          userId: session.userId,
+          userId: user.id,
           actor,
           scopes: session.scopes,
+          authOutcome: "authenticated",
         });
         res.status(200).json(jsonRpcSuccess(parsedRequest.id ?? null, {}));
+        return;
+      }
+      case "notifications/initialized": {
+        logMcpRequest({
+          requestId,
+          method: parsedRequest.method,
+          outcome: "success",
+          userId: user.id,
+          actor,
+          scopes: session.scopes,
+          authOutcome: "authenticated",
+        });
+        res.status(202).end();
         return;
       }
       case "tools/list": {
@@ -449,9 +359,10 @@ export function createMcpRouter({
           requestId,
           method: parsedRequest.method,
           outcome: "success",
-          userId: session.userId,
+          userId: user.id,
           actor,
           scopes: session.scopes,
+          authOutcome: "authenticated",
         });
         res.status(200).json(
           jsonRpcSuccess(parsedRequest.id ?? null, {
@@ -467,19 +378,20 @@ export function createMcpRouter({
             requestId,
             method: parsedRequest.method,
             outcome: "error",
-            userId: session.userId,
+            userId: user.id,
             actor,
             scopes: session.scopes,
-            errorCode: normalized.error?.code as string | undefined,
+            authOutcome: "authenticated",
+            errorCode: normalized.error?.code,
           });
           res.status(400).json(
             jsonRpcError({
               id: parsedRequest.id ?? null,
               code: -32602,
-              message: normalized.error?.message as string,
+              message: normalized.error?.message || "Invalid params",
               data:
                 normalized.error ||
-                buildStructuredError({
+                buildStructuredMcpError({
                   code: "MCP_INVALID_PARAMS",
                   message: "Invalid tool call params",
                   retryable: false,
@@ -494,7 +406,7 @@ export function createMcpRouter({
           !tool ||
           (tool.requiresProjectService && !agentExecutor.hasProjectService())
         ) {
-          const error = buildStructuredError({
+          const error = buildStructuredMcpError({
             code: "MCP_TOOL_NOT_FOUND",
             message: `Tool "${normalized.name}" is not available`,
             retryable: false,
@@ -504,10 +416,11 @@ export function createMcpRouter({
             requestId,
             method: parsedRequest.method,
             outcome: "error",
-            userId: session.userId,
+            userId: user.id,
             actor,
             scopes: session.scopes,
             toolName: normalized.name,
+            authOutcome: "authenticated",
             errorCode: error.code,
           });
           res.status(200).json(
@@ -526,24 +439,21 @@ export function createMcpRouter({
           return;
         }
 
-        if (!hasMcpScope(session.scopes, tool.requiredScope)) {
-          const error = buildStructuredError({
-            code: "MCP_SCOPE_REQUIRED",
-            message: `Tool "${tool.name}" requires ${tool.requiredScope} scope`,
-            retryable: false,
-            hint: "Mint a new MCP token with the required scopes via /auth/mcp/token.",
-            details: {
-              requiredScope: tool.requiredScope,
-            },
+        if (!hasRequiredToolScopes(session.scopes, tool.requiredScopes)) {
+          const error = buildScopeError({
+            toolName: tool.name,
+            requiredScopes: tool.requiredScopes,
           });
           logMcpRequest({
             requestId,
             method: parsedRequest.method,
             outcome: "error",
-            userId: session.userId,
+            userId: user.id,
             actor,
             scopes: session.scopes,
             toolName: normalized.name,
+            authOutcome: "scope_denied",
+            requiredScopes: tool.requiredScopes,
             errorCode: error.code,
           });
           res.status(200).json(
@@ -577,7 +487,7 @@ export function createMcpRouter({
           tool.name as AgentActionName,
           toolArguments,
           {
-            userId: session.userId,
+            userId: user.id,
             requestId,
             actor,
             surface: "mcp",
@@ -590,10 +500,11 @@ export function createMcpRouter({
             requestId,
             method: parsedRequest.method,
             outcome: "success",
-            userId: session.userId,
+            userId: user.id,
             actor,
             scopes: session.scopes,
             toolName: normalized.name,
+            authOutcome: "authenticated",
           });
           res.status(200).json(
             jsonRpcSuccess(parsedRequest.id ?? null, {
@@ -613,10 +524,11 @@ export function createMcpRouter({
           requestId,
           method: parsedRequest.method,
           outcome: "error",
-          userId: session.userId,
+          userId: user.id,
           actor,
           scopes: session.scopes,
           toolName: normalized.name,
+          authOutcome: "authenticated",
           errorCode: result.body.error.code,
         });
         res
@@ -630,19 +542,20 @@ export function createMcpRouter({
         return;
       }
       default: {
-        const error = buildStructuredError({
+        const error = buildStructuredMcpError({
           code: "MCP_METHOD_NOT_FOUND",
           message: `Method "${parsedRequest.method}" is not supported`,
           retryable: false,
-          hint: "Use initialize, ping, tools/list, or tools/call.",
+          hint: "Use initialize, ping, tools/list, tools/call, or notifications/initialized.",
         });
         logMcpRequest({
           requestId,
           method: parsedRequest.method,
           outcome: "error",
-          userId: session.userId,
+          userId: user.id,
           actor,
           scopes: session.scopes,
+          authOutcome: "authenticated",
           errorCode: error.code,
         });
         res.status(404).json(

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -5,6 +5,7 @@ import { createHash, createHmac, randomUUID, timingSafeEqual } from "crypto";
 import { EmailService } from "./emailService";
 import { config } from "../config";
 import { McpScope } from "../types";
+import { formatMcpScopes, normalizeMcpScopes } from "../mcp/mcpScopes";
 
 export interface RegisterDto {
   email: string;
@@ -36,13 +37,18 @@ export interface McpTokenPayload extends JwtPayload {
   tokenType: "mcp";
   scopes: McpScope[];
   assistantName?: string;
+  clientId?: string;
 }
 
 export interface McpTokenResponse {
   token: string;
+  tokenType: "Bearer";
+  scope: string;
   scopes: McpScope[];
   expiresAt: string;
+  expiresIn: number;
   assistantName?: string;
+  clientId?: string;
 }
 
 export interface AdminBootstrapStatus {
@@ -217,14 +223,19 @@ export class AuthService {
     email: string;
     scopes: McpScope[];
     assistantName?: string;
+    clientId?: string;
   }): McpTokenResponse {
+    const normalizedScopes = normalizeMcpScopes(input.scopes, {
+      requireNonEmpty: true,
+    });
     const token = jwt.sign(
       {
         userId: input.userId,
         email: input.email,
         tokenType: "mcp",
-        scopes: input.scopes,
+        scopes: normalizedScopes,
         ...(input.assistantName ? { assistantName: input.assistantName } : {}),
+        ...(input.clientId ? { clientId: input.clientId } : {}),
       },
       this.ACCESS_JWT_SECRET,
       {
@@ -234,11 +245,15 @@ export class AuthService {
 
     return {
       token,
-      scopes: [...input.scopes],
+      tokenType: "Bearer",
+      scope: formatMcpScopes(normalizedScopes),
+      scopes: [...normalizedScopes],
       expiresAt: new Date(
         Date.now() + this.MCP_JWT_EXPIRES_IN_MS,
       ).toISOString(),
+      expiresIn: Math.floor(this.MCP_JWT_EXPIRES_IN_MS / 1000),
       ...(input.assistantName ? { assistantName: input.assistantName } : {}),
+      ...(input.clientId ? { clientId: input.clientId } : {}),
     };
   }
 
@@ -253,11 +268,12 @@ export class AuthService {
         throw new Error("Invalid MCP token");
       }
 
-      if (
-        !Array.isArray(payload.scopes) ||
-        payload.scopes.length === 0 ||
-        payload.scopes.some((scope) => scope !== "read" && scope !== "write")
-      ) {
+      let scopes: McpScope[];
+      try {
+        scopes = normalizeMcpScopes(payload.scopes, {
+          requireNonEmpty: true,
+        });
+      } catch (_error) {
         throw new Error("Invalid MCP token");
       }
 
@@ -272,10 +288,13 @@ export class AuthService {
         userId: payload.userId,
         email: payload.email,
         tokenType: "mcp",
-        scopes: payload.scopes as McpScope[],
+        scopes,
         ...(typeof payload.assistantName === "string" &&
         payload.assistantName.trim()
           ? { assistantName: payload.assistantName.trim() }
+          : {}),
+        ...(typeof payload.clientId === "string" && payload.clientId.trim()
+          ? { clientId: payload.clientId.trim() }
           : {}),
       };
     } catch (error: any) {

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -1,0 +1,118 @@
+import { createHash, randomUUID } from "crypto";
+import { McpScope } from "../types";
+
+export interface CreateMcpAuthorizationCodeInput {
+  userId: string;
+  email: string;
+  clientId: string;
+  redirectUri: string;
+  scopes: McpScope[];
+  assistantName?: string;
+  state?: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+}
+
+export interface ExchangeMcpAuthorizationCodeInput {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+interface AuthorizationCodeRecord extends CreateMcpAuthorizationCodeInput {
+  code: string;
+  expiresAt: number;
+  used: boolean;
+}
+
+function toBase64Url(buffer: Buffer): string {
+  return buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function sha256Base64Url(value: string): string {
+  return toBase64Url(createHash("sha256").update(value, "utf8").digest());
+}
+
+export class McpOAuthService {
+  private readonly authCodes = new Map<string, AuthorizationCodeRecord>();
+  private readonly AUTH_CODE_TTL_MS = 10 * 60 * 1000;
+
+  private pruneExpiredCodes() {
+    const now = Date.now();
+    for (const [code, record] of this.authCodes.entries()) {
+      if (record.expiresAt <= now) {
+        this.authCodes.delete(code);
+      }
+    }
+  }
+
+  createAuthorizationCode(input: CreateMcpAuthorizationCodeInput) {
+    this.pruneExpiredCodes();
+
+    const code = randomUUID();
+    const record: AuthorizationCodeRecord = {
+      ...input,
+      code,
+      expiresAt: Date.now() + this.AUTH_CODE_TTL_MS,
+      used: false,
+    };
+    this.authCodes.set(code, record);
+
+    return {
+      code,
+      expiresAt: new Date(record.expiresAt).toISOString(),
+      clientId: input.clientId,
+      redirectUri: input.redirectUri,
+      scopes: [...input.scopes],
+      ...(input.assistantName ? { assistantName: input.assistantName } : {}),
+      ...(input.state ? { state: input.state } : {}),
+    };
+  }
+
+  exchangeAuthorizationCode(input: ExchangeMcpAuthorizationCodeInput) {
+    this.pruneExpiredCodes();
+
+    const record = this.authCodes.get(input.code);
+    if (!record) {
+      throw new Error("Invalid authorization code");
+    }
+    if (record.used) {
+      this.authCodes.delete(input.code);
+      throw new Error("Authorization code already used");
+    }
+    if (record.expiresAt <= Date.now()) {
+      this.authCodes.delete(input.code);
+      throw new Error("Authorization code expired");
+    }
+    if (
+      record.clientId !== input.clientId ||
+      record.redirectUri !== input.redirectUri
+    ) {
+      throw new Error("Authorization code binding mismatch");
+    }
+    if (record.codeChallengeMethod !== "S256") {
+      throw new Error("Unsupported code challenge method");
+    }
+
+    const derivedChallenge = sha256Base64Url(input.codeVerifier);
+    if (derivedChallenge !== record.codeChallenge) {
+      throw new Error("Invalid code verifier");
+    }
+
+    record.used = true;
+    this.authCodes.delete(input.code);
+
+    return {
+      userId: record.userId,
+      email: record.email,
+      scopes: [...record.scopes],
+      clientId: record.clientId,
+      ...(record.assistantName ? { assistantName: record.assistantName } : {}),
+    };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 export type Priority = "low" | "medium" | "high";
-export type McpScope = "read" | "write";
+export type McpScope =
+  | "tasks.read"
+  | "tasks.write"
+  | "projects.read"
+  | "projects.write";
 export type TodoSortBy =
   | "order"
   | "createdAt"

--- a/src/validation/mcpValidation.ts
+++ b/src/validation/mcpValidation.ts
@@ -1,12 +1,39 @@
 import { McpScope } from "../types";
+import {
+  formatMcpScopes,
+  hasAllMcpScopes,
+  normalizeMcpScopes,
+} from "../mcp/mcpScopes";
 import { ValidationError } from "./validation";
 
-const VALID_MCP_SCOPES: McpScope[] = ["read", "write"];
 const MAX_ASSISTANT_NAME_LENGTH = 100;
+const MAX_CLIENT_ID_LENGTH = 200;
+const MAX_STATE_LENGTH = 200;
+const PKCE_MIN_LENGTH = 43;
+const PKCE_MAX_LENGTH = 128;
 
 export interface CreateMcpTokenDto {
   scopes: McpScope[];
   assistantName?: string;
+  clientId?: string;
+}
+
+export interface CreateMcpAuthorizationCodeDto {
+  clientId: string;
+  redirectUri: string;
+  scopes: McpScope[];
+  assistantName?: string;
+  state?: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+}
+
+export interface ExchangeMcpAuthorizationCodeDto {
+  grantType: "authorization_code";
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeVerifier: string;
 }
 
 function ensureObject(data: unknown): Record<string, unknown> {
@@ -16,67 +43,122 @@ function ensureObject(data: unknown): Record<string, unknown> {
   return data as Record<string, unknown>;
 }
 
-function normalizeScopes(value: unknown): McpScope[] {
-  if (value === undefined) {
-    return ["read"];
+function normalizeStringField(input: {
+  value: unknown;
+  field: string;
+  maxLength?: number;
+  required?: boolean;
+}): string | undefined {
+  if (input.value === undefined || input.value === null) {
+    if (input.required) {
+      throw new ValidationError(`${input.field} is required`);
+    }
+    return undefined;
   }
 
-  if (!Array.isArray(value)) {
-    throw new ValidationError("scopes must be an array");
+  if (typeof input.value !== "string") {
+    throw new ValidationError(`${input.field} must be a string`);
   }
 
-  const uniqueScopes = Array.from(
-    new Set(
-      value.map((entry) => {
-        if (typeof entry !== "string") {
-          throw new ValidationError("scopes entries must be strings");
-        }
-        const scope = entry.trim().toLowerCase() as McpScope;
-        if (!VALID_MCP_SCOPES.includes(scope)) {
-          throw new ValidationError(
-            'scopes must only include "read" or "write"',
-          );
-        }
-        return scope;
-      }),
-    ),
-  );
-
-  if (uniqueScopes.length === 0) {
-    throw new ValidationError("scopes cannot be empty");
+  const normalized = input.value.trim();
+  if (!normalized) {
+    throw new ValidationError(`${input.field} cannot be empty`);
   }
 
-  if (uniqueScopes.includes("write") && !uniqueScopes.includes("read")) {
-    return ["read", "write"];
+  if (input.maxLength && normalized.length > input.maxLength) {
+    throw new ValidationError(
+      `${input.field} cannot exceed ${input.maxLength} characters`,
+    );
   }
 
-  return uniqueScopes.sort((left, right) =>
-    left.localeCompare(right),
-  ) as McpScope[];
+  return normalized;
+}
+
+function normalizeRedirectUri(value: unknown): string {
+  const redirectUri = normalizeStringField({
+    value,
+    field: "redirectUri",
+    required: true,
+    maxLength: 1000,
+  });
+
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri!);
+  } catch (_error) {
+    throw new ValidationError("redirectUri must be a valid absolute URL");
+  }
+
+  const isLoopbackHttp =
+    parsed.protocol === "http:" &&
+    ["localhost", "127.0.0.1"].includes(parsed.hostname);
+  if (parsed.protocol !== "https:" && !isLoopbackHttp) {
+    throw new ValidationError(
+      "redirectUri must use https or localhost http for development",
+    );
+  }
+
+  return redirectUri!;
+}
+
+function normalizePkceField(input: {
+  value: unknown;
+  field: "codeChallenge" | "codeVerifier";
+}): string {
+  const normalized = normalizeStringField({
+    value: input.value,
+    field: input.field,
+    required: true,
+    maxLength: PKCE_MAX_LENGTH,
+  });
+
+  if (
+    normalized!.length < PKCE_MIN_LENGTH ||
+    normalized!.length > PKCE_MAX_LENGTH
+  ) {
+    throw new ValidationError(
+      `${input.field} must be between ${PKCE_MIN_LENGTH} and ${PKCE_MAX_LENGTH} characters`,
+    );
+  }
+
+  if (!/^[A-Za-z0-9\-._~]+$/.test(normalized!)) {
+    throw new ValidationError(`${input.field} must use the PKCE character set`);
+  }
+
+  return normalized!;
 }
 
 function normalizeAssistantName(value: unknown): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string") {
-    throw new ValidationError("assistantName must be a string");
-  }
-  const normalized = value.trim();
-  if (!normalized) {
-    throw new ValidationError("assistantName cannot be empty");
-  }
-  if (normalized.length > MAX_ASSISTANT_NAME_LENGTH) {
-    throw new ValidationError(
-      `assistantName cannot exceed ${MAX_ASSISTANT_NAME_LENGTH} characters`,
-    );
-  }
-  return normalized;
+  return normalizeStringField({
+    value,
+    field: "assistantName",
+    maxLength: MAX_ASSISTANT_NAME_LENGTH,
+  });
+}
+
+function normalizeClientId(
+  value: unknown,
+  required: boolean,
+): string | undefined {
+  return normalizeStringField({
+    value,
+    field: "clientId",
+    required,
+    maxLength: MAX_CLIENT_ID_LENGTH,
+  });
+}
+
+function normalizeState(value: unknown): string | undefined {
+  return normalizeStringField({
+    value,
+    field: "state",
+    maxLength: MAX_STATE_LENGTH,
+  });
 }
 
 export function validateCreateMcpTokenInput(data: unknown): CreateMcpTokenDto {
   const body = ensureObject(data);
-  const allowedKeys = ["scopes", "assistantName"];
+  const allowedKeys = ["scopes", "assistantName", "clientId"];
   const unknownKeys = Object.keys(body).filter(
     (key) => !allowedKeys.includes(key),
   );
@@ -87,14 +169,113 @@ export function validateCreateMcpTokenInput(data: unknown): CreateMcpTokenDto {
   }
 
   return {
-    scopes: normalizeScopes(body.scopes),
+    scopes: normalizeMcpScopes(body.scopes),
     assistantName: normalizeAssistantName(body.assistantName),
+    clientId: normalizeClientId(body.clientId, false),
+  };
+}
+
+export function validateCreateMcpAuthorizationCodeInput(
+  data: unknown,
+): CreateMcpAuthorizationCodeDto {
+  const body = ensureObject(data);
+  const allowedKeys = [
+    "clientId",
+    "redirectUri",
+    "scopes",
+    "assistantName",
+    "state",
+    "codeChallenge",
+    "codeChallengeMethod",
+  ];
+  const unknownKeys = Object.keys(body).filter(
+    (key) => !allowedKeys.includes(key),
+  );
+  if (unknownKeys.length > 0) {
+    throw new ValidationError(
+      `Request body contains unsupported field(s): ${unknownKeys.join(", ")}`,
+    );
+  }
+
+  const codeChallengeMethod = normalizeStringField({
+    value: body.codeChallengeMethod ?? "S256",
+    field: "codeChallengeMethod",
+    required: true,
+  });
+  if (codeChallengeMethod !== "S256") {
+    throw new ValidationError("codeChallengeMethod must be S256");
+  }
+
+  return {
+    clientId: normalizeClientId(body.clientId, true)!,
+    redirectUri: normalizeRedirectUri(body.redirectUri),
+    scopes: normalizeMcpScopes(body.scopes),
+    assistantName: normalizeAssistantName(body.assistantName),
+    state: normalizeState(body.state),
+    codeChallenge: normalizePkceField({
+      value: body.codeChallenge,
+      field: "codeChallenge",
+    }),
+    codeChallengeMethod: "S256",
+  };
+}
+
+export function validateExchangeMcpAuthorizationCodeInput(
+  data: unknown,
+): ExchangeMcpAuthorizationCodeDto {
+  const body = ensureObject(data);
+  const allowedKeys = [
+    "grantType",
+    "code",
+    "clientId",
+    "redirectUri",
+    "codeVerifier",
+  ];
+  const unknownKeys = Object.keys(body).filter(
+    (key) => !allowedKeys.includes(key),
+  );
+  if (unknownKeys.length > 0) {
+    throw new ValidationError(
+      `Request body contains unsupported field(s): ${unknownKeys.join(", ")}`,
+    );
+  }
+
+  const grantType = normalizeStringField({
+    value: body.grantType,
+    field: "grantType",
+    required: true,
+  });
+  if (grantType !== "authorization_code") {
+    throw new ValidationError('grantType must be "authorization_code"');
+  }
+
+  return {
+    grantType: "authorization_code",
+    code: normalizeStringField({
+      value: body.code,
+      field: "code",
+      required: true,
+      maxLength: 200,
+    })!,
+    clientId: normalizeClientId(body.clientId, true)!,
+    redirectUri: normalizeRedirectUri(body.redirectUri),
+    codeVerifier: normalizePkceField({
+      value: body.codeVerifier,
+      field: "codeVerifier",
+    }),
   };
 }
 
 export function hasMcpScope(
   availableScopes: McpScope[],
-  requiredScope: McpScope,
+  requiredScopes: McpScope | McpScope[],
 ): boolean {
-  return availableScopes.includes(requiredScope);
+  return hasAllMcpScopes(
+    availableScopes,
+    Array.isArray(requiredScopes) ? requiredScopes : [requiredScopes],
+  );
+}
+
+export function describeMcpScopes(scopes: McpScope[]): string {
+  return formatMcpScopes(scopes);
 }


### PR DESCRIPTION
Implemented a thin OAuth-style PKCE linking layer for the remote MCP surface without duplicating business logic. /auth/mcp/oauth/authorize now binds a short-lived authorization code to the signed-in app user, requested scopes, client
  identity, redirect URI, and PKCE challenge; /auth/mcp/oauth/token exchanges that code for a scoped MCP bearer token. /mcp now resolves every request to a real app user via token verification plus getUserById, enforces explicit tasks.* and
  projects.* scopes per tool, returns structured auth errors, and logs auth/scope decisions alongside tool execution.

  The MCP tool catalog now exposes auth metadata, the scope model is explicit in code and docs, the local dev mint endpoint remains available behind normal app auth, and focused tests cover linking, token exchange, missing/expired auth, invalid
  session, insufficient scope, cross-user isolation, and a successful idempotent mutation path.

  Files Changed

  - docs/README.md
  - docs/agent-accessibility.md
  - docs/assistant-mcp.md
  - docs/memory/index/INDEX.md
  - docs/remote-mcp-auth.md
  - src/agent/agentExecutor.ts
  - src/app.ts
  - src/mcp/mcpAuth.ts
  - src/mcp/mcpErrors.ts
  - src/mcp/mcpScopes.ts
  - src/mcp/mcpToolCatalog.ts
  - src/mcpRouter.test.ts
  - src/routes/authRouter.ts
  - src/routes/mcpRouter.ts
  - src/services/authService.ts
  - src/services/mcpOAuthService.ts
  - src/types.ts
  - src/validation/mcpValidation.ts

Why: move the remote MCP server from manually minted dev tokens to a real user-linked auth path with explicit server-side scope enforcement and user isolation.
  - What changed: added PKCE-style MCP linking endpoints, explicit tool scope mapping, centralized MCP auth resolution, structured auth/scope errors, auth metadata in tool definitions, lightweight audit logs, and focused docs/tests.
  - Verification: npx tsc --noEmit, npm run format:check, npm run lint:html, npm run lint:css, npm run test:unit, CI=1 npm run test:ui:fast.
  - Closes #212