### PR TITLE
feat(api): add MCP project management tools

### DIFF
--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -27,8 +27,12 @@ Supported actions:
 - `create_task`
 - `update_task`
 - `complete_task`
+- `move_task_to_project`
 - `list_projects`
 - `create_project`
+- `update_project`
+- `delete_project`
+- `archive_project`
 
 ## Read vs Write
 
@@ -44,7 +48,9 @@ That split is reflected in both code and the manifest metadata.
 - Agent actions reuse the existing `todoService` and `projectService` implementations.
 - Existing server-side validation remains the source of truth for create/update rules.
 - The first pass preserves the current project/category compatibility path already used by the server. Task payloads still use the current task shape rather than inventing a parallel domain model.
-- Destructive deletes, bulk operations, and natural-language resolution are intentionally not part of this first pass.
+- Project deletion defaults to unassigning linked tasks unless a target project ID is provided for reassignment.
+- Project archiving is metadata-only in this pass. Archived projects still appear in list responses with `archived: true`.
+- Bulk operations and natural-language resolution are intentionally not part of this first pass.
 
 ## Errors
 
@@ -92,5 +98,5 @@ This is enough for first-pass auditability without introducing a new persistence
 
 - extend idempotency beyond create flows if retry semantics are needed for more writes
 - decide whether project/category compatibility should eventually become a first-class `projectId` agent contract
-- add destructive confirmation patterns before exposing delete or bulk write actions
+- add destructive confirmation patterns before exposing broader delete or bulk write actions
 - add richer persisted audit storage if log-only tracing is no longer sufficient

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -46,8 +46,12 @@ Initial public tools:
 - `create_task`
 - `update_task`
 - `complete_task`
+- `move_task_to_project`
 - `list_projects`
 - `create_project`
+- `update_project`
+- `delete_project`
+- `archive_project`
 
 `tools/list` only returns tools allowed by the current token scopes.
 
@@ -118,6 +122,8 @@ Current behavior:
 Current limitation:
 
 - idempotency state is still process-local and in-memory
+- `delete_project` unassigns tasks by default unless `moveTasksToProjectId` is supplied
+- project archiving is metadata-only in this pass; archived projects remain listable
 
 ## Deployment and Connector Validation
 

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -153,8 +153,12 @@ The older `read` / `write` aliases are still accepted by validation and expanded
 | `create_task`    | No        | `tasks.write`    |
 | `update_task`    | No        | `tasks.write`    |
 | `complete_task`  | No        | `tasks.write`    |
+| `move_task_to_project` | No  | `tasks.write`    |
 | `list_projects`  | Yes       | `projects.read`  |
 | `create_project` | No        | `projects.write` |
+| `update_project` | No        | `projects.write` |
+| `delete_project` | No        | `projects.write` |
+| `archive_project` | No       | `projects.write` |
 
 `tools/list` only returns tools the token is allowed to use.
 

--- a/prisma/migrations/20260311211500_add_project_archived_flag/migration.sql
+++ b/prisma/migrations/20260311211500_add_project_archived_flag/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "projects"
+ADD COLUMN "archived" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,7 @@ model RefreshToken {
 model Project {
   id        String   @id @default(uuid())
   name      String   @db.VarChar(50)
+  archived  Boolean  @default(false)
   userId    String   @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -95,6 +95,7 @@
       "properties": {
         "id": "string",
         "name": "string",
+        "archived": "boolean",
         "userId": "string",
         "createdAt": "ISO-8601 string",
         "updatedAt": "ISO-8601 string",
@@ -348,10 +349,123 @@
       },
       "errorModel": "structured_agent_error",
       "idempotency": "optional_header_for_create_flow"
+    },
+    {
+      "name": "update_project",
+      "description": "Rename an existing project by ID.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/update_project",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string", "maxLength": 50 }
+        }
+      },
+      "output": {
+        "dataKey": "project",
+        "$ref": "#/definitions/project"
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "delete_project",
+      "description": "Delete a project and either reassign its tasks or unassign them, following existing server-side rules.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/delete_project",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "moveTasksToProjectId": {
+            "type": ["string", "null"],
+            "format": "uuid"
+          }
+        }
+      },
+      "output": {
+        "dataKey": "result",
+        "type": "object",
+        "properties": {
+          "deleted": { "type": "boolean" },
+          "projectId": { "type": "string" },
+          "movedTasksToProjectId": { "type": ["string", "null"] },
+          "taskDisposition": {
+            "type": "string",
+            "enum": ["reassigned", "unassigned"]
+          }
+        }
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "move_task_to_project",
+      "description": "Move a task to another project by project ID, or unassign it when projectId is null.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/move_task_to_project",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["taskId"],
+        "properties": {
+          "taskId": { "type": "string", "format": "uuid" },
+          "projectId": { "type": ["string", "null"], "format": "uuid" }
+        }
+      },
+      "output": {
+        "dataKey": "task",
+        "$ref": "#/definitions/todo"
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "archive_project",
+      "description": "Set the archived state for a project by ID.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/archive_project",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "archived"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "archived": { "type": "boolean" }
+        }
+      },
+      "output": {
+        "dataKey": "project",
+        "$ref": "#/definitions/project"
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
     }
   ],
   "notes": [
-    "This first pass does not expose destructive deletes, bulk mutations, or natural-language resolution.",
+    "Project deletion through the agent surface defaults to unassigning linked tasks unless moveTasksToProjectId is provided.",
+    "Project archiving is metadata-only in this pass; archived projects remain visible in list_projects responses.",
     "Create-flow idempotency is process-local and intended as a pragmatic retry guard, not a durable cross-process guarantee.",
     "Task project association currently follows the existing category/project compatibility rules already enforced by server services."
   ]

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -5,13 +5,17 @@ import agentManifest from "./agent-manifest.json";
 import { AgentIdempotencyService } from "../services/agentIdempotencyService";
 import { AgentService } from "../services/agentService";
 import {
+  validateAgentArchiveProjectInput,
   validateAgentCompleteTaskInput,
   validateAgentCreateProjectInput,
   validateAgentCreateTaskInput,
+  validateAgentDeleteProjectInput,
   validateAgentGetTaskInput,
   validateAgentListProjectsInput,
   validateAgentListTasksInput,
+  validateAgentMoveTaskToProjectInput,
   validateAgentSearchTasksInput,
+  validateAgentUpdateProjectInput,
   validateAgentUpdateTaskInput,
 } from "../validation/agentValidation";
 
@@ -23,7 +27,11 @@ export type AgentActionName =
   | "update_task"
   | "complete_task"
   | "list_projects"
-  | "create_project";
+  | "create_project"
+  | "update_project"
+  | "delete_project"
+  | "move_task_to_project"
+  | "archive_project";
 
 interface AgentExecutorDeps {
   todoService: ITodoService;
@@ -382,6 +390,85 @@ export class AgentExecutor {
         case "create_project": {
           const createInput = validateAgentCreateProjectInput(input);
           return await this.handleCreateProject(action, context, createInput);
+        }
+        case "update_project": {
+          const { id, changes } = validateAgentUpdateProjectInput(input);
+          const project = await this.agentService.updateProject(
+            context.userId,
+            id,
+            changes,
+          );
+          if (!project) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Project not found",
+              false,
+              "Verify the project ID belongs to the authenticated user.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, { project });
+        }
+        case "delete_project": {
+          const { id, moveTasksToProjectId } =
+            validateAgentDeleteProjectInput(input);
+          const deleted = await this.agentService.deleteProject(
+            context.userId,
+            id,
+            moveTasksToProjectId,
+          );
+          if (!deleted) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Project not found",
+              false,
+              "Verify the source and target project IDs belong to the authenticated user.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, {
+            deleted: true,
+            projectId: id,
+            movedTasksToProjectId: moveTasksToProjectId,
+            taskDisposition: moveTasksToProjectId ? "reassigned" : "unassigned",
+          });
+        }
+        case "move_task_to_project": {
+          const { taskId, projectId } =
+            validateAgentMoveTaskToProjectInput(input);
+          const task = await this.agentService.moveTaskToProject(
+            context.userId,
+            taskId,
+            projectId,
+          );
+          if (!task) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Task or project not found",
+              false,
+              "Verify the task ID and target project ID belong to the authenticated user.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, { task });
+        }
+        case "archive_project": {
+          const { id, archived } = validateAgentArchiveProjectInput(input);
+          const project = await this.agentService.archiveProject(
+            context.userId,
+            id,
+            archived,
+          );
+          if (!project) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Project not found",
+              false,
+              "Verify the project ID belongs to the authenticated user.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, { project });
         }
       }
     } catch (error) {

--- a/src/agentRouter.test.ts
+++ b/src/agentRouter.test.ts
@@ -14,14 +14,16 @@ import type {
 function createProjectServiceMock(): jest.Mocked<IProjectService> {
   return {
     findAll: jest.fn<Promise<Project[]>, [string]>(),
+    findById: jest.fn<Promise<Project | null>, [string, string]>(),
     create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
     update: jest.fn<
       Promise<Project | null>,
       [string, string, UpdateProjectDto]
     >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
     delete: jest.fn<
       Promise<boolean>,
-      [string, string, ProjectTaskDisposition]
+      [string, string, ProjectTaskDisposition, (string | null)?]
     >(),
   };
 }
@@ -172,6 +174,7 @@ describe("Agent router", () => {
     projectService.create.mockResolvedValue({
       id: "proj-1",
       name: "Platform",
+      archived: false,
       userId: "default-user",
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -220,5 +223,115 @@ describe("Agent router", () => {
     expect(response.body.readOnly).toBe(true);
     expect(response.body.error.code).toBe("AUTH_REQUIRED");
     expect(response.body.trace.requestId).toBeDefined();
+  });
+
+  it("rejects invalid project rename input before calling the project service", async () => {
+    const response = await request(app)
+      .post("/agent/write/update_project")
+      .send({
+        id: "00000000-0000-1000-8000-000000000000",
+        name: "   ",
+      })
+      .expect(400);
+
+    expect(response.body.ok).toBe(false);
+    expect(response.body.action).toBe("update_project");
+    expect(response.body.error.code).toBe("INVALID_INPUT");
+    expect(projectService.update).not.toHaveBeenCalled();
+  });
+
+  it("moves a task to another project through the agent surface", async () => {
+    const task = await todoService.create("default-user", {
+      title: "Move this task",
+    });
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000001",
+      name: "Platform",
+      archived: false,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 3,
+      openTodoCount: 2,
+    });
+
+    const response = await request(app)
+      .post("/agent/write/move_task_to_project")
+      .send({
+        taskId: task.id,
+        projectId: "00000000-0000-1000-8000-000000000001",
+      })
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data.task.category).toBe("Platform");
+    expect(projectService.findById).toHaveBeenCalledWith(
+      "default-user",
+      "00000000-0000-1000-8000-000000000001",
+    );
+  });
+
+  it("rejects cross-user project moves through the agent surface", async () => {
+    const task = await todoService.create("default-user", {
+      title: "Private task",
+    });
+    projectService.findById.mockResolvedValue(null);
+
+    const response = await request(app)
+      .post("/agent/write/move_task_to_project")
+      .send({
+        taskId: task.id,
+        projectId: "00000000-0000-1000-8000-000000000002",
+      })
+      .expect(404);
+
+    expect(response.body.ok).toBe(false);
+    expect(response.body.action).toBe("move_task_to_project");
+    expect(response.body.error.code).toBe("RESOURCE_NOT_FOUND_OR_FORBIDDEN");
+  });
+
+  it("deletes projects with reassignment through the agent surface", async () => {
+    projectService.delete.mockResolvedValue(true);
+
+    const response = await request(app)
+      .post("/agent/write/delete_project")
+      .send({
+        id: "00000000-0000-1000-8000-000000000010",
+        moveTasksToProjectId: "00000000-0000-1000-8000-000000000011",
+      })
+      .expect(200);
+
+    expect(projectService.delete).toHaveBeenCalledWith(
+      "default-user",
+      "00000000-0000-1000-8000-000000000010",
+      "unsorted",
+      "00000000-0000-1000-8000-000000000011",
+    );
+    expect(response.body.data.deleted).toBe(true);
+    expect(response.body.data.taskDisposition).toBe("reassigned");
+  });
+
+  it("archives projects through the agent surface", async () => {
+    projectService.setArchived.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000020",
+      name: "Platform",
+      archived: true,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 4,
+      openTodoCount: 2,
+    });
+
+    const response = await request(app)
+      .post("/agent/write/archive_project")
+      .send({
+        id: "00000000-0000-1000-8000-000000000020",
+        archived: true,
+      })
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data.project.archived).toBe(true);
   });
 });

--- a/src/aiApplyService.test.ts
+++ b/src/aiApplyService.test.ts
@@ -69,8 +69,10 @@ function buildMockProjectService(
 ): IProjectService {
   return {
     findAll: jest.fn().mockResolvedValue([]),
+    findById: jest.fn().mockResolvedValue(null),
     create: jest.fn(),
     update: jest.fn(),
+    setArchived: jest.fn(),
     delete: jest.fn(),
     ...overrides,
   };

--- a/src/api.contract.test.ts
+++ b/src/api.contract.test.ts
@@ -99,6 +99,8 @@ describe("API Contract", () => {
       expect(schemas.Todo.properties.notes).toBeDefined();
       expect(schemas.Todo.properties.order).toBeDefined();
       expect(schemas.Todo.properties.subtasks).toBeDefined();
+      expect(schemas.Project.properties.archived).toBeDefined();
+      expect(schemas.Project.properties.openTodoCount).toBeDefined();
     });
 
     it("documents todo list query params for filtering and pagination", async () => {

--- a/src/interfaces/IProjectService.ts
+++ b/src/interfaces/IProjectService.ts
@@ -7,15 +7,22 @@ import {
 
 export interface IProjectService {
   findAll(userId: string): Promise<Project[]>;
+  findById(userId: string, projectId: string): Promise<Project | null>;
   create(userId: string, dto: CreateProjectDto): Promise<Project>;
   update(
     userId: string,
     projectId: string,
     dto: UpdateProjectDto,
   ): Promise<Project | null>;
+  setArchived(
+    userId: string,
+    projectId: string,
+    archived: boolean,
+  ): Promise<Project | null>;
   delete(
     userId: string,
     projectId: string,
     taskDisposition: ProjectTaskDisposition,
+    moveTasksToProjectId?: string | null,
   ): Promise<boolean>;
 }

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -33,10 +33,14 @@ function requiredScopesForAction(actionName: AgentActionName): McpScope[] {
     case "create_task":
     case "update_task":
     case "complete_task":
+    case "move_task_to_project":
       return [TASK_WRITE_SCOPE];
     case "list_projects":
       return [PROJECT_READ_SCOPE];
     case "create_project":
+    case "update_project":
+    case "delete_project":
+    case "archive_project":
       return [PROJECT_WRITE_SCOPE];
   }
 }
@@ -91,7 +95,7 @@ export function listMcpTools(input: {
     inputSchema: cloneJson(tool.inputSchema),
     annotations: {
       readOnlyHint: tool.readOnly,
-      destructiveHint: false,
+      destructiveHint: tool.name === "delete_project",
       idempotentHint: tool.name === "create_task",
       openWorldHint: false,
     },

--- a/src/mcpPublicRouter.test.ts
+++ b/src/mcpPublicRouter.test.ts
@@ -15,14 +15,16 @@ import type {
 function createProjectServiceMock(): jest.Mocked<IProjectService> {
   return {
     findAll: jest.fn<Promise<Project[]>, [string]>(),
+    findById: jest.fn<Promise<Project | null>, [string, string]>(),
     create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
     update: jest.fn<
       Promise<Project | null>,
       [string, string, UpdateProjectDto]
     >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
     delete: jest.fn<
       Promise<boolean>,
-      [string, string, ProjectTaskDisposition]
+      [string, string, ProjectTaskDisposition, (string | null)?]
     >(),
   };
 }

--- a/src/mcpRouter.test.ts
+++ b/src/mcpRouter.test.ts
@@ -15,14 +15,16 @@ import type {
 function createProjectServiceMock(): jest.Mocked<IProjectService> {
   return {
     findAll: jest.fn<Promise<Project[]>, [string]>(),
+    findById: jest.fn<Promise<Project | null>, [string, string]>(),
     create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
     update: jest.fn<
       Promise<Project | null>,
       [string, string, UpdateProjectDto]
     >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
     delete: jest.fn<
       Promise<boolean>,
-      [string, string, ProjectTaskDisposition]
+      [string, string, ProjectTaskDisposition, (string | null)?]
     >(),
   };
 }
@@ -333,6 +335,43 @@ describe("Remote MCP router auth and scopes", () => {
     });
   });
 
+  it("exposes the new project-management tools when write scopes are granted", async () => {
+    currentSession = buildMcpSession("user-1", [
+      "projects.read",
+      "projects.write",
+      "tasks.read",
+      "tasks.write",
+    ]);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer write-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 4.1,
+        method: "tools/list",
+      })
+      .expect(200);
+
+    const toolNames = response.body.result.tools.map(
+      (tool: { name: string }) => tool.name,
+    );
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        "update_project",
+        "delete_project",
+        "move_task_to_project",
+        "archive_project",
+      ]),
+    );
+
+    const deleteProjectTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "delete_project",
+    );
+    expect(deleteProjectTool.annotations.destructiveHint).toBe(true);
+    expect(deleteProjectTool.auth.requiredScopes).toEqual(["projects.write"]);
+  });
+
   it("rejects write tools when write scope is missing", async () => {
     currentSession = buildMcpSession("user-1", ["tasks.read"]);
 
@@ -443,5 +482,44 @@ describe("Remote MCP router auth and scopes", () => {
     );
 
     logSpy.mockRestore();
+  });
+
+  it("moves a task to a project through the MCP surface", async () => {
+    currentSession = buildMcpSession("user-1", ["tasks.read", "tasks.write"]);
+    const task = await todoService.create("user-1", {
+      title: "Move via MCP",
+    });
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000031",
+      name: "Ops",
+      archived: false,
+      userId: "user-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 1,
+      openTodoCount: 1,
+    });
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer task-write-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 9,
+        method: "tools/call",
+        params: {
+          name: "move_task_to_project",
+          arguments: {
+            taskId: task.id,
+            projectId: "00000000-0000-1000-8000-000000000031",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(response.body.result.isError).toBeUndefined();
+    expect(response.body.result.structuredContent.data.task.category).toBe(
+      "Ops",
+    );
   });
 });

--- a/src/projectService.test.ts
+++ b/src/projectService.test.ts
@@ -1,0 +1,163 @@
+import { prisma } from "./prismaClient";
+import {
+  DuplicateProjectNameError,
+  PrismaProjectService,
+} from "./services/projectService";
+import { PrismaTodoService } from "./services/prismaTodoService";
+
+const TEST_USER_ID = "test-user-123";
+const TEST_USER_ID_2 = "test-user-456";
+
+describe("PrismaProjectService (Integration)", () => {
+  let projectService: PrismaProjectService;
+  let todoService: PrismaTodoService;
+
+  beforeAll(() => {
+    projectService = new PrismaProjectService(prisma);
+    todoService = new PrismaTodoService(prisma);
+  });
+
+  beforeEach(async () => {
+    await prisma.heading.deleteMany();
+    await prisma.todo.deleteMany();
+    await prisma.project.deleteMany();
+    await prisma.user.deleteMany();
+
+    await prisma.user.create({
+      data: {
+        id: TEST_USER_ID,
+        email: "projects@example.com",
+        password: "hashed-password",
+        name: "Projects User",
+      },
+    });
+
+    await prisma.user.create({
+      data: {
+        id: TEST_USER_ID_2,
+        email: "projects-2@example.com",
+        password: "hashed-password",
+        name: "Projects User 2",
+      },
+    });
+  });
+
+  it("renames a project and synchronizes linked task categories", async () => {
+    const project = await projectService.create(TEST_USER_ID, {
+      name: "Work / Client A",
+    });
+    const todo = await todoService.create(TEST_USER_ID, {
+      title: "Ship report",
+      category: "Work / Client A",
+    });
+
+    const updated = await projectService.update(TEST_USER_ID, project.id, {
+      name: "Work / Client B",
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated?.name).toBe("Work / Client B");
+    expect(updated?.archived).toBe(false);
+
+    const refreshedTodo = await todoService.findById(TEST_USER_ID, todo.id);
+    expect(refreshedTodo?.category).toBe("Work / Client B");
+
+    const dbTodo = await prisma.todo.findUnique({
+      where: { id: todo.id },
+      include: { project: true },
+    });
+    expect(dbTodo?.project?.name).toBe("Work / Client B");
+  });
+
+  it("rejects duplicate project names on rename", async () => {
+    await projectService.create(TEST_USER_ID, { name: "Platform" });
+    const project = await projectService.create(TEST_USER_ID, {
+      name: "Support",
+    });
+
+    await expect(
+      projectService.update(TEST_USER_ID, project.id, { name: "Platform" }),
+    ).rejects.toBeInstanceOf(DuplicateProjectNameError);
+  });
+
+  it("deletes a project and reassigns its tasks when a target project is provided", async () => {
+    const source = await projectService.create(TEST_USER_ID, { name: "Alpha" });
+    const target = await projectService.create(TEST_USER_ID, { name: "Beta" });
+    const todo = await todoService.create(TEST_USER_ID, {
+      title: "Move me",
+      category: "Alpha",
+    });
+
+    const deleted = await projectService.delete(
+      TEST_USER_ID,
+      source.id,
+      "unsorted",
+      target.id,
+    );
+
+    expect(deleted).toBe(true);
+    expect(await projectService.findById(TEST_USER_ID, source.id)).toBeNull();
+
+    const movedTodo = await todoService.findById(TEST_USER_ID, todo.id);
+    expect(movedTodo?.category).toBe("Beta");
+
+    const dbTodo = await prisma.todo.findUnique({
+      where: { id: todo.id },
+      include: { project: true },
+    });
+    expect(dbTodo?.projectId).toBe(target.id);
+    expect(dbTodo?.project?.name).toBe("Beta");
+    expect(dbTodo?.headingId).toBeNull();
+  });
+
+  it("deletes a project and unassigns its tasks when no reassignment target is provided", async () => {
+    const source = await projectService.create(TEST_USER_ID, { name: "Alpha" });
+    const todo = await todoService.create(TEST_USER_ID, {
+      title: "Unassign me",
+      category: "Alpha",
+    });
+
+    const deleted = await projectService.delete(
+      TEST_USER_ID,
+      source.id,
+      "unsorted",
+    );
+
+    expect(deleted).toBe(true);
+
+    const unassignedTodo = await todoService.findById(TEST_USER_ID, todo.id);
+    expect(unassignedTodo?.category).toBeUndefined();
+
+    const dbTodo = await prisma.todo.findUnique({
+      where: { id: todo.id },
+    });
+    expect(dbTodo?.projectId).toBeNull();
+    expect(dbTodo?.category).toBeNull();
+    expect(dbTodo?.headingId).toBeNull();
+  });
+
+  it("toggles a project's archived state without changing ownership", async () => {
+    const project = await projectService.create(TEST_USER_ID, {
+      name: "Archive Me",
+    });
+
+    const archived = await projectService.setArchived(
+      TEST_USER_ID,
+      project.id,
+      true,
+    );
+    expect(archived?.archived).toBe(true);
+
+    const unarchived = await projectService.setArchived(
+      TEST_USER_ID,
+      project.id,
+      false,
+    );
+    expect(unarchived?.archived).toBe(false);
+
+    const projects = await projectService.findAll(TEST_USER_ID);
+    expect(projects.find((item) => item.id === project.id)?.archived).toBe(
+      false,
+    );
+  });
+});

--- a/src/projectsRouter.test.ts
+++ b/src/projectsRouter.test.ts
@@ -13,14 +13,16 @@ import type {
 function createProjectServiceMock(): jest.Mocked<IProjectService> {
   return {
     findAll: jest.fn<Promise<Project[]>, [string]>(),
+    findById: jest.fn<Promise<Project | null>, [string, string]>(),
     create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
     update: jest.fn<
       Promise<Project | null>,
       [string, string, UpdateProjectDto]
     >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
     delete: jest.fn<
       Promise<boolean>,
-      [string, string, ProjectTaskDisposition]
+      [string, string, ProjectTaskDisposition, (string | null)?]
     >(),
   };
 }

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -100,6 +100,22 @@ export function createAgentRouter({
     "/write/create_project",
     createAgentActionHandler(agentExecutor, "create_project"),
   );
+  router.post(
+    "/write/update_project",
+    createAgentActionHandler(agentExecutor, "update_project"),
+  );
+  router.post(
+    "/write/delete_project",
+    createAgentActionHandler(agentExecutor, "delete_project"),
+  );
+  router.post(
+    "/write/move_task_to_project",
+    createAgentActionHandler(agentExecutor, "move_task_to_project"),
+  );
+  router.post(
+    "/write/archive_project",
+    createAgentActionHandler(agentExecutor, "archive_project"),
+  );
 
   return router;
 }

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -6,6 +6,7 @@ import {
   FindTodosQuery,
   Project,
   Todo,
+  UpdateProjectDto,
   UpdateTodoDto,
 } from "../types";
 
@@ -61,5 +62,70 @@ export class AgentService {
       throw new Error("Projects not configured");
     }
     return this.deps.projectService.create(userId, dto);
+  }
+
+  async updateProject(
+    userId: string,
+    id: string,
+    dto: UpdateProjectDto,
+  ): Promise<Project | null> {
+    if (!this.deps.projectService) {
+      throw new Error("Projects not configured");
+    }
+    return this.deps.projectService.update(userId, id, dto);
+  }
+
+  async deleteProject(
+    userId: string,
+    id: string,
+    moveTasksToProjectId?: string | null,
+  ): Promise<boolean> {
+    if (!this.deps.projectService) {
+      throw new Error("Projects not configured");
+    }
+    return this.deps.projectService.delete(
+      userId,
+      id,
+      "unsorted",
+      moveTasksToProjectId,
+    );
+  }
+
+  async moveTaskToProject(
+    userId: string,
+    taskId: string,
+    projectId: string | null,
+  ): Promise<Todo | null> {
+    if (!this.deps.projectService) {
+      throw new Error("Projects not configured");
+    }
+
+    let category: string | null = null;
+    if (projectId) {
+      const project = await this.deps.projectService.findById(
+        userId,
+        projectId,
+      );
+      if (!project) {
+        return null;
+      }
+      category = project.name;
+    }
+
+    return this.deps.todoService.update(userId, taskId, {
+      category,
+      headingId: null,
+    });
+  }
+
+  async archiveProject(
+    userId: string,
+    id: string,
+    archived: boolean,
+  ): Promise<Project | null> {
+    if (!this.deps.projectService) {
+      throw new Error("Projects not configured");
+    }
+    return this.deps.projectService.setArchived(userId, id, archived);
   }
 }

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -18,6 +18,35 @@ export class DuplicateProjectNameError extends Error {
 export class PrismaProjectService implements IProjectService {
   constructor(private prisma: PrismaClient) {}
 
+  private async mapProjectRows(
+    userId: string,
+    rows: Array<{
+      id: string;
+      name: string;
+      archived: boolean;
+      userId: string;
+      createdAt: Date;
+      updatedAt: Date;
+      _count: { todos: number };
+    }>,
+  ): Promise<Project[]> {
+    const openTodoCountByProjectId = await this.getOpenTodoCountMap(
+      userId,
+      rows.map((row) => row.id),
+    );
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      archived: row.archived,
+      userId: row.userId,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      todoCount: row._count.todos,
+      openTodoCount: openTodoCountByProjectId.get(row.id) || 0,
+    }));
+  }
+
   private async getOpenTodoCountMap(
     userId: string,
     projectIds: string[],
@@ -53,25 +82,38 @@ export class PrismaProjectService implements IProjectService {
         },
       },
     });
-    const openTodoCountByProjectId = await this.getOpenTodoCountMap(
-      userId,
-      rows.map((row) => row.id),
-    );
-    return rows.map((row) => ({
-      id: row.id,
-      name: row.name,
-      userId: row.userId,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-      todoCount: row._count.todos,
-      openTodoCount: openTodoCountByProjectId.get(row.id) || 0,
-    }));
+    return this.mapProjectRows(userId, rows);
+  }
+
+  async findById(userId: string, projectId: string): Promise<Project | null> {
+    try {
+      const row = await this.prisma.project.findFirst({
+        where: { id: projectId, userId },
+        include: {
+          _count: {
+            select: { todos: true },
+          },
+        },
+      });
+      if (!row) {
+        return null;
+      }
+
+      const [project] = await this.mapProjectRows(userId, [row]);
+      return project;
+    } catch (error: unknown) {
+      if (hasPrismaCode(error, ["P2023"])) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   async create(userId: string, dto: CreateProjectDto): Promise<Project> {
     try {
       const row = await this.prisma.project.create({
         data: {
+          archived: false,
           name: dto.name,
           userId,
         },
@@ -79,6 +121,7 @@ export class PrismaProjectService implements IProjectService {
       return {
         id: row.id,
         name: row.name,
+        archived: row.archived,
         userId: row.userId,
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
@@ -127,6 +170,7 @@ export class PrismaProjectService implements IProjectService {
         return {
           id: updated.id,
           name: updated.name,
+          archived: updated.archived,
           userId: updated.userId,
           createdAt: updated.createdAt,
           updatedAt: updated.updatedAt,
@@ -145,10 +189,56 @@ export class PrismaProjectService implements IProjectService {
     }
   }
 
+  async setArchived(
+    userId: string,
+    projectId: string,
+    archived: boolean,
+  ): Promise<Project | null> {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const existing = await tx.project.findFirst({
+          where: { id: projectId, userId },
+        });
+        if (!existing) {
+          return null;
+        }
+
+        const updated = await tx.project.update({
+          where: { id: projectId },
+          data: { archived },
+        });
+
+        const [count, openTodoCount] = await Promise.all([
+          tx.todo.count({ where: { userId, projectId } }),
+          tx.todo.count({
+            where: { userId, projectId, completed: false },
+          }),
+        ]);
+
+        return {
+          id: updated.id,
+          name: updated.name,
+          archived: updated.archived,
+          userId: updated.userId,
+          createdAt: updated.createdAt,
+          updatedAt: updated.updatedAt,
+          todoCount: count,
+          openTodoCount,
+        };
+      });
+    } catch (error: unknown) {
+      if (hasPrismaCode(error, ["P2023"])) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
   async delete(
     userId: string,
     projectId: string,
     taskDisposition: ProjectTaskDisposition,
+    moveTasksToProjectId?: string | null,
   ): Promise<boolean> {
     try {
       return await this.prisma.$transaction(async (tx) => {
@@ -160,7 +250,24 @@ export class PrismaProjectService implements IProjectService {
           return false;
         }
 
-        if (taskDisposition === "delete") {
+        if (moveTasksToProjectId) {
+          const targetProject = await tx.project.findFirst({
+            where: { id: moveTasksToProjectId, userId },
+            select: { id: true, name: true },
+          });
+          if (!targetProject) {
+            return false;
+          }
+
+          await tx.todo.updateMany({
+            where: { userId, projectId },
+            data: {
+              projectId: targetProject.id,
+              category: targetProject.name,
+              headingId: null,
+            },
+          });
+        } else if (taskDisposition === "delete") {
           await tx.todo.deleteMany({
             where: { userId, projectId },
           });
@@ -170,6 +277,7 @@ export class PrismaProjectService implements IProjectService {
             data: {
               projectId: null,
               category: null,
+              headingId: null,
             },
           });
         }

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -162,6 +162,10 @@ const options: swaggerJsdoc.Options = {
               maxLength: 50,
               description: "Project path/name",
             },
+            archived: {
+              type: "boolean",
+              description: "Whether the project is archived",
+            },
             userId: {
               type: "string",
               format: "uuid",
@@ -170,6 +174,10 @@ const options: swaggerJsdoc.Options = {
             todoCount: {
               type: "integer",
               description: "Number of todos linked to this project",
+            },
+            openTodoCount: {
+              type: "integer",
+              description: "Number of incomplete todos linked to this project",
             },
             createdAt: {
               type: "string",

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Subtask {
 export interface Project {
   id: string;
   name: string;
+  archived: boolean;
   userId: string;
   createdAt: Date;
   updatedAt: Date;

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -5,6 +5,7 @@ import {
   Priority,
   SortOrder,
   TodoSortBy,
+  UpdateProjectDto,
   UpdateTodoDto,
 } from "../types";
 import {
@@ -57,6 +58,10 @@ const CREATE_TASK_KEYS = [
 const UPDATE_TASK_KEYS = ["id", ...CREATE_TASK_KEYS, "completed", "order"];
 const COMPLETE_TASK_KEYS = ["id", "completed"];
 const CREATE_PROJECT_KEYS = ["name"];
+const UPDATE_PROJECT_KEYS = ["id", "name"];
+const DELETE_PROJECT_KEYS = ["id", "moveTasksToProjectId"];
+const MOVE_TASK_TO_PROJECT_KEYS = ["taskId", "projectId"];
+const ARCHIVE_PROJECT_KEYS = ["id", "archived"];
 
 function ensureObject(data: unknown, label: string): Record<string, unknown> {
   if (data === undefined || data === null) {
@@ -355,4 +360,82 @@ export function validateAgentCreateProjectInput(
   const body = ensureObject(data, "Agent action input");
   rejectUnknownKeys(body, CREATE_PROJECT_KEYS, "Agent action input");
   return validateCreateProject(body);
+}
+
+export function validateAgentUpdateProjectInput(data: unknown): {
+  id: string;
+  changes: UpdateProjectDto;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, UPDATE_PROJECT_KEYS, "Agent action input");
+  const id = parseId(body);
+  const { id: _id, ...changes } = body;
+  return { id, changes: validateCreateProject(changes) };
+}
+
+export function validateAgentDeleteProjectInput(data: unknown): {
+  id: string;
+  moveTasksToProjectId: string | null;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, DELETE_PROJECT_KEYS, "Agent action input");
+  const id = parseId(body);
+
+  if (
+    body.moveTasksToProjectId === undefined ||
+    body.moveTasksToProjectId === null
+  ) {
+    return { id, moveTasksToProjectId: null };
+  }
+
+  if (typeof body.moveTasksToProjectId !== "string") {
+    throw new ValidationError("moveTasksToProjectId must be a string or null");
+  }
+
+  validateId(body.moveTasksToProjectId);
+  if (body.moveTasksToProjectId === id) {
+    throw new ValidationError(
+      "moveTasksToProjectId must reference a different project",
+    );
+  }
+
+  return { id, moveTasksToProjectId: body.moveTasksToProjectId };
+}
+
+export function validateAgentMoveTaskToProjectInput(data: unknown): {
+  taskId: string;
+  projectId: string | null;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, MOVE_TASK_TO_PROJECT_KEYS, "Agent action input");
+
+  if (typeof body.taskId !== "string") {
+    throw new ValidationError("taskId is required and must be a string");
+  }
+  validateId(body.taskId);
+
+  if (body.projectId === undefined || body.projectId === null) {
+    return { taskId: body.taskId, projectId: null };
+  }
+
+  if (typeof body.projectId !== "string") {
+    throw new ValidationError("projectId must be a string or null");
+  }
+  validateId(body.projectId);
+
+  return { taskId: body.taskId, projectId: body.projectId };
+}
+
+export function validateAgentArchiveProjectInput(data: unknown): {
+  id: string;
+  archived: boolean;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, ARCHIVE_PROJECT_KEYS, "Agent action input");
+  const id = parseId(body);
+  const archived = parseOptionalBoolean(body.archived, "archived");
+  if (archived === undefined) {
+    throw new ValidationError("archived is required and must be a boolean");
+  }
+  return { id, archived };
 }


### PR DESCRIPTION
## Why
The remote MCP surface already supports basic task and project actions, but ChatGPT still cannot fully manage projects. This closes the main project-management gap by exposing rename, delete, archive, and task-to-project move operations through the existing agent and MCP layers instead of adding a parallel path.

## What changed
- added `update_project`, `delete_project`, `move_task_to_project`, and `archive_project` to the agent manifest, executor, routes, and MCP tool catalog
- extended the project service with owned-project lookup, archive toggling, and delete-time task reassignment while preserving the existing default of unassigning tasks when no destination project is provided
- added the `archived` project field end-to-end, including the Prisma migration and API schema updates
- added focused unit/integration coverage for rename conflicts, delete flows, move-task authorization, and archive toggles
- updated the agent and MCP docs to describe the new tools and their behavior

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

## Migration
- deploy `prisma/migrations/20260311211500_add_project_archived_flag/migration.sql` with the normal `npx prisma migrate deploy` rollout step
- no data backfill is required because `Project.archived` defaults to `false`
