### PR TITLE
fix(api): split planner suggest and apply scopes

### DIFF
--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -72,6 +72,10 @@ Initial public tools:
 
 `tools/list` only returns tools allowed by the current token scopes.
 
+For the planner write-capable tools, `tools/list` exposes the minimum scopes
+needed to run the default `mode: "suggest"` behavior, plus mode-scoped
+requirements for `apply`.
+
 ## Auth and Scope Model
 
 - browser-based account linking reuses the app's existing user auth
@@ -82,6 +86,9 @@ Initial public tools:
   - `projects.read`
   - `projects.write`
 - write tools are denied unless the token carries the matching write scope
+- `plan_project`, `ensure_next_action`, and `weekly_review` are mode-aware:
+  - `mode: "suggest"` requires `projects.read` + `tasks.read`
+  - `mode: "apply"` additionally requires `tasks.write`
 - no MCP path trusts caller-provided user IDs for authorization
 
 ## Protocol Shape

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -168,9 +168,9 @@ The older `read` / `write` aliases are still accepted by validation and expanded
 | `get_project`    | Yes       | `projects.read`  |
 | `review_projects` | Yes      | `projects.read`  |
 | `list_projects_without_next_action` | Yes | `projects.read`, `tasks.read` |
-| `plan_project` | No | `projects.read`, `tasks.read`, `tasks.write` |
-| `ensure_next_action` | No | `projects.read`, `tasks.read`, `tasks.write` |
-| `weekly_review` | No | `projects.read`, `tasks.read`, `tasks.write` |
+| `plan_project` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
+| `ensure_next_action` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
+| `weekly_review` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
 | `create_project` | No        | `projects.write` |
 | `update_project` | No        | `projects.write` |
 | `rename_project` | No        | `projects.write` |
@@ -178,6 +178,10 @@ The older `read` / `write` aliases are still accepted by validation and expanded
 | `archive_project` | No       | `projects.write` |
 
 `tools/list` only returns tools the token is allowed to use.
+
+For the planner tools above, `tools/list` exposes the minimum scopes needed to
+run the default `mode: "suggest"` behavior, plus mode-scoped requirements for
+`apply`.
 
 ## Auth-Related Errors
 

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -17,6 +17,8 @@ type ToolCatalogEntry = {
   inputSchema: Record<string, unknown>;
   readOnly: boolean;
   requiredScopes: McpScope[];
+  modeScopedRequiredScopes?: Partial<Record<"suggest" | "apply", McpScope[]>>;
+  defaultMode?: "suggest";
   requiresProjectService: boolean;
 };
 
@@ -24,7 +26,32 @@ function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-function requiredScopesForAction(actionName: AgentActionName): McpScope[] {
+const PLANNER_MODE_SCOPED_ACTIONS = new Set<AgentActionName>([
+  "plan_project",
+  "ensure_next_action",
+  "weekly_review",
+]);
+
+const PLANNER_SUGGEST_SCOPES: McpScope[] = [
+  PROJECT_READ_SCOPE,
+  TASK_READ_SCOPE,
+];
+
+const PLANNER_APPLY_SCOPES: McpScope[] = [
+  PROJECT_READ_SCOPE,
+  TASK_READ_SCOPE,
+  TASK_WRITE_SCOPE,
+];
+
+function isPlannerModeScopedAction(
+  actionName: AgentActionName,
+): actionName is "plan_project" | "ensure_next_action" | "weekly_review" {
+  return PLANNER_MODE_SCOPED_ACTIONS.has(actionName);
+}
+
+function minimumRequiredScopesForAction(
+  actionName: AgentActionName,
+): McpScope[] {
   switch (actionName) {
     case "list_tasks":
     case "search_tasks":
@@ -54,7 +81,7 @@ function requiredScopesForAction(actionName: AgentActionName): McpScope[] {
     case "plan_project":
     case "ensure_next_action":
     case "weekly_review":
-      return [PROJECT_READ_SCOPE, TASK_READ_SCOPE, TASK_WRITE_SCOPE];
+      return [...PLANNER_SUGGEST_SCOPES];
     case "decide_next_work":
     case "analyze_project_health":
     case "analyze_work_graph":
@@ -66,6 +93,36 @@ function requiredScopesForAction(actionName: AgentActionName): McpScope[] {
     case "archive_project":
       return [PROJECT_WRITE_SCOPE];
   }
+}
+
+function modeScopedRequiredScopesForAction(
+  actionName: AgentActionName,
+): Partial<Record<"suggest" | "apply", McpScope[]>> | undefined {
+  if (!isPlannerModeScopedAction(actionName)) {
+    return undefined;
+  }
+
+  return {
+    suggest: [...PLANNER_SUGGEST_SCOPES],
+    apply: [...PLANNER_APPLY_SCOPES],
+  };
+}
+
+function isApplyMode(args: Record<string, unknown>): boolean {
+  return (
+    typeof args.mode === "string" && args.mode.trim().toLowerCase() === "apply"
+  );
+}
+
+export function requiredScopesForToolCall(
+  actionName: AgentActionName,
+  args: Record<string, unknown>,
+): McpScope[] {
+  if (isPlannerModeScopedAction(actionName) && isApplyMode(args)) {
+    return [...PLANNER_APPLY_SCOPES];
+  }
+
+  return minimumRequiredScopesForAction(actionName);
 }
 
 function buildCatalog(): ToolCatalogEntry[] {
@@ -92,7 +149,15 @@ function buildCatalog(): ToolCatalogEntry[] {
       description: action.description,
       inputSchema,
       readOnly: action.readOnly,
-      requiredScopes: requiredScopesForAction(action.name as AgentActionName),
+      requiredScopes: minimumRequiredScopesForAction(
+        action.name as AgentActionName,
+      ),
+      modeScopedRequiredScopes: modeScopedRequiredScopesForAction(
+        action.name as AgentActionName,
+      ),
+      defaultMode: isPlannerModeScopedAction(action.name as AgentActionName)
+        ? "suggest"
+        : undefined,
       requiresProjectService: Boolean(
         action.availability?.requires?.includes("project_service"),
       ),
@@ -126,6 +191,12 @@ export function listMcpTools(input: {
     auth: {
       required: true,
       requiredScopes: [...tool.requiredScopes],
+      ...(tool.modeScopedRequiredScopes
+        ? {
+            modeScopedRequiredScopes: cloneJson(tool.modeScopedRequiredScopes),
+            defaultMode: tool.defaultMode,
+          }
+        : {}),
       readOnly: tool.readOnly,
       errors: [
         "MCP_UNAUTHENTICATED",

--- a/src/mcpPublicRouter.test.ts
+++ b/src/mcpPublicRouter.test.ts
@@ -384,6 +384,9 @@ describe("Public MCP OAuth and discovery routes", () => {
     );
     expect(toolNames).toEqual(
       expect.arrayContaining([
+        "plan_project",
+        "ensure_next_action",
+        "weekly_review",
         "decide_next_work",
         "analyze_project_health",
         "analyze_work_graph",

--- a/src/mcpRouter.test.ts
+++ b/src/mcpRouter.test.ts
@@ -315,6 +315,16 @@ describe("Remote MCP router auth and scopes", () => {
     );
     expect(toolNames).toContain("list_tasks");
     expect(toolNames).toContain("list_projects");
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        "plan_project",
+        "ensure_next_action",
+        "weekly_review",
+        "decide_next_work",
+        "analyze_project_health",
+        "analyze_work_graph",
+      ]),
+    );
     expect(toolNames).not.toContain("create_task");
     expect(toolNames).not.toContain("create_project");
 
@@ -333,6 +343,19 @@ describe("Remote MCP router auth and scopes", () => {
         "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
       ],
     });
+
+    const ensureNextActionTool = response.body.result.tools.find(
+      (tool: { name: string }) => tool.name === "ensure_next_action",
+    );
+    expect(ensureNextActionTool.auth.requiredScopes).toEqual([
+      "projects.read",
+      "tasks.read",
+    ]);
+    expect(ensureNextActionTool.auth.modeScopedRequiredScopes).toEqual({
+      suggest: ["projects.read", "tasks.read"],
+      apply: ["projects.read", "tasks.read", "tasks.write"],
+    });
+    expect(ensureNextActionTool.auth.defaultMode).toBe("suggest");
   });
 
   it("exposes the new project-management tools when write scopes are granted", async () => {
@@ -433,8 +456,11 @@ describe("Remote MCP router auth and scopes", () => {
     expect(ensureNextActionTool.auth.requiredScopes).toEqual([
       "projects.read",
       "tasks.read",
-      "tasks.write",
     ]);
+    expect(ensureNextActionTool.auth.modeScopedRequiredScopes).toEqual({
+      suggest: ["projects.read", "tasks.read"],
+      apply: ["projects.read", "tasks.read", "tasks.write"],
+    });
 
     const decideNextWorkTool = response.body.result.tools.find(
       (tool: { name: string }) => tool.name === "decide_next_work",
@@ -469,6 +495,140 @@ describe("Remote MCP router auth and scopes", () => {
     expect(
       response.body.result.structuredContent.error.details.requiredScopes,
     ).toEqual(["tasks.write"]);
+  });
+
+  it("allows planner suggest calls with read-only scopes", async () => {
+    currentSession = buildMcpSession("user-1", ["projects.read", "tasks.read"]);
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000091",
+      name: "Planner",
+      goal: "Ship planner docs",
+      status: "active",
+      archived: false,
+      userId: "user-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project);
+    projectService.findAll.mockResolvedValue([
+      {
+        id: "00000000-0000-1000-8000-000000000091",
+        name: "Planner",
+        goal: "Ship planner docs",
+        status: "active",
+        archived: false,
+        userId: "user-1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        todoCount: 0,
+        openTodoCount: 0,
+      } as Project,
+    ]);
+
+    const planResponse = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer planner-read-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 5.1,
+        method: "tools/call",
+        params: {
+          name: "plan_project",
+          arguments: {
+            projectId: "00000000-0000-1000-8000-000000000091",
+            mode: "suggest",
+          },
+        },
+      })
+      .expect(200);
+
+    const ensureResponse = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer planner-read-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 5.2,
+        method: "tools/call",
+        params: {
+          name: "ensure_next_action",
+          arguments: {
+            projectId: "00000000-0000-1000-8000-000000000091",
+            mode: "suggest",
+          },
+        },
+      })
+      .expect(200);
+
+    const reviewResponse = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer planner-read-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 5.3,
+        method: "tools/call",
+        params: {
+          name: "weekly_review",
+          arguments: {
+            mode: "suggest",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(planResponse.body.result.isError).toBeUndefined();
+    expect(
+      planResponse.body.result.structuredContent.data.plan.suggestedTasks
+        .length,
+    ).toBeGreaterThan(0);
+    expect(ensureResponse.body.result.isError).toBeUndefined();
+    expect(
+      ensureResponse.body.result.structuredContent.data.result.created,
+    ).toBe(false);
+    expect(reviewResponse.body.result.isError).toBeUndefined();
+    expect(
+      reviewResponse.body.result.structuredContent.data.review.summary,
+    ).toBeDefined();
+  });
+
+  it("rejects planner apply calls when write scope is missing", async () => {
+    currentSession = buildMcpSession("user-1", ["projects.read", "tasks.read"]);
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000092",
+      name: "Planner",
+      status: "active",
+      archived: false,
+      userId: "user-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project);
+
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer planner-readonly-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 5.4,
+        method: "tools/call",
+        params: {
+          name: "ensure_next_action",
+          arguments: {
+            projectId: "00000000-0000-1000-8000-000000000092",
+            mode: "apply",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(response.body.result.isError).toBe(true);
+    expect(response.body.result.structuredContent.error.code).toBe(
+      "MCP_INSUFFICIENT_SCOPE",
+    );
+    expect(
+      response.body.result.structuredContent.error.details.requiredScopes,
+    ).toEqual(["projects.read", "tasks.read", "tasks.write"]);
   });
 
   it("blocks cross-user task access through the MCP surface", async () => {

--- a/src/routes/mcpRouter.ts
+++ b/src/routes/mcpRouter.ts
@@ -14,6 +14,7 @@ import {
   getMcpToolDefinition,
   listMcpTools,
   MCP_PROTOCOL_VERSION,
+  requiredScopesForToolCall,
 } from "../mcp/mcpToolCatalog";
 import { AuthService } from "../services/authService";
 import { McpScope } from "../types";
@@ -545,10 +546,15 @@ export function createMcpRouter({
           return;
         }
 
-        if (!hasRequiredToolScopes(session.scopes, tool.requiredScopes)) {
+        const requiredScopes = requiredScopesForToolCall(
+          tool.name,
+          normalized.args,
+        );
+
+        if (!hasRequiredToolScopes(session.scopes, requiredScopes)) {
           const error = buildScopeError({
             toolName: tool.name,
-            requiredScopes: tool.requiredScopes,
+            requiredScopes,
           });
           logMcpRequest({
             requestId,
@@ -559,7 +565,7 @@ export function createMcpRouter({
             scopes: session.scopes,
             toolName: normalized.name,
             authOutcome: "scope_denied",
-            requiredScopes: tool.requiredScopes,
+            requiredScopes,
             errorCode: error.code,
             httpStatus: 200,
             latencyMs: Date.now() - startedAt,


### PR DESCRIPTION
## Why
Planner tools were exposed as write-scoped MCP actions even when called in their default `suggest` mode. That blocked read-only assistant tokens from using suggest-only planning flows and made the MCP auth contract coarser than the actual behavior.

Closes #230.

## What changed
- added mode-aware scope metadata for planner tools in the MCP catalog
- enforced dynamic scope checks in `/mcp` based on tool arguments instead of static tool scope lists
- kept `suggest` on read scopes and required `tasks.write` only for `apply`
- updated MCP/public router coverage for read-only planner discovery and scope denial on apply
- documented the suggest/apply scope split in the MCP docs

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`