### PR TITLE
fix(build): include runtime type deps for Railway builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.19.2",
+        "@types/bcrypt": "^6.0.0",
         "@types/cors": "^2.8.19",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.2.1",
         "@types/nodemailer": "^7.0.9",
         "@types/swagger-jsdoc": "^6.0.4",
@@ -33,10 +35,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
-        "@types/jsonwebtoken": "^9.0.10",
         "@types/supertest": "^6.0.3",
         "@types/uuid": "^10.0.0",
         "html-validate": "^10.0.0",
@@ -1708,7 +1708,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
       "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1826,7 +1825,6 @@
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
       "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*",
@@ -1844,7 +1842,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^6.19.2",
+    "@types/bcrypt": "^6.0.0",
     "@types/cors": "^2.8.19",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.2.1",
     "@types/nodemailer": "^7.0.9",
     "@types/swagger-jsdoc": "^6.0.4",
@@ -67,10 +69,8 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",
     "html-validate": "^10.0.0",


### PR DESCRIPTION
## Why
Railway preview builds install production dependencies before running `tsc`. `@types/bcrypt` and `@types/jsonwebtoken` were still in `devDependencies`, so preview deployments failed during build even though the repo validated locally.

## What changed
- moved `@types/bcrypt` into `dependencies`
- moved `@types/jsonwebtoken` into `dependencies`
- updated `package-lock.json` accordingly

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
