### PR TITLE
fix(db): generate valid legacy project uuids in migration

### DIFF
--- a/prisma/migrations/20260312143000_normalize_entity_ids_to_uuid/migration.sql
+++ b/prisma/migrations/20260312143000_normalize_entity_ids_to_uuid/migration.sql
@@ -12,8 +12,13 @@ SELECT
     ELSE (
       SUBSTRING(md5('legacy-project:' || p."id") FROM 1 FOR 8) || '-' ||
       SUBSTRING(md5('legacy-project:' || p."id") FROM 9 FOR 4) || '-' ||
-      SUBSTRING(md5('legacy-project:' || p."id") FROM 13 FOR 4) || '-' ||
-      SUBSTRING(md5('legacy-project:' || p."id") FROM 17 FOR 4) || '-' ||
+      '5' || SUBSTRING(md5('legacy-project:' || p."id") FROM 14 FOR 3) || '-' ||
+      SUBSTRING(
+        '89ab'
+        FROM ((get_byte(decode(SUBSTRING(md5('legacy-project:' || p."id") FROM 17 FOR 2), 'hex'), 0) % 4) + 1)
+        FOR 1
+      ) ||
+      SUBSTRING(md5('legacy-project:' || p."id") FROM 19 FOR 3) || '-' ||
       SUBSTRING(md5('legacy-project:' || p."id") FROM 21 FOR 12)
     )::UUID
   END


### PR DESCRIPTION
## Why
The UUID normalization migration generated deterministic replacement project IDs for legacy hash-based rows, but the generated strings did not always satisfy the repo's strict UUID validator. That caused the migration to fail in production and left Railway unable to start.

## What changed
- updated the legacy project ID mapping in `20260312143000_normalize_entity_ids_to_uuid`
- generate deterministic RFC-compliant UUIDs by forcing the version and variant bits in the derived value
- kept the migration shape otherwise unchanged

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

## Operational note
Production was repaired manually first by replaying the corrected migration SQL and clearing the failed Prisma migration record, then Railway was redeployed successfully. This PR keeps the repo migration history aligned so future environments don't fail the same way.
