### PR TITLE
feat(api): add MCP assistant revocation and disconnect flow

### DIFF
--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -145,3 +145,4 @@ This is enough for operational debugging without introducing a separate analytic
 - decide when the project/category compatibility path can be retired in favor of `projectId` only
 - add destructive confirmation patterns before exposing broader delete or bulk write actions
 - add richer audit reporting or revocation UI if operational needs outgrow the current trace tables
+- keep the new MCP assistant-session revoke APIs aligned with any future in-app assistant management UI

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -29,6 +29,12 @@ Runtime endpoints:
   Browser-based user sign-in and consent page.
 - `POST /oauth/token`
   Authorization code exchange for an MCP bearer token.
+- `POST /oauth/revoke`
+  First-pass OAuth token/session revocation for remote connectors.
+- `GET /auth/mcp/sessions`
+  Signed-in app route for listing active MCP assistant sessions.
+- `POST /auth/mcp/sessions/revoke`
+  Signed-in app route for revoking one assistant session or revoking all MCP sessions.
 - `GET /healthz`
   Liveness signal for the deployed service.
 - `GET /readyz`
@@ -139,6 +145,7 @@ Stable auth and authorization codes include:
 - `MCP_UNAUTHENTICATED`
 - `MCP_INVALID_TOKEN`
 - `MCP_AUTH_EXPIRED`
+- `MCP_AUTH_REVOKED`
 - `MCP_INVALID_SESSION`
 - `MCP_INSUFFICIENT_SCOPE`
 - `RESOURCE_NOT_FOUND_OR_FORBIDDEN`
@@ -182,7 +189,7 @@ Those docs also record what remains manual from this sandboxed environment.
 
 ## Current Limitations
 
-- no user-facing token revocation UI or assistant session management yet
+- revocation/session management exists as API routes, but there is still no polished in-app assistant management UI
 - idempotency is implemented for `create_task` and `create_project`
 - persisted audit records are lightweight operational traces, not a full analytics platform
 - the public deployment and real ChatGPT/Claude connector validation must be completed from a networked environment with Railway access

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -41,6 +41,7 @@ Returns:
 - `issuer`
 - `authorization_endpoint`
 - `token_endpoint`
+- `revocation_endpoint`
 - `registration_endpoint`
 - `response_types_supported`
 - `grant_types_supported`
@@ -109,12 +110,42 @@ Response:
 - `expires_in`
 - `expires_at`
 - `scope`
+- `session_id`
+
+### `POST /oauth/revoke`
+
+Revokes an issued MCP token.
+
+Form input:
+
+- `token`
+- `client_id` (optional)
+- `token_type_hint` (`refresh_token` or `access_token`, optional)
+
+Behavior:
+
+- revoking a refresh token invalidates the linked assistant session when present
+- revoking an access token invalidates the backing assistant session for newer session-backed tokens
+- older legacy tokens without a session binding fall back to revoke-all for that user
 
 ### `POST /auth/mcp/token`
 
 Local development shortcut only.
 
 This bypasses the public authorization-code flow and mints an MCP token directly from a signed-in app user session. Keep it for local verification, not provider-facing account linking.
+
+### `GET /auth/mcp/sessions`
+
+Lists active MCP assistant sessions for the signed-in app user.
+
+### `POST /auth/mcp/sessions/revoke`
+
+Revokes MCP assistant access for the signed-in app user.
+
+JSON input:
+
+- `{ "sessionId": "<uuid>" }` to revoke one session
+- `{ "revokeAll": true }` to revoke all MCP sessions without rotating unrelated app auth
 
 ## MCP Request Authentication
 
@@ -126,9 +157,11 @@ The server then:
 
 1. verifies token signature and expiry
 2. validates token type is `mcp`
-3. resolves the token to a concrete app user via `getUserById`
-4. enforces scopes before tool execution
-5. denies the request if the linked user is no longer valid
+3. rejects tokens bound to revoked MCP assistant sessions
+4. rejects tokens issued before a user-level MCP revoke-all timestamp
+5. resolves the token to a concrete app user via `getUserById`
+6. enforces scopes before tool execution
+7. denies the request if the linked user is no longer valid
 
 No MCP tool trusts a client-provided user ID.
 
@@ -204,6 +237,7 @@ Important auth codes:
 - `MCP_INVALID_AUTHORIZATION`
 - `MCP_INVALID_TOKEN`
 - `MCP_AUTH_EXPIRED`
+- `MCP_AUTH_REVOKED`
 - `MCP_INVALID_SESSION`
 - `MCP_INSUFFICIENT_SCOPE`
 - `MCP_INVALID_CLIENT`
@@ -225,6 +259,7 @@ The public MCP layer logs lightweight structured events for:
 - login success/failure during connector linking
 - code approval / denial
 - token exchange success/failure
+- revoke success/failure
 - MCP auth success/failure
 - scope denials
 - tool calls with request ID, tool name, user ID, and latency
@@ -246,6 +281,9 @@ Current behavior:
 
 - the server issues refresh tokens for clients registered with `grant_types=["authorization_code","refresh_token"]`
 - refresh-token exchange rotates the refresh token and returns a new access token plus a replacement refresh token
+- public OAuth metadata advertises `revocation_endpoint`
+- signed-in app users can list and revoke assistant sessions through `/auth/mcp/sessions`
+- `POST /oauth/revoke` supports first-pass connector disconnect without touching normal app auth
 
 ## Local Development
 
@@ -268,7 +306,8 @@ Detailed deployment and smoke steps live in:
 
 ## Current Limitations
 
-- MCP access tokens are still JWTs and are not individually revocable yet
-- refresh tokens are rotated, stored durably, and survive app restarts, but there is no user-facing revoke-all-assistants UI yet
+- MCP access tokens are session-revocable, but there is still no polished in-app assistant management UI
+- refresh tokens are rotated, stored durably, and survive app restarts
+- older pre-session MCP tokens are only guaranteed to be invalidated by revoke-all once they are rotated onto the newer session-backed flow
 - persisted audit records are lightweight operational traces, not a full analytics pipeline
 - real public deployment and connector validation must be completed from a networked environment with Railway and provider access

--- a/prisma/migrations/20260312213000_add_mcp_assistant_sessions/migration.sql
+++ b/prisma/migrations/20260312213000_add_mcp_assistant_sessions/migration.sql
@@ -1,0 +1,42 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE "users"
+ADD COLUMN "mcp_revoked_after" TIMESTAMP(3);
+
+CREATE TABLE "mcp_assistant_sessions" (
+  "id" UUID NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "client_id" VARCHAR(5000),
+  "assistant_name" VARCHAR(100),
+  "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  "source" VARCHAR(20) NOT NULL,
+  "revoked_at" TIMESTAMP(3),
+  "last_access_token_issued_at" TIMESTAMP(3),
+  "last_used_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "mcp_assistant_sessions_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "mcp_refresh_tokens"
+ADD COLUMN "session_id" UUID;
+
+CREATE INDEX "mcp_assistant_sessions_user_id_revoked_at_idx"
+ON "mcp_assistant_sessions"("user_id", "revoked_at");
+
+CREATE INDEX "mcp_assistant_sessions_client_id_idx"
+ON "mcp_assistant_sessions"("client_id");
+
+CREATE INDEX "mcp_refresh_tokens_session_id_idx"
+ON "mcp_refresh_tokens"("session_id");
+
+ALTER TABLE "mcp_assistant_sessions"
+ADD CONSTRAINT "mcp_assistant_sessions_user_id_fkey"
+FOREIGN KEY ("user_id") REFERENCES "users"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "mcp_refresh_tokens"
+ADD CONSTRAINT "mcp_refresh_tokens_session_id_fkey"
+FOREIGN KEY ("session_id") REFERENCES "mcp_assistant_sessions"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,7 @@ model User {
   resetTokenExpiry  DateTime?      @map("reset_token_expiry")
   role              UserRole       @default(user)
   plan              UserPlan       @default(free)
+  mcpRevokedAfter   DateTime?      @map("mcp_revoked_after")
   createdAt         DateTime       @default(now()) @map("created_at")
   updatedAt         DateTime       @updatedAt @map("updated_at")
 
@@ -108,6 +109,7 @@ model User {
   projects          Project[]
   refreshTokens     RefreshToken[]
   mcpAuthorizationCodes McpAuthorizationCode[]
+  mcpAssistantSessions McpAssistantSession[]
   mcpRefreshTokens  McpRefreshToken[]
   agentIdempotencyRecords AgentIdempotencyRecord[]
   agentActionAudits AgentActionAudit[]
@@ -127,6 +129,27 @@ model RefreshToken {
 
   @@map("refresh_tokens")
   @@index([userId])
+}
+
+model McpAssistantSession {
+  id                    String    @id @default(uuid()) @db.Uuid
+  userId                String    @map("user_id")
+  clientId              String?   @db.VarChar(5000) @map("client_id")
+  assistantName         String?   @db.VarChar(100) @map("assistant_name")
+  scopes                String[]  @default([])
+  source                String    @db.VarChar(20)
+  revokedAt             DateTime? @map("revoked_at")
+  lastAccessTokenIssuedAt DateTime? @map("last_access_token_issued_at")
+  lastUsedAt            DateTime? @map("last_used_at")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  refreshTokens McpRefreshToken[]
+
+  @@map("mcp_assistant_sessions")
+  @@index([userId, revokedAt])
+  @@index([clientId])
 }
 
 model McpAuthorizationCode {
@@ -155,6 +178,7 @@ model McpRefreshToken {
   id            String   @id @default(uuid()) @db.Uuid
   tokenHash     String   @unique @db.VarChar(128) @map("token_hash")
   userId        String   @map("user_id")
+  sessionId     String?  @map("session_id") @db.Uuid
   email         String   @db.VarChar(255)
   scopes        String[] @default([])
   assistantName String?  @db.VarChar(100) @map("assistant_name")
@@ -166,9 +190,11 @@ model McpRefreshToken {
   updatedAt     DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  session McpAssistantSession? @relation(fields: [sessionId], references: [id], onDelete: Cascade)
 
   @@map("mcp_refresh_tokens")
   @@index([userId])
+  @@index([sessionId])
   @@index([expiresAt])
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -251,6 +251,7 @@ export function createApp(
     createMcpRouter({
       agentExecutor,
       authService,
+      mcpOAuthService,
     }),
   );
 

--- a/src/auth.api.test.ts
+++ b/src/auth.api.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import request from "supertest";
 import { createApp } from "./app";
 import { PrismaTodoService } from "./services/prismaTodoService";
@@ -776,6 +777,213 @@ describe("Authentication API", () => {
       expect(Array.isArray(list.body)).toBe(true);
       expect(list.body.length).toBeGreaterThan(0);
       expectTodoShape(list.body[0]);
+    });
+  });
+
+  describe("MCP assistant session revocation", () => {
+    async function completePublicMcpLink(input: {
+      email: string;
+      password: string;
+      scope?: string;
+    }) {
+      const registerClient = await request(app)
+        .post("/oauth/register")
+        .send({
+          redirect_uris: ["https://chat.openai.com/aip/callback"],
+          client_name: "ChatGPT",
+          grant_types: ["authorization_code", "refresh_token"],
+        })
+        .expect(201);
+
+      const verifier =
+        "oauth-verifier-auth-api-11111111111111111111111111111111111";
+      const challenge = createHash("sha256")
+        .update(verifier, "utf8")
+        .digest("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/g, "");
+      const scope = input.scope || "projects.read tasks.read tasks.write";
+      const agent = request.agent(app);
+
+      const authorizeUrl = `/oauth/authorize?client_id=${encodeURIComponent(
+        registerClient.body.client_id,
+      )}&redirect_uri=${encodeURIComponent(
+        "https://chat.openai.com/aip/callback",
+      )}&response_type=code&scope=${encodeURIComponent(
+        scope,
+      )}&code_challenge=${encodeURIComponent(
+        challenge,
+      )}&code_challenge_method=S256`;
+
+      await agent.get(authorizeUrl).expect(200);
+      const login = await agent
+        .post("/oauth/authorize/login")
+        .type("form")
+        .send({
+          email: input.email,
+          password: input.password,
+          client_id: registerClient.body.client_id,
+          redirect_uri: "https://chat.openai.com/aip/callback",
+          response_type: "code",
+          scope,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        })
+        .expect(303);
+      await agent.get(login.headers.location).expect(200);
+      const approve = await agent
+        .post("/oauth/authorize/decision")
+        .type("form")
+        .send({
+          decision: "approve",
+          client_id: registerClient.body.client_id,
+          redirect_uri: "https://chat.openai.com/aip/callback",
+          response_type: "code",
+          scope,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+        })
+        .expect(303);
+
+      const code = new URL(approve.headers.location).searchParams.get("code");
+      const token = await request(app)
+        .post("/oauth/token")
+        .type("form")
+        .send({
+          grant_type: "authorization_code",
+          code,
+          client_id: registerClient.body.client_id,
+          redirect_uri: "https://chat.openai.com/aip/callback",
+          code_verifier: verifier,
+        })
+        .expect(200);
+
+      return {
+        clientId: registerClient.body.client_id as string,
+        accessToken: token.body.access_token as string,
+        refreshToken: token.body.refresh_token as string,
+        sessionId: token.body.session_id as string,
+      };
+    }
+
+    it("revokes a linked assistant session and requires reconnect before MCP use resumes", async () => {
+      const register = await request(app)
+        .post("/auth/register")
+        .send({
+          email: "mcp-revoke@example.com",
+          password: "password123",
+          name: "MCP Revoke",
+        })
+        .expect(201);
+
+      const appToken = register.body.token as string;
+      const linked = await completePublicMcpLink({
+        email: "mcp-revoke@example.com",
+        password: "password123",
+      });
+
+      const sessions = await request(app)
+        .get("/auth/mcp/sessions")
+        .set("Authorization", `Bearer ${appToken}`)
+        .expect(200);
+      expect(sessions.body.sessions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: linked.sessionId,
+            clientId: linked.clientId,
+          }),
+        ]),
+      );
+
+      await request(app)
+        .post("/auth/mcp/sessions/revoke")
+        .set("Authorization", `Bearer ${appToken}`)
+        .send({
+          sessionId: linked.sessionId,
+        })
+        .expect(200);
+
+      const revokedAccess = await request(app)
+        .post("/mcp")
+        .set("Authorization", `Bearer ${linked.accessToken}`)
+        .send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "ping",
+        })
+        .expect(401);
+      expect(revokedAccess.body.error.data.code).toBe("MCP_AUTH_REVOKED");
+
+      const revokedRefresh = await request(app)
+        .post("/oauth/token")
+        .type("form")
+        .send({
+          grant_type: "refresh_token",
+          refresh_token: linked.refreshToken,
+          client_id: linked.clientId,
+        })
+        .expect(401);
+      expect(revokedRefresh.body.error_details.code).toBe(
+        "MCP_ASSISTANT_SESSION_REVOKED",
+      );
+
+      const relinked = await completePublicMcpLink({
+        email: "mcp-revoke@example.com",
+        password: "password123",
+      });
+
+      await request(app)
+        .post("/mcp")
+        .set("Authorization", `Bearer ${relinked.accessToken}`)
+        .send({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "ping",
+        })
+        .expect(200);
+    });
+
+    it("supports revoke-all without rotating the normal app session", async () => {
+      const register = await request(app)
+        .post("/auth/register")
+        .send({
+          email: "mcp-revoke-all@example.com",
+          password: "password123",
+          name: "MCP Revoke All",
+        })
+        .expect(201);
+
+      const appToken = register.body.token as string;
+      const linked = await completePublicMcpLink({
+        email: "mcp-revoke-all@example.com",
+        password: "password123",
+      });
+
+      const revokeAll = await request(app)
+        .post("/auth/mcp/sessions/revoke")
+        .set("Authorization", `Bearer ${appToken}`)
+        .send({
+          revokeAll: true,
+        })
+        .expect(200);
+      expect(revokeAll.body.revokedAll).toBe(true);
+
+      await request(app)
+        .get("/users/me")
+        .set("Authorization", `Bearer ${appToken}`)
+        .expect(200);
+
+      const revokedAccess = await request(app)
+        .post("/mcp")
+        .set("Authorization", `Bearer ${linked.accessToken}`)
+        .send({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "ping",
+        })
+        .expect(401);
+      expect(revokedAccess.body.error.data.code).toBe("MCP_AUTH_REVOKED");
     });
   });
 });

--- a/src/mcp/mcpAuth.ts
+++ b/src/mcp/mcpAuth.ts
@@ -5,6 +5,7 @@ import { McpScope } from "../types";
 import { buildStructuredMcpError } from "./mcpErrors";
 import { hasAllMcpScopes } from "./mcpScopes";
 import { config } from "../config";
+import { McpOAuthService } from "../services/mcpOAuthService";
 
 type JsonRpcId = number | string | null;
 
@@ -62,6 +63,7 @@ export function buildMcpActor(
 export async function resolveMcpAuthContext(input: {
   req: Request;
   authService?: AuthService;
+  mcpOAuthService?: McpOAuthService;
   requestId: string;
 }): Promise<{
   httpStatus: number;
@@ -108,7 +110,7 @@ export async function resolveMcpAuthContext(input: {
 
   let session: McpTokenPayload;
   try {
-    session = input.authService.verifyMcpToken(parts[1]);
+    session = await input.authService.verifyMcpToken(parts[1]);
   } catch (error) {
     const message = error instanceof Error ? error.message : "";
     if (message === "Token expired") {
@@ -119,6 +121,17 @@ export async function resolveMcpAuthContext(input: {
           message: "MCP access token expired",
           retryable: false,
           hint: "Use the MCP refresh-token grant if available, or repeat the link flow to mint a fresh token.",
+        }),
+      };
+    }
+    if (message === "MCP token revoked") {
+      return {
+        httpStatus: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_AUTH_REVOKED",
+          message: "MCP access token has been revoked",
+          retryable: false,
+          hint: "Reconnect the assistant or mint a new token after re-authorizing access.",
         }),
       };
     }
@@ -145,6 +158,10 @@ export async function resolveMcpAuthContext(input: {
         hint: "Re-link the user account to mint a fresh token.",
       }),
     };
+  }
+
+  if (session.sessionId && input.mcpOAuthService) {
+    await input.mcpOAuthService.recordAssistantSessionUsage(session.sessionId);
   }
 
   return {

--- a/src/mcpOAuthService.test.ts
+++ b/src/mcpOAuthService.test.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "crypto";
 import { McpOAuthService } from "./services/mcpOAuthService";
 
 function createMockPrisma() {
   const authorizationCodes = new Map<string, any>();
+  const assistantSessions = new Map<string, any>();
   const refreshTokens = new Map<string, any>();
 
   return {
@@ -20,6 +22,52 @@ function createMockPrisma() {
         return updated;
       }),
     },
+    mcpAssistantSession: {
+      create: jest.fn(async ({ data }) => {
+        const created = {
+          id: data.id || randomUUID(),
+          ...data,
+          revokedAt: null,
+          lastAccessTokenIssuedAt: null,
+          lastUsedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        assistantSessions.set(created.id, created);
+        return created;
+      }),
+      findUnique: jest.fn(async ({ where }) => {
+        return assistantSessions.get(where.id) || null;
+      }),
+      findMany: jest.fn(async ({ where }) => {
+        return Array.from(assistantSessions.values()).filter(
+          (session) =>
+            session.userId === where.userId &&
+            (where.revokedAt === null ? session.revokedAt === null : true),
+        );
+      }),
+      updateMany: jest.fn(async ({ where, data }) => {
+        let count = 0;
+        for (const [id, session] of assistantSessions.entries()) {
+          if (session.id !== where.id && where.id !== undefined) {
+            continue;
+          }
+          if (session.userId !== where.userId && where.userId !== undefined) {
+            continue;
+          }
+          if (where.revokedAt === null && session.revokedAt !== null) {
+            continue;
+          }
+          assistantSessions.set(id, {
+            ...session,
+            ...data,
+            updatedAt: new Date(),
+          });
+          count += 1;
+        }
+        return { count };
+      }),
+    },
     mcpRefreshToken: {
       create: jest.fn(async ({ data }) => {
         refreshTokens.set(data.tokenHash, {
@@ -29,14 +77,44 @@ function createMockPrisma() {
         });
         return data;
       }),
-      findUnique: jest.fn(async ({ where }) => {
-        return refreshTokens.get(where.tokenHash) || null;
+      findUnique: jest.fn(async ({ where, include }) => {
+        const record = refreshTokens.get(where.tokenHash) || null;
+        if (!record || !include?.session || !record.sessionId) {
+          return record;
+        }
+        return {
+          ...record,
+          session: assistantSessions.get(record.sessionId) || null,
+        };
       }),
       update: jest.fn(async ({ where, data }) => {
         const record = refreshTokens.get(where.tokenHash);
         const updated = { ...record, ...data };
         refreshTokens.set(where.tokenHash, updated);
         return updated;
+      }),
+      updateMany: jest.fn(async ({ where, data }) => {
+        let count = 0;
+        for (const [tokenHash, record] of refreshTokens.entries()) {
+          if (record.userId !== where.userId && where.userId !== undefined) {
+            continue;
+          }
+          if (
+            record.sessionId !== where.sessionId &&
+            where.sessionId !== undefined
+          ) {
+            continue;
+          }
+          if (where.revokedAt === null && record.revokedAt !== null) {
+            continue;
+          }
+          refreshTokens.set(tokenHash, {
+            ...record,
+            ...data,
+          });
+          count += 1;
+        }
+        return { count };
       }),
     },
   };
@@ -89,5 +167,38 @@ describe("McpOAuthService durability", () => {
 
     expect(refreshed.refreshToken).toEqual(expect.any(String));
     expect(refreshed.refreshToken).not.toBe(issued.refreshToken);
+  });
+
+  it("revokes an assistant session and blocks future refresh exchanges", async () => {
+    const prisma = createMockPrisma();
+    const service = new McpOAuthService(prisma as any);
+
+    const session = await service.createAssistantSession({
+      userId: "user-1",
+      scopes: ["tasks.read"],
+      assistantName: "ChatGPT",
+      clientId: "chatgpt-client",
+      source: "oauth",
+    });
+    const issued = await service.createRefreshToken({
+      userId: "user-1",
+      email: "user-1@example.com",
+      scopes: ["tasks.read"],
+      assistantName: "ChatGPT",
+      clientId: "chatgpt-client",
+      sessionId: session.id,
+    });
+
+    await service.revokeAssistantSession({
+      userId: "user-1",
+      sessionId: session.id,
+    });
+
+    await expect(
+      service.exchangeRefreshToken({
+        refreshToken: issued.refreshToken,
+        clientId: "chatgpt-client",
+      }),
+    ).rejects.toThrow("Assistant session revoked");
   });
 });

--- a/src/mcpPublicRouter.test.ts
+++ b/src/mcpPublicRouter.test.ts
@@ -58,6 +58,8 @@ describe("Public MCP OAuth and discovery routes", () => {
     verifyToken: jest.Mock;
     createMcpToken: jest.Mock;
     verifyMcpToken: jest.Mock;
+    decodeMcpToken: jest.Mock;
+    revokeAllMcpTokensForUser: jest.Mock;
     getUserById: jest.Mock;
   };
 
@@ -87,6 +89,13 @@ describe("Public MCP OAuth and discovery routes", () => {
         clientId: input.clientId,
       })),
       verifyMcpToken: jest.fn().mockImplementation(() => currentSession),
+      decodeMcpToken: jest.fn().mockImplementation(() => ({
+        ...currentSession,
+        issuedAt: Math.floor(Date.now() / 1000),
+      })),
+      revokeAllMcpTokensForUser: jest
+        .fn()
+        .mockResolvedValue("2026-03-12T00:00:00.000Z"),
       getUserById: jest.fn().mockImplementation(async (userId: string) => {
         if (userId === "missing-user") {
           return null;
@@ -123,6 +132,7 @@ describe("Public MCP OAuth and discovery routes", () => {
 
     expect(response.body.authorization_endpoint).toMatch(/\/oauth\/authorize$/);
     expect(response.body.token_endpoint).toMatch(/\/oauth\/token$/);
+    expect(response.body.revocation_endpoint).toMatch(/\/oauth\/revoke$/);
     expect(response.body.registration_endpoint).toMatch(/\/oauth\/register$/);
     expect(response.body.code_challenge_methods_supported).toContain("S256");
   });
@@ -275,6 +285,7 @@ describe("Public MCP OAuth and discovery routes", () => {
     expect(token.body.access_token).toBe("mcp-token-user-1");
     expect(token.body.token_type).toBe("Bearer");
     expect(token.body.scope).toBe("tasks.read tasks.write");
+    expect(token.body.session_id).toEqual(expect.any(String));
     expect(token.body.refresh_token).toEqual(expect.any(String));
     expect(token.body.refresh_token_expires_at).toEqual(expect.any(String));
     expect(token.body.refresh_token_expires_in).toBe(2592000);
@@ -359,6 +370,7 @@ describe("Public MCP OAuth and discovery routes", () => {
       .expect(200);
 
     expect(token.body.scope).toBe("projects.read tasks.read");
+    expect(token.body.session_id).toEqual(expect.any(String));
   });
 
   it("rotates refresh tokens through the public OAuth token endpoint", async () => {
@@ -441,8 +453,88 @@ describe("Public MCP OAuth and discovery routes", () => {
       .expect(200);
 
     expect(refreshed.body.access_token).toBe("mcp-token-user-1");
+    expect(refreshed.body.session_id).toEqual(expect.any(String));
     expect(refreshed.body.refresh_token).toEqual(expect.any(String));
     expect(refreshed.body.refresh_token).not.toBe(token.body.refresh_token);
+  });
+
+  it("accepts OAuth revoke requests for issued refresh tokens", async () => {
+    const register = await request(app)
+      .post("/oauth/register")
+      .send({
+        redirect_uris: ["https://chat.openai.com/aip/callback"],
+        client_name: "ChatGPT",
+        grant_types: ["authorization_code", "refresh_token"],
+      })
+      .expect(201);
+
+    const pkce = createPkcePair(
+      "oauth-verifier-public-revoke-11111111111111111111111111111",
+    );
+    const agent = request.agent(app);
+
+    const authorizeUrl = `/oauth/authorize?client_id=${encodeURIComponent(
+      register.body.client_id,
+    )}&redirect_uri=${encodeURIComponent(
+      "https://chat.openai.com/aip/callback",
+    )}&response_type=code&scope=${encodeURIComponent(
+      "tasks.read",
+    )}&code_challenge=${encodeURIComponent(
+      pkce.challenge,
+    )}&code_challenge_method=S256`;
+
+    await agent.get(authorizeUrl).expect(200);
+    const login = await agent
+      .post("/oauth/authorize/login")
+      .type("form")
+      .send({
+        email: "user-1@example.com",
+        password: "password123",
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        response_type: "code",
+        scope: "tasks.read",
+        code_challenge: pkce.challenge,
+        code_challenge_method: "S256",
+      })
+      .expect(303);
+    await agent.get(login.headers.location).expect(200);
+    const approve = await agent
+      .post("/oauth/authorize/decision")
+      .type("form")
+      .send({
+        decision: "approve",
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        response_type: "code",
+        scope: "tasks.read",
+        code_challenge: pkce.challenge,
+        code_challenge_method: "S256",
+      })
+      .expect(303);
+
+    const code = new URL(approve.headers.location).searchParams.get("code");
+    const token = await request(app)
+      .post("/oauth/token")
+      .type("form")
+      .send({
+        grant_type: "authorization_code",
+        code,
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        code_verifier: pkce.verifier,
+      })
+      .expect(200);
+
+    await request(app)
+      .post("/oauth/revoke")
+      .type("form")
+      .send({
+        token: token.body.refresh_token,
+        client_id: register.body.client_id,
+        token_type_hint: "refresh_token",
+      })
+      .expect(200);
   });
 
   it("advertises resource metadata when MCP auth is missing", async () => {

--- a/src/mcpRouter.test.ts
+++ b/src/mcpRouter.test.ts
@@ -132,6 +132,7 @@ describe("Remote MCP router auth and scopes", () => {
       scopes: ["tasks.write"],
       assistantName: "ChatGPT",
       clientId: "chatgpt-client",
+      sessionId: expect.any(String),
     });
     expect(response.body).toEqual({
       token: "mcp-token-user-1",
@@ -142,6 +143,7 @@ describe("Remote MCP router auth and scopes", () => {
       expiresIn: 2592000,
       assistantName: "ChatGPT",
       clientId: "chatgpt-client",
+      sessionId: expect.any(String),
     });
   });
 
@@ -205,6 +207,7 @@ describe("Remote MCP router auth and scopes", () => {
       scopes: ["tasks.read", "tasks.write"],
       assistantName: "ChatGPT",
       clientId: "chatgpt-client",
+      sessionId: expect.any(String),
     });
     expect(exchange.body).toEqual({
       accessToken: "mcp-token-user-1",
@@ -215,6 +218,7 @@ describe("Remote MCP router auth and scopes", () => {
       scopes: ["tasks.read", "tasks.write"],
       assistantName: "ChatGPT",
       clientId: "chatgpt-client",
+      sessionId: expect.any(String),
       refreshToken: expect.any(String),
       refreshTokenExpiresAt: expect.any(String),
       refreshTokenExpiresIn: 2592000,
@@ -262,6 +266,65 @@ describe("Remote MCP router auth and scopes", () => {
     expect(refreshed.body.accessToken).toBe("mcp-token-user-1");
     expect(refreshed.body.refreshToken).toEqual(expect.any(String));
     expect(refreshed.body.refreshToken).not.toBe(exchange.body.refreshToken);
+    expect(refreshed.body.sessionId).toEqual(expect.any(String));
+  });
+
+  it("lists active MCP assistant sessions for the authenticated app user", async () => {
+    await request(app)
+      .post("/auth/mcp/token")
+      .set("Authorization", "Bearer app-access-token")
+      .send({
+        scopes: ["tasks.write"],
+        assistantName: "ChatGPT",
+        clientId: "chatgpt-client",
+      })
+      .expect(201);
+
+    const response = await request(app)
+      .get("/auth/mcp/sessions")
+      .set("Authorization", "Bearer app-access-token")
+      .expect(200);
+
+    expect(response.body.sessions).toEqual([
+      expect.objectContaining({
+        id: expect.any(String),
+        clientId: "chatgpt-client",
+        assistantName: "ChatGPT",
+        scopes: ["tasks.write"],
+        source: "local",
+      }),
+    ]);
+  });
+
+  it("revokes an MCP assistant session for the authenticated app user", async () => {
+    const issued = await request(app)
+      .post("/auth/mcp/token")
+      .set("Authorization", "Bearer app-access-token")
+      .send({
+        scopes: ["tasks.write"],
+        assistantName: "ChatGPT",
+        clientId: "chatgpt-client",
+      })
+      .expect(201);
+
+    const revoke = await request(app)
+      .post("/auth/mcp/sessions/revoke")
+      .set("Authorization", "Bearer app-access-token")
+      .send({
+        sessionId: issued.body.sessionId,
+      })
+      .expect(200);
+
+    expect(revoke.body).toEqual({
+      revoked: true,
+      sessionId: issued.body.sessionId,
+    });
+
+    const listed = await request(app)
+      .get("/auth/mcp/sessions")
+      .set("Authorization", "Bearer app-access-token")
+      .expect(200);
+    expect(listed.body.sessions).toEqual([]);
   });
 
   it("returns structured errors when the PKCE verifier is wrong", async () => {

--- a/src/routes/authRouter.ts
+++ b/src/routes/authRouter.ts
@@ -15,6 +15,7 @@ import {
   validateCreateMcpAuthorizationCodeInput,
   validateCreateMcpTokenInput,
   validateExchangeMcpAuthorizationCodeInput,
+  validateRevokeMcpSessionInput,
 } from "../validation/mcpValidation";
 
 interface AuthRouterDeps {
@@ -41,7 +42,11 @@ function logMcpLinkEvent(input: {
     | "token_exchange_success"
     | "token_exchange_error"
     | "legacy_token_success"
-    | "legacy_token_error";
+    | "legacy_token_error"
+    | "session_list_success"
+    | "session_list_error"
+    | "session_revoke_success"
+    | "session_revoke_error";
   userId?: string;
   clientId?: string;
   assistantName?: string;
@@ -262,6 +267,16 @@ function mapAuthorizationCodeError(error: unknown) {
           hint: "Use the same clientId that originally received the refresh token.",
         }),
       };
+    case "Assistant session revoked":
+      return {
+        status: 401,
+        error: buildStructuredMcpError({
+          code: "MCP_ASSISTANT_SESSION_REVOKED",
+          message: "Assistant session has been revoked",
+          retryable: false,
+          hint: "Reconnect the assistant to mint a fresh MCP token set.",
+        }),
+      };
     default:
       return mapAgentFacingError(error);
   }
@@ -461,13 +476,22 @@ export function createAuthRouter({
         }
 
         const input = validateCreateMcpTokenInput(req.body);
+        const session = await mcpOAuthService.createAssistantSession({
+          userId: resolvedUser.user.id,
+          scopes: input.scopes,
+          assistantName: input.assistantName,
+          clientId: input.clientId,
+          source: "local",
+        });
         const token = authService!.createMcpToken({
           userId: resolvedUser.user.id,
           email: resolvedUser.user.email,
           scopes: input.scopes,
           assistantName: input.assistantName,
           clientId: input.clientId,
+          sessionId: session.id,
         });
+        await mcpOAuthService.recordAccessTokenIssued(session.id);
 
         logMcpLinkEvent({
           requestId,
@@ -477,7 +501,10 @@ export function createAuthRouter({
           assistantName: input.assistantName,
           scopes: input.scopes,
         });
-        res.status(201).json(token);
+        res.status(201).json({
+          ...token,
+          sessionId: session.id,
+        });
       } catch (error) {
         const requestId = buildLinkRequestId(req);
         const mapped = mapAgentFacingError(error);
@@ -613,13 +640,26 @@ export function createAuthRouter({
           return sendStructuredError(res, 401, error);
         }
 
+        const existingSessionId =
+          "sessionId" in linkedSession ? linkedSession.sessionId : undefined;
+        const session = existingSessionId
+          ? { id: existingSessionId }
+          : await mcpOAuthService.createAssistantSession({
+              userId: linkedSession.userId,
+              scopes: linkedSession.scopes,
+              assistantName: linkedSession.assistantName,
+              clientId: linkedSession.clientId,
+              source: "oauth",
+            });
         const token = authService.createMcpToken({
           userId: linkedSession.userId,
           email: linkedSession.email,
           scopes: linkedSession.scopes,
           assistantName: linkedSession.assistantName,
           clientId: linkedSession.clientId,
+          sessionId: session.id,
         });
+        await mcpOAuthService.recordAccessTokenIssued(session.id);
         const refreshToken =
           input.grantType === "authorization_code"
             ? await mcpOAuthService.createRefreshToken({
@@ -628,6 +668,7 @@ export function createAuthRouter({
                 scopes: linkedSession.scopes,
                 assistantName: linkedSession.assistantName,
                 clientId: linkedSession.clientId,
+                sessionId: session.id,
               })
             : null;
         const refreshTokenPayload = refreshExchange
@@ -657,6 +698,7 @@ export function createAuthRouter({
             ? { assistantName: token.assistantName }
             : {}),
           ...(token.clientId ? { clientId: token.clientId } : {}),
+          sessionId: session.id,
           refreshToken: refreshTokenPayload!.refreshToken,
           refreshTokenExpiresAt: refreshTokenPayload!.expiresAt,
           refreshTokenExpiresIn: refreshTokenPayload!.expiresIn,
@@ -669,6 +711,132 @@ export function createAuthRouter({
           errorCode: mapped.error.code,
         });
         sendStructuredError(res, mapped.status, mapped.error);
+      }
+    },
+  );
+
+  router.get(
+    "/mcp/sessions",
+    authLimiter,
+    async (req: Request, res: Response) => {
+      const requestId = buildLinkRequestId(req);
+
+      try {
+        const resolvedUser = await resolveAppUserForMcpLink(req, authService);
+        if ("error" in resolvedUser) {
+          logMcpLinkEvent({
+            requestId,
+            event: "session_list_error",
+            errorCode: resolvedUser.error.code,
+          });
+          return sendStructuredError(
+            res,
+            resolvedUser.httpStatus,
+            resolvedUser.error,
+          );
+        }
+
+        const sessions = await mcpOAuthService.listAssistantSessions(
+          resolvedUser.user.id,
+        );
+        logMcpLinkEvent({
+          requestId,
+          event: "session_list_success",
+          userId: resolvedUser.user.id,
+        });
+        return res.status(200).json({ sessions });
+      } catch (error) {
+        const mapped = mapAgentFacingError(error);
+        logMcpLinkEvent({
+          requestId,
+          event: "session_list_error",
+          errorCode: mapped.error.code,
+        });
+        return sendStructuredError(res, mapped.status, mapped.error);
+      }
+    },
+  );
+
+  router.post(
+    "/mcp/sessions/revoke",
+    authLimiter,
+    async (req: Request, res: Response) => {
+      const requestId = buildLinkRequestId(req);
+
+      try {
+        const resolvedUser = await resolveAppUserForMcpLink(req, authService);
+        if ("error" in resolvedUser) {
+          logMcpLinkEvent({
+            requestId,
+            event: "session_revoke_error",
+            errorCode: resolvedUser.error.code,
+          });
+          return sendStructuredError(
+            res,
+            resolvedUser.httpStatus,
+            resolvedUser.error,
+          );
+        }
+
+        const input = validateRevokeMcpSessionInput(req.body);
+        if ("revokeAll" in input && input.revokeAll) {
+          const revokedAt = await authService!.revokeAllMcpTokensForUser(
+            resolvedUser.user.id,
+          );
+          const revokedSessionCount =
+            await mcpOAuthService.revokeAllAssistantSessions(
+              resolvedUser.user.id,
+            );
+          logMcpLinkEvent({
+            requestId,
+            event: "session_revoke_success",
+            userId: resolvedUser.user.id,
+          });
+          return res.status(200).json({
+            revokedAll: true,
+            revokedAt,
+            revokedSessionCount,
+          });
+        }
+
+        const revoked = await mcpOAuthService.revokeAssistantSession({
+          userId: resolvedUser.user.id,
+          sessionId: input.sessionId,
+        });
+
+        if (!revoked) {
+          const error = buildStructuredMcpError({
+            code: "MCP_ASSISTANT_SESSION_NOT_FOUND",
+            message: "Assistant session not found",
+            retryable: false,
+            hint: "Fetch active assistant sessions first and retry with a current sessionId.",
+          });
+          logMcpLinkEvent({
+            requestId,
+            event: "session_revoke_error",
+            userId: resolvedUser.user.id,
+            errorCode: error.code,
+          });
+          return sendStructuredError(res, 404, error);
+        }
+
+        logMcpLinkEvent({
+          requestId,
+          event: "session_revoke_success",
+          userId: resolvedUser.user.id,
+        });
+        return res.status(200).json({
+          revoked: true,
+          sessionId: input.sessionId,
+        });
+      } catch (error) {
+        const mapped = mapAgentFacingError(error);
+        logMcpLinkEvent({
+          requestId,
+          event: "session_revoke_error",
+          errorCode: mapped.error.code,
+        });
+        return sendStructuredError(res, mapped.status, mapped.error);
       }
     },
   );

--- a/src/routes/mcpPublicRouter.ts
+++ b/src/routes/mcpPublicRouter.ts
@@ -13,6 +13,7 @@ import {
   validateExchangeMcpAuthorizationCodeInput,
   validateOAuthAuthorizeRequest,
   validateRegisterMcpClientInput,
+  validateRevokeMcpOAuthTokenInput,
 } from "../validation/mcpValidation";
 import { config } from "../config";
 
@@ -181,7 +182,9 @@ function logMcpOauthEvent(input: {
     | "approve_error"
     | "deny"
     | "token_success"
-    | "token_error";
+    | "token_error"
+    | "revoke_success"
+    | "revoke_error";
   userId?: string;
   clientId?: string;
   clientName?: string;
@@ -303,6 +306,14 @@ function mapTokenExchangeError(error: unknown) {
         code: "MCP_REFRESH_TOKEN_CLIENT_MISMATCH",
         hint: "Use the same client_id that originally received the refresh token.",
       };
+    case "Assistant session revoked":
+      return {
+        status: 401,
+        error: "invalid_grant",
+        description: "Assistant session has been revoked",
+        code: "MCP_ASSISTANT_SESSION_REVOKED",
+        hint: "Reconnect the assistant to mint a fresh token set.",
+      };
     case "Invalid OAuth client":
     case "OAuth client expired":
       return {
@@ -375,7 +386,7 @@ export function createMcpPublicRouter({
         title: "Signed Out",
         message:
           "The local MCP linking session has been cleared on this device.",
-        hint: "Existing issued MCP bearer tokens are not revoked automatically.",
+        hint: "Disconnect active assistant sessions from the app or call POST /oauth/revoke to revoke issued MCP tokens.",
       }),
     );
   });
@@ -399,9 +410,10 @@ export function createMcpPublicRouter({
       issuer: config.baseUrl,
       authorization_endpoint: `${config.baseUrl}/oauth/authorize`,
       token_endpoint: `${config.baseUrl}/oauth/token`,
+      revocation_endpoint: `${config.baseUrl}/oauth/revoke`,
       registration_endpoint: `${config.baseUrl}/oauth/register`,
       response_types_supported: ["code"],
-      grant_types_supported: ["authorization_code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
       token_endpoint_auth_methods_supported: ["none"],
       code_challenge_methods_supported: ["S256"],
       scopes_supported: [
@@ -800,13 +812,26 @@ export function createMcpPublicRouter({
         throw new Error("Linked user account no longer exists");
       }
 
+      const existingSessionId =
+        "sessionId" in linkedSession ? linkedSession.sessionId : undefined;
+      const session = existingSessionId
+        ? { id: existingSessionId }
+        : await mcpOAuthService.createAssistantSession({
+            userId: linkedSession.userId,
+            scopes: linkedSession.scopes,
+            assistantName: linkedSession.assistantName || client.clientName,
+            clientId: linkedSession.clientId,
+            source: "oauth",
+          });
       const token = authService.createMcpToken({
         userId: linkedSession.userId,
         email: linkedSession.email,
         scopes: linkedSession.scopes,
         assistantName: linkedSession.assistantName || client.clientName,
         clientId: linkedSession.clientId,
+        sessionId: session.id,
       });
+      await mcpOAuthService.recordAccessTokenIssued(session.id);
       const shouldIssueRefreshToken =
         client.grantTypes.includes("refresh_token") ||
         input.grantType === "refresh_token";
@@ -818,6 +843,7 @@ export function createMcpPublicRouter({
               scopes: linkedSession.scopes,
               assistantName: linkedSession.assistantName || client.clientName,
               clientId: linkedSession.clientId,
+              sessionId: session.id,
             })
           : null;
       const rotatedRefreshToken =
@@ -846,6 +872,7 @@ export function createMcpPublicRouter({
         expires_in: token.expiresIn,
         scope: token.scope,
         ...(token.expiresAt ? { expires_at: token.expiresAt } : {}),
+        session_id: session.id,
         ...(refreshTokenPayload
           ? {
               refresh_token: refreshTokenPayload.refreshToken,
@@ -866,6 +893,97 @@ export function createMcpPublicRouter({
         description: mapped.description,
         code: mapped.code,
         hint: mapped.hint,
+      });
+    }
+  });
+
+  router.post("/oauth/revoke", async (req, res) => {
+    const requestId = buildRequestId(req);
+    setRequestId(res, requestId);
+    setNoStoreHeaders(res);
+
+    try {
+      if (!authService) {
+        logMcpOauthEvent({
+          requestId,
+          event: "revoke_error",
+          errorCode: "MCP_NOT_CONFIGURED",
+        });
+        return sendOAuthTokenError(res, 501, {
+          error: "server_error",
+          description: "Authentication not configured",
+          code: "MCP_NOT_CONFIGURED",
+        });
+      }
+
+      const input = validateRevokeMcpOAuthTokenInput({
+        token: req.body.token,
+        clientId: req.body.client_id || req.body.clientId,
+        tokenTypeHint: req.body.token_type_hint || req.body.tokenTypeHint,
+      });
+
+      let userId: string | undefined;
+      if (input.tokenTypeHint !== "access_token") {
+        const revokedRefreshToken = await mcpOAuthService.revokeRefreshToken({
+          refreshToken: input.token,
+          clientId: input.clientId,
+        });
+        if (revokedRefreshToken.userId) {
+          userId = revokedRefreshToken.userId;
+        }
+      }
+
+      if (!userId && input.tokenTypeHint !== "refresh_token") {
+        try {
+          const decoded = authService.decodeMcpToken(input.token);
+          userId = decoded.userId;
+          if (decoded.sessionId) {
+            await mcpOAuthService.revokeAssistantSession({
+              userId: decoded.userId,
+              sessionId: decoded.sessionId,
+            });
+          } else {
+            await authService.revokeAllMcpTokensForUser(decoded.userId);
+            await mcpOAuthService.revokeAllAssistantSessions(decoded.userId);
+          }
+        } catch (_error) {
+          // OAuth revocation is intentionally idempotent for invalid or expired tokens.
+        }
+      }
+
+      logMcpOauthEvent({
+        requestId,
+        event: "revoke_success",
+        userId,
+        clientId: input.clientId,
+      });
+      return res.status(200).send();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      if (message === "Refresh token client mismatch") {
+        logMcpOauthEvent({
+          requestId,
+          event: "revoke_error",
+          errorCode: "MCP_REFRESH_TOKEN_CLIENT_MISMATCH",
+        });
+        return sendOAuthTokenError(res, 401, {
+          error: "invalid_client",
+          description: "Refresh token client binding mismatch",
+          code: "MCP_REFRESH_TOKEN_CLIENT_MISMATCH",
+          hint: "Use the same client_id that originally received the refresh token.",
+        });
+      }
+
+      logMcpOauthEvent({
+        requestId,
+        event: "revoke_error",
+        errorCode: "MCP_OAUTH_REVOKE_FAILED",
+      });
+      return sendOAuthTokenError(res, 500, {
+        error: "server_error",
+        description: "OAuth revocation failed",
+        code: "MCP_OAUTH_REVOKE_FAILED",
+        hint: "Retry the revoke request. If it persists, inspect the server logs using the request ID.",
       });
     }
   });

--- a/src/routes/mcpRouter.ts
+++ b/src/routes/mcpRouter.ts
@@ -17,6 +17,7 @@ import {
   requiredScopesForToolCall,
 } from "../mcp/mcpToolCatalog";
 import { AuthService } from "../services/authService";
+import { McpOAuthService } from "../services/mcpOAuthService";
 import { McpScope } from "../types";
 
 type JsonRpcId = number | string | null;
@@ -31,6 +32,7 @@ interface JsonRpcRequest {
 interface McpRouterDeps {
   agentExecutor: AgentExecutor;
   authService?: AuthService;
+  mcpOAuthService?: McpOAuthService;
 }
 
 function jsonRpcSuccess(id: JsonRpcId, result: Record<string, unknown>) {
@@ -200,6 +202,7 @@ function logMcpRequest(input: {
 export function createMcpRouter({
   agentExecutor,
   authService,
+  mcpOAuthService,
 }: McpRouterDeps): Router {
   const router = Router();
 
@@ -209,6 +212,7 @@ export function createMcpRouter({
     const auth = await resolveMcpAuthContext({
       req,
       authService,
+      mcpOAuthService,
       requestId,
     });
 
@@ -338,6 +342,7 @@ export function createMcpRouter({
     const auth = await resolveMcpAuthContext({
       req,
       authService,
+      mcpOAuthService,
       requestId,
     });
     if (!auth.context || auth.error) {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -38,6 +38,7 @@ export interface McpTokenPayload extends JwtPayload {
   scopes: McpScope[];
   assistantName?: string;
   clientId?: string;
+  sessionId?: string;
 }
 
 export interface McpTokenResponse {
@@ -247,6 +248,7 @@ export class AuthService {
     scopes: McpScope[];
     assistantName?: string;
     clientId?: string;
+    sessionId?: string;
   }): McpTokenResponse {
     const normalizedScopes = normalizeMcpScopes(input.scopes, {
       requireNonEmpty: true,
@@ -259,6 +261,7 @@ export class AuthService {
         scopes: normalizedScopes,
         ...(input.assistantName ? { assistantName: input.assistantName } : {}),
         ...(input.clientId ? { clientId: input.clientId } : {}),
+        ...(input.sessionId ? { sessionId: input.sessionId } : {}),
       },
       this.ACCESS_JWT_SECRET,
       {
@@ -280,12 +283,14 @@ export class AuthService {
     };
   }
 
-  verifyMcpToken(token: string): McpTokenPayload {
+  private decodeVerifiedMcpToken(token: string): McpTokenPayload & {
+    issuedAt: number;
+  } {
     try {
       const payload = jwt.verify(
         token,
         this.ACCESS_JWT_SECRET,
-      ) as Partial<McpTokenPayload>;
+      ) as Partial<McpTokenPayload> & { iat?: unknown };
 
       if (payload.tokenType !== "mcp") {
         throw new Error("Invalid MCP token");
@@ -307,17 +312,25 @@ export class AuthService {
         throw new Error("Invalid MCP token");
       }
 
+      if (typeof payload.iat !== "number") {
+        throw new Error("Invalid MCP token");
+      }
+
       return {
         userId: payload.userId,
         email: payload.email,
         tokenType: "mcp",
         scopes,
+        issuedAt: payload.iat,
         ...(typeof payload.assistantName === "string" &&
         payload.assistantName.trim()
           ? { assistantName: payload.assistantName.trim() }
           : {}),
         ...(typeof payload.clientId === "string" && payload.clientId.trim()
           ? { clientId: payload.clientId.trim() }
+          : {}),
+        ...(typeof payload.sessionId === "string" && payload.sessionId.trim()
+          ? { sessionId: payload.sessionId.trim() }
           : {}),
       };
     } catch (error: any) {
@@ -326,6 +339,69 @@ export class AuthService {
       }
       throw new Error("Invalid MCP token");
     }
+  }
+
+  decodeMcpToken(token: string): McpTokenPayload & {
+    issuedAt: number;
+  } {
+    return this.decodeVerifiedMcpToken(token);
+  }
+
+  async verifyMcpToken(token: string): Promise<McpTokenPayload> {
+    const decoded = this.decodeVerifiedMcpToken(token);
+    const issuedAt = decoded.issuedAt * 1000;
+
+    const userRevocation = await this.prisma.user.findUnique({
+      where: { id: decoded.userId },
+      select: { mcpRevokedAfter: true },
+    });
+
+    if (
+      userRevocation?.mcpRevokedAfter &&
+      issuedAt <= userRevocation.mcpRevokedAfter.getTime()
+    ) {
+      throw new Error("MCP token revoked");
+    }
+
+    if (decoded.sessionId) {
+      const session = await this.prisma.mcpAssistantSession.findUnique({
+        where: { id: decoded.sessionId },
+        select: {
+          userId: true,
+          revokedAt: true,
+        },
+      });
+      if (
+        !session ||
+        session.userId !== decoded.userId ||
+        session.revokedAt !== null
+      ) {
+        throw new Error("MCP token revoked");
+      }
+    }
+
+    return {
+      userId: decoded.userId,
+      email: decoded.email,
+      tokenType: "mcp",
+      scopes: decoded.scopes,
+      ...(decoded.assistantName
+        ? { assistantName: decoded.assistantName }
+        : {}),
+      ...(decoded.clientId ? { clientId: decoded.clientId } : {}),
+      ...(decoded.sessionId ? { sessionId: decoded.sessionId } : {}),
+    };
+  }
+
+  async revokeAllMcpTokensForUser(userId: string): Promise<string> {
+    const revokedAt = new Date();
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        mcpRevokedAfter: revokedAt,
+      },
+    });
+    return revokedAt.toISOString();
   }
 
   getPrismaClient(): PrismaClient {

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -23,12 +23,35 @@ export interface ExchangeMcpAuthorizationCodeInput {
   codeVerifier: string;
 }
 
+export interface CreateMcpAssistantSessionInput {
+  userId: string;
+  scopes: McpScope[];
+  assistantName?: string;
+  clientId?: string;
+  source: "oauth" | "local";
+}
+
+export interface McpAssistantSessionSummary {
+  id: string;
+  userId: string;
+  scopes: McpScope[];
+  source: "oauth" | "local";
+  clientId?: string;
+  assistantName?: string;
+  revokedAt?: string;
+  lastAccessTokenIssuedAt?: string;
+  lastUsedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface CreateMcpRefreshTokenInput {
   userId: string;
   email: string;
   scopes: McpScope[];
   assistantName?: string;
   clientId?: string;
+  sessionId?: string;
 }
 
 export interface ExchangeMcpRefreshTokenInput {
@@ -40,6 +63,15 @@ interface AuthorizationCodeRecord extends CreateMcpAuthorizationCodeInput {
   code: string;
   expiresAt: number;
   used: boolean;
+}
+
+interface AssistantSessionRecord extends CreateMcpAssistantSessionInput {
+  id: string;
+  createdAt: number;
+  updatedAt: number;
+  revokedAt?: number;
+  lastAccessTokenIssuedAt?: number;
+  lastUsedAt?: number;
 }
 
 interface RefreshTokenRecord extends CreateMcpRefreshTokenInput {
@@ -61,10 +93,18 @@ function sha256Base64Url(value: string): string {
   return toBase64Url(createHash("sha256").update(value, "utf8").digest());
 }
 
+function toIso(value?: number | null): string | undefined {
+  return typeof value === "number" ? new Date(value).toISOString() : undefined;
+}
+
 export class McpOAuthService {
   constructor(private readonly prisma?: PrismaClient) {}
 
   private readonly authCodes = new Map<string, AuthorizationCodeRecord>();
+  private readonly assistantSessions = new Map<
+    string,
+    AssistantSessionRecord
+  >();
   private readonly refreshTokens = new Map<string, RefreshTokenRecord>();
   private readonly AUTH_CODE_TTL_MS = 10 * 60 * 1000;
   private readonly REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
@@ -91,6 +131,28 @@ export class McpOAuthService {
     return createHmac("sha256", config.refreshJwtSecret)
       .update(token)
       .digest("hex");
+  }
+
+  private serializeSessionFromMemory(
+    session: AssistantSessionRecord,
+  ): McpAssistantSessionSummary {
+    return {
+      id: session.id,
+      userId: session.userId,
+      scopes: [...session.scopes],
+      source: session.source,
+      ...(session.clientId ? { clientId: session.clientId } : {}),
+      ...(session.assistantName
+        ? { assistantName: session.assistantName }
+        : {}),
+      ...(session.revokedAt ? { revokedAt: toIso(session.revokedAt) } : {}),
+      ...(session.lastAccessTokenIssuedAt
+        ? { lastAccessTokenIssuedAt: toIso(session.lastAccessTokenIssuedAt) }
+        : {}),
+      ...(session.lastUsedAt ? { lastUsedAt: toIso(session.lastUsedAt) } : {}),
+      createdAt: new Date(session.createdAt).toISOString(),
+      updatedAt: new Date(session.updatedAt).toISOString(),
+    };
   }
 
   async createAuthorizationCode(input: CreateMcpAuthorizationCodeInput) {
@@ -249,6 +311,262 @@ export class McpOAuthService {
     };
   }
 
+  async createAssistantSession(input: CreateMcpAssistantSessionInput) {
+    if (this.prisma) {
+      const session = await this.prisma.mcpAssistantSession.create({
+        data: {
+          userId: input.userId,
+          clientId: input.clientId,
+          assistantName: input.assistantName,
+          scopes: [...input.scopes],
+          source: input.source,
+        },
+      });
+
+      return {
+        id: session.id,
+        userId: session.userId,
+        scopes: normalizeMcpScopes(session.scopes),
+        source: session.source as "oauth" | "local",
+        ...(session.clientId ? { clientId: session.clientId } : {}),
+        ...(session.assistantName
+          ? { assistantName: session.assistantName }
+          : {}),
+        createdAt: session.createdAt.toISOString(),
+        updatedAt: session.updatedAt.toISOString(),
+      };
+    }
+
+    const now = Date.now();
+    const session: AssistantSessionRecord = {
+      id: randomUUID(),
+      userId: input.userId,
+      scopes: [...input.scopes],
+      source: input.source,
+      ...(input.clientId ? { clientId: input.clientId } : {}),
+      ...(input.assistantName ? { assistantName: input.assistantName } : {}),
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.assistantSessions.set(session.id, session);
+    return this.serializeSessionFromMemory(session);
+  }
+
+  async listAssistantSessions(userId: string) {
+    if (this.prisma) {
+      const sessions = await this.prisma.mcpAssistantSession.findMany({
+        where: {
+          userId,
+          revokedAt: null,
+        },
+        orderBy: {
+          updatedAt: "desc",
+        },
+      });
+
+      return sessions.map((session) => ({
+        id: session.id,
+        userId: session.userId,
+        scopes: normalizeMcpScopes(session.scopes),
+        source: session.source as "oauth" | "local",
+        ...(session.clientId ? { clientId: session.clientId } : {}),
+        ...(session.assistantName
+          ? { assistantName: session.assistantName }
+          : {}),
+        ...(session.revokedAt
+          ? { revokedAt: session.revokedAt.toISOString() }
+          : {}),
+        ...(session.lastAccessTokenIssuedAt
+          ? {
+              lastAccessTokenIssuedAt:
+                session.lastAccessTokenIssuedAt.toISOString(),
+            }
+          : {}),
+        ...(session.lastUsedAt
+          ? { lastUsedAt: session.lastUsedAt.toISOString() }
+          : {}),
+        createdAt: session.createdAt.toISOString(),
+        updatedAt: session.updatedAt.toISOString(),
+      }));
+    }
+
+    return Array.from(this.assistantSessions.values())
+      .filter((session) => session.userId === userId && !session.revokedAt)
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .map((session) => this.serializeSessionFromMemory(session));
+  }
+
+  async recordAccessTokenIssued(sessionId: string): Promise<void> {
+    const now = new Date();
+    if (this.prisma) {
+      await this.prisma.mcpAssistantSession.updateMany({
+        where: {
+          id: sessionId,
+          revokedAt: null,
+        },
+        data: {
+          lastAccessTokenIssuedAt: now,
+        },
+      });
+      return;
+    }
+
+    const session = this.assistantSessions.get(sessionId);
+    if (!session || session.revokedAt) {
+      return;
+    }
+    session.lastAccessTokenIssuedAt = now.getTime();
+    session.updatedAt = now.getTime();
+  }
+
+  async recordAssistantSessionUsage(sessionId: string): Promise<void> {
+    const now = new Date();
+    if (this.prisma) {
+      await this.prisma.mcpAssistantSession.updateMany({
+        where: {
+          id: sessionId,
+          revokedAt: null,
+        },
+        data: {
+          lastUsedAt: now,
+        },
+      });
+      return;
+    }
+
+    const session = this.assistantSessions.get(sessionId);
+    if (!session || session.revokedAt) {
+      return;
+    }
+    session.lastUsedAt = now.getTime();
+    session.updatedAt = now.getTime();
+  }
+
+  async revokeAssistantSession(input: {
+    userId: string;
+    sessionId: string;
+  }): Promise<boolean> {
+    const revokedAt = new Date();
+    if (this.prisma) {
+      const result = await this.prisma.mcpAssistantSession.updateMany({
+        where: {
+          id: input.sessionId,
+          userId: input.userId,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt,
+        },
+      });
+      if (result.count > 0) {
+        await this.prisma.mcpRefreshToken.updateMany({
+          where: {
+            sessionId: input.sessionId,
+            revokedAt: null,
+          },
+          data: {
+            revokedAt,
+          },
+        });
+      }
+      return result.count > 0;
+    }
+
+    const session = this.assistantSessions.get(input.sessionId);
+    if (!session || session.userId !== input.userId || session.revokedAt) {
+      return false;
+    }
+    session.revokedAt = revokedAt.getTime();
+    session.updatedAt = revokedAt.getTime();
+    for (const [token, record] of this.refreshTokens.entries()) {
+      if (record.sessionId === input.sessionId) {
+        record.revoked = true;
+        this.refreshTokens.delete(token);
+      }
+    }
+    return true;
+  }
+
+  async revokeAllAssistantSessions(userId: string): Promise<number> {
+    const revokedAt = new Date();
+    if (this.prisma) {
+      const result = await this.prisma.mcpAssistantSession.updateMany({
+        where: {
+          userId,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt,
+        },
+      });
+      await this.prisma.mcpRefreshToken.updateMany({
+        where: {
+          userId,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt,
+        },
+      });
+      return result.count;
+    }
+
+    let count = 0;
+    for (const session of this.assistantSessions.values()) {
+      if (session.userId === userId && !session.revokedAt) {
+        session.revokedAt = revokedAt.getTime();
+        session.updatedAt = revokedAt.getTime();
+        count += 1;
+      }
+    }
+    for (const [token, record] of this.refreshTokens.entries()) {
+      if (record.userId === userId) {
+        record.revoked = true;
+        this.refreshTokens.delete(token);
+      }
+    }
+    return count;
+  }
+
+  private async ensureSessionForRefreshTokenRecord(input: {
+    userId: string;
+    scopes: McpScope[];
+    assistantName?: string;
+    clientId?: string;
+    sessionId?: string | null;
+    tokenHash: string;
+  }) {
+    if (input.sessionId) {
+      return input.sessionId;
+    }
+
+    const session = await this.createAssistantSession({
+      userId: input.userId,
+      scopes: input.scopes,
+      assistantName: input.assistantName,
+      clientId: input.clientId,
+      source: "oauth",
+    });
+
+    if (this.prisma) {
+      await this.prisma.mcpRefreshToken.update({
+        where: {
+          tokenHash: input.tokenHash,
+        },
+        data: {
+          sessionId: session.id,
+        },
+      });
+    } else {
+      const memoryRecord = this.refreshTokens.get(input.tokenHash);
+      if (memoryRecord) {
+        memoryRecord.sessionId = session.id;
+      }
+    }
+
+    return session.id;
+  }
+
   async createRefreshToken(input: CreateMcpRefreshTokenInput) {
     this.pruneExpiredRefreshTokens();
 
@@ -260,6 +578,7 @@ export class McpOAuthService {
         data: {
           tokenHash: this.hashRefreshToken(refreshToken),
           userId: input.userId,
+          sessionId: input.sessionId,
           email: input.email,
           scopes: [...input.scopes],
           assistantName: input.assistantName,
@@ -294,16 +613,23 @@ export class McpOAuthService {
           scopes: McpScope[];
           assistantName?: string;
           clientId?: string;
+          sessionId?: string;
           expiresAt: number;
           revoked: boolean;
           rotated: boolean;
+          sessionRevoked: boolean;
+          tokenHash: string;
         }
       | undefined;
 
     if (this.prisma) {
+      const tokenHash = this.hashRefreshToken(input.refreshToken);
       const persisted = await this.prisma.mcpRefreshToken.findUnique({
         where: {
-          tokenHash: this.hashRefreshToken(input.refreshToken),
+          tokenHash,
+        },
+        include: {
+          session: true,
         },
       });
       if (persisted) {
@@ -315,14 +641,20 @@ export class McpOAuthService {
             ? { assistantName: persisted.assistantName }
             : {}),
           ...(persisted.clientId ? { clientId: persisted.clientId } : {}),
+          ...(persisted.sessionId ? { sessionId: persisted.sessionId } : {}),
           expiresAt: persisted.expiresAt.getTime(),
           revoked: Boolean(persisted.revokedAt),
           rotated: Boolean(persisted.rotatedAt),
+          sessionRevoked: Boolean(persisted.session?.revokedAt),
+          tokenHash,
         };
       }
     } else {
       const memoryRecord = this.refreshTokens.get(input.refreshToken);
       if (memoryRecord) {
+        const session = memoryRecord.sessionId
+          ? this.assistantSessions.get(memoryRecord.sessionId)
+          : undefined;
         record = {
           userId: memoryRecord.userId,
           email: memoryRecord.email,
@@ -331,9 +663,14 @@ export class McpOAuthService {
             ? { assistantName: memoryRecord.assistantName }
             : {}),
           ...(memoryRecord.clientId ? { clientId: memoryRecord.clientId } : {}),
+          ...(memoryRecord.sessionId
+            ? { sessionId: memoryRecord.sessionId }
+            : {}),
           expiresAt: memoryRecord.expiresAt,
           revoked: memoryRecord.revoked,
           rotated: memoryRecord.rotated,
+          sessionRevoked: Boolean(session?.revokedAt),
+          tokenHash: input.refreshToken,
         };
       }
     }
@@ -341,7 +678,13 @@ export class McpOAuthService {
     if (!record) {
       throw new Error("Invalid refresh token");
     }
-    if (record.revoked || record.rotated) {
+    if (record.sessionRevoked) {
+      throw new Error("Assistant session revoked");
+    }
+    if (record.revoked && !record.rotated) {
+      throw new Error("Assistant session revoked");
+    }
+    if (record.rotated) {
       throw new Error("Refresh token already rotated");
     }
     if (record.expiresAt <= Date.now()) {
@@ -355,18 +698,28 @@ export class McpOAuthService {
       throw new Error("Refresh token client mismatch");
     }
 
+    const sessionId = await this.ensureSessionForRefreshTokenRecord({
+      userId: record.userId,
+      scopes: record.scopes,
+      assistantName: record.assistantName,
+      clientId: record.clientId,
+      sessionId: record.sessionId,
+      tokenHash: record.tokenHash,
+    });
+
     const nextRefreshToken = await this.createRefreshToken({
       userId: record.userId,
       email: record.email,
       scopes: record.scopes,
       assistantName: record.assistantName,
       clientId: record.clientId,
+      sessionId,
     });
 
     if (this.prisma) {
       await this.prisma.mcpRefreshToken.update({
         where: {
-          tokenHash: this.hashRefreshToken(input.refreshToken),
+          tokenHash: record.tokenHash,
         },
         data: {
           revokedAt: new Date(),
@@ -386,11 +739,83 @@ export class McpOAuthService {
       userId: record.userId,
       email: record.email,
       scopes: record.scopes,
+      sessionId,
       ...(record.assistantName ? { assistantName: record.assistantName } : {}),
       ...(record.clientId ? { clientId: record.clientId } : {}),
       refreshToken: nextRefreshToken.refreshToken,
       refreshTokenExpiresAt: nextRefreshToken.expiresAt,
       refreshTokenExpiresIn: nextRefreshToken.expiresIn,
+    };
+  }
+
+  async revokeRefreshToken(input: {
+    refreshToken: string;
+    clientId?: string;
+  }): Promise<{ revoked: boolean; sessionId?: string; userId?: string }> {
+    const tokenHash = this.hashRefreshToken(input.refreshToken);
+
+    if (this.prisma) {
+      const persisted = await this.prisma.mcpRefreshToken.findUnique({
+        where: { tokenHash },
+      });
+      if (!persisted) {
+        return { revoked: false };
+      }
+      if (
+        persisted.clientId &&
+        input.clientId &&
+        persisted.clientId !== input.clientId
+      ) {
+        throw new Error("Refresh token client mismatch");
+      }
+      await this.prisma.mcpRefreshToken.update({
+        where: { tokenHash },
+        data: {
+          revokedAt: new Date(),
+        },
+      });
+      if (persisted.sessionId) {
+        await this.prisma.mcpAssistantSession.updateMany({
+          where: {
+            id: persisted.sessionId,
+            revokedAt: null,
+          },
+          data: {
+            revokedAt: new Date(),
+          },
+        });
+      }
+      return {
+        revoked: true,
+        ...(persisted.sessionId ? { sessionId: persisted.sessionId } : {}),
+        userId: persisted.userId,
+      };
+    }
+
+    const memoryRecord = this.refreshTokens.get(input.refreshToken);
+    if (!memoryRecord) {
+      return { revoked: false };
+    }
+    if (
+      memoryRecord.clientId &&
+      input.clientId &&
+      memoryRecord.clientId !== input.clientId
+    ) {
+      throw new Error("Refresh token client mismatch");
+    }
+    memoryRecord.revoked = true;
+    this.refreshTokens.delete(input.refreshToken);
+    if (memoryRecord.sessionId) {
+      const session = this.assistantSessions.get(memoryRecord.sessionId);
+      if (session && !session.revokedAt) {
+        session.revokedAt = Date.now();
+        session.updatedAt = Date.now();
+      }
+    }
+    return {
+      revoked: true,
+      ...(memoryRecord.sessionId ? { sessionId: memoryRecord.sessionId } : {}),
+      userId: memoryRecord.userId,
     };
   }
 }

--- a/src/validation/mcpValidation.ts
+++ b/src/validation/mcpValidation.ts
@@ -5,7 +5,7 @@ import {
   hasAllMcpScopes,
   normalizeMcpScopes,
 } from "../mcp/mcpScopes";
-import { ValidationError } from "./validation";
+import { ValidationError, validateId } from "./validation";
 
 const MAX_ASSISTANT_NAME_LENGTH = 100;
 const MAX_CLIENT_ID_LENGTH = 5000;
@@ -62,6 +62,21 @@ export interface OAuthAuthorizeRequestDto {
   state?: string;
   codeChallenge: string;
   codeChallengeMethod: "S256";
+}
+
+export type RevokeMcpSessionDto =
+  | {
+      sessionId: string;
+      revokeAll?: false;
+    }
+  | {
+      revokeAll: true;
+    };
+
+export interface RevokeMcpOAuthTokenDto {
+  token: string;
+  clientId?: string;
+  tokenTypeHint?: "refresh_token" | "access_token";
 }
 
 function ensureObject(data: unknown): Record<string, unknown> {
@@ -461,6 +476,68 @@ export function validateRegisterMcpClientInput(
     tokenEndpointAuthMethod: normalizeTokenEndpointAuthMethod(
       body.token_endpoint_auth_method,
     ),
+  };
+}
+
+export function validateRevokeMcpSessionInput(
+  data: unknown,
+): RevokeMcpSessionDto {
+  const body = ensureObject(data);
+
+  if (body.revokeAll === true) {
+    if (body.sessionId !== undefined) {
+      throw new ValidationError(
+        "sessionId cannot be combined with revokeAll=true",
+      );
+    }
+    return { revokeAll: true };
+  }
+
+  const sessionId = normalizeStringField({
+    value: body.sessionId,
+    field: "sessionId",
+    required: true,
+    maxLength: 36,
+  });
+  validateId(sessionId!);
+  return { sessionId: sessionId! };
+}
+
+export function validateRevokeMcpOAuthTokenInput(
+  data: unknown,
+): RevokeMcpOAuthTokenDto {
+  const body = ensureObject(data);
+
+  const token = normalizeStringField({
+    value: body.token,
+    field: "token",
+    required: true,
+    maxLength: 5000,
+  });
+  const clientId = normalizeClientId(body.clientId ?? body.client_id, false);
+
+  let tokenTypeHint: "refresh_token" | "access_token" | undefined;
+  const rawHint = body.tokenTypeHint ?? body.token_type_hint;
+  if (rawHint !== undefined && rawHint !== null) {
+    if (typeof rawHint !== "string" || !rawHint.trim()) {
+      throw new ValidationError("tokenTypeHint must be a string");
+    }
+    const normalizedHint = rawHint.trim();
+    if (
+      normalizedHint !== "refresh_token" &&
+      normalizedHint !== "access_token"
+    ) {
+      throw new ValidationError(
+        'tokenTypeHint must be "refresh_token" or "access_token"',
+      );
+    }
+    tokenTypeHint = normalizedHint;
+  }
+
+  return {
+    token: token!,
+    ...(clientId ? { clientId } : {}),
+    ...(tokenTypeHint ? { tokenTypeHint } : {}),
   };
 }
 


### PR DESCRIPTION
## Why
The public MCP OAuth surface can issue durable assistant sessions now, but users still need a clean way to disconnect assistants and revoke existing access without deleting their app account. This change adds explicit revocation at both the app-authenticated and OAuth-facing layers.

Closes #247.

## What changed
- added durable MCP assistant sessions plus user-level MCP revocation timestamps
- added app-authenticated session listing and revoke endpoints for connected assistants
- added OAuth token revocation for refresh-token based assistant disconnect flows
- tied MCP access tokens to assistant sessions and reject revoked sessions predictably
- updated MCP auth metadata/docs and added focused integration coverage for revoke/reconnect flows

## Verification
- `npm exec tsc -- --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `npm run test:integration`
- `CI=1 npm run test:ui:fast`
