### PR TITLE
refactor(auth): remove legacy plaintext refresh-token fallback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Navigation map for this directory.
 | `planner-runtime.md`     | Planner runtime architecture and tool-to-engine mapping                       |
 | `ops/railway-remote-mcp-deploy.md` | Railway deployment runbook for the public MCP surface            |
 | `ops/connector-smoke-checklist.md` | Manual ChatGPT / Claude connector smoke checklist                  |
+| `ops/refresh-token-fallback-removal.md` | Refresh-token cutover and legacy cleanup step               |
 | `ops/`                   | Repo operations runbooks and GitHub project setup notes                       |
 | `agent-ops/`             | Dual-agent protocol (state machine, review contract)                          |
 | `agent-queue/`           | Legacy markdown task archive and historical prompts                           |

--- a/docs/ops/refresh-token-fallback-removal.md
+++ b/docs/ops/refresh-token-fallback-removal.md
@@ -1,0 +1,32 @@
+# Refresh Token Fallback Removal
+
+The app auth flow now treats hashed refresh tokens as the only supported format.
+Older plaintext `refresh_tokens.token` rows are no longer rotated in-place during
+`refreshAccessToken`.
+
+## Pre-deploy check
+
+Run this against the target database:
+
+```sql
+SELECT COUNT(*) AS legacy_refresh_tokens
+FROM refresh_tokens
+WHERE token !~ '^[a-f0-9]{64}$';
+```
+
+If the count is `0`, no cleanup is required.
+
+## Cleanup action
+
+If the count is greater than `0`, remove the legacy rows before or immediately
+after deploying this change:
+
+```sql
+DELETE FROM refresh_tokens
+WHERE token !~ '^[a-f0-9]{64}$';
+```
+
+Effect:
+- affected users will need to sign in again to obtain a new hashed refresh token
+- current access tokens continue to work until they expire
+- hashed refresh-token rotation and revoke behavior remain unchanged

--- a/src/authService.test.ts
+++ b/src/authService.test.ts
@@ -357,7 +357,7 @@ describe("AuthService", () => {
       ).rejects.toThrow("Invalid refresh token");
     });
 
-    it("keeps legacy plaintext refresh token fallback disabled by default", async () => {
+    it("rejects legacy plaintext refresh token rows", async () => {
       const user = await prisma.user.create({
         data: {
           email: "legacy-refresh-default-off@example.com",
@@ -380,58 +380,6 @@ describe("AuthService", () => {
       await expect(
         authService.refreshAccessToken(legacyPlaintextToken),
       ).rejects.toThrow("Invalid refresh token");
-    });
-
-    it("allows legacy plaintext fallback only when explicitly enabled", async () => {
-      const previousFlag = process.env.ALLOW_LEGACY_PLAINTEXT_REFRESH_TOKEN;
-      const previousCutoff = process.env.LEGACY_REFRESH_TOKEN_FALLBACK_UNTIL;
-      process.env.ALLOW_LEGACY_PLAINTEXT_REFRESH_TOKEN = "true";
-      process.env.LEGACY_REFRESH_TOKEN_FALLBACK_UNTIL =
-        "2099-01-01T00:00:00.000Z";
-
-      try {
-        const fallbackService = new AuthService(prisma);
-        const user = await prisma.user.create({
-          data: {
-            email: "legacy-refresh-enabled@example.com",
-            password: await bcrypt.hash("password123", 10),
-          },
-        });
-        const legacyPlaintextToken = jwt.sign(
-          { userId: user.id, jti: "legacy-enabled" },
-          TEST_JWT_SECRET,
-          { expiresIn: "7d" },
-        );
-        await prisma.refreshToken.create({
-          data: {
-            token: legacyPlaintextToken,
-            userId: user.id,
-            expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-          },
-        });
-
-        const refreshed =
-          await fallbackService.refreshAccessToken(legacyPlaintextToken);
-        expect(refreshed.refreshToken).toBeDefined();
-
-        const refreshedRows = await prisma.refreshToken.findMany({
-          where: { userId: user.id },
-        });
-        expect(refreshedRows).toHaveLength(1);
-        expect(refreshedRows[0].token).toMatch(/^[a-f0-9]{64}$/);
-        expect(refreshedRows[0].token).not.toBe(legacyPlaintextToken);
-      } finally {
-        if (previousFlag === undefined) {
-          delete process.env.ALLOW_LEGACY_PLAINTEXT_REFRESH_TOKEN;
-        } else {
-          process.env.ALLOW_LEGACY_PLAINTEXT_REFRESH_TOKEN = previousFlag;
-        }
-        if (previousCutoff === undefined) {
-          delete process.env.LEGACY_REFRESH_TOKEN_FALLBACK_UNTIL;
-        } else {
-          process.env.LEGACY_REFRESH_TOKEN_FALLBACK_UNTIL = previousCutoff;
-        }
-      }
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,21 +21,6 @@ const databaseUrl =
   nodeEnv === "test"
     ? testDatabaseUrlFromAlias || databaseUrlTestRaw
     : process.env.DATABASE_URL;
-const allowLegacyPlaintextRefreshTokenFallback =
-  (
-    process.env.ALLOW_LEGACY_PLAINTEXT_REFRESH_TOKEN || "false"
-  ).toLowerCase() === "true";
-const legacyRefreshTokenFallbackUntilRaw = (
-  process.env.LEGACY_REFRESH_TOKEN_FALLBACK_UNTIL || "2026-12-31T23:59:59.000Z"
-).trim();
-const legacyRefreshTokenFallbackUntilDate = new Date(
-  legacyRefreshTokenFallbackUntilRaw,
-);
-const legacyRefreshTokenFallbackUntil = Number.isNaN(
-  legacyRefreshTokenFallbackUntilDate.getTime(),
-)
-  ? null
-  : legacyRefreshTokenFallbackUntilDate;
 const corsOrigins = (process.env.CORS_ORIGINS || "")
   .split(",")
   .map((origin) => origin.trim())
@@ -215,8 +200,6 @@ export const config = {
   aiProviderBaseUrl,
   aiProviderApiKey,
   aiProviderModel,
-  allowLegacyPlaintextRefreshTokenFallback,
-  legacyRefreshTokenFallbackUntil,
   aiDailySuggestionLimit:
     Number.isInteger(aiDailySuggestionLimit) && aiDailySuggestionLimit > 0
       ? aiDailySuggestionLimit

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -65,8 +65,6 @@ export class AuthService {
   private readonly MCP_JWT_EXPIRES_IN = "30d";
   private readonly MCP_JWT_EXPIRES_IN_MS = 30 * 24 * 60 * 60 * 1000;
   private readonly REFRESH_TOKEN_EXPIRES_IN = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
-  private readonly allowLegacyPlaintextRefreshTokenFallback: boolean;
-  private readonly legacyRefreshTokenFallbackUntil: Date | null;
   private emailService: EmailService;
 
   constructor(private prisma: PrismaClient) {
@@ -79,22 +77,7 @@ export class AuthService {
       process.env.JWT_REFRESH_SECRET ||
       process.env.JWT_SECRET ||
       config.refreshJwtSecret;
-    this.allowLegacyPlaintextRefreshTokenFallback =
-      (process.env.ALLOW_LEGACY_PLAINTEXT_REFRESH_TOKEN || "").toLowerCase() ===
-        "true" || config.allowLegacyPlaintextRefreshTokenFallback;
-    this.legacyRefreshTokenFallbackUntil =
-      config.legacyRefreshTokenFallbackUntil || null;
     this.emailService = new EmailService();
-  }
-
-  private shouldAllowLegacyPlaintextRefreshTokenFallback(): boolean {
-    if (!this.allowLegacyPlaintextRefreshTokenFallback) {
-      return false;
-    }
-    if (!this.legacyRefreshTokenFallbackUntil) {
-      return true;
-    }
-    return Date.now() <= this.legacyRefreshTokenFallbackUntil.getTime();
   }
 
   // Keep auth responses off the SMTP critical path.
@@ -593,38 +576,6 @@ export class AuthService {
       where: { token: hashedToken },
       include: { user: true },
     });
-
-    // Backward compatibility: opt-in and time-bound one-time rotation from older plaintext rows.
-    // TODO: Remove this fallback entirely after migration window closes.
-    if (!storedToken && this.shouldAllowLegacyPlaintextRefreshTokenFallback()) {
-      const legacyToken = await this.prisma.refreshToken.findUnique({
-        where: { token: refreshToken },
-        include: { user: true },
-      });
-      if (legacyToken) {
-        console.warn(
-          "[auth] rotating legacy plaintext refresh token row",
-          JSON.stringify({
-            refreshTokenId: legacyToken.id,
-            userId: legacyToken.userId,
-          }),
-        );
-        storedToken = await this.prisma.refreshToken.update({
-          where: { id: legacyToken.id },
-          data: { token: hashedToken },
-          include: { user: true },
-        });
-      }
-    } else if (
-      !storedToken &&
-      this.allowLegacyPlaintextRefreshTokenFallback &&
-      this.legacyRefreshTokenFallbackUntil &&
-      Date.now() > this.legacyRefreshTokenFallbackUntil.getTime()
-    ) {
-      console.warn(
-        `[auth] legacy plaintext refresh token fallback disabled after cutoff ${this.legacyRefreshTokenFallbackUntil.toISOString()}`,
-      );
-    }
 
     if (!storedToken) {
       throw new Error("Invalid refresh token");


### PR DESCRIPTION
## Why
The canonical refresh-token path still had a temporary compatibility branch for older plaintext rows. The hashed path is now the only supported format, so this removes the fallback and documents the one-time production cleanup step.

Closes #248.

## What changed
- removed the legacy plaintext refresh-token fallback branch from `AuthService.refreshAccessToken`
- removed the related config flags from `src/config.ts`
- reduced auth-service coverage to the post-fallback behavior only
- added an ops note documenting the pre-deploy query and cleanup SQL for any remaining plaintext refresh-token rows

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `npm run test:integration`
- `CI=1 npm run test:ui:fast`

## Ops note
A direct production query found legacy plaintext refresh-token rows still present, so `docs/ops/refresh-token-fallback-removal.md` includes the exact cleanup query and delete step to run during cutover.
