### PR TITLE
refactor(db): normalize todo domain ids to uuid

### DIFF
--- a/prisma/migrations/20260312143000_normalize_entity_ids_to_uuid/migration.sql
+++ b/prisma/migrations/20260312143000_normalize_entity_ids_to_uuid/migration.sql
@@ -1,0 +1,177 @@
+CREATE TABLE "_project_id_uuid_map" (
+  "old_id" TEXT PRIMARY KEY,
+  "new_id" UUID NOT NULL UNIQUE
+);
+
+INSERT INTO "_project_id_uuid_map" ("old_id", "new_id")
+SELECT
+  p."id",
+  CASE
+    WHEN p."id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      THEN p."id"::UUID
+    ELSE (
+      SUBSTRING(md5('legacy-project:' || p."id") FROM 1 FOR 8) || '-' ||
+      SUBSTRING(md5('legacy-project:' || p."id") FROM 9 FOR 4) || '-' ||
+      SUBSTRING(md5('legacy-project:' || p."id") FROM 13 FOR 4) || '-' ||
+      SUBSTRING(md5('legacy-project:' || p."id") FROM 17 FOR 4) || '-' ||
+      SUBSTRING(md5('legacy-project:' || p."id") FROM 21 FOR 12)
+    )::UUID
+  END
+FROM "projects" p;
+
+ALTER TABLE "headings"
+  DROP CONSTRAINT IF EXISTS "headings_project_id_fkey";
+
+ALTER TABLE "todos"
+  DROP CONSTRAINT IF EXISTS "todos_project_id_fkey",
+  DROP CONSTRAINT IF EXISTS "todos_heading_id_fkey";
+
+ALTER TABLE "subtasks"
+  DROP CONSTRAINT IF EXISTS "subtasks_todo_id_fkey";
+
+ALTER TABLE "ai_suggestion_applied_todos"
+  DROP CONSTRAINT IF EXISTS "ai_suggestion_applied_todos_todo_id_fkey";
+
+UPDATE "headings" h
+SET "project_id" = map."new_id"::TEXT
+FROM "_project_id_uuid_map" map
+WHERE h."project_id" = map."old_id";
+
+UPDATE "todos" t
+SET "project_id" = map."new_id"::TEXT
+FROM "_project_id_uuid_map" map
+WHERE t."project_id" = map."old_id";
+
+UPDATE "projects" p
+SET "id" = map."new_id"::TEXT
+FROM "_project_id_uuid_map" map
+WHERE p."id" = map."old_id";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "projects"
+    WHERE NOT ("id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization expected all projects.id values to be UUID-compatible after remapping';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "headings"
+    WHERE NOT ("id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization requires headings.id values to already be UUID-compatible';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "headings"
+    WHERE NOT ("project_id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization expected all headings.project_id values to be UUID-compatible after project remapping';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "todos"
+    WHERE NOT ("id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization requires todos.id values to already be UUID-compatible';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "todos"
+    WHERE "project_id" IS NOT NULL
+      AND BTRIM("project_id") <> ''
+      AND NOT ("project_id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization expected all todos.project_id values to be UUID-compatible after project remapping';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "todos"
+    WHERE "heading_id" IS NOT NULL
+      AND BTRIM("heading_id") <> ''
+      AND NOT ("heading_id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization requires todos.heading_id values to already be UUID-compatible';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "subtasks"
+    WHERE NOT ("id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization requires subtasks.id values to already be UUID-compatible';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "subtasks"
+    WHERE NOT ("todo_id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization requires subtasks.todo_id values to already be UUID-compatible';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "ai_suggestion_applied_todos"
+    WHERE NOT ("todo_id" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+  ) THEN
+    RAISE EXCEPTION 'UUID normalization requires ai_suggestion_applied_todos.todo_id values to already be UUID-compatible';
+  END IF;
+END $$;
+
+ALTER TABLE "projects"
+  ALTER COLUMN "id" TYPE UUID USING "id"::UUID;
+
+ALTER TABLE "headings"
+  ALTER COLUMN "id" TYPE UUID USING "id"::UUID,
+  ALTER COLUMN "project_id" TYPE UUID USING "project_id"::UUID;
+
+ALTER TABLE "todos"
+  ALTER COLUMN "id" TYPE UUID USING "id"::UUID,
+  ALTER COLUMN "project_id" TYPE UUID USING CASE
+    WHEN "project_id" IS NULL OR BTRIM("project_id") = '' THEN NULL
+    ELSE "project_id"::UUID
+  END,
+  ALTER COLUMN "heading_id" TYPE UUID USING CASE
+    WHEN "heading_id" IS NULL OR BTRIM("heading_id") = '' THEN NULL
+    ELSE "heading_id"::UUID
+  END;
+
+ALTER TABLE "subtasks"
+  ALTER COLUMN "id" TYPE UUID USING "id"::UUID,
+  ALTER COLUMN "todo_id" TYPE UUID USING "todo_id"::UUID;
+
+ALTER TABLE "ai_suggestion_applied_todos"
+  ALTER COLUMN "todo_id" TYPE UUID USING "todo_id"::UUID;
+
+ALTER TABLE "headings"
+  ADD CONSTRAINT "headings_project_id_fkey"
+  FOREIGN KEY ("project_id") REFERENCES "projects"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "todos"
+  ADD CONSTRAINT "todos_project_id_fkey"
+  FOREIGN KEY ("project_id") REFERENCES "projects"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "todos_heading_id_fkey"
+  FOREIGN KEY ("heading_id") REFERENCES "headings"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "subtasks"
+  ADD CONSTRAINT "subtasks_todo_id_fkey"
+  FOREIGN KEY ("todo_id") REFERENCES "todos"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ai_suggestion_applied_todos"
+  ADD CONSTRAINT "ai_suggestion_applied_todos_todo_id_fkey"
+  FOREIGN KEY ("todo_id") REFERENCES "todos"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+DROP TABLE "_project_id_uuid_map";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -126,7 +126,7 @@ model RefreshToken {
 }
 
 model Project {
-  id             String                @id @default(uuid())
+  id             String                @id @default(uuid()) @db.Uuid
   name           String                @db.VarChar(50)
   description    String?               @db.Text
   status         ProjectStatus         @default(active)
@@ -152,8 +152,8 @@ model Project {
 }
 
 model Heading {
-  id        String   @id @default(uuid())
-  projectId String   @map("project_id")
+  id        String   @id @default(uuid()) @db.Uuid
+  projectId String   @db.Uuid @map("project_id")
   name      String   @db.VarChar(100)
   sortOrder Int      @default(0) @map("sort_order")
   createdAt DateTime @default(now()) @map("created_at")
@@ -168,14 +168,14 @@ model Heading {
 }
 
 model Todo {
-  id                    String             @id @default(uuid())
+  id                    String             @id @default(uuid()) @db.Uuid
   title                 String             @db.VarChar(200)
   description           String?            @db.VarChar(1000)
   status                TodoStatus         @default(next)
   completed             Boolean            @default(false)
   category              String?            @db.VarChar(50)
-  projectId             String?            @map("project_id")
-  headingId             String?            @map("heading_id")
+  projectId             String?            @db.Uuid @map("project_id")
+  headingId             String?            @db.Uuid @map("heading_id")
   context               String?            @db.VarChar(100)
   energy                TodoEnergy?
   dueDate               DateTime?          @map("due_date")
@@ -221,12 +221,12 @@ model Todo {
 }
 
 model Subtask {
-  id          String   @id @default(uuid())
+  id          String   @id @default(uuid()) @db.Uuid
   title       String   @db.VarChar(200)
   completed   Boolean  @default(false)
   order       Int      @default(0)
   completedAt DateTime? @map("completed_at")
-  todoId      String   @map("todo_id")
+  todoId      String   @db.Uuid @map("todo_id")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
@@ -261,7 +261,7 @@ model AiSuggestion {
 model AiSuggestionAppliedTodo {
   id           String   @id @default(uuid())
   suggestionId String   @map("suggestion_id")
-  todoId       String   @map("todo_id")
+  todoId       String   @db.Uuid @map("todo_id")
   createdAt    DateTime @default(now()) @map("created_at")
 
   suggestion AiSuggestion @relation(fields: [suggestionId], references: [id], onDelete: Cascade)

--- a/src/aiValidation.test.ts
+++ b/src/aiValidation.test.ts
@@ -20,6 +20,15 @@ describe("AI validation", () => {
     ).toThrow(new ValidationError("todoId is required"));
   });
 
+  it("rejects non-UUID todoId for persisted decision-assist surfaces", () => {
+    expect(() =>
+      validateDecisionAssistLatestQuery({
+        surface: "task_drawer",
+        todoId: "todo-1",
+      }),
+    ).toThrow(new ValidationError("Invalid ID format"));
+  });
+
   it("accepts home_focus stub input with candidate alias payload", () => {
     const result = validateDecisionAssistStubInput({
       surface: "home_focus",

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -189,17 +189,18 @@ describe("Validation", () => {
       ).not.toThrow();
     });
 
-    it("should validate a valid CUID", () => {
-      expect(() => validateId("ck6h4g2xk000001l7f57x8m6f")).not.toThrow();
-    });
-
-    it("should validate a valid ULID", () => {
-      expect(() => validateId("01ARZ3NDEKTSV4RRFFQ69G5FAV")).not.toThrow();
-    });
-
     it("should throw error for non-UUID string", () => {
       expect(() => validateId("valid-id")).toThrow(ValidationError);
       expect(() => validateId("valid-id")).toThrow("Invalid ID format");
+    });
+
+    it("should reject legacy non-UUID ID formats", () => {
+      expect(() => validateId("ck6h4g2xk000001l7f57x8m6f")).toThrow(
+        ValidationError,
+      );
+      expect(() => validateId("01ARZ3NDEKTSV4RRFFQ69G5FAV")).toThrow(
+        ValidationError,
+      );
     });
 
     it("should throw error for empty ID", () => {

--- a/src/validation/aiValidation.ts
+++ b/src/validation/aiValidation.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from "./validation";
+import { ValidationError, validateId } from "./validation";
 import { Priority } from "../types";
 import {
   CritiqueTaskInput,
@@ -263,10 +263,9 @@ export function validateDecisionAssistLatestQuery(query: any): {
     if (typeof query.todoId !== "string" || query.todoId.trim().length === 0) {
       throw new ValidationError("todoId must be a non-empty string");
     }
-    if (query.todoId.trim().length > 120) {
-      throw new ValidationError("todoId cannot exceed 120 characters");
-    }
-    todoId = query.todoId.trim();
+    const normalizedTodoId = query.todoId.trim();
+    validateId(normalizedTodoId);
+    todoId = normalizedTodoId;
   }
 
   if (TODO_REQUIRED_DECISION_ASSIST_SURFACES.includes(surface) && !todoId) {

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -1257,14 +1257,7 @@ export function validateId(id: string): void {
   const normalized = id.trim();
   const uuidPattern =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-  const cuidPattern = /^c[a-z0-9]{24}$/;
-  const ulidPattern = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
-
-  if (
-    !uuidPattern.test(normalized) &&
-    !cuidPattern.test(normalized) &&
-    !ulidPattern.test(normalized)
-  ) {
+  if (!uuidPattern.test(normalized)) {
     throw new ValidationError("Invalid ID format");
   }
 }


### PR DESCRIPTION
## Why
Legacy project records still use hashed IDs while newer validation and contracts increasingly assume UUIDs. That mismatch is the main source of compatibility logic and leaves the database weaker than the API surface claims.

This PR tackles the UUID normalization first and defers the larger task/project lifecycle redesign to a later pass.

## What changed
- normalize persisted todo-domain IDs to native Postgres `UUID` columns in Prisma
- add a one-time migration that remaps legacy hashed `projects.id` values to deterministic UUIDs and rewrites dependent foreign keys
- tighten runtime ID validation to UUID-only
- tighten AI latest-query validation so persisted `todoId` values must be UUIDs
- add test coverage for the UUID-only validator behavior
- add migration preflight checks so unexpected legacy non-UUID task/heading/subtask IDs fail clearly instead of casting mid-migration

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

## Rollout
- run `npx prisma migrate deploy`
- no separate manual backfill is needed for legacy project IDs beyond applying the migration
- if any unexpected non-UUID `todos.id`, `headings.id`, or `subtasks.id` rows exist, the migration now aborts with a clear error
