### PR TITLE
refactor(api): retire planner category fallback

### DIFF
--- a/src/agentService.test.ts
+++ b/src/agentService.test.ts
@@ -167,11 +167,13 @@ describe("AgentService", () => {
 
     await todoService.create(USER_ID, {
       title: "Work next action",
+      projectId: "project-1",
       category: "Work",
       status: "next",
     });
     await todoService.create(USER_ID, {
       title: "Personal waiting task",
+      projectId: "project-2",
       category: "Personal",
       status: "waiting",
     });
@@ -185,5 +187,25 @@ describe("AgentService", () => {
     expect(withoutNextAction.map((project) => project.name)).toEqual([
       "Personal",
     ]);
+  });
+
+  it("does not treat category-only tasks as canonical project membership", async () => {
+    const todoService = new TodoService();
+    const projects = [makeProject("project-1", "Work")];
+    const projectService = createProjectServiceMock(projects);
+
+    await todoService.create(USER_ID, {
+      title: "Legacy category-only next action",
+      category: "Work",
+      status: "next",
+    });
+
+    const agentService = new AgentService({ todoService, projectService });
+    const withoutNextAction = await agentService.listProjectsWithoutNextAction(
+      USER_ID,
+      { includeOnHold: false },
+    );
+
+    expect(withoutNextAction.map((project) => project.name)).toEqual(["Work"]);
   });
 });

--- a/src/plannerHeuristics.test.ts
+++ b/src/plannerHeuristics.test.ts
@@ -5,6 +5,7 @@ import {
   findExistingNextAction,
   findWeeklyReviewFindings,
   projectHasNextAction,
+  projectTasksForProject,
 } from "./services/plannerHeuristics";
 
 const USER_ID = "user-1";
@@ -121,6 +122,24 @@ describe("plannerHeuristics", () => {
     expect(suggestion).not.toBeNull();
     expect(suggestion?.title).toBe("Follow up on vendor quote");
     expect(suggestion?.status).toBe("next");
+  });
+
+  it("uses canonical projectId when matching project tasks", () => {
+    const project = makeProject("project-1", "Platform");
+    const matchingTask = makeTask("task-1", "Canonical task", {
+      projectId: project.id,
+      category: "Platform",
+    });
+    const legacyOnlyTask = makeTask("task-2", "Legacy category-only task", {
+      category: "Platform",
+    });
+
+    const projectTasks = projectTasksForProject(project, [
+      matchingTask,
+      legacyOnlyTask,
+    ]);
+
+    expect(projectTasks.map((task) => task.id)).toEqual(["task-1"]);
   });
 
   it("classifies weekly review findings and recommends safe follow-up actions", () => {

--- a/src/plannerService.test.ts
+++ b/src/plannerService.test.ts
@@ -319,6 +319,38 @@ describe("PlannerService", () => {
     );
   });
 
+  it("does not treat category-only tasks as existing project work", async () => {
+    const todoService = new TodoService();
+    const project = makeProject("project-1", "Ops");
+    const plannerService = new PlannerService({
+      todoService,
+      projectService: createProjectServiceMock([project]),
+    });
+
+    await todoService.create(USER_ID, {
+      title: "Legacy category-only next action",
+      category: project.name,
+      status: "next",
+    });
+
+    const result = await plannerService.ensureNextAction({
+      userId: USER_ID,
+      projectId: project.id,
+      mode: "apply",
+    });
+
+    expect(result?.created).toBe(true);
+    expect(result?.task?.title).toBe("Define the first concrete step for Ops");
+
+    const projectTasks = await todoService.findAll(USER_ID, {
+      archived: false,
+      projectId: project.id,
+    });
+    expect(projectTasks.map((task) => task.title)).toEqual([
+      "Define the first concrete step for Ops",
+    ]);
+  });
+
   it("analyzes the work graph for blocked and unblocked tasks", async () => {
     const todoService = new TodoService();
     const project = makeProject("project-1", "Launch");

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -69,7 +69,7 @@ export class AgentService {
   }
 
   private projectMatchesTask(project: Project, task: Todo): boolean {
-    return task.projectId === project.id || task.category === project.name;
+    return task.projectId === project.id;
   }
 
   async listTasks(userId: string, query: FindTodosQuery): Promise<Todo[]> {

--- a/src/services/planner/plannerHeuristics.ts
+++ b/src/services/planner/plannerHeuristics.ts
@@ -45,7 +45,7 @@ export function isOpenTask(task: Todo): boolean {
 }
 
 export function includesProjectTask(project: Project, task: Todo): boolean {
-  return task.projectId === project.id || task.category === project.name;
+  return task.projectId === project.id;
 }
 
 export function projectTasksForProject(


### PR DESCRIPTION
## Why
The UUID migration is already in place, but planner and agent logic still treated a task as belonging to a project when `task.category === project.name`. That compatibility path kept legacy semantics alive in new runtime code even after canonical `projectId` relationships were available.

## What changed
- removed planner/runtime project membership fallback from `category === project.name`
- made planner project matching and `listProjectsWithoutNextAction` rely on canonical `projectId` only
- updated and added regression tests so category-only legacy tasks no longer count as project membership in planner/agent flows

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

Closes #231
