### PR TITLE
fix(api): accept MCP refresh grant metadata

### DIFF
--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -56,7 +56,7 @@ Input:
 
 - `redirect_uris`
 - `client_name` (optional)
-- `grant_types` (`authorization_code` only)
+- `grant_types` (`authorization_code`, or `authorization_code` plus `refresh_token` for connector compatibility)
 - `response_types` (`code` only)
 - `token_endpoint_auth_method` (`none` only)
 
@@ -213,7 +213,7 @@ First-pass compatibility target:
 
 Current limitation:
 
-- no refresh-token flow yet, so reconnect or relink is required once the MCP access token expires
+- client registration accepts `refresh_token` metadata for compatibility, but the server does not issue refresh tokens yet, so reconnect or relink is still required once the MCP access token expires
 
 ## Local Development
 

--- a/src/mcpPublicRouter.test.ts
+++ b/src/mcpPublicRouter.test.ts
@@ -141,7 +141,46 @@ describe("Public MCP OAuth and discovery routes", () => {
     expect(response.body.redirect_uris).toEqual([
       "https://chat.openai.com/aip/callback",
     ]);
+    expect(response.body.grant_types).toEqual(["authorization_code"]);
     expect(response.body.token_endpoint_auth_method).toBe("none");
+  });
+
+  it("accepts public clients that request refresh-token grant metadata", async () => {
+    const response = await request(app)
+      .post("/oauth/register")
+      .send({
+        redirect_uris: ["https://chat.openai.com/aip/callback"],
+        client_name: "Codex",
+        grant_types: ["refresh_token", "authorization_code"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+      })
+      .expect(201);
+
+    expect(response.body.client_id).toEqual(expect.any(String));
+    expect(response.body.grant_types).toEqual([
+      "authorization_code",
+      "refresh_token",
+    ]);
+    expect(response.body.response_types).toEqual(["code"]);
+  });
+
+  it("rejects unsupported OAuth client grant types during registration", async () => {
+    const response = await request(app)
+      .post("/oauth/register")
+      .send({
+        redirect_uris: ["https://chat.openai.com/aip/callback"],
+        grant_types: ["authorization_code", "client_credentials"],
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe("invalid_client_metadata");
+    expect(response.body.error_description).toContain(
+      '"authorization_code" and optional "refresh_token"',
+    );
+    expect(response.body.error_details.code).toBe(
+      "MCP_OAUTH_AUTHORIZE_INVALID",
+    );
   });
 
   it("completes the browser-style OAuth code flow for a registered connector", async () => {

--- a/src/services/mcpClientService.ts
+++ b/src/services/mcpClientService.ts
@@ -1,6 +1,9 @@
 import jwt from "jsonwebtoken";
 import { config } from "../config";
 
+const OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE = "authorization_code";
+const OAUTH_CLIENT_GRANT_REFRESH_TOKEN = "refresh_token";
+
 export interface McpRegisteredClient {
   clientId: string;
   redirectUris: string[];
@@ -30,13 +33,52 @@ interface McpClientPayload {
   exp?: number;
 }
 
+function normalizeSupportedGrantTypes(grantTypes?: unknown): string[] {
+  if (grantTypes !== undefined && !Array.isArray(grantTypes)) {
+    throw new Error("Unsupported OAuth client metadata");
+  }
+
+  const requestedGrantTypes =
+    grantTypes && grantTypes.length > 0
+      ? Array.from(
+          new Set(
+            grantTypes.map((grantType) => {
+              if (typeof grantType !== "string" || !grantType.trim()) {
+                throw new Error("Unsupported OAuth client metadata");
+              }
+              return grantType.trim();
+            }),
+          ),
+        )
+      : [OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE];
+
+  if (!requestedGrantTypes.includes(OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE)) {
+    throw new Error("Unsupported OAuth client metadata");
+  }
+
+  const allowedGrantTypes = new Set([
+    OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE,
+    OAUTH_CLIENT_GRANT_REFRESH_TOKEN,
+  ]);
+  if (
+    requestedGrantTypes.some((grantType) => !allowedGrantTypes.has(grantType))
+  ) {
+    throw new Error("Unsupported OAuth client metadata");
+  }
+
+  return [
+    OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE,
+    ...(requestedGrantTypes.includes(OAUTH_CLIENT_GRANT_REFRESH_TOKEN)
+      ? [OAUTH_CLIENT_GRANT_REFRESH_TOKEN]
+      : []),
+  ];
+}
+
 export class McpClientService {
   private readonly CLIENT_ID_TTL_SECONDS = 365 * 24 * 60 * 60;
 
   registerClient(input: RegisterMcpClientInput): McpRegisteredClient {
-    const grantTypes = input.grantTypes?.length
-      ? [...input.grantTypes]
-      : ["authorization_code"];
+    const grantTypes = normalizeSupportedGrantTypes(input.grantTypes);
     const responseTypes = input.responseTypes?.length
       ? [...input.responseTypes]
       : ["code"];
@@ -44,7 +86,6 @@ export class McpClientService {
 
     if (
       tokenEndpointAuthMethod !== "none" ||
-      grantTypes.some((grantType) => grantType !== "authorization_code") ||
       responseTypes.some((responseType) => responseType !== "code")
     ) {
       throw new Error("Unsupported OAuth client metadata");
@@ -83,6 +124,9 @@ export class McpClientService {
         clientId,
         config.accessJwtSecret,
       ) as Partial<McpClientPayload>;
+      const normalizedGrantTypes = normalizeSupportedGrantTypes(
+        payload.grantTypes,
+      );
 
       if (
         payload.tokenType !== "mcp_oauth_client" ||
@@ -93,9 +137,6 @@ export class McpClientService {
       }
 
       if (
-        payload.grantTypes?.some(
-          (grantType) => grantType !== "authorization_code",
-        ) ||
         payload.responseTypes?.some((responseType) => responseType !== "code")
       ) {
         throw new Error("Invalid OAuth client");
@@ -111,10 +152,7 @@ export class McpClientService {
         ...(typeof payload.clientName === "string" && payload.clientName.trim()
           ? { clientName: payload.clientName.trim() }
           : {}),
-        grantTypes:
-          payload.grantTypes && payload.grantTypes.length > 0
-            ? [...payload.grantTypes]
-            : ["authorization_code"],
+        grantTypes: normalizedGrantTypes,
         responseTypes:
           payload.responseTypes && payload.responseTypes.length > 0
             ? [...payload.responseTypes]

--- a/src/validation/mcpValidation.ts
+++ b/src/validation/mcpValidation.ts
@@ -12,6 +12,8 @@ const MAX_STATE_LENGTH = 200;
 const MAX_CLIENT_NAME_LENGTH = 120;
 const PKCE_MIN_LENGTH = 43;
 const PKCE_MAX_LENGTH = 128;
+const OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE = "authorization_code";
+const OAUTH_CLIENT_GRANT_REFRESH_TOKEN = "refresh_token";
 
 export interface CreateMcpTokenDto {
   scopes: McpScope[];
@@ -193,13 +195,13 @@ function normalizeState(value: unknown): string | undefined {
 
 function normalizeGrantTypes(value: unknown): string[] {
   if (value === undefined) {
-    return ["authorization_code"];
+    return [OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE];
   }
   if (!Array.isArray(value) || value.length === 0) {
     throw new ValidationError("grant_types must be a non-empty array");
   }
 
-  const grantTypes = Array.from(
+  const requestedGrantTypes = Array.from(
     new Set(
       value.map((entry) => {
         if (typeof entry !== "string" || !entry.trim()) {
@@ -210,13 +212,28 @@ function normalizeGrantTypes(value: unknown): string[] {
     ),
   );
 
-  if (grantTypes.some((grantType) => grantType !== "authorization_code")) {
+  const allowedGrantTypes = new Set([
+    OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE,
+    OAUTH_CLIENT_GRANT_REFRESH_TOKEN,
+  ]);
+  if (
+    requestedGrantTypes.some((grantType) => !allowedGrantTypes.has(grantType))
+  ) {
     throw new ValidationError(
-      'grant_types must only include "authorization_code"',
+      'grant_types must only include "authorization_code" and optional "refresh_token"',
     );
   }
 
-  return grantTypes;
+  if (!requestedGrantTypes.includes(OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE)) {
+    throw new ValidationError('grant_types must include "authorization_code"');
+  }
+
+  return [
+    OAUTH_CLIENT_GRANT_AUTHORIZATION_CODE,
+    ...(requestedGrantTypes.includes(OAUTH_CLIENT_GRANT_REFRESH_TOKEN)
+      ? [OAUTH_CLIENT_GRANT_REFRESH_TOKEN]
+      : []),
+  ];
 }
 
 function normalizeResponseTypes(value: unknown): string[] {


### PR DESCRIPTION
What’s ready:

  - branch is pushed
  - commit is clean and scoped
  - PR title to use: fix(api): accept MCP refresh grant metadata

  Suggested PR body:

  ## Why
  Codex MCP client registration is failing against production MCP OAuth because `/oauth/register` rejects standard dynamic client metadata when `grant_types` includes `refresh_token` alongside `authorization_code`.

  Real MCP OAuth clients commonly register with `grant_types=["authorization_code","refresh_token"]` even when refresh-token issuance is not yet implemented. The server-side validator was over-strict and blocked registration before the
  connector could complete the auth flow.

  ## What changed
  - relaxed MCP dynamic client registration validation to allow `authorization_code` with optional `refresh_token`
  - preserved that grant metadata in registered client payloads and client resolution
  - added focused registration tests for accepted refresh-token metadata and unsupported grant rejection
  - clarified in the MCP auth docs that registration accepts `refresh_token` metadata for compatibility, but the server still does not issue refresh tokens yet

  ## Verification
  - `npx tsc --noEmit`
  - `npm run format:check`
  - `npm run lint:html`
  - `npm run lint:css`
  - `npm run test:unit`
  - `CI=1 npm run test:ui:fast` currently still hits the existing unrelated failures in `tests/ui/quick-entry-natural-date.spec.ts` on both `chromium` and `chromium-mobile`