### PR TITLE
docs: document planner runtime and MCP tools

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Navigation map for this directory.
 | `agent-accessibility.md` | First-pass server contract and safety model for machine agents                |
 | `assistant-mcp.md`       | Remote MCP adapter for assistant clients                                      |
 | `remote-mcp-auth.md`     | Account linking, auth, scopes, and local testing for the remote MCP surface   |
+| `planner-runtime.md`     | Planner runtime architecture and tool-to-engine mapping                       |
 | `ops/railway-remote-mcp-deploy.md` | Railway deployment runbook for the public MCP surface            |
 | `ops/connector-smoke-checklist.md` | Manual ChatGPT / Claude connector smoke checklist                  |
 | `ops/`                   | Repo operations runbooks and GitHub project setup notes                       |

--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -18,6 +18,8 @@ This is intentionally a thin layer over the existing Express routers and service
 The initial machine-readable contract lives in `src/agent/agent-manifest.json` and is exposed at runtime through `GET /agent/manifest`.
 
 The remote assistant-facing MCP adapter that builds on this internal layer is documented in `docs/assistant-mcp.md`, with auth and scope details in `docs/remote-mcp-auth.md`.
+The planner runtime that now sits under the planning tools is documented in
+`docs/planner-runtime.md`.
 Public deployment and connector validation runbooks live under `docs/ops/`.
 Supported actions:
 
@@ -45,11 +47,35 @@ Supported actions:
 - `plan_project`
 - `ensure_next_action`
 - `weekly_review`
+- `decide_next_work`
+- `analyze_project_health`
+- `analyze_work_graph`
 - `create_project`
 - `update_project`
 - `rename_project`
 - `delete_project`
 - `archive_project`
+
+## Planner Runtime
+
+Planning behavior now routes through a dedicated planner layer instead of
+living directly in MCP handlers, agent routes, or UI code:
+
+- MCP tools / AI routes / UI routes
+- `PlannerService`
+- planner engines
+- canonical `projectService` / `todoService`
+- database
+
+Current engine boundaries:
+
+- `ProjectPlanningEngine`: `plan_project`, `ensure_next_action`
+- `ReviewEngine`: `weekly_review`, `analyze_project_health`
+- `DecisionEngine`: `decide_next_work`
+- `WorkGraphEngine`: `analyze_work_graph`
+
+This keeps planning logic reusable for MCP today and AI/UI surfaces later
+without introducing a second business-logic stack.
 
 ## Read vs Write
 

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -64,6 +64,9 @@ Initial public tools:
 - `plan_project`
 - `ensure_next_action`
 - `weekly_review`
+- `decide_next_work`
+- `analyze_project_health`
+- `analyze_work_graph`
 - `create_project`
 - `update_project`
 - `rename_project`
@@ -75,6 +78,8 @@ Initial public tools:
 For the planner write-capable tools, `tools/list` exposes the minimum scopes
 needed to run the default `mode: "suggest"` behavior, plus mode-scoped
 requirements for `apply`.
+
+Planner runtime details live in `docs/planner-runtime.md`.
 
 ## Auth and Scope Model
 
@@ -89,7 +94,24 @@ requirements for `apply`.
 - `plan_project`, `ensure_next_action`, and `weekly_review` are mode-aware:
   - `mode: "suggest"` requires `projects.read` + `tasks.read`
   - `mode: "apply"` additionally requires `tasks.write`
+- `decide_next_work`, `analyze_project_health`, and `analyze_work_graph` are
+  read-only planner analysis tools:
+  - they require `projects.read` + `tasks.read`
+  - they do not mutate in the current runtime
 - no MCP path trusts caller-provided user IDs for authorization
+
+## Planner Runtime
+
+The planner MCP tools now route through a dedicated internal planner runtime:
+
+- `PlannerService` is the public facade for planner operations
+- `ProjectPlanningEngine` powers project plans and next-action derivation
+- `ReviewEngine` powers weekly-review findings and project-health analysis
+- `DecisionEngine` powers next-work ranking
+- `WorkGraphEngine` powers dependency and blocked/unblocked analysis
+
+Those engines reuse the canonical task/project services underneath, so MCP
+connectors do not get a parallel business-logic path.
 
 ## Protocol Shape
 

--- a/docs/memory/index/INDEX.md
+++ b/docs/memory/index/INDEX.md
@@ -54,6 +54,7 @@ Quick-reference to find things. Keep this flat and current.
 | Agent accessibility | `docs/agent-accessibility.md`  |
 | Assistant MCP       | `docs/assistant-mcp.md`        |
 | Remote MCP auth     | `docs/remote-mcp-auth.md`      |
+| Planner runtime     | `docs/planner-runtime.md`      |
 | MCP deploy runbook  | `docs/ops/railway-remote-mcp-deploy.md` |
 | Connector smoke     | `docs/ops/connector-smoke-checklist.md` |
 | Codex task prompts  | `docs/codex-prompts.md`        |

--- a/docs/planner-runtime.md
+++ b/docs/planner-runtime.md
@@ -1,0 +1,67 @@
+# Planner Runtime
+
+Concise architecture note for the planner layer that sits above the canonical
+task/project services and below MCP, AI, and UI surfaces.
+
+## Layering
+
+Planner flows now route through one shared runtime:
+
+- MCP tools / AI routes / UI routes
+- `PlannerService`
+- planner engines
+- canonical `projectService` / `todoService`
+- database
+
+This keeps planning behavior reusable without creating a parallel
+task/project business-logic stack.
+
+## Current Engines
+
+- `ProjectPlanningEngine`
+  - builds project task plans
+  - derives next actions
+  - prevents duplicate next-action creation
+- `ReviewEngine`
+  - builds weekly-review summaries
+  - generates findings and safe recommendations
+  - powers project-health analysis
+- `DecisionEngine`
+  - ranks the best next tasks to work on
+  - stays deterministic and read-only in the current runtime
+- `WorkGraphEngine`
+  - analyzes dependency state
+  - classifies blocked vs unblocked work
+  - returns critical-path and parallel-work views
+
+## Current Tool Mapping
+
+- `plan_project` -> `PlannerService.planProject()` -> `ProjectPlanningEngine`
+- `ensure_next_action` -> `PlannerService.ensureNextAction()` -> `ProjectPlanningEngine`
+- `weekly_review` -> `PlannerService.weeklyReview()` -> `ReviewEngine`
+- `decide_next_work` -> `PlannerService.decideNextWork()` -> `DecisionEngine`
+- `analyze_project_health` -> `PlannerService.analyzeProjectHealth()` -> `ReviewEngine`
+- `analyze_work_graph` -> `PlannerService.analyzeWorkGraph()` -> `WorkGraphEngine`
+
+## Scope and Mutation Rules
+
+- `plan_project`, `ensure_next_action`, and `weekly_review` are mode-aware:
+  - `mode: "suggest"` is read-only
+  - `mode: "apply"` creates safe follow-up work through the canonical task
+    service
+- `decide_next_work`, `analyze_project_health`, and `analyze_work_graph` are
+  read-only analysis tools in the current runtime
+- all reads and writes remain scoped to the authenticated user
+- planner code never calls MCP tools recursively; it uses the underlying
+  services directly
+
+## Current Limitations
+
+- planner reasoning is deterministic-first and explainable; it is not an LLM
+  planning engine
+- `weekly_review` apply mode only performs safe starter actions such as
+  creating a next action
+- the runtime still carries the repo's temporary `projectId` / `category`
+  compatibility bridge until that migration follow-up is retired
+- UI and Home AI surfaces can reuse this runtime later, but are not yet routed
+  through it

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -171,6 +171,9 @@ The older `read` / `write` aliases are still accepted by validation and expanded
 | `plan_project` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
 | `ensure_next_action` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
 | `weekly_review` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
+| `decide_next_work` | Yes | `projects.read`, `tasks.read` |
+| `analyze_project_health` | Yes | `projects.read`, `tasks.read` |
+| `analyze_work_graph` | Yes | `projects.read`, `tasks.read` |
 | `create_project` | No        | `projects.write` |
 | `update_project` | No        | `projects.write` |
 | `rename_project` | No        | `projects.write` |
@@ -182,6 +185,9 @@ The older `read` / `write` aliases are still accepted by validation and expanded
 For the planner tools above, `tools/list` exposes the minimum scopes needed to
 run the default `mode: "suggest"` behavior, plus mode-scoped requirements for
 `apply`.
+
+The planner-runtime architecture behind these tools is documented in
+`docs/planner-runtime.md`.
 
 ## Auth-Related Errors
 


### PR DESCRIPTION
## Why
The planner runtime and its newer MCP analysis tools are already live in code, but the repo docs still describe only the original planner slice. This follow-up documents the shipped architecture and current planner tool behavior so MCP/agent docs stay aligned with the implementation.

## What changed
- added a concise `docs/planner-runtime.md` note for the planner layer and engine boundaries
- updated the existing agent/MCP docs to include `decide_next_work`, `analyze_project_health`, and `analyze_work_graph`
- documented the current planner scope behavior for suggest/apply vs read-only analysis tools
- added doc index links to the new planner runtime note

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

Closes #229
