### PR TITLE
ci: add dedicated MCP test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,25 @@ jobs:
       - name: Unit tests
         run: npm run test:unit
 
+  mcp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: MCP tests
+        run: npm run test:mcp
+
   integration:
     runs-on: ubuntu-latest
 

--- a/jest.mcp.config.js
+++ b/jest.mcp.config.js
@@ -1,0 +1,13 @@
+const base = require("./jest.config");
+
+module.exports = {
+  ...base,
+  testMatch: [
+    "**/src/api.contract.test.ts",
+    "**/src/agentRouter.test.ts",
+    "**/src/mcpRouter.test.ts",
+    "**/src/mcpPublicRouter.test.ts",
+    "**/src/mcpOAuthService.test.ts",
+    "**/src/agentIdempotencyService.test.ts",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npm run test:unit",
     "test:all": "NODE_ENV=test jest --runInBand",
     "test:unit": "NODE_ENV=test SKIP_DB_SETUP=true jest --config jest.unit.config.js --runInBand",
+    "test:mcp": "NODE_ENV=test SKIP_DB_SETUP=true jest --config jest.mcp.config.js --runInBand",
     "test:integration": "NODE_ENV=test EMAIL_FEATURES_ENABLED=false jest --config jest.integration.config.js --runInBand",
     "test:ci": "npx tsc --noEmit && npm run test:unit",
     "test:watch": "NODE_ENV=test jest --watch",


### PR DESCRIPTION
## Why
The repo already has meaningful MCP coverage, but it is buried inside the broader unit suite. Adding a dedicated MCP-focused test entry point makes the protocol surface explicit in CI and gives us a stable place to grow connector/auth/tool coverage without relying on the rest of the unit run to catch regressions incidentally.

## What changed
- added a dedicated `npm run test:mcp` script
- added `jest.mcp.config.js` to run the focused MCP and adjacent agent-contract tests
- added a dedicated `mcp` job to CI so MCP coverage is visible as its own gate
- kept the existing unit suite behavior intact for backward compatibility

## Verification
- `npm run test:mcp`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
