### PR TITLE
feat(api): add planner service tools

### DIFF
--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -42,6 +42,9 @@ Supported actions:
 - `list_projects`
 - `list_projects_without_next_action`
 - `review_projects`
+- `plan_project`
+- `ensure_next_action`
+- `weekly_review`
 - `create_project`
 - `update_project`
 - `rename_project`

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -61,6 +61,9 @@ Initial public tools:
 - `list_projects`
 - `list_projects_without_next_action`
 - `review_projects`
+- `plan_project`
+- `ensure_next_action`
+- `weekly_review`
 - `create_project`
 - `update_project`
 - `rename_project`

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -168,6 +168,9 @@ The older `read` / `write` aliases are still accepted by validation and expanded
 | `get_project`    | Yes       | `projects.read`  |
 | `review_projects` | Yes      | `projects.read`  |
 | `list_projects_without_next_action` | Yes | `projects.read`, `tasks.read` |
+| `plan_project` | No | `projects.read`, `tasks.read`, `tasks.write` |
+| `ensure_next_action` | No | `projects.read`, `tasks.read`, `tasks.write` |
+| `weekly_review` | No | `projects.read`, `tasks.read`, `tasks.write` |
 | `create_project` | No        | `projects.write` |
 | `update_project` | No        | `projects.write` |
 | `rename_project` | No        | `projects.write` |

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -233,6 +233,46 @@
         "createdAt": { "type": "string", "format": "date-time" },
         "updatedAt": { "type": "string", "format": "date-time" }
       }
+    },
+    "plannerMode": {
+      "type": "string",
+      "enum": ["suggest", "apply"]
+    },
+    "plannerTaskSuggestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string" },
+        "description": { "type": ["string", "null"] },
+        "priority": {
+          "type": ["string", "null"],
+          "enum": ["low", "medium", "high", "urgent", null]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["next", "in_progress", "waiting", "scheduled", "someday"]
+        },
+        "reason": { "type": "string" }
+      }
+    },
+    "plannerFindingType": {
+      "type": "string",
+      "enum": [
+        "missing_next_action",
+        "stale_task",
+        "waiting_task",
+        "upcoming_deadline",
+        "empty_active_project"
+      ]
+    },
+    "plannerRecommendationType": {
+      "type": "string",
+      "enum": [
+        "create_next_action",
+        "review_stale_task",
+        "follow_up_waiting_task",
+        "plan_project"
+      ]
     }
   },
   "actions": [
@@ -1093,6 +1133,174 @@
         "dataKey": "projects",
         "type": "array",
         "items": { "$ref": "#/definitions/project" }
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "plan_project",
+      "description": "Generate a practical project plan and optionally create the missing tasks through the canonical task service.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/plan_project",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "projectId": { "type": "string", "format": "uuid" },
+          "goal": { "type": ["string", "null"], "maxLength": 200 },
+          "constraints": {
+            "type": "array",
+            "items": { "type": "string", "maxLength": 200 },
+            "maxItems": 20
+          },
+          "mode": { "$ref": "#/definitions/plannerMode" }
+        },
+        "required": ["projectId"]
+      },
+      "output": {
+        "dataKey": "plan",
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string", "format": "uuid" },
+              "name": { "type": "string" }
+            }
+          },
+          "summary": { "type": "string" },
+          "suggestedTasks": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/plannerTaskSuggestion" }
+          },
+          "createdTaskIds": {
+            "type": "array",
+            "items": { "type": "string", "format": "uuid" }
+          }
+        }
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "ensure_next_action",
+      "description": "Ensure a project has one concrete next action and optionally create it through the canonical task service.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/ensure_next_action",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "projectId": { "type": "string", "format": "uuid" },
+          "mode": { "$ref": "#/definitions/plannerMode" }
+        },
+        "required": ["projectId"]
+      },
+      "output": {
+        "dataKey": "result",
+        "type": "object",
+        "properties": {
+          "projectId": { "type": "string", "format": "uuid" },
+          "hasNextAction": { "type": "boolean" },
+          "created": { "type": "boolean" },
+          "task": {
+            "type": ["object", "null"],
+            "properties": {
+              "id": { "type": ["string", "null"], "format": "uuid" },
+              "title": { "type": "string" },
+              "status": {
+                "type": "string",
+                "enum": ["next", "in_progress"]
+              }
+            }
+          },
+          "reason": { "type": "string" }
+        }
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "weekly_review",
+      "description": "Review the user's system, return structured findings, and optionally apply safe next-action creation.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/weekly_review",
+      "availability": {
+        "requires": ["project_service"]
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": { "$ref": "#/definitions/plannerMode" },
+          "includeArchived": { "type": "boolean" }
+        }
+      },
+      "output": {
+        "dataKey": "review",
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "object",
+            "properties": {
+              "projectsWithoutNextAction": { "type": "integer" },
+              "staleTasks": { "type": "integer" },
+              "waitingTasks": { "type": "integer" },
+              "upcomingTasks": { "type": "integer" }
+            }
+          },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": { "$ref": "#/definitions/plannerFindingType" },
+                "projectId": { "type": "string", "format": "uuid" },
+                "projectName": { "type": "string" },
+                "taskId": { "type": "string", "format": "uuid" },
+                "taskTitle": { "type": "string" },
+                "reason": { "type": "string" }
+              }
+            }
+          },
+          "recommendedActions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": { "$ref": "#/definitions/plannerRecommendationType" },
+                "projectId": { "type": "string", "format": "uuid" },
+                "taskId": { "type": "string", "format": "uuid" },
+                "title": { "type": "string" },
+                "reason": { "type": "string" },
+                "createdTaskId": { "type": "string", "format": "uuid" }
+              }
+            }
+          },
+          "appliedActions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": { "$ref": "#/definitions/plannerRecommendationType" },
+                "projectId": { "type": "string", "format": "uuid" },
+                "taskId": { "type": "string", "format": "uuid" },
+                "title": { "type": "string" },
+                "reason": { "type": "string" },
+                "createdTaskId": { "type": "string", "format": "uuid" }
+              }
+            }
+          }
+        }
       },
       "errorModel": "structured_agent_error",
       "idempotency": "not_applicable"

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -25,12 +25,15 @@ import {
   validateAgentListUpcomingInput,
   validateAgentListWaitingOnInput,
   validateAgentMoveTaskToProjectInput,
+  validateAgentPlanProjectInput,
   validateAgentRenameProjectInput,
   validateAgentReviewProjectsInput,
   validateAgentSearchTasksInput,
+  validateAgentEnsureNextActionInput,
   validateAgentUpdateSubtaskInput,
   validateAgentUpdateProjectInput,
   validateAgentUpdateTaskInput,
+  validateAgentWeeklyReviewInput,
 } from "../validation/agentValidation";
 
 export type AgentActionName =
@@ -59,7 +62,10 @@ export type AgentActionName =
   | "list_upcoming"
   | "list_stale_tasks"
   | "list_projects_without_next_action"
-  | "review_projects";
+  | "review_projects"
+  | "plan_project"
+  | "ensure_next_action"
+  | "weekly_review";
 
 interface AgentExecutorDeps {
   todoService: ITodoService;
@@ -745,6 +751,48 @@ export class AgentExecutor {
             filters,
           );
           return this.success(action, readOnly, context, 200, { projects });
+        }
+        case "plan_project": {
+          const plannerInput = validateAgentPlanProjectInput(input);
+          const plan = await this.agentService.planProjectForUser(
+            context.userId,
+            plannerInput,
+          );
+          if (!plan) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Project not found",
+              false,
+              "Verify the project ID belongs to the authenticated user.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, { plan });
+        }
+        case "ensure_next_action": {
+          const plannerInput = validateAgentEnsureNextActionInput(input);
+          const result = await this.agentService.ensureNextActionForUser(
+            context.userId,
+            plannerInput,
+          );
+          if (!result) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Project not found",
+              false,
+              "Verify the project ID belongs to the authenticated user.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, { result });
+        }
+        case "weekly_review": {
+          const plannerInput = validateAgentWeeklyReviewInput(input);
+          const review = await this.agentService.weeklyReviewForUser(
+            context.userId,
+            plannerInput,
+          );
+          return this.success(action, readOnly, context, 200, { review });
         }
       }
     } catch (error) {

--- a/src/agentRouter.test.ts
+++ b/src/agentRouter.test.ts
@@ -77,6 +77,21 @@ describe("Agent router", () => {
           enabled: true,
           readOnly: true,
         }),
+        expect.objectContaining({
+          name: "plan_project",
+          enabled: true,
+          readOnly: false,
+        }),
+        expect.objectContaining({
+          name: "ensure_next_action",
+          enabled: true,
+          readOnly: false,
+        }),
+        expect.objectContaining({
+          name: "weekly_review",
+          enabled: true,
+          readOnly: false,
+        }),
       ]),
     );
   });
@@ -215,6 +230,100 @@ describe("Agent router", () => {
     expect(projectService.create).toHaveBeenCalledTimes(1);
     expect(firstResponse.body.data.project.name).toBe("Platform");
     expect(replayResponse.body.trace.replayed).toBe(true);
+  });
+
+  it("plans a project through the write surface", async () => {
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000041",
+      name: "Vacation",
+      goal: "Plan anniversary vacation",
+      status: "active",
+      archived: false,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project);
+
+    const response = await request(app)
+      .post("/agent/write/plan_project")
+      .send({
+        projectId: "00000000-0000-1000-8000-000000000041",
+        goal: "Plan anniversary vacation",
+        mode: "suggest",
+      })
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.action).toBe("plan_project");
+    expect(response.body.data.plan.project).toEqual({
+      id: "00000000-0000-1000-8000-000000000041",
+      name: "Vacation",
+    });
+    expect(response.body.data.plan.suggestedTasks.length).toBeGreaterThan(0);
+  });
+
+  it("creates a missing next action through the write surface", async () => {
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000042",
+      name: "Ops",
+      status: "active",
+      archived: false,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project);
+
+    const response = await request(app)
+      .post("/agent/write/ensure_next_action")
+      .send({
+        projectId: "00000000-0000-1000-8000-000000000042",
+        mode: "apply",
+      })
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.action).toBe("ensure_next_action");
+    expect(response.body.data.result.created).toBe(true);
+    expect(response.body.data.result.task.status).toBe("next");
+  });
+
+  it("returns weekly review findings through the write surface", async () => {
+    projectService.findAll.mockResolvedValue([
+      {
+        id: "00000000-0000-1000-8000-000000000043",
+        name: "Admin",
+        status: "active",
+        archived: false,
+        userId: "default-user",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        todoCount: 0,
+        openTodoCount: 0,
+      } as Project,
+    ]);
+
+    const response = await request(app)
+      .post("/agent/write/weekly_review")
+      .send({
+        mode: "suggest",
+      })
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.action).toBe("weekly_review");
+    expect(response.body.data.review.summary.projectsWithoutNextAction).toBe(0);
+    expect(response.body.data.review.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "empty_active_project",
+          projectName: "Admin",
+        }),
+      ]),
+    );
   });
 
   it("returns agent auth errors in the structured action envelope", async () => {

--- a/src/api.contract.test.ts
+++ b/src/api.contract.test.ts
@@ -2,6 +2,30 @@ import request from "supertest";
 import { createApp } from "./app";
 import { TodoService } from "./services/todoService";
 import type { Express } from "express";
+import type { IProjectService } from "./interfaces/IProjectService";
+import type {
+  CreateProjectDto,
+  Project,
+  ProjectTaskDisposition,
+  UpdateProjectDto,
+} from "./types";
+
+function createProjectServiceMock(): jest.Mocked<IProjectService> {
+  return {
+    findAll: jest.fn<Promise<Project[]>, [string]>(),
+    findById: jest.fn<Promise<Project | null>, [string, string]>(),
+    create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
+    update: jest.fn<
+      Promise<Project | null>,
+      [string, string, UpdateProjectDto]
+    >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
+    delete: jest.fn<
+      Promise<boolean>,
+      [string, string, ProjectTaskDisposition, (string | null)?]
+    >(),
+  };
+}
 
 describe("API Contract", () => {
   let app: Express;
@@ -164,6 +188,34 @@ describe("API Contract", () => {
       expect(
         response.body?.paths?.["/ai/todos/{id}/breakdown"]?.post,
       ).toBeDefined();
+    });
+
+    it("exposes planner actions in the runtime agent manifest", async () => {
+      const appWithProjects = createApp(
+        new TodoService(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        createProjectServiceMock(),
+        true,
+      );
+
+      const response = await request(appWithProjects)
+        .get("/agent/manifest")
+        .expect(200);
+
+      const actionNames = response.body.data.manifest.actions.map(
+        (action: { name: string }) => action.name,
+      );
+      expect(actionNames).toEqual(
+        expect.arrayContaining([
+          "plan_project",
+          "ensure_next_action",
+          "weekly_review",
+        ]),
+      );
     });
   });
 

--- a/src/interfaces/IPlannerService.ts
+++ b/src/interfaces/IPlannerService.ts
@@ -1,0 +1,18 @@
+import type {
+  EnsureNextActionInput,
+  EnsureNextActionResult,
+  PlanProjectInput,
+  PlanProjectResult,
+  WeeklyReviewInput,
+  WeeklyReviewResult,
+} from "../types/plannerTypes";
+
+export type { PlannerMode, PlannerTaskSuggestion } from "../types/plannerTypes";
+
+export interface IPlannerService {
+  planProject(input: PlanProjectInput): Promise<PlanProjectResult | null>;
+  ensureNextAction(
+    input: EnsureNextActionInput,
+  ): Promise<EnsureNextActionResult | null>;
+  weeklyReview(input: WeeklyReviewInput): Promise<WeeklyReviewResult>;
+}

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -51,6 +51,10 @@ function requiredScopesForAction(actionName: AgentActionName): McpScope[] {
       return [PROJECT_READ_SCOPE];
     case "list_projects_without_next_action":
       return [PROJECT_READ_SCOPE, TASK_READ_SCOPE];
+    case "plan_project":
+    case "ensure_next_action":
+    case "weekly_review":
+      return [PROJECT_READ_SCOPE, TASK_READ_SCOPE, TASK_WRITE_SCOPE];
     case "create_project":
     case "update_project":
     case "rename_project":

--- a/src/mcpRouter.test.ts
+++ b/src/mcpRouter.test.ts
@@ -408,6 +408,9 @@ describe("Remote MCP router auth and scopes", () => {
         "list_stale_tasks",
         "list_projects_without_next_action",
         "review_projects",
+        "plan_project",
+        "ensure_next_action",
+        "weekly_review",
         "rename_project",
       ]),
     );
@@ -420,6 +423,15 @@ describe("Remote MCP router auth and scopes", () => {
         type: "string",
       }),
     );
+
+    const ensureNextActionTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "ensure_next_action",
+    );
+    expect(ensureNextActionTool.auth.requiredScopes).toEqual([
+      "projects.read",
+      "tasks.read",
+      "tasks.write",
+    ]);
   });
 
   it("rejects write tools when write scope is missing", async () => {
@@ -571,6 +583,50 @@ describe("Remote MCP router auth and scopes", () => {
     expect(response.body.result.isError).toBeUndefined();
     expect(response.body.result.structuredContent.data.task.category).toBe(
       "Ops",
+    );
+  });
+
+  it("creates a next action through the planner MCP tool", async () => {
+    currentSession = buildMcpSession("user-1", [
+      "projects.read",
+      "tasks.read",
+      "tasks.write",
+    ]);
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000051",
+      name: "Ops",
+      status: "active",
+      archived: false,
+      userId: "user-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    });
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer planner-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 10,
+        method: "tools/call",
+        params: {
+          name: "ensure_next_action",
+          arguments: {
+            projectId: "00000000-0000-1000-8000-000000000051",
+            mode: "apply",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(response.body.result.isError).toBeUndefined();
+    expect(response.body.result.structuredContent.data.result.created).toBe(
+      true,
+    );
+    expect(response.body.result.structuredContent.data.result.task.status).toBe(
+      "next",
     );
   });
 });

--- a/src/plannerHeuristics.test.ts
+++ b/src/plannerHeuristics.test.ts
@@ -1,0 +1,171 @@
+import type { Project, Todo } from "./types";
+import {
+  buildProjectPlan,
+  deriveNextAction,
+  findExistingNextAction,
+  findWeeklyReviewFindings,
+  projectHasNextAction,
+} from "./services/plannerHeuristics";
+
+const USER_ID = "user-1";
+
+function makeProject(
+  id: string,
+  name: string,
+  overrides: Partial<Project> = {},
+): Project {
+  return {
+    id,
+    name,
+    status: "active",
+    archived: false,
+    userId: USER_ID,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    taskCount: 0,
+    openTaskCount: 0,
+    completedTaskCount: 0,
+    todoCount: 0,
+    openTodoCount: 0,
+    ...overrides,
+  };
+}
+
+function makeTask(
+  id: string,
+  title: string,
+  overrides: Partial<Todo> = {},
+): Todo {
+  return {
+    id,
+    title,
+    status: "next",
+    completed: false,
+    tags: [],
+    dependsOnTaskIds: [],
+    order: 0,
+    priority: "medium",
+    archived: false,
+    recurrence: { type: "none" },
+    userId: USER_ID,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    subtasks: [],
+    ...overrides,
+  };
+}
+
+describe("plannerHeuristics", () => {
+  it("builds deterministic project plan suggestions and skips duplicate titles", () => {
+    const project = makeProject("project-1", "Vacation", {
+      goal: "Plan anniversary vacation",
+    });
+    const existing = makeTask(
+      "task-1",
+      "Define success criteria for Plan anniversary vacation",
+      {
+        projectId: project.id,
+        category: project.name,
+      },
+    );
+
+    const suggestions = buildProjectPlan({
+      project,
+      tasks: [existing],
+      goal: "Plan anniversary vacation",
+      constraints: ["Stay under budget", "Travel in June"],
+    });
+
+    expect(suggestions).toHaveLength(4);
+    expect(suggestions[0].title).toBe(
+      "Gather inputs and constraints for Plan anniversary vacation",
+    );
+    expect(suggestions.every((task) => task.reason.length > 0)).toBe(true);
+    expect(
+      suggestions.some((task) =>
+        String(task.description).includes("Stay under budget"),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects and returns the highest-priority existing next action", () => {
+    const tasks = [
+      makeTask("task-1", "In progress item", { status: "in_progress" }),
+      makeTask("task-2", "High-priority next action", {
+        status: "next",
+        priority: "high",
+      }),
+      makeTask("task-3", "Archived next action", {
+        status: "next",
+        archived: true,
+      }),
+    ];
+
+    expect(projectHasNextAction(tasks)).toBe(true);
+    expect(findExistingNextAction(tasks)?.id).toBe("task-2");
+  });
+
+  it("derives a follow-up next action from waiting work", () => {
+    const project = makeProject("project-1", "Platform");
+    const tasks = [
+      makeTask("task-1", "Await vendor quote", {
+        projectId: project.id,
+        category: project.name,
+        status: "waiting",
+        waitingOn: "vendor quote",
+      }),
+    ];
+
+    const suggestion = deriveNextAction(project, tasks);
+
+    expect(suggestion).not.toBeNull();
+    expect(suggestion?.title).toBe("Follow up on vendor quote");
+    expect(suggestion?.status).toBe("next");
+  });
+
+  it("classifies weekly review findings and recommends safe follow-up actions", () => {
+    const now = new Date("2026-03-12T12:00:00.000Z");
+    const emptyProject = makeProject("project-1", "Admin");
+    const blockedProject = makeProject("project-2", "Launch");
+    const waitingTask = makeTask("task-1", "Await legal approval", {
+      projectId: blockedProject.id,
+      category: blockedProject.name,
+      status: "waiting",
+      waitingOn: "legal approval",
+      updatedAt: new Date("2026-01-01T12:00:00.000Z"),
+      dueDate: new Date("2026-03-14T12:00:00.000Z"),
+    });
+
+    const review = findWeeklyReviewFindings({
+      projects: [emptyProject, blockedProject],
+      tasks: [waitingTask],
+      now,
+      includeArchived: false,
+      staleTaskDays: 30,
+      upcomingDays: 7,
+    });
+
+    expect(review.summary).toEqual({
+      projectsWithoutNextAction: 1,
+      staleTasks: 1,
+      waitingTasks: 1,
+      upcomingTasks: 1,
+    });
+    expect(review.findings.map((finding) => finding.type)).toEqual(
+      expect.arrayContaining([
+        "empty_active_project",
+        "missing_next_action",
+        "stale_task",
+        "waiting_task",
+        "upcoming_deadline",
+      ]),
+    );
+    expect(review.recommendedActions.map((action) => action.type)).toEqual(
+      expect.arrayContaining([
+        "create_next_action",
+        "review_stale_task",
+        "follow_up_waiting_task",
+      ]),
+    );
+  });
+});

--- a/src/plannerService.test.ts
+++ b/src/plannerService.test.ts
@@ -1,0 +1,245 @@
+import type { IProjectService } from "./interfaces/IProjectService";
+import { PlannerService } from "./services/plannerService";
+import { TodoService } from "./services/todoService";
+import type {
+  CreateProjectDto,
+  Project,
+  ProjectTaskDisposition,
+  UpdateProjectDto,
+} from "./types";
+
+const USER_ID = "user-1";
+
+function makeProject(
+  id: string,
+  name: string,
+  overrides: Partial<Project> = {},
+): Project {
+  return {
+    id,
+    name,
+    status: "active",
+    archived: false,
+    userId: USER_ID,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    taskCount: 0,
+    openTaskCount: 0,
+    completedTaskCount: 0,
+    todoCount: 0,
+    openTodoCount: 0,
+    ...overrides,
+  };
+}
+
+function createProjectServiceMock(
+  projects: Project[],
+): jest.Mocked<IProjectService> {
+  return {
+    findAll: jest
+      .fn<Promise<Project[]>, [string]>()
+      .mockImplementation(async () => projects),
+    findById: jest
+      .fn<Promise<Project | null>, [string, string]>()
+      .mockImplementation(
+        async (_userId, projectId) =>
+          projects.find((project) => project.id === projectId) ?? null,
+      ),
+    create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
+    update: jest.fn<
+      Promise<Project | null>,
+      [string, string, UpdateProjectDto]
+    >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
+    delete: jest.fn<
+      Promise<boolean>,
+      [string, string, ProjectTaskDisposition, (string | null)?]
+    >(),
+  };
+}
+
+describe("PlannerService", () => {
+  it("returns project planning suggestions in suggest mode", async () => {
+    const todoService = new TodoService();
+    const project = makeProject("project-1", "Vacation", {
+      goal: "Plan anniversary vacation",
+    });
+    const plannerService = new PlannerService({
+      todoService,
+      projectService: createProjectServiceMock([project]),
+    });
+
+    await todoService.create(USER_ID, {
+      title: "Define success criteria for Plan anniversary vacation",
+      projectId: project.id,
+      category: project.name,
+    });
+
+    const result = await plannerService.planProject({
+      userId: USER_ID,
+      projectId: project.id,
+      goal: "Plan anniversary vacation",
+      mode: "suggest",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.project).toEqual({
+      id: project.id,
+      name: project.name,
+    });
+    expect(result?.createdTaskIds).toEqual([]);
+    expect(result?.suggestedTasks).toHaveLength(4);
+  });
+
+  it("creates missing plan tasks in apply mode", async () => {
+    const todoService = new TodoService();
+    const project = makeProject("project-1", "Launch");
+    const plannerService = new PlannerService({
+      todoService,
+      projectService: createProjectServiceMock([project]),
+    });
+
+    const result = await plannerService.planProject({
+      userId: USER_ID,
+      projectId: project.id,
+      goal: "Launch customer beta",
+      mode: "apply",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.createdTaskIds.length).toBeGreaterThan(0);
+
+    const createdTasks = await todoService.findAll(USER_ID, {
+      archived: false,
+      projectId: project.id,
+    });
+    expect(createdTasks).toHaveLength(result?.createdTaskIds.length || 0);
+  });
+
+  it("returns an existing next action when one already exists", async () => {
+    const todoService = new TodoService();
+    const project = makeProject("project-1", "Platform");
+    const plannerService = new PlannerService({
+      todoService,
+      projectService: createProjectServiceMock([project]),
+    });
+    const existingTask = await todoService.create(USER_ID, {
+      title: "Ship changelog",
+      projectId: project.id,
+      category: project.name,
+      status: "next",
+    });
+
+    const result = await plannerService.ensureNextAction({
+      userId: USER_ID,
+      projectId: project.id,
+      mode: "apply",
+    });
+
+    expect(result).toEqual({
+      projectId: project.id,
+      hasNextAction: true,
+      created: false,
+      task: {
+        id: existingTask.id,
+        title: existingTask.title,
+        status: "next",
+      },
+      reason: "The project already has an actionable next step.",
+    });
+  });
+
+  it("creates a concrete next action when none exists", async () => {
+    const todoService = new TodoService();
+    const project = makeProject("project-1", "Ops");
+    const plannerService = new PlannerService({
+      todoService,
+      projectService: createProjectServiceMock([project]),
+    });
+
+    await todoService.create(USER_ID, {
+      title: "Await vendor quote",
+      projectId: project.id,
+      category: project.name,
+      status: "waiting",
+      waitingOn: "vendor quote",
+    });
+
+    const result = await plannerService.ensureNextAction({
+      userId: USER_ID,
+      projectId: project.id,
+      mode: "apply",
+    });
+
+    expect(result?.created).toBe(true);
+    expect(result?.hasNextAction).toBe(true);
+    expect(result?.task?.id).toBeDefined();
+    expect(result?.task?.title).toBe("Follow up on vendor quote");
+
+    const tasks = await todoService.findAll(USER_ID, {
+      archived: false,
+      projectId: project.id,
+    });
+    expect(tasks.map((task) => task.title)).toEqual(
+      expect.arrayContaining(["Follow up on vendor quote"]),
+    );
+  });
+
+  it("returns expected weekly review categories and can apply next-action fixes", async () => {
+    const todoService = new TodoService();
+    const emptyProject = makeProject("project-1", "Admin");
+    const blockedProject = makeProject("project-2", "Launch");
+    const plannerService = new PlannerService({
+      todoService,
+      projectService: createProjectServiceMock([emptyProject, blockedProject]),
+    });
+
+    const waitingTask = await todoService.create(USER_ID, {
+      title: "Await legal approval",
+      projectId: blockedProject.id,
+      category: blockedProject.name,
+      status: "waiting",
+      waitingOn: "legal approval",
+      dueDate: new Date("2026-03-14T12:00:00.000Z"),
+    });
+    waitingTask.updatedAt = new Date("2026-01-01T12:00:00.000Z");
+
+    const suggested = await plannerService.weeklyReview({
+      userId: USER_ID,
+      mode: "suggest",
+      includeArchived: false,
+    });
+
+    expect(suggested.summary).toEqual({
+      projectsWithoutNextAction: 1,
+      staleTasks: 1,
+      waitingTasks: 1,
+      upcomingTasks: 1,
+    });
+    expect(suggested.findings.map((finding) => finding.type)).toEqual(
+      expect.arrayContaining([
+        "empty_active_project",
+        "missing_next_action",
+        "stale_task",
+        "waiting_task",
+        "upcoming_deadline",
+      ]),
+    );
+
+    const applied = await plannerService.weeklyReview({
+      userId: USER_ID,
+      mode: "apply",
+      includeArchived: false,
+    });
+
+    expect(applied.appliedActions.map((action) => action.type)).toContain(
+      "create_next_action",
+    );
+    const tasks = await todoService.findAll(USER_ID, { archived: false });
+    expect(
+      tasks.some(
+        (task) => task.status === "next" && task.projectId === emptyProject.id,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -175,6 +175,18 @@ export function createAgentRouter({
     "/write/archive_project",
     createAgentActionHandler(agentExecutor, "archive_project"),
   );
+  router.post(
+    "/write/plan_project",
+    createAgentActionHandler(agentExecutor, "plan_project"),
+  );
+  router.post(
+    "/write/ensure_next_action",
+    createAgentActionHandler(agentExecutor, "ensure_next_action"),
+  );
+  router.post(
+    "/write/weekly_review",
+    createAgentActionHandler(agentExecutor, "weekly_review"),
+  );
 
   return router;
 }

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -1,5 +1,7 @@
 import { IProjectService } from "../interfaces/IProjectService";
+import { IPlannerService } from "../interfaces/IPlannerService";
 import { ITodoService } from "../interfaces/ITodoService";
+import { PlannerService } from "./plannerService";
 import {
   CreateProjectDto,
   CreateSubtaskDto,
@@ -13,14 +15,31 @@ import {
   UpdateSubtaskDto,
   UpdateTodoDto,
 } from "../types";
+import {
+  EnsureNextActionResult,
+  PlanProjectResult,
+  WeeklyReviewResult,
+} from "../types/plannerTypes";
 
 interface AgentServiceDeps {
   todoService: ITodoService;
   projectService?: IProjectService;
+  plannerService?: IPlannerService;
 }
 
 export class AgentService {
-  constructor(private readonly deps: AgentServiceDeps) {}
+  private readonly plannerService?: IPlannerService;
+
+  constructor(private readonly deps: AgentServiceDeps) {
+    this.plannerService =
+      deps.plannerService ||
+      (deps.projectService
+        ? new PlannerService({
+            todoService: deps.todoService,
+            projectService: deps.projectService,
+          })
+        : undefined);
+  }
 
   private startOfDay(date: Date): Date {
     return new Date(
@@ -408,6 +427,61 @@ export class AgentService {
         nextReview.getDate() + cadenceDays[project.reviewCadence],
       );
       return nextReview <= now;
+    });
+  }
+
+  async planProjectForUser(
+    userId: string,
+    input: {
+      projectId: string;
+      goal?: string | null;
+      constraints?: string[];
+      mode?: "suggest" | "apply";
+    },
+  ): Promise<PlanProjectResult | null> {
+    if (!this.plannerService) {
+      throw new Error("Projects not configured");
+    }
+    return this.plannerService.planProject({
+      userId,
+      projectId: input.projectId,
+      goal: input.goal,
+      constraints: input.constraints,
+      mode: input.mode,
+    });
+  }
+
+  async ensureNextActionForUser(
+    userId: string,
+    input: {
+      projectId: string;
+      mode?: "suggest" | "apply";
+    },
+  ): Promise<EnsureNextActionResult | null> {
+    if (!this.plannerService) {
+      throw new Error("Projects not configured");
+    }
+    return this.plannerService.ensureNextAction({
+      userId,
+      projectId: input.projectId,
+      mode: input.mode,
+    });
+  }
+
+  async weeklyReviewForUser(
+    userId: string,
+    input: {
+      mode?: "suggest" | "apply";
+      includeArchived?: boolean;
+    },
+  ): Promise<WeeklyReviewResult> {
+    if (!this.plannerService) {
+      throw new Error("Projects not configured");
+    }
+    return this.plannerService.weeklyReview({
+      userId,
+      mode: input.mode,
+      includeArchived: input.includeArchived,
     });
   }
 }

--- a/src/services/plannerHeuristics.ts
+++ b/src/services/plannerHeuristics.ts
@@ -1,0 +1,342 @@
+import type { Project, Todo } from "../types";
+import type {
+  PlannerTaskSuggestion,
+  WeeklyReviewAction,
+  WeeklyReviewFinding,
+} from "../types/plannerTypes";
+
+function normalizeTitle(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function priorityRank(
+  priority?: Project["priority"] | Todo["priority"] | null,
+) {
+  switch (priority) {
+    case "urgent":
+      return 0;
+    case "high":
+      return 1;
+    case "medium":
+      return 2;
+    case "low":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function isOpenTask(task: Todo): boolean {
+  return !task.archived && !task.completed;
+}
+
+function includesProjectTask(project: Project, task: Todo): boolean {
+  return task.projectId === project.id || task.category === project.name;
+}
+
+function buildConstraintSentence(constraints: string[]): string {
+  if (!constraints.length) {
+    return "";
+  }
+  return ` Constraints: ${constraints.join("; ")}.`;
+}
+
+export function projectTasksForProject(
+  project: Project,
+  tasks: Todo[],
+): Todo[] {
+  return tasks.filter((task) => includesProjectTask(project, task));
+}
+
+export function projectHasNextAction(tasks: Todo[]): boolean {
+  return tasks.some(
+    (task) =>
+      isOpenTask(task) &&
+      (task.status === "next" || task.status === "in_progress"),
+  );
+}
+
+export function findExistingNextAction(tasks: Todo[]): Todo | null {
+  const candidates = tasks
+    .filter(
+      (task) =>
+        isOpenTask(task) &&
+        (task.status === "next" || task.status === "in_progress"),
+    )
+    .sort((left, right) => {
+      if (left.status !== right.status) {
+        return left.status === "next" ? -1 : 1;
+      }
+      if (priorityRank(left.priority) !== priorityRank(right.priority)) {
+        return priorityRank(left.priority) - priorityRank(right.priority);
+      }
+      if (left.dueDate && right.dueDate) {
+        return left.dueDate.getTime() - right.dueDate.getTime();
+      }
+      if (left.dueDate) return -1;
+      if (right.dueDate) return 1;
+      return left.order - right.order;
+    });
+
+  return candidates[0] || null;
+}
+
+export function buildProjectPlan(input: {
+  project: Project;
+  tasks: Todo[];
+  goal: string;
+  constraints: string[];
+}): PlannerTaskSuggestion[] {
+  const goalLabel = input.goal.trim() || input.project.name;
+  const constraintSentence = buildConstraintSentence(input.constraints);
+  const baseSuggestions: PlannerTaskSuggestion[] = [
+    {
+      title: `Define success criteria for ${goalLabel}`,
+      description: `Write down what done means, who it serves, and the non-negotiable outcomes.${constraintSentence}`,
+      priority: "high",
+      status: "next",
+      reason: "Clarifies the target before more work is added.",
+    },
+    {
+      title: `Gather inputs and constraints for ${goalLabel}`,
+      description: `Collect the facts, dependencies, and open questions needed to plan the project.${constraintSentence}`,
+      priority: "medium",
+      status: "next",
+      reason: "Prevents avoidable rework before decisions are made.",
+    },
+    {
+      title: `Decide the approach for ${input.project.name}`,
+      description:
+        "Choose the primary direction, tradeoffs, and decision owner so execution can move.",
+      priority: "high",
+      status: "next",
+      reason: "Creates a single decision point that unblocks execution.",
+    },
+    {
+      title: `Draft the first execution milestone for ${goalLabel}`,
+      description:
+        "Break the first milestone into a concrete deliverable with a clear owner and finish line.",
+      priority: "high",
+      status: "next",
+      reason: "Turns planning into the first actionable delivery step.",
+    },
+    {
+      title: `Review progress and capture follow-up for ${goalLabel}`,
+      description:
+        "Check what worked, what is blocked, and the next follow-up after the first milestone ships.",
+      priority: "medium",
+      status: "scheduled",
+      reason:
+        "Keeps the project reviewable instead of drifting after execution starts.",
+    },
+  ];
+
+  const existingTitles = new Set(
+    input.tasks
+      .filter((task) => !task.archived)
+      .map((task) => normalizeTitle(task.title)),
+  );
+
+  return baseSuggestions.filter(
+    (suggestion) => !existingTitles.has(normalizeTitle(suggestion.title)),
+  );
+}
+
+export function deriveNextAction(
+  project: Project,
+  tasks: Todo[],
+): PlannerTaskSuggestion | null {
+  const openTasks = tasks.filter(isOpenTask);
+  const waitingTask = openTasks.find(
+    (task) =>
+      task.status === "waiting" || Boolean(String(task.waitingOn || "").trim()),
+  );
+  if (waitingTask) {
+    const blocker = String(waitingTask.waitingOn || waitingTask.title).trim();
+    return {
+      title: `Follow up on ${blocker}`,
+      description: `Unblock ${project.name} by confirming the external dependency and deciding the next move.`,
+      priority: waitingTask.priority || "high",
+      status: "next",
+      reason:
+        "The project is blocked on a waiting item and needs an explicit follow-up.",
+    };
+  }
+
+  const oldestOpenTask = [...openTasks].sort(
+    (left, right) => left.updatedAt.getTime() - right.updatedAt.getTime(),
+  )[0];
+  if (oldestOpenTask) {
+    return {
+      title: `Review ${oldestOpenTask.title} and choose the next step`,
+      description: `Use the current project state to turn ${oldestOpenTask.title} into one concrete action for ${project.name}.`,
+      priority: oldestOpenTask.priority || "medium",
+      status: "next",
+      reason:
+        "The project has open work but nothing explicitly actionable right now.",
+    };
+  }
+
+  const goalLabel = project.goal || project.description || project.name;
+  return {
+    title: `Define the first concrete step for ${goalLabel}`,
+    description: `Capture the first action that would move ${project.name} forward this week.`,
+    priority: project.priority || "medium",
+    status: "next",
+    reason: "The project has no open tasks yet and needs a starting action.",
+  };
+}
+
+export function findWeeklyReviewFindings(input: {
+  projects: Project[];
+  tasks: Todo[];
+  now: Date;
+  includeArchived: boolean;
+  staleTaskDays: number;
+  upcomingDays: number;
+}): {
+  findings: WeeklyReviewFinding[];
+  recommendedActions: WeeklyReviewAction[];
+  summary: {
+    projectsWithoutNextAction: number;
+    staleTasks: number;
+    waitingTasks: number;
+    upcomingTasks: number;
+  };
+} {
+  const activeProjects = input.projects.filter((project) => {
+    if (input.includeArchived) {
+      return true;
+    }
+    return !project.archived && project.status !== "archived";
+  });
+  const activeTasks = input.tasks.filter(
+    (task) => !task.archived || input.includeArchived,
+  );
+  const openTasks = activeTasks.filter(isOpenTask);
+  const staleCutoff = new Date(input.now);
+  staleCutoff.setDate(staleCutoff.getDate() - input.staleTaskDays);
+  const upcomingCutoff = new Date(input.now);
+  upcomingCutoff.setDate(upcomingCutoff.getDate() + input.upcomingDays);
+
+  const findings: WeeklyReviewFinding[] = [];
+  const recommendedActions: WeeklyReviewAction[] = [];
+  let projectsWithoutNextAction = 0;
+
+  for (const project of activeProjects) {
+    const projectTasks = projectTasksForProject(project, activeTasks);
+    const openProjectTasks = projectTasks.filter(isOpenTask);
+
+    if (openProjectTasks.length === 0 && project.status === "active") {
+      findings.push({
+        type: "empty_active_project",
+        projectId: project.id,
+        projectName: project.name,
+        reason:
+          "This active project has no open tasks, so it cannot move forward without a starter action.",
+      });
+      const suggestion = deriveNextAction(project, projectTasks);
+      if (suggestion) {
+        recommendedActions.push({
+          type: "create_next_action",
+          projectId: project.id,
+          title: suggestion.title,
+          reason: suggestion.reason,
+        });
+      }
+      continue;
+    }
+
+    if (!projectHasNextAction(projectTasks)) {
+      projectsWithoutNextAction += 1;
+      findings.push({
+        type: "missing_next_action",
+        projectId: project.id,
+        projectName: project.name,
+        reason:
+          "The project has open work, but nothing is marked next or in progress.",
+      });
+      const suggestion = deriveNextAction(project, projectTasks);
+      if (suggestion) {
+        recommendedActions.push({
+          type: "create_next_action",
+          projectId: project.id,
+          title: suggestion.title,
+          reason: suggestion.reason,
+        });
+      }
+    }
+  }
+
+  const staleTasks = openTasks.filter((task) => task.updatedAt <= staleCutoff);
+  staleTasks.forEach((task) => {
+    findings.push({
+      type: "stale_task",
+      projectId: task.projectId || undefined,
+      taskId: task.id,
+      taskTitle: task.title,
+      reason: `This task has not been updated in at least ${input.staleTaskDays} days.`,
+    });
+    recommendedActions.push({
+      type: "review_stale_task",
+      projectId: task.projectId || undefined,
+      taskId: task.id,
+      title: `Review stale task: ${task.title}`,
+      reason: "Stale work should be clarified, rescheduled, or closed.",
+    });
+  });
+
+  const waitingTasks = openTasks.filter(
+    (task) =>
+      task.status === "waiting" || Boolean(String(task.waitingOn || "").trim()),
+  );
+  waitingTasks.forEach((task) => {
+    findings.push({
+      type: "waiting_task",
+      projectId: task.projectId || undefined,
+      taskId: task.id,
+      taskTitle: task.title,
+      reason:
+        "This task is waiting on an external dependency and needs follow-up.",
+    });
+    recommendedActions.push({
+      type: "follow_up_waiting_task",
+      projectId: task.projectId || undefined,
+      taskId: task.id,
+      title: `Follow up on ${String(task.waitingOn || task.title).trim()}`,
+      reason: "Waiting tasks only move when someone explicitly follows up.",
+    });
+  });
+
+  const upcomingTasks = openTasks.filter((task) => {
+    const dueMatch =
+      !!task.dueDate &&
+      task.dueDate >= input.now &&
+      task.dueDate <= upcomingCutoff;
+    const scheduledMatch =
+      !!task.scheduledDate &&
+      task.scheduledDate >= input.now &&
+      task.scheduledDate <= upcomingCutoff;
+    return dueMatch || scheduledMatch;
+  });
+  upcomingTasks.forEach((task) => {
+    findings.push({
+      type: "upcoming_deadline",
+      projectId: task.projectId || undefined,
+      taskId: task.id,
+      taskTitle: task.title,
+      reason: `This task is due or scheduled within the next ${input.upcomingDays} days.`,
+    });
+  });
+
+  return {
+    findings,
+    recommendedActions,
+    summary: {
+      projectsWithoutNextAction,
+      staleTasks: staleTasks.length,
+      waitingTasks: waitingTasks.length,
+      upcomingTasks: upcomingTasks.length,
+    },
+  };
+}

--- a/src/services/plannerService.ts
+++ b/src/services/plannerService.ts
@@ -1,0 +1,254 @@
+import type { IPlannerService } from "../interfaces/IPlannerService";
+import type { IProjectService } from "../interfaces/IProjectService";
+import type { ITodoService } from "../interfaces/ITodoService";
+import type {
+  EnsureNextActionInput,
+  EnsureNextActionResult,
+  PlanProjectInput,
+  PlanProjectResult,
+  WeeklyReviewAction,
+  WeeklyReviewInput,
+  WeeklyReviewResult,
+} from "../types/plannerTypes";
+import {
+  buildProjectPlan,
+  deriveNextAction,
+  findExistingNextAction,
+  findWeeklyReviewFindings,
+  projectTasksForProject,
+} from "./plannerHeuristics";
+
+interface PlannerServiceDeps {
+  projectService?: IProjectService;
+  todoService: ITodoService;
+}
+
+export class PlannerService implements IPlannerService {
+  constructor(private readonly deps: PlannerServiceDeps) {}
+
+  private getProjectService(): IProjectService {
+    if (!this.deps.projectService) {
+      throw new Error("Projects not configured");
+    }
+    return this.deps.projectService;
+  }
+
+  private async loadProjectContext(userId: string, projectId: string) {
+    const projectService = this.getProjectService();
+    const project = await projectService.findById(userId, projectId);
+    if (!project) {
+      return null;
+    }
+    const tasks = await this.deps.todoService.findAll(userId, {
+      archived: false,
+    });
+    return {
+      project,
+      tasks,
+      projectTasks: projectTasksForProject(project, tasks),
+    };
+  }
+
+  async planProject(
+    input: PlanProjectInput,
+  ): Promise<PlanProjectResult | null> {
+    const mode = input.mode || "suggest";
+    const context = await this.loadProjectContext(
+      input.userId,
+      input.projectId,
+    );
+    if (!context) {
+      return null;
+    }
+
+    const goal =
+      String(
+        input.goal ||
+          context.project.goal ||
+          context.project.description ||
+          context.project.name,
+      ).trim() || context.project.name;
+    const suggestedTasks = buildProjectPlan({
+      project: context.project,
+      tasks: context.projectTasks,
+      goal,
+      constraints: input.constraints || [],
+    });
+
+    if (mode !== "apply") {
+      return {
+        project: {
+          id: context.project.id,
+          name: context.project.name,
+        },
+        summary: suggestedTasks.length
+          ? `Generated ${suggestedTasks.length} planning steps for ${context.project.name}.`
+          : `No additional planning steps are needed for ${context.project.name}.`,
+        suggestedTasks,
+        createdTaskIds: [],
+      };
+    }
+
+    const createdTaskIds: string[] = [];
+    for (const suggestion of suggestedTasks) {
+      const createdTask = await this.deps.todoService.create(input.userId, {
+        title: suggestion.title,
+        description: suggestion.description ?? null,
+        projectId: context.project.id,
+        status: suggestion.status ?? "next",
+        priority: suggestion.priority ?? "medium",
+      });
+      createdTaskIds.push(createdTask.id);
+    }
+
+    return {
+      project: {
+        id: context.project.id,
+        name: context.project.name,
+      },
+      summary: createdTaskIds.length
+        ? `Created ${createdTaskIds.length} planning tasks for ${context.project.name}.`
+        : `No new planning tasks were needed for ${context.project.name}.`,
+      suggestedTasks,
+      createdTaskIds,
+    };
+  }
+
+  async ensureNextAction(
+    input: EnsureNextActionInput,
+  ): Promise<EnsureNextActionResult | null> {
+    const mode = input.mode || "suggest";
+    const context = await this.loadProjectContext(
+      input.userId,
+      input.projectId,
+    );
+    if (!context) {
+      return null;
+    }
+
+    const existing = findExistingNextAction(context.projectTasks);
+    if (existing) {
+      return {
+        projectId: context.project.id,
+        hasNextAction: true,
+        created: false,
+        task: {
+          id: existing.id,
+          title: existing.title,
+          status: existing.status === "in_progress" ? "in_progress" : "next",
+        },
+        reason: "The project already has an actionable next step.",
+      };
+    }
+
+    const suggestion = deriveNextAction(context.project, context.projectTasks);
+    if (!suggestion) {
+      return {
+        projectId: context.project.id,
+        hasNextAction: false,
+        created: false,
+        task: null,
+        reason:
+          "No concrete next action could be derived from the current project state.",
+      };
+    }
+
+    if (mode !== "apply") {
+      return {
+        projectId: context.project.id,
+        hasNextAction: false,
+        created: false,
+        task: {
+          id: null,
+          title: suggestion.title,
+          status: "next",
+        },
+        reason: suggestion.reason,
+      };
+    }
+
+    const createdTask = await this.deps.todoService.create(input.userId, {
+      title: suggestion.title,
+      description: suggestion.description ?? null,
+      projectId: context.project.id,
+      status: suggestion.status ?? "next",
+      priority: suggestion.priority ?? "medium",
+    });
+
+    return {
+      projectId: context.project.id,
+      hasNextAction: true,
+      created: true,
+      task: {
+        id: createdTask.id,
+        title: createdTask.title,
+        status: createdTask.status === "in_progress" ? "in_progress" : "next",
+      },
+      reason: suggestion.reason,
+    };
+  }
+
+  async weeklyReview(input: WeeklyReviewInput): Promise<WeeklyReviewResult> {
+    const mode = input.mode || "suggest";
+    const includeArchived = input.includeArchived === true;
+    const projectService = this.getProjectService();
+    const [projects, activeTasks, archivedTasks] = await Promise.all([
+      projectService.findAll(input.userId),
+      this.deps.todoService.findAll(input.userId, {
+        archived: false,
+      }),
+      includeArchived
+        ? this.deps.todoService.findAll(input.userId, {
+            archived: true,
+          })
+        : Promise.resolve([]),
+    ]);
+    const tasks = includeArchived
+      ? [...activeTasks, ...archivedTasks]
+      : activeTasks;
+
+    const base = findWeeklyReviewFindings({
+      projects,
+      tasks,
+      now: new Date(),
+      includeArchived,
+      staleTaskDays: 30,
+      upcomingDays: 7,
+    });
+
+    if (mode !== "apply") {
+      return {
+        summary: base.summary,
+        findings: base.findings,
+        recommendedActions: base.recommendedActions,
+        appliedActions: [],
+      };
+    }
+
+    const appliedActions: WeeklyReviewAction[] = [];
+    for (const action of base.recommendedActions) {
+      if (action.type !== "create_next_action" || !action.projectId) {
+        continue;
+      }
+      const ensured = await this.ensureNextAction({
+        userId: input.userId,
+        projectId: action.projectId,
+        mode: "apply",
+      });
+      if (!ensured?.created || !ensured.task?.id) {
+        continue;
+      }
+      appliedActions.push({
+        ...action,
+        createdTaskId: ensured.task.id,
+      });
+    }
+
+    return {
+      summary: base.summary,
+      findings: base.findings,
+      recommendedActions: base.recommendedActions,
+      appliedActions,
+    };
+  }
+}

--- a/src/types/plannerTypes.ts
+++ b/src/types/plannerTypes.ts
@@ -1,0 +1,104 @@
+import type { Priority, Project, TaskStatus } from "../types";
+
+export type PlannerMode = "suggest" | "apply";
+
+export type PlannerTaskStatus =
+  | "next"
+  | "in_progress"
+  | "waiting"
+  | "scheduled"
+  | "someday";
+
+export type PlannerRecommendationType =
+  | "create_next_action"
+  | "review_stale_task"
+  | "follow_up_waiting_task"
+  | "plan_project";
+
+export type PlannerFindingType =
+  | "missing_next_action"
+  | "stale_task"
+  | "waiting_task"
+  | "upcoming_deadline"
+  | "empty_active_project";
+
+export interface PlannerTaskSuggestion {
+  title: string;
+  description?: string | null;
+  priority?: Priority | null;
+  status?: PlannerTaskStatus;
+  reason: string;
+}
+
+export interface PlanProjectInput {
+  userId: string;
+  projectId: string;
+  goal?: string | null;
+  constraints?: string[];
+  mode?: PlannerMode;
+}
+
+export interface PlanProjectResult {
+  project: Pick<Project, "id" | "name">;
+  summary: string;
+  suggestedTasks: PlannerTaskSuggestion[];
+  createdTaskIds: string[];
+}
+
+export interface EnsureNextActionInput {
+  userId: string;
+  projectId: string;
+  mode?: PlannerMode;
+}
+
+export interface PlannerTaskReference {
+  id: string | null;
+  title: string;
+  status: Extract<TaskStatus, "next" | "in_progress">;
+}
+
+export interface EnsureNextActionResult {
+  projectId: string;
+  hasNextAction: boolean;
+  created: boolean;
+  task: PlannerTaskReference | null;
+  reason: string;
+}
+
+export interface WeeklyReviewInput {
+  userId: string;
+  mode?: PlannerMode;
+  includeArchived?: boolean;
+}
+
+export interface WeeklyReviewSummary {
+  projectsWithoutNextAction: number;
+  staleTasks: number;
+  waitingTasks: number;
+  upcomingTasks: number;
+}
+
+export interface WeeklyReviewFinding {
+  type: PlannerFindingType;
+  projectId?: string;
+  projectName?: string;
+  taskId?: string;
+  taskTitle?: string;
+  reason: string;
+}
+
+export interface WeeklyReviewAction {
+  type: PlannerRecommendationType;
+  projectId?: string;
+  taskId?: string;
+  title: string;
+  reason: string;
+  createdTaskId?: string;
+}
+
+export interface WeeklyReviewResult {
+  summary: WeeklyReviewSummary;
+  findings: WeeklyReviewFinding[];
+  recommendedActions: WeeklyReviewAction[];
+  appliedActions: WeeklyReviewAction[];
+}

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -14,6 +14,7 @@ import {
   UpdateSubtaskDto,
   UpdateTodoDto,
 } from "../types";
+import { PlannerMode } from "../types/plannerTypes";
 import {
   ValidationError,
   validateCreateProject,
@@ -157,6 +158,9 @@ const LIST_UPCOMING_KEYS = ["days", "includeScheduled", "includeDue"];
 const LIST_STALE_TASK_KEYS = ["daysSinceUpdate", "completed"];
 const LIST_PROJECTS_WITHOUT_NEXT_ACTION_KEYS = ["includeOnHold"];
 const REVIEW_PROJECTS_KEYS = ["dueForReviewOnly"];
+const PLAN_PROJECT_KEYS = ["projectId", "goal", "constraints", "mode"];
+const ENSURE_NEXT_ACTION_KEYS = ["projectId", "mode"];
+const WEEKLY_REVIEW_KEYS = ["mode", "includeArchived"];
 
 function ensureObject(data: unknown, label: string): Record<string, unknown> {
   if (data === undefined || data === null) {
@@ -384,6 +388,20 @@ function parseOptionalSortOrder(value: unknown): SortOrder | undefined {
     throw new ValidationError("sortOrder must be asc or desc");
   }
   return sortOrder;
+}
+
+function parseOptionalPlannerMode(value: unknown): PlannerMode | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new ValidationError('mode must be "suggest" or "apply"');
+  }
+  const mode = value.toLowerCase() as PlannerMode;
+  if (mode !== "suggest" && mode !== "apply") {
+    throw new ValidationError('mode must be "suggest" or "apply"');
+  }
+  return mode;
 }
 
 function parseId(body: Record<string, unknown>): string {
@@ -931,5 +949,59 @@ export function validateAgentReviewProjectsInput(data: unknown): {
   return {
     dueForReviewOnly:
       parseOptionalBoolean(body.dueForReviewOnly, "dueForReviewOnly") ?? true,
+  };
+}
+
+export function validateAgentPlanProjectInput(data: unknown): {
+  projectId: string;
+  goal?: string | null;
+  constraints?: string[];
+  mode: PlannerMode;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, PLAN_PROJECT_KEYS, "Agent action input");
+
+  const goal =
+    body.goal === undefined || body.goal === null
+      ? body.goal === null
+        ? null
+        : undefined
+      : parseOptionalString(body.goal, "goal", 200);
+
+  return {
+    projectId: parseRequiredId(body, "projectId"),
+    goal,
+    constraints: parseOptionalStringList(
+      body.constraints,
+      "constraints",
+      20,
+      200,
+    ),
+    mode: parseOptionalPlannerMode(body.mode) ?? "suggest",
+  };
+}
+
+export function validateAgentEnsureNextActionInput(data: unknown): {
+  projectId: string;
+  mode: PlannerMode;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, ENSURE_NEXT_ACTION_KEYS, "Agent action input");
+  return {
+    projectId: parseRequiredId(body, "projectId"),
+    mode: parseOptionalPlannerMode(body.mode) ?? "suggest",
+  };
+}
+
+export function validateAgentWeeklyReviewInput(data: unknown): {
+  mode: PlannerMode;
+  includeArchived: boolean;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, WEEKLY_REVIEW_KEYS, "Agent action input");
+  return {
+    mode: parseOptionalPlannerMode(body.mode) ?? "suggest",
+    includeArchived:
+      parseOptionalBoolean(body.includeArchived, "includeArchived") ?? false,
   };
 }


### PR DESCRIPTION
## Why
Add a planner layer above the existing todo/project services so MCP and agent surfaces can produce structured recommendations and optionally apply safe task changes without bypassing current business logic.

## What changed
- added `PlannerService` plus pure planner heuristics for deterministic project planning, next-action generation, and weekly review findings
- added new planner actions end-to-end: `plan_project`, `ensure_next_action`, and `weekly_review`
- wired planner actions through agent validation, agent execution, agent routes, MCP tool registration, and the agent manifest
- added focused unit, route, MCP, and contract coverage for the new planner surface
- documented the planner tools in the existing agent/MCP docs

## Verification
- `npx prisma generate`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
