### PR TITLE
feat(ai): add home focus suggestion surface

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -7,7 +7,6 @@ import {
   createInitialTaskDrawerAssistState,
   createInitialOnCreateAssistState,
   createInitialTodayPlanState,
-  createInitialHomeTopFocusState,
 } from "./modules/store.js";
 import {
   buildTodosQueryParams,
@@ -414,6 +413,10 @@ import {
 import * as TaskDrawerAssist from "./modules/taskDrawerAssist.js";
 import * as OnCreateAssist from "./modules/onCreateAssist.js";
 import * as TodayPlan from "./modules/todayPlan.js";
+import {
+  applyHomeFocusSuggestion,
+  dismissHomeFocusSuggestion,
+} from "./modules/homeAiService.js";
 import { EventBus } from "./modules/eventBus.js";
 
 // Configuration
@@ -486,6 +489,7 @@ const {
   AI_DEBUG_ENABLED,
   ON_CREATE_SURFACE,
   TODAY_PLAN_SURFACE,
+  HOME_FOCUS_SURFACE,
   AI_SURFACE_TYPES,
   AI_SURFACE_IMPACT,
   isKnownSuggestionType,
@@ -550,7 +554,6 @@ const {
 const SIDEBAR_NAV_ITEMS = [];
 state.onCreateAssistState.dismissedTodoIds =
   OnCreateAssist.loadOnCreateDismissedTodoIds();
-const HOME_TOP_FOCUS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const QUICK_ENTRY_NATURAL_DATE_DEBOUNCE_MS = 320;
 
 function emitAiSuggestionUndoTelemetry({
@@ -1558,6 +1561,7 @@ function bindDeclarativeHandlers() {
   hooks.impactRankForSurface = impactRankForSurface;
   hooks.ON_CREATE_SURFACE = ON_CREATE_SURFACE;
   hooks.TODAY_PLAN_SURFACE = TODAY_PLAN_SURFACE;
+  hooks.HOME_FOCUS_SURFACE = HOME_FOCUS_SURFACE;
   hooks.isKnownSuggestionType = isKnownSuggestionType;
   hooks.initializeDrawerDraft = initializeDrawerDraft;
   hooks.setDrawerSaveState = setDrawerSaveState;
@@ -1706,6 +1710,8 @@ window.createHeadingForSelectedProject = createHeadingForSelectedProject;
 // Home workspace
 window.openHomeProject = openHomeProject;
 window.openHomeTileList = openHomeTileList;
+window.applyHomeFocusSuggestion = applyHomeFocusSuggestion;
+window.dismissHomeFocusSuggestion = dismissHomeFocusSuggestion;
 // Admin
 window.changeUserRole = changeUserRole;
 window.deleteUser = deleteUser;

--- a/client/modules/homeAiService.js
+++ b/client/modules/homeAiService.js
@@ -1,0 +1,314 @@
+// =============================================================================
+// homeAiService.js — Home dashboard AI suggestion lifecycle.
+// Reuses the existing AI suggestion endpoints instead of a custom Home path.
+// =============================================================================
+
+import { state, hooks } from "./store.js";
+import { runAsyncLifecycle } from "./asyncLifecycle.js";
+import { applyAsyncAction } from "./stateActions.js";
+
+const HOME_FOCUS_SURFACE = "home_focus";
+
+function rerenderHomeSurface(reason) {
+  hooks.applyFiltersAndRender?.({ reason });
+}
+
+function clampConfidence(value) {
+  const numeric = Number(value) || 0;
+  return Math.max(0, Math.min(1, numeric));
+}
+
+function parseSource(value) {
+  return value === "ai" || value === "hybrid" ? value : "deterministic";
+}
+
+function normalizeHomeFocusSuggestion(rawSuggestion, index) {
+  if (!rawSuggestion || typeof rawSuggestion !== "object") return null;
+
+  const payload =
+    rawSuggestion.payload && typeof rawSuggestion.payload === "object"
+      ? rawSuggestion.payload
+      : {};
+  const type = String(rawSuggestion.type || "");
+  if (type !== "focus_task") return null;
+
+  const suggestionId = String(rawSuggestion.suggestionId || "").trim();
+  const todoId = String(
+    rawSuggestion.todoId ||
+      payload.todoId ||
+      rawSuggestion.taskId ||
+      payload.taskId ||
+      "",
+  ).trim();
+  const title = String(rawSuggestion.title || payload.title || "").trim();
+  const summary = String(rawSuggestion.summary || payload.summary || "").trim();
+
+  if (!suggestionId || !todoId || !title || !summary) {
+    return null;
+  }
+
+  return {
+    type,
+    suggestionId,
+    todoId,
+    taskId: String(rawSuggestion.taskId || payload.taskId || todoId).trim(),
+    projectId: String(
+      rawSuggestion.projectId || payload.projectId || "",
+    ).trim(),
+    title,
+    summary: hooks.truncateRationale(summary, 140),
+    source: parseSource(rawSuggestion.source || payload.source),
+    confidence: clampConfidence(rawSuggestion.confidence),
+    payload,
+    order: Number.isFinite(index) ? index : 0,
+  };
+}
+
+function normalizeHomeFocusEnvelope(rawEnvelope) {
+  const suggestions = (
+    Array.isArray(rawEnvelope?.suggestions) ? rawEnvelope.suggestions : []
+  )
+    .map((suggestion, index) => normalizeHomeFocusSuggestion(suggestion, index))
+    .filter(Boolean);
+
+  const sortedSuggestions =
+    typeof hooks.sortSuggestions === "function"
+      ? hooks.sortSuggestions(HOME_FOCUS_SURFACE, suggestions)
+      : suggestions;
+
+  return {
+    contractVersion: Number(rawEnvelope?.contractVersion) || 1,
+    generatedAt: String(rawEnvelope?.generatedAt || new Date().toISOString()),
+    requestId: String(rawEnvelope?.requestId || "home-focus"),
+    surface: HOME_FOCUS_SURFACE,
+    must_abstain: !!rawEnvelope?.must_abstain,
+    suggestions: Array.isArray(sortedSuggestions)
+      ? sortedSuggestions.slice(0, 3)
+      : [],
+  };
+}
+
+async function fetchHomeFocusLatestSuggestion() {
+  return hooks.apiCall(
+    `${hooks.API_URL}/ai/suggestions/latest?surface=${HOME_FOCUS_SURFACE}`,
+  );
+}
+
+async function generateHomeFocusSuggestions(candidates) {
+  return hooks.apiCall(`${hooks.API_URL}/ai/decision-assist/stub`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      surface: HOME_FOCUS_SURFACE,
+      topN: 3,
+      candidates,
+    }),
+  });
+}
+
+function shouldReuseHomeFocusState(requestKey, force) {
+  if (!requestKey) return true;
+  if (state.homeAi.requestKey !== requestKey) return false;
+  if (state.homeAi.status === "loading") return true;
+  if (!force && state.homeAi.lastLoadedAt) return true;
+  return false;
+}
+
+export async function loadHomeFocusSuggestions({
+  candidates = [],
+  requestKey = "",
+  force = false,
+} = {}) {
+  const normalizedRequestKey = String(requestKey || "");
+  if (
+    !normalizedRequestKey ||
+    !Array.isArray(candidates) ||
+    !candidates.length
+  ) {
+    if (
+      state.homeAi.status !== "idle" ||
+      state.homeAi.suggestions.length > 0 ||
+      state.homeAi.requestKey
+    ) {
+      applyAsyncAction("homeAi/reset");
+      rerenderHomeSurface("home-focus-reset");
+    }
+    return;
+  }
+
+  if (shouldReuseHomeFocusState(normalizedRequestKey, force)) {
+    return;
+  }
+
+  await runAsyncLifecycle({
+    start: () => {
+      applyAsyncAction("homeAi/start", { requestKey: normalizedRequestKey });
+      rerenderHomeSurface("home-focus-loading");
+    },
+    run: async () => {
+      let latestResponse = await fetchHomeFocusLatestSuggestion();
+      if (latestResponse.status === 403 || latestResponse.status === 404) {
+        return { outcome: "unavailable" };
+      }
+
+      if (latestResponse.status === 204) {
+        const generated = await generateHomeFocusSuggestions(candidates);
+        if (generated.status === 403 || generated.status === 404) {
+          return { outcome: "unavailable" };
+        }
+        if (!generated.ok) {
+          return { outcome: "failure" };
+        }
+        latestResponse = await fetchHomeFocusLatestSuggestion();
+      }
+
+      if (latestResponse.status === 204) {
+        return {
+          outcome: "empty",
+          envelope: normalizeHomeFocusEnvelope({
+            surface: HOME_FOCUS_SURFACE,
+            must_abstain: true,
+            suggestions: [],
+          }),
+        };
+      }
+
+      if (!latestResponse.ok) {
+        return { outcome: "failure" };
+      }
+
+      const payload = await hooks.parseApiBody(latestResponse);
+      const envelope = normalizeHomeFocusEnvelope(
+        payload?.outputEnvelope || {},
+      );
+      if (envelope.must_abstain || envelope.suggestions.length === 0) {
+        return { outcome: "empty", envelope };
+      }
+
+      return {
+        outcome: "success",
+        payload: {
+          aiSuggestionId: String(payload?.aiSuggestionId || ""),
+          suggestions: envelope.suggestions,
+        },
+      };
+    },
+    success: (result) => {
+      if (state.homeAi.requestKey !== normalizedRequestKey) {
+        return;
+      }
+
+      if (result?.outcome === "unavailable") {
+        applyAsyncAction("homeAi/unavailable");
+      } else if (result?.outcome === "empty") {
+        applyAsyncAction("homeAi/empty");
+      } else if (result?.outcome === "failure") {
+        applyAsyncAction("homeAi/failure", {
+          error: "Could not load AI focus right now.",
+        });
+      } else if (result?.outcome === "success") {
+        applyAsyncAction("homeAi/success", result.payload);
+      }
+      rerenderHomeSurface("home-focus-loaded");
+    },
+    failure: (error) => {
+      if (state.homeAi.requestKey !== normalizedRequestKey) {
+        return;
+      }
+      console.error("Home focus AI load failed:", error);
+      applyAsyncAction("homeAi/failure", {
+        error: "Could not load AI focus right now.",
+      });
+      rerenderHomeSurface("home-focus-failed");
+    },
+  });
+}
+
+export async function refreshHomeFocusSuggestions() {
+  const nextRequestKey = String(state.homeAi.requestKey || "");
+  applyAsyncAction("homeAi/reset", { requestKey: nextRequestKey });
+  rerenderHomeSurface("home-focus-refresh");
+}
+
+export async function applyHomeFocusSuggestion(suggestionId) {
+  const normalizedSuggestionId = String(suggestionId || "").trim();
+  if (!normalizedSuggestionId || !state.homeAi.aiSuggestionId) return;
+
+  applyAsyncAction("homeAi/apply:start", {
+    suggestionId: normalizedSuggestionId,
+  });
+  rerenderHomeSurface("home-focus-apply-start");
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/ai/suggestions/${encodeURIComponent(state.homeAi.aiSuggestionId)}/apply`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ suggestionId: normalizedSuggestionId }),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+    if (!response || !response.ok) {
+      throw new Error(String(data?.error || "home-focus-apply-failed"));
+    }
+
+    applyAsyncAction("homeAi/apply:complete");
+    applyAsyncAction("homeAi/reset");
+    rerenderHomeSurface("home-focus-applied");
+
+    if (data?.todo?.id) {
+      hooks.openTodoDrawer?.(
+        String(data.todo.id),
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null,
+      );
+    }
+  } catch (error) {
+    console.error("Home focus apply failed:", error);
+    applyAsyncAction("homeAi/apply:complete");
+    applyAsyncAction("homeAi/error:set", {
+      error: "Could not apply focus suggestion.",
+    });
+    rerenderHomeSurface("home-focus-apply-failed");
+  }
+}
+
+export async function dismissHomeFocusSuggestion(suggestionId) {
+  const normalizedSuggestionId = String(suggestionId || "").trim();
+  if (!state.homeAi.aiSuggestionId) return;
+
+  applyAsyncAction("homeAi/dismiss:start", {
+    suggestionId: normalizedSuggestionId,
+  });
+  rerenderHomeSurface("home-focus-dismiss-start");
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/ai/suggestions/${encodeURIComponent(state.homeAi.aiSuggestionId)}/dismiss`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          suggestionId: normalizedSuggestionId || undefined,
+        }),
+      },
+    );
+    if (!response || !response.ok) {
+      const data = response ? await hooks.parseApiBody(response) : {};
+      throw new Error(String(data?.error || "home-focus-dismiss-failed"));
+    }
+
+    applyAsyncAction("homeAi/dismiss:complete");
+    applyAsyncAction("homeAi/reset");
+    rerenderHomeSurface("home-focus-dismissed");
+  } catch (error) {
+    console.error("Home focus dismiss failed:", error);
+    applyAsyncAction("homeAi/dismiss:complete");
+    applyAsyncAction("homeAi/error:set", {
+      error: "Could not dismiss focus suggestion.",
+    });
+    rerenderHomeSurface("home-focus-dismiss-failed");
+  }
+}

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -10,18 +10,15 @@ import {
   setDateView,
   setSelectedProjectKey,
   clearHomeListDrilldown,
-  isHomeWorkspaceActive,
-  renderTodos,
 } from "./filterLogic.js";
 import { selectProjectFromRail } from "./railUi.js";
 import { openTodoDrawer } from "./drawerUi.js";
-import { STORAGE_KEYS } from "../utils/storageKeys.js";
+import { loadHomeFocusSuggestions } from "./homeAiService.js";
 
 const { escapeHtml } = window.Utils || {};
 const { getProjectLeafName, normalizeProjectPath } =
   window.ProjectPathUtils || {};
 
-const HOME_TOP_FOCUS_CACHE_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const HOME_STALE_RISK_DAYS = 14;
 
 // ---------------------------------------------------------------------------
@@ -118,13 +115,20 @@ export function getHomeTopFocusDeterministicReason(todo) {
   return "";
 }
 
+export function getHomeAiSuggestionByTodoId(todoId) {
+  const normalizedTodoId = String(todoId || "");
+  if (!normalizedTodoId) return null;
+  return (
+    (Array.isArray(state.homeAi?.suggestions)
+      ? state.homeAi.suggestions
+      : []
+    ).find((suggestion) => suggestion.todoId === normalizedTodoId) || null
+  );
+}
+
 export function getHomeTopFocusReason(todo) {
-  const id = String(todo?.id || "");
-  const aiReason =
-    id && state.homeTopFocusState.reasonsById
-      ? state.homeTopFocusState.reasonsById[id]
-      : null;
-  if (aiReason) return aiReason;
+  const aiSuggestion = getHomeAiSuggestionByTodoId(todo?.id);
+  if (aiSuggestion?.summary) return aiSuggestion.summary;
   return getHomeTopFocusDeterministicReason(todo);
 }
 
@@ -370,195 +374,61 @@ export function getHomeTopFocusRequestKey(candidates) {
     .join("|");
 }
 
-export function readCachedHomeTopFocus(requestKey) {
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEYS.HOME_TOP_FOCUS_CACHE);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    if (!parsed || parsed.requestKey !== requestKey) return null;
-    if (Date.now() - Number(parsed.ts || 0) > HOME_TOP_FOCUS_CACHE_MAX_AGE_MS) {
-      return null;
-    }
-    if (!Array.isArray(parsed.items)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
+export function readCachedHomeTopFocus() {
+  return null;
 }
 
-export function writeCachedHomeTopFocus(
-  requestKey,
-  items,
-  reasonsById,
-  source = "ai",
-) {
-  try {
-    window.localStorage.setItem(
-      STORAGE_KEYS.HOME_TOP_FOCUS_CACHE,
-      JSON.stringify({
-        ts: Date.now(),
-        requestKey,
-        items,
-        reasonsById,
-        source,
-      }),
-    );
-  } catch {
-    // Ignore storage failures.
-  }
+export function writeCachedHomeTopFocus() {
+  return null;
 }
 
-export function applyHomeTopFocusResult(
-  items,
-  reasonsById,
-  { source = "fallback", requestKey = "" } = {},
-) {
-  const nextItems = Array.isArray(items) ? items.slice(0, 3) : [];
-  const nextReasonsById = reasonsById || {};
-  const nextRequestKey = requestKey || state.homeTopFocusState.requestKey;
-
-  const prevItemIds = (state.homeTopFocusState.items || []).map((todo) =>
-    String(todo?.id || ""),
+export function buildHomeAiTopFocusItems() {
+  const todoById = new Map(
+    getOpenTodos().map((todo) => [String(todo.id), todo]),
   );
-  const nextItemIds = nextItems.map((todo) => String(todo?.id || ""));
-  const isSameItems =
-    prevItemIds.length === nextItemIds.length &&
-    prevItemIds.every((id, index) => id === nextItemIds[index]);
-  const isSameReasons =
-    JSON.stringify(state.homeTopFocusState.reasonsById || {}) ===
-    JSON.stringify(nextReasonsById);
-  const isSameState =
-    isSameItems &&
-    isSameReasons &&
-    state.homeTopFocusState.source === source &&
-    state.homeTopFocusState.loading === false &&
-    state.homeTopFocusState.requestKey === nextRequestKey;
-
-  if (isSameState) {
-    return;
+  const selected = [];
+  for (const suggestion of Array.isArray(state.homeAi?.suggestions)
+    ? state.homeAi.suggestions
+    : []) {
+    const todo = todoById.get(String(suggestion.todoId || ""));
+    if (!todo) continue;
+    if (selected.some((item) => String(item.id) === String(todo.id))) continue;
+    selected.push(todo);
+    if (selected.length >= 3) break;
   }
+  return selected;
+}
 
-  state.homeTopFocusState.items = nextItems;
-  state.homeTopFocusState.reasonsById = nextReasonsById;
-  state.homeTopFocusState.source = source;
-  state.homeTopFocusState.loading = false;
-  state.homeTopFocusState.requestKey = nextRequestKey;
-  const topFocusBody = document.getElementById("homeTopFocusBody");
-  if (topFocusBody instanceof HTMLElement || isHomeWorkspaceActive()) {
-    renderTodos();
-  }
+export function applyHomeTopFocusResult() {
+  return null;
 }
 
 export async function hydrateHomeTopFocusIfNeeded() {
   const candidates = buildHomeTopFocusCandidates();
   const requestKey = getHomeTopFocusRequestKey(candidates);
   if (!requestKey) {
-    applyHomeTopFocusResult([], {}, { source: "fallback", requestKey: "" });
+    await loadHomeFocusSuggestions({ candidates: [], requestKey: "" });
     return;
   }
-  if (
-    state.homeTopFocusState.loading &&
-    state.homeTopFocusState.requestKey === requestKey
-  )
-    return;
-  if (
-    state.homeTopFocusState.requestKey === requestKey &&
-    state.homeTopFocusState.items.length > 0
-  )
-    return;
-
-  const cached = readCachedHomeTopFocus(requestKey);
-  if (cached) {
-    const cachedIds = new Set(candidates.map((todo) => String(todo.id)));
-    const cachedItems = (Array.isArray(cached.items) ? cached.items : [])
-      .map((id) => candidates.find((todo) => String(todo.id) === String(id)))
-      .filter(Boolean);
-    if (cachedItems.length > 0) {
-      applyHomeTopFocusResult(cachedItems, cached.reasonsById || {}, {
-        source: String(cached.source || "ai"),
-        requestKey,
-      });
-      if (cachedIds.size > 0) return;
-    }
-  }
-
-  state.homeTopFocusState.loading = true;
-  state.homeTopFocusState.requestKey = requestKey;
-  if (isHomeWorkspaceActive()) {
-    renderTodos();
-  }
-
-  const payload = {
-    surface: "home_focus",
-    topN: 3,
+  await loadHomeFocusSuggestions({
     candidates: candidates.map((todo) => ({
       id: String(todo.id),
       title: String(todo.title || ""),
       dueAt: todo.dueDate || null,
       priority: normalizePriorityValue(todo.priority),
+      projectId:
+        typeof todo.projectId === "string" && todo.projectId.trim()
+          ? todo.projectId.trim()
+          : null,
       projectName: normalizeProjectPath(todo.category) || null,
+      category: normalizeProjectPath(todo.category) || null,
       createdAt: todo.createdAt || null,
       updatedAt: todo.updatedAt || null,
       hasSubtasks: Array.isArray(todo.subtasks) && todo.subtasks.length > 0,
       notesPresent: !!String(todo.notes || "").trim(),
     })),
-  };
-
-  try {
-    const response = await hooks.apiCall(
-      `${hooks.API_URL}/ai/decision-assist/stub`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      },
-    );
-    if (!response || !response.ok) {
-      throw new Error("home-focus-ai-failed");
-    }
-    const data = await hooks.parseApiBody(response);
-    const topFocusRaw = Array.isArray(data?.topFocus) ? data.topFocus : [];
-    const candidateById = new Map(
-      candidates.map((todo) => [String(todo.id), todo]),
-    );
-    const selected = [];
-    const reasonsById = {};
-    for (const item of topFocusRaw) {
-      const todoId = String(item?.todoId || "").trim();
-      if (!todoId || !candidateById.has(todoId)) continue;
-      if (selected.some((todo) => String(todo.id) === todoId)) continue;
-      const reason = String(item?.reason || "")
-        .trim()
-        .slice(0, 80);
-      selected.push(candidateById.get(todoId));
-      if (reason) reasonsById[todoId] = reason;
-      if (selected.length >= 3) break;
-    }
-    if (selected.length === 0) {
-      throw new Error("home-focus-ai-empty");
-    }
-    if (state.homeTopFocusState.requestKey !== requestKey) return;
-    applyHomeTopFocusResult(selected, reasonsById, {
-      source: "ai",
-      requestKey,
-    });
-    writeCachedHomeTopFocus(
-      requestKey,
-      selected.map((todo) => String(todo.id)),
-      reasonsById,
-      "ai",
-    );
-  } catch (error) {
-    if (state.homeTopFocusState.requestKey !== requestKey) return;
-    const fallback = getTopFocusFallbackTodos(3);
-    applyHomeTopFocusResult(fallback, {}, { source: "fallback", requestKey });
-    writeCachedHomeTopFocus(
-      requestKey,
-      fallback.map((todo) => String(todo.id)),
-      {},
-      "fallback",
-    );
-  }
+    requestKey,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -572,6 +442,13 @@ const HOME_BADGE_ICONS = {
 };
 
 export function renderHomeTaskRow(todo, { reason = "" } = {}) {
+  const aiSuggestion = getHomeAiSuggestionByTodoId(todo?.id);
+  const isApplying =
+    !!aiSuggestion &&
+    state.homeAi?.applyingSuggestionId === aiSuggestion.suggestionId;
+  const isDismissing =
+    !!aiSuggestion &&
+    state.homeAi?.dismissingSuggestionId === aiSuggestion.suggestionId;
   const dueBadge = formatHomeDueBadge(todo);
   const badgeIcon =
     HOME_BADGE_ICONS[dueBadge] ??
@@ -597,8 +474,43 @@ export function renderHomeTaskRow(todo, { reason = "" } = {}) {
       </button>
       ${dueBadge ? `<span class="home-task-row__badge ${dueBadge === "Overdue" ? "home-task-row__badge--overdue" : ""}">${badgeIcon}${escapeHtml(dueBadge)}</span>` : ""}
       ${reason ? `<div class="home-task-row__reason">${escapeHtml(reason)}</div>` : ""}
+      ${
+        aiSuggestion
+          ? `<div class="home-task-row__actions">
+              <button
+                type="button"
+                class="mini-btn home-task-row__action"
+                data-onclick="applyHomeFocusSuggestion('${escapeHtml(aiSuggestion.suggestionId)}')"
+                ${isApplying || isDismissing ? "disabled" : ""}
+              >
+                ${isApplying ? "Opening…" : "Use focus"}
+              </button>
+              <button
+                type="button"
+                class="mini-btn home-task-row__action home-task-row__action--secondary"
+                data-onclick="dismissHomeFocusSuggestion('${escapeHtml(aiSuggestion.suggestionId)}')"
+                ${isApplying || isDismissing ? "disabled" : ""}
+              >
+                ${isDismissing ? "Dismissing…" : "Dismiss"}
+              </button>
+            </div>`
+          : ""
+      }
     </div>
   `;
+}
+
+function getHomeTopFocusHelperMessage() {
+  if (state.homeAi?.status === "loading") {
+    return "Refreshing focus…";
+  }
+  if (state.homeAi?.error) {
+    return state.homeAi.error;
+  }
+  if (state.homeAi?.unavailable) {
+    return "Using focus fallback.";
+  }
+  return "";
 }
 
 export function renderHomeTaskTile({
@@ -660,8 +572,8 @@ export function renderHomeTaskTile({
       <div class="home-tile__body" ${key === "top_focus" ? 'id="homeTopFocusBody"' : ""}>
         ${bodyHtml}
         ${
-          key === "top_focus" && state.homeTopFocusState.loading
-            ? '<div class="home-tile__helper" role="status">Refreshing focus\u2026</div>'
+          key === "top_focus" && getHomeTopFocusHelperMessage()
+            ? `<div class="home-tile__helper" role="status">${escapeHtml(getHomeTopFocusHelperMessage())}</div>`
             : ""
         }
       </div>
@@ -704,11 +616,10 @@ export function renderProjectsToNudgeTile(items = []) {
 }
 
 export function renderHomeDashboard() {
+  const aiTopFocusItems = buildHomeAiTopFocusItems();
   const fallbackTopFocus = getTopFocusFallbackTodos(3);
   const topFocusItems =
-    state.homeTopFocusState.items.length > 0
-      ? state.homeTopFocusState.items
-      : fallbackTopFocus;
+    aiTopFocusItems.length > 0 ? aiTopFocusItems : fallbackTopFocus;
   const model = getHomeDashboardModel({ topFocusItems });
   void hydrateHomeTopFocusIfNeeded();
 

--- a/client/modules/stateActions.js
+++ b/client/modules/stateActions.js
@@ -8,6 +8,7 @@ import {
   createInitialTaskDrawerAssistState,
   createInitialOnCreateAssistState,
   createInitialTodayPlanState,
+  createInitialHomeAiState,
 } from "./store.js";
 
 function getNormalizedProjectKey(value) {
@@ -31,6 +32,13 @@ function createOnCreateAssistState() {
   return {
     ...createInitialOnCreateAssistState(),
     dismissedTodoIds,
+  };
+}
+
+function createHomeAiState(requestKey = "") {
+  return {
+    ...createInitialHomeAiState(),
+    requestKey: String(requestKey || ""),
   };
 }
 
@@ -406,6 +414,96 @@ export function applyAsyncAction(type, payload = {}) {
       state.todayPlanState.loadingMessage = "";
       state.todayPlanState.lastApplyBatch = null;
       return state.todayPlanState;
+    case "homeAi/reset":
+      state.homeAi = createHomeAiState(payload.requestKey);
+      return state.homeAi;
+    case "homeAi/start":
+      state.homeAi =
+        state.homeAi?.requestKey === String(payload.requestKey || "")
+          ? {
+              ...state.homeAi,
+              status: "loading",
+              error: null,
+              unavailable: false,
+              applyingSuggestionId: "",
+              dismissingSuggestionId: "",
+            }
+          : {
+              ...createHomeAiState(payload.requestKey),
+              status: "loading",
+            };
+      return state.homeAi;
+    case "homeAi/unavailable":
+      state.homeAi = {
+        ...state.homeAi,
+        status: "unavailable",
+        aiSuggestionId: "",
+        suggestions: [],
+        error: null,
+        unavailable: true,
+        lastLoadedAt: new Date().toISOString(),
+        applyingSuggestionId: "",
+        dismissingSuggestionId: "",
+      };
+      return state.homeAi;
+    case "homeAi/empty":
+      state.homeAi = {
+        ...state.homeAi,
+        status: "ready",
+        aiSuggestionId: "",
+        suggestions: [],
+        error: null,
+        unavailable: false,
+        lastLoadedAt: new Date().toISOString(),
+        applyingSuggestionId: "",
+        dismissingSuggestionId: "",
+      };
+      return state.homeAi;
+    case "homeAi/success":
+      state.homeAi = {
+        ...state.homeAi,
+        status: "ready",
+        aiSuggestionId: String(payload.aiSuggestionId || ""),
+        suggestions: Array.isArray(payload.suggestions)
+          ? payload.suggestions
+          : [],
+        error: null,
+        unavailable: false,
+        lastLoadedAt: new Date().toISOString(),
+        applyingSuggestionId: "",
+        dismissingSuggestionId: "",
+      };
+      return state.homeAi;
+    case "homeAi/failure":
+      state.homeAi = {
+        ...state.homeAi,
+        status: "error",
+        aiSuggestionId: "",
+        suggestions: [],
+        error: String(payload.error || "Could not load home focus."),
+        unavailable: false,
+        lastLoadedAt: new Date().toISOString(),
+        applyingSuggestionId: "",
+        dismissingSuggestionId: "",
+      };
+      return state.homeAi;
+    case "homeAi/error:set":
+      state.homeAi.error = String(payload.error || "");
+      return state.homeAi;
+    case "homeAi/apply:start":
+      state.homeAi.applyingSuggestionId = String(payload.suggestionId || "");
+      state.homeAi.error = null;
+      return state.homeAi;
+    case "homeAi/apply:complete":
+      state.homeAi.applyingSuggestionId = "";
+      return state.homeAi;
+    case "homeAi/dismiss:start":
+      state.homeAi.dismissingSuggestionId = String(payload.suggestionId || "");
+      state.homeAi.error = null;
+      return state.homeAi;
+    case "homeAi/dismiss:complete":
+      state.homeAi.dismissingSuggestionId = "";
+      return state.homeAi;
     default:
       return undefined;
   }

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -80,13 +80,17 @@ export function createInitialTodayPlanState() {
   };
 }
 
-export function createInitialHomeTopFocusState() {
+export function createInitialHomeAiState() {
   return {
-    loading: false,
+    status: "idle",
+    aiSuggestionId: "",
     requestKey: "",
-    items: [],
-    reasonsById: {},
-    source: "fallback",
+    suggestions: [],
+    lastLoadedAt: null,
+    error: null,
+    unavailable: false,
+    applyingSuggestionId: "",
+    dismissingSuggestionId: "",
   };
 }
 
@@ -217,8 +221,8 @@ export const state = {
   lastTaskComposerTrigger: null,
   taskComposerDefaultProject: "",
 
-  // Home top focus
-  homeTopFocusState: null, // initialized below
+  // Home AI
+  homeAi: null, // initialized below
 
   // Chrono natural date
   chronoNaturalDateModulePromise: null,
@@ -253,7 +257,7 @@ export const state = {
 state.taskDrawerAssistState = createInitialTaskDrawerAssistState();
 state.onCreateAssistState = createInitialOnCreateAssistState();
 state.todayPlanState = createInitialTodayPlanState();
-state.homeTopFocusState = createInitialHomeTopFocusState();
+state.homeAi = createInitialHomeAiState();
 
 // ---------------------------------------------------------------------------
 // Cross-module hooks — app.js wires all hooks after all modules are loaded.

--- a/client/modules/todosService.js
+++ b/client/modules/todosService.js
@@ -2,7 +2,7 @@
 // todosService.js — Todo CRUD, undo, reorder, bulk operations.
 // Imports state from store.js. Cross-module calls go through hooks.
 // =============================================================================
-import { state, hooks, createInitialHomeTopFocusState } from "./store.js";
+import { state, hooks, createInitialHomeAiState } from "./store.js";
 import {
   hasTodoRow,
   patchBulkToolbar,
@@ -218,14 +218,14 @@ async function loadTodos() {
       state.todos = await response.json();
       state.todosLoadState = "ready";
       state.todosLoadErrorMessage = "";
-      state.homeTopFocusState = createInitialHomeTopFocusState();
+      state.homeAi = createInitialHomeAiState();
       await refreshVisibleTodosIfNeeded();
       EventBus.dispatch("todos:changed", { reason: "todos-loaded" });
       hooks.refreshProjectCatalog?.();
     } else {
       state.todos = [];
       state.selectedTodos.clear();
-      state.homeTopFocusState = createInitialHomeTopFocusState();
+      state.homeAi = createInitialHomeAiState();
       clearVisibleTodosState();
       state.todosLoadState = "error";
       state.todosLoadErrorMessage = "Couldn't load tasks";
@@ -236,7 +236,7 @@ async function loadTodos() {
   } catch (error) {
     state.todos = [];
     state.selectedTodos.clear();
-    state.homeTopFocusState = createInitialHomeTopFocusState();
+    state.homeAi = createInitialHomeAiState();
     clearVisibleTodosState();
     state.todosLoadState = "error";
     state.todosLoadErrorMessage = "Couldn't load tasks";

--- a/client/styles.css
+++ b/client/styles.css
@@ -5855,6 +5855,23 @@ body.is-todos-view .projects-rail-item__count {
   line-height: 1.25;
 }
 
+.home-task-row__actions {
+  grid-column: 2 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.home-task-row__action {
+  padding: 4px 8px;
+  font-size: 0.72rem;
+}
+
+.home-task-row__action--secondary {
+  background: transparent;
+}
+
 .home-task-group {
   display: grid;
   gap: 4px;

--- a/client/utils/aiSuggestionUtils.js
+++ b/client/utils/aiSuggestionUtils.js
@@ -12,6 +12,7 @@
 
   var ON_CREATE_SURFACE = "on_create";
   var TODAY_PLAN_SURFACE = "today_plan";
+  var HOME_FOCUS_SURFACE = "home_focus";
 
   var AI_SURFACE_TYPES = Object.freeze({
     [ON_CREATE_SURFACE]: new Set([
@@ -28,6 +29,7 @@
       "split_subtasks",
       "propose_next_action",
     ]),
+    [HOME_FOCUS_SURFACE]: new Set(["focus_task"]),
     task_drawer: new Set([
       "rewrite_title",
       "split_subtasks",
@@ -55,6 +57,9 @@
       set_priority: 1,
       split_subtasks: 2,
       propose_next_action: 3,
+    }),
+    [HOME_FOCUS_SURFACE]: Object.freeze({
+      focus_task: 0,
     }),
     task_drawer: Object.freeze({
       propose_next_action: 0,
@@ -127,6 +132,7 @@
       split_subtasks: "Split subtasks",
       propose_next_action: "Propose next action",
       propose_create_project: "Propose create project",
+      focus_task: "Focus task",
     };
     return labels[String(type || "")] || "Suggestion";
   }
@@ -182,6 +188,7 @@
     AI_DEBUG_ENABLED: AI_DEBUG_ENABLED,
     ON_CREATE_SURFACE: ON_CREATE_SURFACE,
     TODAY_PLAN_SURFACE: TODAY_PLAN_SURFACE,
+    HOME_FOCUS_SURFACE: HOME_FOCUS_SURFACE,
     AI_SURFACE_TYPES: AI_SURFACE_TYPES,
     AI_SURFACE_IMPACT: AI_SURFACE_IMPACT,
     isKnownSuggestionType: isKnownSuggestionType,

--- a/src/ai.api.integration.test.ts
+++ b/src/ai.api.integration.test.ts
@@ -211,6 +211,63 @@ describe("AI API Integration", () => {
     expect(Array.isArray(latest.body.outputEnvelope.suggestions)).toBe(true);
   });
 
+  it("generates home_focus stub and returns latest pending envelope without todoId", async () => {
+    const todoA = await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ title: "Decide on the island to go", priority: "high" })
+      .expect(201);
+    const todoB = await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ title: "Book ferry tickets", priority: "medium" })
+      .expect(201);
+
+    const generated = await request(app)
+      .post("/ai/decision-assist/stub")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        surface: "home_focus",
+        topN: 3,
+        candidates: [
+          {
+            id: todoA.body.id,
+            title: todoA.body.title,
+            priority: "high",
+            projectName: "Anniversary vacation",
+          },
+          {
+            id: todoB.body.id,
+            title: todoB.body.title,
+            priority: "medium",
+            dueAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+            projectName: "Anniversary vacation",
+          },
+        ],
+      })
+      .expect(200);
+
+    expect(generated.body.suggestionId).toBeDefined();
+
+    const latest = await request(app)
+      .get("/ai/suggestions/latest?surface=home_focus")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(latest.body.aiSuggestionId).toBe(generated.body.suggestionId);
+    expect(latest.body.status).toBe("pending");
+    expect(latest.body.outputEnvelope.surface).toBe("home_focus");
+    expect(Array.isArray(latest.body.outputEnvelope.suggestions)).toBe(true);
+    expect(latest.body.outputEnvelope.suggestions[0]).toEqual(
+      expect.objectContaining({
+        type: "focus_task",
+        todoId: expect.any(String),
+        title: expect.any(String),
+        summary: expect.any(String),
+      }),
+    );
+  });
+
   it("throttles decision-assist generation after repeated rejects", async () => {
     const todoId = await createTaskDrawerTodo("reject burst throttle");
     for (let i = 0; i < 3; i += 1) {
@@ -817,6 +874,53 @@ describe("AI API Integration", () => {
       .expect(400);
   });
 
+  it("applies home_focus suggestion by returning the selected todo", async () => {
+    const todo = await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ title: "Review contractor shortlist", priority: "high" })
+      .expect(201);
+
+    const generated = await request(app)
+      .post("/ai/decision-assist/stub")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        surface: "home_focus",
+        topN: 3,
+        candidates: [
+          {
+            id: todo.body.id,
+            title: todo.body.title,
+            priority: "high",
+            projectName: "House project",
+          },
+        ],
+      })
+      .expect(200);
+
+    const latest = await request(app)
+      .get("/ai/suggestions/latest?surface=home_focus")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    const focusSuggestion = latest.body.outputEnvelope.suggestions[0];
+    expect(focusSuggestion?.suggestionId).toBeDefined();
+
+    const applied = await request(app)
+      .post(`/ai/suggestions/${generated.body.suggestionId}/apply`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ suggestionId: focusSuggestion.suggestionId })
+      .expect(200);
+
+    expect(applied.body.todo.id).toBe(todo.body.id);
+    expect(applied.body.appliedSuggestionId).toBe(focusSuggestion.suggestionId);
+
+    const persisted = await prisma.aiSuggestion.findUnique({
+      where: { id: generated.body.suggestionId },
+    });
+    expect(persisted?.status).toBe("accepted");
+  });
+
   it("rejects on_create apply when requiresConfirmation is true and confirmed is missing", async () => {
     const createdTodo = await request(app)
       .post("/todos")
@@ -953,6 +1057,42 @@ describe("AI API Integration", () => {
     expect(persisted?.status).toBe("rejected");
   });
 
+  it("dismisses home_focus suggestion set by marking suggestion rejected", async () => {
+    const todo = await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ title: "Pick anniversary venue", priority: "high" })
+      .expect(201);
+
+    const generated = await request(app)
+      .post("/ai/decision-assist/stub")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        surface: "home_focus",
+        topN: 3,
+        candidates: [
+          {
+            id: todo.body.id,
+            title: todo.body.title,
+            priority: "high",
+            projectName: "Anniversary vacation",
+          },
+        ],
+      })
+      .expect(200);
+
+    await request(app)
+      .post(`/ai/suggestions/${generated.body.suggestionId}/dismiss`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ dismissAll: true })
+      .expect(204);
+
+    const persisted = await prisma.aiSuggestion.findUnique({
+      where: { id: generated.body.suggestionId },
+    });
+    expect(persisted?.status).toBe("rejected");
+  });
+
   it("emits decision assist telemetry lifecycle events for all surfaces", async () => {
     const emitSpy = jest
       .spyOn(decisionAssistTelemetry, "emitDecisionAssistTelemetry")
@@ -972,6 +1112,11 @@ describe("AI API Integration", () => {
       .post("/todos")
       .set("Authorization", `Bearer ${authToken}`)
       .send({ title: "telemetry today plan todo" })
+      .expect(201);
+    const homeFocusTodo = await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ title: "telemetry home focus todo" })
       .expect(201);
 
     const taskDrawerGenerated = await request(app)
@@ -1054,6 +1199,33 @@ describe("AI API Integration", () => {
       .set("Authorization", `Bearer ${authToken}`)
       .expect(200);
 
+    const homeFocusGenerated = await request(app)
+      .post("/ai/decision-assist/stub")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        surface: "home_focus",
+        candidates: [
+          {
+            id: homeFocusTodo.body.id,
+            title: homeFocusTodo.body.title,
+            priority: "high",
+            projectName: "Telemetry",
+          },
+        ],
+      })
+      .expect(200);
+
+    const homeFocusLatest = await request(app)
+      .get("/ai/suggestions/latest?surface=home_focus")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    await request(app)
+      .post(`/ai/suggestions/${homeFocusGenerated.body.suggestionId}/dismiss`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({ dismissAll: true })
+      .expect(204);
+
     const lifecycleEvents = new Set(
       emitSpy.mock.calls.map((call) => String(call[0]?.eventName || "")),
     );
@@ -1072,7 +1244,12 @@ describe("AI API Integration", () => {
         .map((call) => call[0]?.surface),
     );
     expect(Array.from(generatedSurfaces)).toEqual(
-      expect.arrayContaining(["task_drawer", "on_create", "today_plan"]),
+      expect.arrayContaining([
+        "task_drawer",
+        "on_create",
+        "today_plan",
+        "home_focus",
+      ]),
     );
   });
 

--- a/src/aiApplyService.test.ts
+++ b/src/aiApplyService.test.ts
@@ -1,12 +1,12 @@
 import {
+  applyHomeFocusSuggestion,
   applyTodoBoundSuggestion,
   applyTodayPlanSuggestions,
-  ApplyTodoBoundResult,
-  ApplyTodayPlanResult,
 } from "./services/aiApplyService";
 import { ITodoService } from "./interfaces/ITodoService";
 import { IProjectService } from "./interfaces/IProjectService";
 import {
+  NormalizedHomeFocusSuggestion,
   NormalizedTodoBoundSuggestion,
   NormalizedTodayPlanSuggestion,
 } from "./services/aiNormalizationService";
@@ -97,6 +97,30 @@ function makeSuggestion(
     payload,
     suggestionId: "sug-1",
     requiresConfirmation: false,
+    ...overrides,
+  };
+}
+
+function makeHomeFocusSuggestion(
+  overrides: Partial<NormalizedHomeFocusSuggestion> = {},
+): NormalizedHomeFocusSuggestion {
+  return {
+    type: "focus_task",
+    confidence: 0.83,
+    rationale: "This is due soon and should stay visible.",
+    payload: {
+      taskId: TODO_ID,
+      todoId: TODO_ID,
+      title: "Buy groceries",
+      summary: "This is due soon and should stay visible.",
+      source: "deterministic",
+    },
+    suggestionId: "home-focus-1",
+    taskId: TODO_ID,
+    todoId: TODO_ID,
+    title: "Buy groceries",
+    summary: "This is due soon and should stay visible.",
+    source: "deterministic",
     ...overrides,
   };
 }
@@ -347,6 +371,23 @@ describe("applyTodoBoundSuggestion", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(404);
+    }
+  });
+});
+
+describe("applyHomeFocusSuggestion", () => {
+  it("returns the resolved todo for a valid focus suggestion", async () => {
+    const todoService = buildMockTodoService();
+    const result = await applyHomeFocusSuggestion({
+      selected: makeHomeFocusSuggestion(),
+      todoService,
+      userId: USER_ID,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.todo.id).toBe(TODO_ID);
+      expect(result.appliedTodoIds).toEqual([TODO_ID]);
     }
   });
 });

--- a/src/aiContracts.test.ts
+++ b/src/aiContracts.test.ts
@@ -121,6 +121,34 @@ describe("validateDecisionAssistOutput", () => {
 
     expect(result.planPreview?.items).toHaveLength(3);
   });
+
+  it("accepts a valid home_focus payload", () => {
+    const result = validateDecisionAssistOutput({
+      requestId: "req-home-1",
+      surface: "home_focus",
+      must_abstain: false,
+      suggestions: [
+        {
+          type: "focus_task",
+          confidence: 0.81,
+          rationale: "This blocks the rest of anniversary vacation planning.",
+          payload: {
+            taskId: "todo-123",
+            todoId: "todo-123",
+            projectId: "project-456",
+            title: "Decide on the island to go",
+            summary:
+              "This blocks the rest of anniversary vacation planning and is due soon.",
+            reason: "Due soon and likely blocking related work.",
+            source: "deterministic",
+          },
+        },
+      ],
+    });
+
+    expect(result.surface).toBe("home_focus");
+    expect(result.suggestions[0]?.type).toBe("focus_task");
+  });
 });
 
 describe("decision assist golden eval fixtures", () => {
@@ -128,18 +156,24 @@ describe("decision assist golden eval fixtures", () => {
   const readFixture = (name: string) =>
     JSON.parse(fs.readFileSync(path.join(fixtureDir, name), "utf8"));
 
-  it("accepts valid fixtures for task_drawer, on_create, and today_plan", () => {
+  it("accepts valid fixtures for task_drawer, on_create, today_plan, and home_focus", () => {
     const surfaces = [
       "task_drawer.valid.json",
       "on_create.valid.json",
       "today_plan.valid.json",
+      "home_focus.valid.json",
     ]
       .map((fixtureName) =>
         validateDecisionAssistOutput(readFixture(fixtureName)),
       )
       .map((result) => result.surface);
 
-    expect(surfaces).toEqual(["task_drawer", "on_create", "today_plan"]);
+    expect(surfaces).toEqual([
+      "task_drawer",
+      "on_create",
+      "today_plan",
+      "home_focus",
+    ]);
   });
 
   it("rejects malformed fixture cases", () => {

--- a/src/aiEval/fixtures/home_focus.valid.json
+++ b/src/aiEval/fixtures/home_focus.valid.json
@@ -1,0 +1,22 @@
+{
+  "requestId": "home-focus-req-1",
+  "surface": "home_focus",
+  "must_abstain": false,
+  "suggestions": [
+    {
+      "type": "focus_task",
+      "confidence": 0.81,
+      "rationale": "This blocks the rest of anniversary vacation planning and is due soon.",
+      "payload": {
+        "taskId": "task-123",
+        "todoId": "task-123",
+        "projectId": "project-456",
+        "title": "Decide on the island to go",
+        "summary": "This blocks the rest of anniversary vacation planning and is due soon.",
+        "reason": "Due soon and likely blocking related work.",
+        "source": "deterministic"
+      },
+      "suggestionId": "home-focus-1-task-123"
+    }
+  ]
+}

--- a/src/aiValidation.test.ts
+++ b/src/aiValidation.test.ts
@@ -1,0 +1,53 @@
+import {
+  validateDecisionAssistLatestQuery,
+  validateDecisionAssistStubInput,
+} from "./validation/aiValidation";
+import { ValidationError } from "./validation/validation";
+
+describe("AI validation", () => {
+  it("accepts home_focus latest query without todoId", () => {
+    expect(
+      validateDecisionAssistLatestQuery({ surface: "home_focus" }),
+    ).toEqual({
+      surface: "home_focus",
+      todoId: undefined,
+    });
+  });
+
+  it("still requires todoId for task_drawer latest query", () => {
+    expect(() =>
+      validateDecisionAssistLatestQuery({ surface: "task_drawer" }),
+    ).toThrow(new ValidationError("todoId is required"));
+  });
+
+  it("accepts home_focus stub input with candidate alias payload", () => {
+    const result = validateDecisionAssistStubInput({
+      surface: "home_focus",
+      topN: 3,
+      candidates: [
+        {
+          id: "todo-1",
+          title: "Review launch checklist",
+          dueAt: "2026-03-15T12:00:00.000Z",
+          priority: "high",
+          projectName: "Launch",
+          hasSubtasks: true,
+          notesPresent: true,
+        },
+      ],
+    });
+
+    expect(result.surface).toBe("home_focus");
+    expect(result.todoCandidates).toEqual([
+      expect.objectContaining({
+        id: "todo-1",
+        title: "Review launch checklist",
+        dueDate: "2026-03-15T12:00:00.000Z",
+        priority: "high",
+        projectName: "Launch",
+        hasSubtasks: true,
+        notesPresent: true,
+      }),
+    ]);
+  });
+});

--- a/src/api.contract.test.ts
+++ b/src/api.contract.test.ts
@@ -7,7 +7,16 @@ describe("API Contract", () => {
   let app: Express;
 
   beforeEach(() => {
-    app = createApp(new TodoService());
+    app = createApp(
+      new TodoService(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
   });
 
   describe("PUT /todos/reorder", () => {
@@ -303,6 +312,44 @@ describe("API Contract", () => {
       expect(response.body.requestId).toEqual(expect.any(String));
       expect(Array.isArray(response.body.suggestions)).toBe(true);
       expect(response.body.suggestions.length).toBeGreaterThan(0);
+      expect(response.body.suggestionId).toBeDefined();
+
+      const list = await request(app).get("/ai/suggestions").expect(200);
+      expect(list.body[0]).toEqual(
+        expect.objectContaining({
+          id: response.body.suggestionId,
+          type: "task_critic",
+          status: "pending",
+        }),
+      );
+    });
+
+    it("generates contract-validated home_focus suggestion stub and persists it", async () => {
+      const response = await request(app)
+        .post("/ai/decision-assist/stub")
+        .send({
+          surface: "home_focus",
+          topN: 3,
+          candidates: [
+            {
+              id: "todo-home-1",
+              title: "Decide on the island to go",
+              dueAt: "2026-03-15T12:00:00.000Z",
+              priority: "high",
+              projectName: "Anniversary vacation",
+            },
+          ],
+        })
+        .expect(200);
+
+      expect(response.body.surface).toBe("home_focus");
+      expect(response.body.requestId).toEqual(expect.any(String));
+      expect(Array.isArray(response.body.suggestions)).toBe(true);
+      expect(response.body.suggestions[0]).toEqual(
+        expect.objectContaining({
+          type: "focus_task",
+        }),
+      );
       expect(response.body.suggestionId).toBeDefined();
 
       const list = await request(app).get("/ai/suggestions").expect(200);

--- a/src/routes/aiRouter.ts
+++ b/src/routes/aiRouter.ts
@@ -34,24 +34,30 @@ import {
   UserPlan,
 } from "../services/aiQuotaService";
 import {
+  HOME_FOCUS_SURFACE,
   TASK_DRAWER_SURFACE,
   ON_CREATE_SURFACE,
   TODAY_PLAN_SURFACE,
   TODO_BOUND_TYPE,
   TODO_BOUND_SURFACES,
+  normalizeHomeFocusEnvelope,
   normalizeTodoBoundEnvelope,
   normalizeTodayPlanEnvelope,
   parsePlanTasks,
   buildThrottleAbstainEnvelope,
   parseOptionalTopN,
   findLatestPendingDecisionAssistSuggestion,
+  findLatestPendingHomeFocusSuggestion,
   findLatestPendingTodayPlanSuggestion,
+  NormalizedHomeFocusEnvelope,
+  NormalizedHomeFocusSuggestion,
   NormalizedTodoBoundEnvelope,
   NormalizedTodoBoundSuggestion,
   NormalizedTodayPlanEnvelope,
   NormalizedTodayPlanSuggestion,
 } from "../services/aiNormalizationService";
 import {
+  applyHomeFocusSuggestion,
   applyTodoBoundSuggestion,
   applyTodayPlanSuggestions,
 } from "../services/aiApplyService";
@@ -187,6 +193,9 @@ export function createAiRouter({
           if (!ensureDecisionAssistFeatureEnabled(res)) return;
         }
         if (input.surface === TODAY_PLAN_SURFACE) {
+          if (!ensureDecisionAssistFeatureEnabled(res)) return;
+        }
+        if (input.surface === HOME_FOCUS_SURFACE) {
           if (!ensureDecisionAssistFeatureEnabled(res)) return;
         }
         if (
@@ -524,9 +533,11 @@ export function createAiRouter({
         );
         const isTodoBound = TODO_BOUND_SURFACES.has(surface);
         const isTodayPlan = surface === TODAY_PLAN_SURFACE;
-        if (!isTodoBound && !isTodayPlan) {
+        const isHomeFocus = surface === HOME_FOCUS_SURFACE;
+        if (!isTodoBound && !isTodayPlan && !isHomeFocus) {
           return res.status(400).json({
-            error: "surface must be on_create, task_drawer, or today_plan",
+            error:
+              "surface must be on_create, task_drawer, today_plan, or home_focus",
           });
         }
 
@@ -537,7 +548,15 @@ export function createAiRouter({
               String(todoId || ""),
               surface,
             )
-          : await findLatestPendingTodayPlanSuggestion(suggestionStore, userId);
+          : isTodayPlan
+            ? await findLatestPendingTodayPlanSuggestion(
+                suggestionStore,
+                userId,
+              )
+            : await findLatestPendingHomeFocusSuggestion(
+                suggestionStore,
+                userId,
+              );
         if (!latest) {
           const throttle = await shouldThrottleDecisionAssist(userId, surface);
           if (throttle.throttled) {
@@ -564,7 +583,9 @@ export function createAiRouter({
                 String(todoId || ""),
                 surface,
               )
-            : normalizeTodayPlanEnvelope(latest.output);
+            : isTodayPlan
+              ? normalizeTodayPlanEnvelope(latest.output)
+              : normalizeHomeFocusEnvelope(latest.output);
           emitDecisionAssistTelemetrySafe({
             eventName: "ai_suggestion_viewed",
             surface,
@@ -927,7 +948,7 @@ export function createAiRouter({
           });
         }
 
-        // ── Todo-bound apply path ──
+        // ── Home-focus apply path ──
         if (!ensureDecisionAssistFeatureEnabled(res)) return;
         if (suggestion.type !== TODO_BOUND_TYPE) {
           return res.status(400).json({
@@ -939,6 +960,98 @@ export function createAiRouter({
             ? suggestion.input.surface
             : "";
         const inputSurface = inputSurfaceRaw as DecisionAssistSurface;
+        if (inputSurface === HOME_FOCUS_SURFACE) {
+          if (!suggestionId) {
+            return res
+              .status(400)
+              .json({ error: "suggestionId is required for suggestion apply" });
+          }
+
+          if (
+            suggestion.status === "accepted" &&
+            Array.isArray(suggestion.appliedTodoIds) &&
+            suggestion.appliedTodoIds.length > 0
+          ) {
+            const todo = await todoService.findById(
+              userId,
+              suggestion.appliedTodoIds[0],
+            );
+            if (todo) {
+              return res.json({
+                todo,
+                appliedSuggestionId: suggestionId,
+                suggestion,
+                idempotent: true,
+              });
+            }
+          }
+          if (suggestion.status !== "pending") {
+            return res
+              .status(409)
+              .json({ error: "Suggestion is no longer pending" });
+          }
+
+          let envelope: NormalizedHomeFocusEnvelope;
+          try {
+            envelope = normalizeHomeFocusEnvelope(suggestion.output);
+          } catch {
+            return res
+              .status(400)
+              .json({ error: "Stored suggestion output is invalid" });
+          }
+
+          const selected = (
+            envelope.suggestions as NormalizedHomeFocusSuggestion[]
+          ).find((item) => item.suggestionId === suggestionId);
+          if (!selected) {
+            return res.status(404).json({ error: "Suggestion item not found" });
+          }
+
+          const applyResult = await applyHomeFocusSuggestion({
+            selected,
+            todoService,
+            userId,
+          });
+          if (!applyResult.ok) {
+            return res
+              .status(applyResult.status)
+              .json({ error: applyResult.error });
+          }
+
+          const updatedSuggestion = await suggestionStore.markApplied(
+            userId,
+            id,
+            applyResult.appliedTodoIds,
+            {
+              reason: reason || `applied:${selected.suggestionId}`,
+              source: "home_focus_apply",
+              suggestionId: selected.suggestionId,
+              updatedAt: new Date().toISOString(),
+            },
+          );
+          if (!updatedSuggestion) {
+            return res.status(404).json({ error: "Suggestion not found" });
+          }
+
+          emitDecisionAssistTelemetrySafe({
+            eventName: "ai_suggestion_applied",
+            surface: HOME_FOCUS_SURFACE,
+            aiSuggestionDbId: id,
+            suggestionId: selected.suggestionId,
+            todoId: applyResult.todo.id,
+            suggestionCount: envelope.suggestions.length,
+            selectedTodoIdsCount: 1,
+          });
+
+          return res.json({
+            todo: applyResult.todo,
+            appliedSuggestionId: selected.suggestionId,
+            suggestion: updatedSuggestion,
+            idempotent: false,
+          });
+        }
+
+        // ── Todo-bound apply path ──
         if (!TODO_BOUND_SURFACES.has(inputSurface)) {
           return res.status(400).json({
             error: "Only on_create or task_drawer suggestions can be applied",

--- a/src/services/aiApplyService.ts
+++ b/src/services/aiApplyService.ts
@@ -2,6 +2,7 @@ import { ITodoService } from "../interfaces/ITodoService";
 import { IProjectService } from "../interfaces/IProjectService";
 import { Priority } from "../types";
 import {
+  NormalizedHomeFocusSuggestion,
   NormalizedTodoBoundSuggestion,
   NormalizedTodayPlanSuggestion,
 } from "./aiNormalizationService";
@@ -21,6 +22,14 @@ export type ApplyTodayPlanResult =
       updatedTodos: NonNullable<
         Awaited<ReturnType<ITodoService["findById"]>>
       >[];
+      appliedTodoIds: string[];
+    }
+  | { ok: false; status: number; error: string };
+
+export type ApplyHomeFocusResult =
+  | {
+      ok: true;
+      todo: NonNullable<Awaited<ReturnType<ITodoService["findById"]>>>;
       appliedTodoIds: string[];
     }
   | { ok: false; status: number; error: string };
@@ -222,6 +231,42 @@ export async function applyTodoBoundSuggestion(params: {
   }
 
   return { ok: true, updatedTodo };
+}
+
+// ── Home-focus apply ──
+
+export async function applyHomeFocusSuggestion(params: {
+  selected: NormalizedHomeFocusSuggestion;
+  todoService: ITodoService;
+  userId: string;
+}): Promise<ApplyHomeFocusResult> {
+  const { selected, todoService, userId } = params;
+  const todoId =
+    typeof selected.todoId === "string" && selected.todoId.trim()
+      ? selected.todoId.trim()
+      : typeof selected.payload?.todoId === "string"
+        ? selected.payload.todoId.trim()
+        : typeof selected.payload?.taskId === "string"
+          ? selected.payload.taskId.trim()
+          : "";
+  if (!todoId) {
+    return {
+      ok: false,
+      status: 400,
+      error: "focus_task suggestion is missing todo context",
+    };
+  }
+
+  const todo = await todoService.findById(userId, todoId);
+  if (!todo) {
+    return { ok: false, status: 404, error: "Todo not found" };
+  }
+
+  return {
+    ok: true,
+    todo,
+    appliedTodoIds: [todo.id],
+  };
 }
 
 // ── Today-plan apply ──

--- a/src/services/aiDismissService.ts
+++ b/src/services/aiDismissService.ts
@@ -1,6 +1,7 @@
 import { DecisionAssistSurface } from "../validation/aiContracts";
 import { AiSuggestionRecord } from "./aiSuggestionStore";
 import {
+  HOME_FOCUS_SURFACE,
   TODO_BOUND_TYPE,
   TODO_BOUND_SURFACES,
   TODAY_PLAN_SURFACE,
@@ -23,13 +24,22 @@ export function validateDismissable(
     suggestion.input &&
     typeof suggestion.input.surface === "string" &&
     suggestion.input.surface === TODAY_PLAN_SURFACE;
+  const isHomeFocusSuggestion =
+    suggestion.type === TODO_BOUND_TYPE &&
+    suggestion.input &&
+    typeof suggestion.input.surface === "string" &&
+    suggestion.input.surface === HOME_FOCUS_SURFACE;
 
-  if (!isTodoBoundSuggestion && !isTodayPlanSuggestion) {
+  if (
+    !isTodoBoundSuggestion &&
+    !isTodayPlanSuggestion &&
+    !isHomeFocusSuggestion
+  ) {
     return {
       ok: false,
       status: 400,
       error:
-        "Only on_create/task_drawer/today_plan suggestions can be dismissed",
+        "Only on_create/task_drawer/today_plan/home_focus suggestions can be dismissed",
     };
   }
 
@@ -41,13 +51,14 @@ export function validateDismissable(
 
   if (
     !TODO_BOUND_SURFACES.has(inputSurface) &&
-    inputSurface !== TODAY_PLAN_SURFACE
+    inputSurface !== TODAY_PLAN_SURFACE &&
+    inputSurface !== HOME_FOCUS_SURFACE
   ) {
     return {
       ok: false,
       status: 400,
       error:
-        "Only on_create/task_drawer/today_plan suggestions can be dismissed",
+        "Only on_create/task_drawer/today_plan/home_focus suggestions can be dismissed",
     };
   }
 

--- a/src/services/aiNormalizationService.ts
+++ b/src/services/aiNormalizationService.ts
@@ -13,6 +13,7 @@ import { CreateTodoDto, Priority } from "../types";
 export const TASK_DRAWER_SURFACE: DecisionAssistSurface = "task_drawer";
 export const ON_CREATE_SURFACE: DecisionAssistSurface = "on_create";
 export const TODAY_PLAN_SURFACE: DecisionAssistSurface = "today_plan";
+export const HOME_FOCUS_SURFACE: DecisionAssistSurface = "home_focus";
 export const TODO_BOUND_TYPE: "task_critic" = "task_critic";
 
 export const TODO_BOUND_SURFACES = new Set<DecisionAssistSurface>([
@@ -25,6 +26,9 @@ export const TODAY_PLAN_ALLOWED_TYPES = new Set<DecisionAssistSuggestionType>([
   "set_priority",
   "split_subtasks",
   "propose_next_action",
+]);
+export const HOME_FOCUS_ALLOWED_TYPES = new Set<DecisionAssistSuggestionType>([
+  "focus_task",
 ]);
 
 export const TODO_BOUND_ALLOWED_TYPES: Record<
@@ -72,6 +76,21 @@ export type NormalizedTodayPlanSuggestion = DecisionAssistSuggestion & {
 
 export type NormalizedTodayPlanEnvelope = DecisionAssistOutput & {
   suggestions: NormalizedTodayPlanSuggestion[];
+};
+
+export type NormalizedHomeFocusSuggestion = DecisionAssistSuggestion & {
+  suggestionId: string;
+  taskId: string;
+  todoId: string;
+  projectId?: string;
+  title: string;
+  summary: string;
+  source: "deterministic" | "ai" | "hybrid";
+  payload: Record<string, unknown>;
+};
+
+export type NormalizedHomeFocusEnvelope = DecisionAssistOutput & {
+  suggestions: NormalizedHomeFocusSuggestion[];
 };
 
 // ── Small helpers ──
@@ -189,6 +208,93 @@ export function normalizeTodayPlanEnvelope(
   };
 }
 
+function parseHomeFocusSource(
+  value: unknown,
+): "deterministic" | "ai" | "hybrid" {
+  if (value === "ai" || value === "hybrid") {
+    return value;
+  }
+  return "deterministic";
+}
+
+export function normalizeHomeFocusEnvelope(
+  rawOutput: Record<string, unknown>,
+): NormalizedHomeFocusEnvelope {
+  const validated = validateDecisionAssistOutput(rawOutput);
+  if (validated.surface !== HOME_FOCUS_SURFACE) {
+    throw new Error("Suggestion envelope surface mismatch");
+  }
+
+  const normalizedSuggestions = validated.suggestions.reduce<
+    NormalizedHomeFocusSuggestion[]
+  >((acc, item, index) => {
+    if (!HOME_FOCUS_ALLOWED_TYPES.has(item.type)) {
+      return acc;
+    }
+    const rawItem =
+      Array.isArray(rawOutput.suggestions) &&
+      rawOutput.suggestions[index] &&
+      typeof rawOutput.suggestions[index] === "object"
+        ? (rawOutput.suggestions[index] as Record<string, unknown>)
+        : {};
+    const payload =
+      item.payload && typeof item.payload === "object"
+        ? ({ ...item.payload } as Record<string, unknown>)
+        : {};
+    const todoIdRaw =
+      typeof payload.todoId === "string"
+        ? payload.todoId.trim()
+        : typeof payload.taskId === "string"
+          ? payload.taskId.trim()
+          : "";
+    if (!todoIdRaw) {
+      return acc;
+    }
+    const suggestionIdRaw =
+      typeof rawItem.suggestionId === "string"
+        ? rawItem.suggestionId.trim()
+        : "";
+    const title = typeof payload.title === "string" ? payload.title.trim() : "";
+    const summary =
+      typeof payload.summary === "string" && payload.summary.trim()
+        ? payload.summary.trim()
+        : item.rationale;
+    if (!title || !summary) {
+      return acc;
+    }
+    acc.push({
+      ...item,
+      suggestionId: suggestionIdRaw || `home-focus-${index + 1}`,
+      taskId:
+        typeof payload.taskId === "string" && payload.taskId.trim()
+          ? payload.taskId.trim()
+          : todoIdRaw,
+      todoId: todoIdRaw,
+      projectId:
+        typeof payload.projectId === "string" && payload.projectId.trim()
+          ? payload.projectId.trim()
+          : undefined,
+      title,
+      summary,
+      source: parseHomeFocusSource(payload.source),
+      payload: {
+        ...payload,
+        todoId: todoIdRaw,
+        taskId:
+          typeof payload.taskId === "string" && payload.taskId.trim()
+            ? payload.taskId.trim()
+            : todoIdRaw,
+      },
+    });
+    return acc;
+  }, []);
+
+  return {
+    ...validated,
+    suggestions: normalizedSuggestions,
+  };
+}
+
 // ── Plan task parsing ──
 
 export function parsePlanTasks(
@@ -295,6 +401,24 @@ export async function findLatestPendingTodayPlanSuggestion(
       const inputTodoId =
         typeof record.input?.todoId === "string" ? record.input.todoId : "";
       return inputSurface === TODAY_PLAN_SURFACE && !inputTodoId;
+    }) || null
+  );
+}
+
+export async function findLatestPendingHomeFocusSuggestion(
+  suggestionStore: IAiSuggestionStore,
+  userId: string,
+): Promise<AiSuggestionRecord | null> {
+  const records = await suggestionStore.listByUser(userId, 100);
+  return (
+    records.find((record) => {
+      if (record.status !== "pending") return false;
+      if (record.type !== TODO_BOUND_TYPE) return false;
+      const inputSurface =
+        typeof record.input?.surface === "string" ? record.input.surface : "";
+      const inputTodoId =
+        typeof record.input?.todoId === "string" ? record.input.todoId : "";
+      return inputSurface === HOME_FOCUS_SURFACE && !inputTodoId;
     }) || null
   );
 }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -79,6 +79,11 @@ export interface DecisionAssistStubInput {
     priority?: Priority;
     createdAt?: string;
     updatedAt?: string;
+    projectId?: string;
+    projectName?: string;
+    category?: string;
+    hasSubtasks?: boolean;
+    notesPresent?: boolean;
   }>;
 }
 
@@ -504,6 +509,157 @@ function priorityWeight(priority?: string): number {
   return 1;
 }
 
+function startOfToday(now = new Date()): Date {
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+function daysSince(value?: string): number {
+  if (!value) return Infinity;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return Infinity;
+  return Math.max(0, Math.floor((Date.now() - parsed.getTime()) / 86400000));
+}
+
+type HomeFocusCandidate = NonNullable<
+  DecisionAssistStubInput["todoCandidates"]
+>[number];
+
+function getHomeFocusDueBucket(candidate: HomeFocusCandidate): number {
+  if (!candidate.dueDate) return 4;
+  const dueDate = new Date(candidate.dueDate);
+  if (Number.isNaN(dueDate.getTime())) return 4;
+  const today = startOfToday();
+  const dueDay = startOfToday(dueDate);
+  const dayDiff = Math.floor(
+    (dueDay.getTime() - today.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (dayDiff < 0) return 0;
+  if (dayDiff === 0) return 1;
+  if (dayDiff === 1) return 2;
+  if (dayDiff <= 3) return 3;
+  return 4;
+}
+
+function getHomeFocusConfidence(
+  candidate: HomeFocusCandidate,
+  dueBucket: number,
+): number {
+  if (dueBucket === 0) return 0.91;
+  if (dueBucket === 1) return 0.87;
+  if (dueBucket === 2) return 0.82;
+  if (dueBucket === 3) return 0.78;
+  if (priorityWeight(candidate.priority) >= 3) return 0.74;
+  if (daysSince(candidate.updatedAt || candidate.createdAt) >= 14) return 0.69;
+  return 0.62;
+}
+
+function buildHomeFocusSummary(
+  candidate: HomeFocusCandidate,
+  dueBucket: number,
+): string {
+  const projectName = candidate.projectName || candidate.category || "";
+  if (dueBucket === 0) {
+    return projectName
+      ? `This is overdue in ${projectName} and should be resolved before more work slips.`
+      : "This is overdue and should be resolved before more work slips.";
+  }
+  if (dueBucket === 1) {
+    return projectName
+      ? `This is due today in ${projectName}, so it is the safest focus pick.`
+      : "This is due today, so it is the safest focus pick.";
+  }
+  if (dueBucket === 2 || dueBucket === 3) {
+    return projectName
+      ? `This is due soon in ${projectName} and is at risk of slipping if ignored.`
+      : "This is due soon and is at risk of slipping if ignored.";
+  }
+  if (priorityWeight(candidate.priority) >= 3) {
+    return projectName
+      ? `This is a high-priority task in ${projectName} and deserves focused attention next.`
+      : "This is high priority and deserves focused attention next.";
+  }
+  if (daysSince(candidate.updatedAt || candidate.createdAt) >= 14) {
+    return projectName
+      ? `This has been quiet in ${projectName} for a while and looks ready for a decision.`
+      : "This has been quiet for a while and looks ready for a decision.";
+  }
+  if (candidate.hasSubtasks) {
+    return "This already has structure, which makes it a good focus candidate.";
+  }
+  if (candidate.notesPresent) {
+    return "This already has context captured, so it should be quick to resume.";
+  }
+  return projectName
+    ? `This is an active task in ${projectName} with clear enough context to move forward.`
+    : "This is an active task with clear enough context to move forward.";
+}
+
+function buildHomeFocusSuggestions(
+  input: DecisionAssistStubInput,
+): DecisionAssistOutput {
+  const requestId = randomUUID();
+  const candidates = Array.isArray(input.todoCandidates)
+    ? input.todoCandidates.filter((item) => item.id && item.title)
+    : [];
+  if (!candidates.length) {
+    return validateDecisionAssistOutput({
+      requestId,
+      surface: "home_focus",
+      must_abstain: true,
+      suggestions: [],
+    });
+  }
+
+  const selected = [...candidates]
+    .sort((a, b) => {
+      const dueBucketA = getHomeFocusDueBucket(a);
+      const dueBucketB = getHomeFocusDueBucket(b);
+      if (dueBucketA !== dueBucketB) return dueBucketA - dueBucketB;
+
+      const priorityDelta =
+        priorityWeight(b.priority) - priorityWeight(a.priority);
+      if (priorityDelta !== 0) return priorityDelta;
+
+      const staleDelta =
+        daysSince(b.updatedAt || b.createdAt) -
+        daysSince(a.updatedAt || a.createdAt);
+      if (staleDelta !== 0) return staleDelta;
+
+      const projectDelta =
+        Number(!!b.projectName || !!b.category) -
+        Number(!!a.projectName || !!a.category);
+      if (projectDelta !== 0) return projectDelta;
+
+      return String(a.title || "").localeCompare(String(b.title || ""));
+    })
+    .slice(0, Math.min(input.topN || 3, 3));
+
+  return validateDecisionAssistOutput({
+    requestId,
+    surface: "home_focus",
+    must_abstain: selected.length === 0,
+    suggestions: selected.map((candidate, index) => {
+      const dueBucket = getHomeFocusDueBucket(candidate);
+      const summary = buildHomeFocusSummary(candidate, dueBucket);
+      return {
+        type: "focus_task",
+        confidence: getHomeFocusConfidence(candidate, dueBucket),
+        rationale: summary,
+        payload: {
+          taskId: candidate.id,
+          todoId: candidate.id,
+          projectId: candidate.projectId,
+          title: candidate.title,
+          summary,
+          reason: summary,
+          source: "deterministic",
+        },
+        suggestionId: `home-focus-${index + 1}-${candidate.id}`,
+      };
+    }),
+  });
+}
+
 function estimateTodoMinutes(
   title: string,
   mode: "quick" | "deep" | "balanced",
@@ -527,6 +683,10 @@ export function generateDecisionAssistStubOutput(
   const surface = input.surface;
   const requestId = randomUUID();
   const suggestions: DecisionAssistOutput["suggestions"] = [];
+
+  if (surface === "home_focus") {
+    return buildHomeFocusSuggestions(input);
+  }
 
   if (surface === "on_create" || surface === "task_drawer") {
     const title = input.title?.trim() || "Untitled task";

--- a/src/services/decisionAssistThrottle.ts
+++ b/src/services/decisionAssistThrottle.ts
@@ -35,7 +35,8 @@ const extractSurface = (
   if (
     inputSurface === "task_drawer" ||
     inputSurface === "on_create" ||
-    inputSurface === "today_plan"
+    inputSurface === "today_plan" ||
+    inputSurface === "home_focus"
   ) {
     return inputSurface;
   }

--- a/src/validation/aiContracts.ts
+++ b/src/validation/aiContracts.ts
@@ -1,7 +1,11 @@
 import { ValidationError } from "./validation";
 import { Priority } from "../types";
 
-export type DecisionAssistSurface = "on_create" | "task_drawer" | "today_plan";
+export type DecisionAssistSurface =
+  | "on_create"
+  | "task_drawer"
+  | "today_plan"
+  | "home_focus";
 
 export type DecisionAssistSuggestionType =
   | "set_due_date"
@@ -12,7 +16,8 @@ export type DecisionAssistSuggestionType =
   | "propose_next_action"
   | "split_subtasks"
   | "ask_clarification"
-  | "defer_task";
+  | "defer_task"
+  | "focus_task";
 
 export interface DecisionAssistSuggestion {
   type: DecisionAssistSuggestionType;
@@ -50,6 +55,7 @@ const ALLOWED_SURFACES: DecisionAssistSurface[] = [
   "on_create",
   "task_drawer",
   "today_plan",
+  "home_focus",
 ];
 const ALLOWED_SUGGESTION_TYPES: DecisionAssistSuggestionType[] = [
   "set_due_date",
@@ -61,9 +67,11 @@ const ALLOWED_SUGGESTION_TYPES: DecisionAssistSuggestionType[] = [
   "split_subtasks",
   "ask_clarification",
   "defer_task",
+  "focus_task",
 ];
 const ALLOWED_PRIORITIES: Priority[] = ["low", "medium", "high"];
 const ALLOWED_DEFER_STRATEGIES = ["someday", "next_week", "next_month"];
+const ALLOWED_HOME_FOCUS_SOURCES = ["deterministic", "ai", "hybrid"];
 const MAX_RATIONALE_LENGTH = 240;
 const MAX_TEXT_LENGTH = 200;
 const MAX_PROJECT_OR_CATEGORY_LENGTH = 50;
@@ -230,6 +238,40 @@ function validateDeferTaskPayload(payload: Record<string, unknown>) {
   }
 }
 
+function validateFocusTaskPayload(payload: Record<string, unknown>) {
+  const taskId =
+    typeof payload.taskId === "string" ? payload.taskId.trim() : "";
+  const todoId =
+    typeof payload.todoId === "string" ? payload.todoId.trim() : "";
+  if (!taskId && !todoId) {
+    throw new ValidationError(
+      "payload for focus_task must include taskId or todoId",
+    );
+  }
+
+  assertString(payload.title, "payload.title");
+  assertString(payload.summary, "payload.summary", MAX_RATIONALE_LENGTH);
+
+  if (payload.projectId !== undefined) {
+    assertString(payload.projectId, "payload.projectId", 120);
+  }
+  if (payload.reason !== undefined) {
+    assertString(payload.reason, "payload.reason", MAX_RATIONALE_LENGTH);
+  }
+  if (payload.source !== undefined) {
+    if (typeof payload.source !== "string") {
+      throw new ValidationError(
+        "payload.source must be deterministic, ai, or hybrid",
+      );
+    }
+    if (!ALLOWED_HOME_FOCUS_SOURCES.includes(payload.source)) {
+      throw new ValidationError(
+        "payload.source must be deterministic, ai, or hybrid",
+      );
+    }
+  }
+}
+
 function validateSuggestion(
   suggestion: unknown,
   clarificationCount: { count: number },
@@ -291,6 +333,9 @@ function validateSuggestion(
       break;
     case "defer_task":
       validateDeferTaskPayload(payload);
+      break;
+    case "focus_task":
+      validateFocusTaskPayload(payload);
       break;
     default:
       throw new ValidationError(`Unsupported suggestion.type: ${type}`);

--- a/src/validation/aiValidation.ts
+++ b/src/validation/aiValidation.ts
@@ -19,6 +19,11 @@ const ALLOWED_DECISION_ASSIST_SURFACES: DecisionAssistSurface[] = [
   "on_create",
   "task_drawer",
   "today_plan",
+  "home_focus",
+];
+const TODO_REQUIRED_DECISION_ASSIST_SURFACES: DecisionAssistSurface[] = [
+  "on_create",
+  "task_drawer",
 ];
 
 function parseDate(value: unknown, field: string): Date {
@@ -264,7 +269,7 @@ export function validateDecisionAssistLatestQuery(query: any): {
     todoId = query.todoId.trim();
   }
 
-  if (surface !== "today_plan" && !todoId) {
+  if (TODO_REQUIRED_DECISION_ASSIST_SURFACES.includes(surface) && !todoId) {
     throw new ValidationError("todoId is required");
   }
 
@@ -468,12 +473,17 @@ export function validateDecisionAssistStubInput(
     anchorDateISO = parsed.toISOString();
   }
 
+  const rawTodoCandidates =
+    data.todoCandidates !== undefined ? data.todoCandidates : data.candidates;
   let todoCandidates: DecisionAssistStubInput["todoCandidates"];
-  if (data.todoCandidates !== undefined) {
-    if (!Array.isArray(data.todoCandidates)) {
+  if (rawTodoCandidates !== undefined) {
+    if (!Array.isArray(rawTodoCandidates)) {
       throw new ValidationError("todoCandidates must be an array");
     }
-    todoCandidates = data.todoCandidates.map((item: unknown, index: number) => {
+    if (rawTodoCandidates.length > 60) {
+      throw new ValidationError("todoCandidates cannot exceed 60 items");
+    }
+    todoCandidates = rawTodoCandidates.map((item: unknown, index: number) => {
       if (!item || typeof item !== "object") {
         throw new ValidationError(`todoCandidates[${index}] must be an object`);
       }
@@ -484,10 +494,12 @@ export function validateDecisionAssistStubInput(
       if (typeof record.title !== "string" || !record.title.trim()) {
         throw new ValidationError(`todoCandidates[${index}].title is required`);
       }
+      const dueDateRaw =
+        typeof record.dueAt === "string" ? record.dueAt : record.dueDate;
       if (
-        record.dueDate !== undefined &&
-        (typeof record.dueDate !== "string" ||
-          Number.isNaN(new Date(record.dueDate).getTime()))
+        dueDateRaw !== undefined &&
+        (typeof dueDateRaw !== "string" ||
+          Number.isNaN(new Date(dueDateRaw).getTime()))
       ) {
         throw new ValidationError(
           `todoCandidates[${index}].dueDate must be a valid ISO date`,
@@ -502,21 +514,50 @@ export function validateDecisionAssistStubInput(
           `todoCandidates[${index}].priority must be low, medium, or high`,
         );
       }
+      const parseOptionalDateString = (value: unknown, field: string) => {
+        if (value === undefined) {
+          return undefined;
+        }
+        if (
+          typeof value !== "string" ||
+          Number.isNaN(new Date(value).getTime())
+        ) {
+          throw new ValidationError(
+            `todoCandidates[${index}].${field} must be a valid ISO date`,
+          );
+        }
+        return new Date(value).toISOString();
+      };
+
       return {
         id: record.id.trim(),
         title: record.title.trim(),
         dueDate:
-          typeof record.dueDate === "string"
-            ? new Date(record.dueDate).toISOString()
+          typeof dueDateRaw === "string"
+            ? new Date(dueDateRaw).toISOString()
             : undefined,
         priority:
           typeof record.priority === "string"
             ? (record.priority.toLowerCase() as Priority)
             : undefined,
-        createdAt:
-          typeof record.createdAt === "string" ? record.createdAt : undefined,
-        updatedAt:
-          typeof record.updatedAt === "string" ? record.updatedAt : undefined,
+        createdAt: parseOptionalDateString(record.createdAt, "createdAt"),
+        updatedAt: parseOptionalDateString(record.updatedAt, "updatedAt"),
+        projectId:
+          typeof record.projectId === "string" && record.projectId.trim()
+            ? record.projectId.trim()
+            : undefined,
+        projectName:
+          typeof record.projectName === "string" && record.projectName.trim()
+            ? record.projectName.trim()
+            : typeof record.category === "string" && record.category.trim()
+              ? record.category.trim()
+              : undefined,
+        category:
+          typeof record.category === "string" && record.category.trim()
+            ? record.category.trim()
+            : undefined,
+        hasSubtasks: record.hasSubtasks === true,
+        notesPresent: record.notesPresent === true,
       };
     });
   }

--- a/tests/ui/ai-today-plan.spec.ts
+++ b/tests/ui/ai-today-plan.spec.ts
@@ -202,13 +202,13 @@ async function installTodayPlanLiveMockApi(page: Page) {
     }
 
     if (pathname === "/ai/suggestions/latest" && method === "GET") {
-      state.latestFetchCalls += 1;
       const userId = authUserId(route);
       if (!userId) return json(route, 401, { error: "Unauthorized" });
       const surface = searchParams.get("surface") || "";
       if (surface !== "today_plan") {
         return route.fulfill({ status: 204, body: "" });
       }
+      state.latestFetchCalls += 1;
       const plans = plansByUser.get(userId) || [];
       const latest = plans.find((item) => item.status === "pending") || null;
       if (!latest) {

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -41,10 +41,14 @@ async function installHomeFocusMockApi(
   {
     aiDecisionAssistStatus = 500,
     aiTopFocus = null,
+    homeFocusSequences = null,
     seedTodos,
   }: {
     aiDecisionAssistStatus?: number;
     aiTopFocus?: Array<{ todoId: string; reason?: string }> | null;
+    homeFocusSequences?: Array<
+      Array<{ todoId: string; summary?: string; reason?: string }>
+    > | null;
     seedTodos: SeedTodo[];
   },
 ) {
@@ -54,9 +58,16 @@ async function installHomeFocusMockApi(
   >();
   const accessTokens = new Map<string, string>();
   const todosByUser = new Map<string, Array<Record<string, unknown>>>();
+  let latestHomeSuggestion: {
+    id: string;
+    status: "pending" | "accepted" | "rejected";
+    outputEnvelope: Record<string, unknown>;
+  } | null = null;
   let userSeq = 1;
   let tokenSeq = 1;
   let todoSeq = 1000;
+  let homeFocusSeq = 1;
+  let homeFocusGenerateSeq = 0;
 
   const nowIso = () => new Date().toISOString();
   const json = (route: Route, status: number, body: unknown) =>
@@ -69,6 +80,23 @@ async function installHomeFocusMockApi(
   const parseBody = async (route: Route) => {
     const raw = route.request().postData();
     return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+  };
+
+  const getHomeFocusCards = () => {
+    if (Array.isArray(homeFocusSequences) && homeFocusSequences.length > 0) {
+      const index = Math.min(
+        homeFocusGenerateSeq,
+        homeFocusSequences.length - 1,
+      );
+      return homeFocusSequences[index] || [];
+    }
+    return Array.isArray(aiTopFocus)
+      ? aiTopFocus.map((item) => ({
+          todoId: item.todoId,
+          summary: item.reason,
+          reason: item.reason,
+        }))
+      : [];
   };
 
   const buildTodosForUser = (userId: string) =>
@@ -107,6 +135,48 @@ async function installHomeFocusMockApi(
       todosByUser.set(id, buildTodosForUser(id));
     }
     return id;
+  };
+
+  const buildHomeFocusEnvelope = (
+    userId: string,
+    cards: Array<{ todoId: string; summary?: string; reason?: string }>,
+  ) => {
+    const todos = todosByUser.get(userId) || [];
+    const todoById = new Map(
+      todos.map((todo) => [String(todo.id), todo] as const),
+    );
+    const suggestions = cards
+      .map((card) => {
+        const todo = todoById.get(String(card.todoId || ""));
+        if (!todo) return null;
+        const summary = String(
+          card.summary || card.reason || "Suggested focus for Home.",
+        ).trim();
+        return {
+          type: "focus_task",
+          suggestionId: `home-focus-${homeFocusSeq++}`,
+          confidence: 0.81,
+          payload: {
+            todoId: String(todo.id),
+            taskId: String(todo.id),
+            projectId:
+              typeof todo.projectId === "string" ? todo.projectId : undefined,
+            title: String(todo.title || ""),
+            summary,
+            source: "deterministic",
+          },
+        };
+      })
+      .filter(Boolean);
+
+    return {
+      contractVersion: 1,
+      generatedAt: nowIso(),
+      requestId: `home-focus-request-${homeFocusGenerateSeq + 1}`,
+      surface: "home_focus",
+      must_abstain: suggestions.length === 0,
+      suggestions,
+    };
   };
 
   await page.route("**/*", async (route) => {
@@ -210,11 +280,29 @@ async function installHomeFocusMockApi(
     }
 
     if (pathname === "/ai/decision-assist/stub" && method === "POST") {
+      const body = await parseBody(route);
+      if (String(body.surface || "") !== "home_focus") {
+        return json(route, 404, { error: "Not found" });
+      }
       if (aiDecisionAssistStatus >= 400) {
         return json(route, aiDecisionAssistStatus, { error: "AI unavailable" });
       }
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const outputEnvelope = buildHomeFocusEnvelope(
+        userId,
+        getHomeFocusCards(),
+      );
+      const suggestionId = `home-focus-db-${homeFocusGenerateSeq + 1}`;
+      latestHomeSuggestion = {
+        id: suggestionId,
+        status: "pending",
+        outputEnvelope,
+      };
+      homeFocusGenerateSeq += 1;
       return json(route, 200, {
-        topFocus: Array.isArray(aiTopFocus) ? aiTopFocus : [],
+        ...outputEnvelope,
+        suggestionId,
       });
     }
 
@@ -222,7 +310,79 @@ async function installHomeFocusMockApi(
       return json(route, 200, []);
     }
     if (pathname === "/ai/suggestions/latest" && method === "GET") {
-      return json(route, 404, { error: "Not found" });
+      if (url.searchParams.get("surface") !== "home_focus") {
+        return json(route, 404, { error: "Not found" });
+      }
+      if (!latestHomeSuggestion || latestHomeSuggestion.status !== "pending") {
+        return route.fulfill({ status: 204, body: "" });
+      }
+      return json(route, 200, {
+        aiSuggestionId: latestHomeSuggestion.id,
+        status: latestHomeSuggestion.status,
+        outputEnvelope: latestHomeSuggestion.outputEnvelope,
+      });
+    }
+    if (
+      pathname.startsWith("/ai/suggestions/") &&
+      pathname.endsWith("/apply") &&
+      method === "POST"
+    ) {
+      const userId = authUserId(route);
+      if (!userId) return json(route, 401, { error: "Unauthorized" });
+      const suggestionDbId = pathname.split("/")[3];
+      if (!latestHomeSuggestion || latestHomeSuggestion.id !== suggestionDbId) {
+        return json(route, 404, { error: "Suggestion not found" });
+      }
+      const body = await parseBody(route);
+      const selectedSuggestion = Array.isArray(
+        latestHomeSuggestion.outputEnvelope.suggestions,
+      )
+        ? latestHomeSuggestion.outputEnvelope.suggestions.find(
+            (item) =>
+              item &&
+              typeof item === "object" &&
+              String((item as Record<string, unknown>).suggestionId || "") ===
+                String(body.suggestionId || ""),
+          )
+        : null;
+      if (!selectedSuggestion || typeof selectedSuggestion !== "object") {
+        return json(route, 404, { error: "Suggestion item not found" });
+      }
+      const payload =
+        selectedSuggestion.payload &&
+        typeof selectedSuggestion.payload === "object"
+          ? selectedSuggestion.payload
+          : {};
+      const todoId = String(payload.todoId || "");
+      const todo = (todosByUser.get(userId) || []).find(
+        (item) => String(item.id) === todoId,
+      );
+      if (!todo) {
+        return json(route, 404, { error: "Todo not found" });
+      }
+      latestHomeSuggestion = null;
+      return json(route, 200, {
+        todo,
+        appliedSuggestionId: String(body.suggestionId || ""),
+        suggestion: {
+          id: suggestionDbId,
+          status: "accepted",
+          appliedTodoIds: [todoId],
+        },
+        idempotent: false,
+      });
+    }
+    if (
+      pathname.startsWith("/ai/suggestions/") &&
+      pathname.endsWith("/dismiss") &&
+      method === "POST"
+    ) {
+      const suggestionDbId = pathname.split("/")[3];
+      if (!latestHomeSuggestion || latestHomeSuggestion.id !== suggestionDbId) {
+        return json(route, 404, { error: "Suggestion not found" });
+      }
+      latestHomeSuggestion = null;
+      return route.fulfill({ status: 204, body: "" });
     }
     if (pathname === "/ai/usage" && method === "GET") {
       return json(route, 200, {
@@ -536,6 +696,71 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await upNextTile.getByRole("button", { name: "See all" }).click();
     await expect(page.locator("#todosListHeaderTitle")).toHaveText("Up Next");
     await expectListOrEmptyState(page);
+  });
+});
+
+test.describe("Home focus AI lifecycle", () => {
+  test("Home focus suggestions render and dismiss through the shared AI lifecycle", async ({
+    page,
+  }) => {
+    await installHomeFocusMockApi(page, {
+      aiDecisionAssistStatus: 200,
+      homeFocusSequences: [
+        [
+          {
+            todoId: "todo-today",
+            summary: "Due today and blocking the rest of launch prep.",
+          },
+        ],
+        [
+          {
+            todoId: "todo-overdue",
+            summary: "Overdue and should be closed before anything else.",
+          },
+        ],
+      ],
+      seedTodos: buildSeedTodos(),
+    });
+    await openHomeApp(page);
+
+    const focusTile = page.locator('[data-home-tile="top_focus"]');
+    await expect(focusTile).toContainText(
+      "Due today and blocking the rest of launch prep.",
+    );
+    await focusTile.getByRole("button", { name: "Dismiss" }).click();
+    await expect(focusTile).toContainText(
+      "Overdue and should be closed before anything else.",
+    );
+  });
+
+  test("Applying a Home focus suggestion opens the selected task drawer", async ({
+    page,
+  }) => {
+    await installHomeFocusMockApi(page, {
+      aiDecisionAssistStatus: 200,
+      homeFocusSequences: [
+        [
+          {
+            todoId: "todo-today",
+            summary: "Due today and blocking the rest of launch prep.",
+          },
+        ],
+      ],
+      seedTodos: buildSeedTodos(),
+    });
+    await openHomeApp(page);
+
+    const focusTile = page.locator('[data-home-tile="top_focus"]');
+    await expect(focusTile).toContainText(
+      "Due today and blocking the rest of launch prep.",
+    );
+    await focusTile.getByRole("button", { name: "Use focus" }).click();
+    await expect(page.locator("#todoDetailsDrawer")).toHaveClass(
+      /todo-drawer--open/,
+    );
+    await expect(page.locator("#drawerTitleInput")).toHaveValue(
+      "Prepare launch checklist",
+    );
   });
 });
 


### PR DESCRIPTION
## Why
Home already had deterministic focus logic, but it was outside the validated AI suggestion contract. That meant `home_focus` behaved like an unsupported side path instead of a first-class suggestion surface.

This change brings Home into the existing AI suggestion lifecycle so the dashboard can request, render, apply, and dismiss focus suggestions consistently while preserving deterministic fallback behavior when AI is unavailable.

## What changed
- added `home_focus` to the validated backend AI contracts and request validation
- reused the existing AI suggestion routes in `aiRouter` instead of adding a separate Home endpoint
- added deterministic home-focus generation, normalization, apply/dismiss support, and related integration coverage
- introduced a small `homeAi` state slice and `homeAiService.js` on the client to load, refresh, apply, and dismiss Home focus suggestions through the existing AI endpoints
- updated the Home dashboard to render AI-backed focus cards when present and fall back to the existing deterministic top-focus path when not
- added backend and UI tests for the new surface and adjusted the Today Plan mock to ignore unrelated Home latest-fetches

## Verification
- `npx prisma generate`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
