### PR TITLE
fix(api): keep auth email off request path

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -472,6 +472,7 @@ describe("Todos API", () => {
           id: "user-1",
           isVerified: false,
         }),
+        dispatchVerificationEmail: jest.fn(),
         sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
       } as any;
 
@@ -484,6 +485,10 @@ describe("Todos API", () => {
 
       expect(mockAuthService.getUserByEmail).toHaveBeenCalledWith(
         "mixed@example.com",
+      );
+      expect(mockAuthService.dispatchVerificationEmail).toHaveBeenCalledWith(
+        "user-1",
+        "Failed to send verification email after resend request:",
       );
     });
 

--- a/src/authService.test.ts
+++ b/src/authService.test.ts
@@ -93,6 +93,28 @@ describe("AuthService", () => {
       });
       expect(dbUser).toBeDefined();
     });
+
+    it("should not block registration on verification email delivery", async () => {
+      let resolveEmail!: () => void;
+      const emailDeferred = new Promise<void>((resolve) => {
+        resolveEmail = resolve;
+      });
+      const sendVerificationEmailSpy = jest
+        .spyOn(authService, "sendVerificationEmail")
+        .mockReturnValue(emailDeferred);
+
+      const result = await authService.register({
+        email: "async-register@example.com",
+        password: "password123",
+      });
+
+      expect(result.user.email).toBe("async-register@example.com");
+      expect(sendVerificationEmailSpy).toHaveBeenCalledTimes(1);
+
+      resolveEmail();
+      await emailDeferred;
+      sendVerificationEmailSpy.mockRestore();
+    });
   });
 
   describe("login", () => {
@@ -257,6 +279,35 @@ describe("AuthService", () => {
     it("should return null for non-existent user", async () => {
       const user = await authService.getUserById("non-existent-id");
       expect(user).toBeNull();
+    });
+  });
+
+  describe("requestPasswordReset", () => {
+    it("should not block on password reset email delivery", async () => {
+      const hashedPassword = await bcrypt.hash("password123", 10);
+      await prisma.user.create({
+        data: {
+          email: "password-reset@example.com",
+          password: hashedPassword,
+        },
+      });
+
+      let resolveEmail!: () => void;
+      const emailDeferred = new Promise<void>((resolve) => {
+        resolveEmail = resolve;
+      });
+      const sendPasswordResetEmailSpy = jest
+        .spyOn((authService as any).emailService, "sendPasswordResetEmail")
+        .mockReturnValue(emailDeferred);
+
+      await expect(
+        authService.requestPasswordReset("password-reset@example.com"),
+      ).resolves.toBeUndefined();
+      expect(sendPasswordResetEmailSpy).toHaveBeenCalledTimes(1);
+
+      resolveEmail();
+      await emailDeferred;
+      sendPasswordResetEmailSpy.mockRestore();
     });
   });
 

--- a/src/routes/authRouter.ts
+++ b/src/routes/authRouter.ts
@@ -384,7 +384,10 @@ export function createAuthRouter({
         const user = await authService.getUserByEmail(normalizedEmail);
 
         if (user && !user.isVerified) {
-          await authService.sendVerificationEmail(user.id);
+          authService.dispatchVerificationEmail(
+            user.id,
+            "Failed to send verification email after resend request:",
+          );
         }
 
         res.json({

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -96,6 +96,35 @@ export class AuthService {
     return Date.now() <= this.legacyRefreshTokenFallbackUntil.getTime();
   }
 
+  // Keep auth responses off the SMTP critical path.
+  private dispatchAsyncTask(
+    task: () => Promise<void>,
+    onError: (error: unknown) => void,
+  ): void {
+    void Promise.resolve().then(task).catch(onError);
+  }
+
+  dispatchVerificationEmail(
+    userId: string,
+    failureMessage = "Failed to send verification email:",
+  ): void {
+    this.dispatchAsyncTask(
+      () => this.sendVerificationEmail(userId),
+      (error) => {
+        console.error(failureMessage, error);
+      },
+    );
+  }
+
+  private dispatchPasswordResetEmail(email: string, token: string): void {
+    this.dispatchAsyncTask(
+      () => this.emailService.sendPasswordResetEmail(email, token),
+      (error) => {
+        console.error("Failed to send password reset email:", error);
+      },
+    );
+  }
+
   /**
    * Register a new user
    * @throws Error if email already exists or validation fails
@@ -122,13 +151,7 @@ export class AuthService {
       },
     });
 
-    // Send verification email
-    try {
-      await this.sendVerificationEmail(user.id);
-    } catch (error) {
-      console.error("Failed to send verification email:", error);
-      // Continue anyway - user can resend later
-    }
+    this.dispatchVerificationEmail(user.id);
 
     // Generate JWT token and refresh token
     const token = this.generateToken({
@@ -437,15 +460,10 @@ export class AuthService {
 
     // Send new verification email when email changes
     if (emailIsChanging) {
-      try {
-        await this.sendVerificationEmail(userId);
-      } catch (error) {
-        console.error(
-          "Failed to send verification email after email change:",
-          error,
-        );
-        // Continue anyway - user can resend later
-      }
+      this.dispatchVerificationEmail(
+        userId,
+        "Failed to send verification email after email change:",
+      );
     }
 
     return updatedUser;
@@ -645,7 +663,7 @@ export class AuthService {
       },
     });
 
-    await this.emailService.sendPasswordResetEmail(user.email, token);
+    this.dispatchPasswordResetEmail(user.email, token);
   }
 
   /**


### PR DESCRIPTION
## Why
Production registration is blocked on synchronous email delivery. Live verification showed `POST /auth/register` taking about `30.41s`, while `POST /auth/login` for the same account returned in about `0.316s`.

The bottleneck is the verification and reset email path being awaited inside auth requests. That makes SMTP latency part of the user-facing registration and recovery path.

## What changed
- moved verification email dispatch off the request path for registration
- moved resend-verification dispatch off the request path
- moved forgot-password email dispatch off the request path
- moved verification email dispatch after email-change requests off the request path
- preserved token persistence before background email dispatch so semantics stay intact
- added focused unit coverage for non-blocking registration and password reset flows

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
