### PR TITLE
fix(api): cast UUID todo locks in prisma service

### DIFF
--- a/src/services/prismaTodoService.ts
+++ b/src/services/prismaTodoService.ts
@@ -853,7 +853,7 @@ export class PrismaTodoService implements ITodoService {
         const todoRows = await tx.$queryRaw<Array<{ id: string }>>`
           SELECT "id"
           FROM "todos"
-          WHERE "id" = ${todoId} AND "user_id" = ${userId}
+          WHERE "id" = CAST(${todoId} AS UUID) AND "user_id" = ${userId}
           FOR UPDATE
         `;
 
@@ -898,7 +898,7 @@ export class PrismaTodoService implements ITodoService {
         const todoRows = await tx.$queryRaw<Array<{ id: string }>>`
           SELECT "id"
           FROM "todos"
-          WHERE "id" = ${todoId} AND "user_id" = ${userId}
+          WHERE "id" = CAST(${todoId} AS UUID) AND "user_id" = ${userId}
           FOR UPDATE
         `;
         if (todoRows.length === 0) {


### PR DESCRIPTION
## Why
The UUID normalization migration converted todo IDs to UUID-backed columns, but the subtask row-lock queries in `prismaTodoService` still compared `uuid = text`. That broke the integration path for subtask mutations after the schema change.

## What changed
- cast `todoId` to `UUID` in the `createSubtask` row-lock query
- cast `todoId` to `UUID` in the `updateSubtask` row-lock query
- kept the fix narrow so it only addresses the UUID lock mismatch introduced by the migration

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:integration`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
