### PR TITLE
refactor(api): retire category write compatibility

### DIFF
--- a/src/agentRouter.test.ts
+++ b/src/agentRouter.test.ts
@@ -12,10 +12,42 @@ import type {
 } from "./types";
 
 function createProjectServiceMock(): jest.Mocked<IProjectService> {
+  const projects: Project[] = [];
+
   return {
-    findAll: jest.fn<Promise<Project[]>, [string]>(),
-    findById: jest.fn<Promise<Project | null>, [string, string]>(),
-    create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
+    findAll: jest
+      .fn<Promise<Project[]>, [string]>()
+      .mockImplementation(async (userId) =>
+        projects.filter((project) => project.userId === userId),
+      ),
+    findById: jest
+      .fn<Promise<Project | null>, [string, string]>()
+      .mockImplementation(
+        async (userId, id) =>
+          projects.find(
+            (project) => project.userId === userId && project.id === id,
+          ) ?? null,
+      ),
+    create: jest
+      .fn<Promise<Project>, [string, CreateProjectDto]>()
+      .mockImplementation(async (userId, dto) => {
+        const project: Project = {
+          id: `project-${projects.length + 1}`,
+          name: dto.name,
+          status: dto.status ?? "active",
+          archived: dto.archived ?? false,
+          userId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          taskCount: 0,
+          openTaskCount: 0,
+          completedTaskCount: 0,
+          todoCount: 0,
+          openTodoCount: 0,
+        };
+        projects.push(project);
+        return project;
+      }),
     update: jest.fn<
       Promise<Project | null>,
       [string, string, UpdateProjectDto]

--- a/src/agentService.test.ts
+++ b/src/agentService.test.ts
@@ -208,4 +208,37 @@ describe("AgentService", () => {
 
     expect(withoutNextAction.map((project) => project.name)).toEqual(["Work"]);
   });
+
+  it("resolves category-only task creates through the project service edge adapter", async () => {
+    const todoService = new TodoService();
+    const project = makeProject("project-1", "Work");
+    const projectService = createProjectServiceMock([project]);
+
+    const agentService = new AgentService({ todoService, projectService });
+    const created = await agentService.createTask(USER_ID, {
+      title: "Project scoped task",
+      category: "Work",
+    });
+
+    expect(created.projectId).toBe(project.id);
+    expect(created.category).toBe("Work");
+  });
+
+  it("creates a project when category-only agent writes target a missing project", async () => {
+    const todoService = new TodoService();
+    const createdProject = makeProject("project-2", "Backlog");
+    const projectService = createProjectServiceMock([]);
+    projectService.create.mockResolvedValue(createdProject);
+
+    const agentService = new AgentService({ todoService, projectService });
+    const created = await agentService.createTask(USER_ID, {
+      title: "Backlog task",
+      category: "Backlog",
+    });
+
+    expect(projectService.create).toHaveBeenCalledWith(USER_ID, {
+      name: "Backlog",
+    });
+    expect(created.projectId).toBe(createdProject.id);
+  });
 });

--- a/src/aiApplyService.test.ts
+++ b/src/aiApplyService.test.ts
@@ -280,7 +280,10 @@ describe("applyTodoBoundSuggestion", () => {
     expect(todoService.update).toHaveBeenCalledWith(
       USER_ID,
       TODO_ID,
-      expect.objectContaining({ category: "Work" }),
+      expect.objectContaining({
+        category: "Work",
+        projectId: "proj-1",
+      }),
     );
   });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -216,7 +216,14 @@ export function createApp(
 
   app.use("/admin", createAdminRouter({ authService }));
   app.use("/users", createUsersRouter({ authService }));
-  app.use("/todos", createTodosRouter({ todoService, resolveTodoUserId }));
+  app.use(
+    "/todos",
+    createTodosRouter({
+      todoService,
+      projectService,
+      resolveTodoUserId,
+    }),
+  );
   app.use(
     "/projects",
     createProjectsRouter({

--- a/src/auth.api.test.ts
+++ b/src/auth.api.test.ts
@@ -31,6 +31,7 @@ describe("Authentication API", () => {
   beforeEach(async () => {
     // Clean up before each test
     await prisma.todo.deleteMany();
+    await prisma.project.deleteMany();
     await prisma.user.deleteMany();
   });
 
@@ -530,6 +531,63 @@ describe("Authentication API", () => {
         expect(response.body.title).toBe("Authenticated Todo");
         expect(response.body.userId).toBe(userId);
       });
+
+      it("maps legacy category-only creates onto the canonical project relationship", async () => {
+        const response = await request(app)
+          .post("/todos")
+          .set("Authorization", `Bearer ${authToken}`)
+          .send({
+            title: "Legacy project create",
+            category: "Work / Client A",
+          })
+          .expect(201);
+
+        expect(response.body.category).toBe("Work / Client A");
+        expect(response.body.projectId).toEqual(expect.any(String));
+
+        const project = await prisma.project.findUnique({
+          where: {
+            userId_name: {
+              userId,
+              name: "Work / Client A",
+            },
+          },
+        });
+        expect(project?.id).toBe(response.body.projectId);
+      });
+
+      it("keeps renamed projects filterable through the category query", async () => {
+        const createdProject = await request(app)
+          .post("/projects")
+          .set("Authorization", `Bearer ${authToken}`)
+          .send({ name: "Work / Client A" })
+          .expect(201);
+
+        const createdTodo = await request(app)
+          .post("/todos")
+          .set("Authorization", `Bearer ${authToken}`)
+          .send({
+            title: "Ship report",
+            category: "Work / Client A",
+          })
+          .expect(201);
+
+        await request(app)
+          .put(`/projects/${createdProject.body.id}`)
+          .set("Authorization", `Bearer ${authToken}`)
+          .send({ name: "Work / Client B" })
+          .expect(200);
+
+        const filtered = await request(app)
+          .get("/todos")
+          .set("Authorization", `Bearer ${authToken}`)
+          .query({ category: "Work / Client B" })
+          .expect(200);
+
+        expect(filtered.body).toHaveLength(1);
+        expect(filtered.body[0].id).toBe(createdTodo.body.id);
+        expect(filtered.body[0].category).toBe("Work / Client B");
+      });
     });
 
     describe("Projects", () => {
@@ -589,6 +647,35 @@ describe("Authentication API", () => {
           .delete(`/projects/${created.body.id}`)
           .set("Authorization", `Bearer ${otherToken}`)
           .expect(404);
+      });
+    });
+
+    describe("PUT /todos/:id", () => {
+      it("maps legacy category-only updates onto the canonical project relationship", async () => {
+        const created = await request(app)
+          .post("/todos")
+          .set("Authorization", `Bearer ${authToken}`)
+          .send({ title: "Needs project" })
+          .expect(201);
+
+        const updated = await request(app)
+          .put(`/todos/${created.body.id}`)
+          .set("Authorization", `Bearer ${authToken}`)
+          .send({ category: "Work / Backend" })
+          .expect(200);
+
+        expect(updated.body.category).toBe("Work / Backend");
+        expect(updated.body.projectId).toEqual(expect.any(String));
+
+        const project = await prisma.project.findUnique({
+          where: {
+            userId_name: {
+              userId,
+              name: "Work / Backend",
+            },
+          },
+        });
+        expect(project?.id).toBe(updated.body.projectId);
       });
     });
 

--- a/src/prismaTodoService.test.ts
+++ b/src/prismaTodoService.test.ts
@@ -82,7 +82,7 @@ describe("PrismaTodoService (Integration)", () => {
       expect(found!.title).toBe("Persistent Todo");
     });
 
-    it("should create and link a project when category is provided", async () => {
+    it("should keep category-only creates unassigned", async () => {
       const todo = await service.create(TEST_USER_ID, {
         title: "Project linked todo",
         category: "Work / Client A",
@@ -93,12 +93,25 @@ describe("PrismaTodoService (Integration)", () => {
         where: { id: todo.id },
         include: { project: true },
       });
-      expect(dbTodo?.project?.name).toBe("Work / Client A");
+      expect(dbTodo?.projectId).toBeNull();
+      expect(dbTodo?.project).toBeNull();
+    });
 
-      const projectCount = await prisma.project.count({
-        where: { userId: TEST_USER_ID, name: "Work / Client A" },
+    it("should derive category from the linked project when projectId is provided", async () => {
+      const project = await prisma.project.create({
+        data: {
+          userId: TEST_USER_ID,
+          name: "Work / Client A",
+        },
       });
-      expect(projectCount).toBe(1);
+
+      const todo = await service.create(TEST_USER_ID, {
+        title: "Project linked todo",
+        projectId: project.id,
+      });
+
+      expect(todo.projectId).toBe(project.id);
+      expect(todo.category).toBe("Work / Client A");
     });
   });
 
@@ -191,6 +204,12 @@ describe("PrismaTodoService (Integration)", () => {
       todayStart.setHours(0, 0, 0, 0);
       const todayEnd = new Date();
       todayEnd.setHours(23, 59, 59, 999);
+      const project = await prisma.project.create({
+        data: {
+          userId: TEST_USER_ID,
+          name: "Work",
+        },
+      });
 
       await service.create(TEST_USER_ID, {
         title: "Loose today",
@@ -198,7 +217,7 @@ describe("PrismaTodoService (Integration)", () => {
       });
       await service.create(TEST_USER_ID, {
         title: "Project today",
-        category: "Work",
+        projectId: project.id,
         dueDate: new Date(todayStart),
       });
       await service.create(TEST_USER_ID, {
@@ -361,10 +380,17 @@ describe("PrismaTodoService (Integration)", () => {
       expect(found!.title).toBe("Updated");
     });
 
-    it("should update linked project when category changes", async () => {
+    it("should update the stored category without changing projectId", async () => {
       const created = await service.create(TEST_USER_ID, {
         title: "Todo with project",
-        category: "Work / Client A",
+        projectId: (
+          await prisma.project.create({
+            data: {
+              userId: TEST_USER_ID,
+              name: "Work / Client A",
+            },
+          })
+        ).id,
       });
 
       const updated = await service.update(TEST_USER_ID, created.id, {
@@ -372,18 +398,15 @@ describe("PrismaTodoService (Integration)", () => {
       });
 
       expect(updated).not.toBeNull();
-      expect(updated!.category).toBe("Work / Client B");
+      expect(updated!.category).toBe("Work / Client A");
 
       const dbTodo = await prisma.todo.findUnique({
         where: { id: created.id },
         include: { project: true },
       });
-      expect(dbTodo?.project?.name).toBe("Work / Client B");
-
-      const newProjectCount = await prisma.project.count({
-        where: { userId: TEST_USER_ID, name: "Work / Client B" },
-      });
-      expect(newProjectCount).toBe(1);
+      expect(dbTodo?.category).toBe("Work / Client B");
+      expect(dbTodo?.project?.name).toBe("Work / Client A");
+      expect(dbTodo?.projectId).toBe(created.projectId);
     });
   });
 

--- a/src/projectService.test.ts
+++ b/src/projectService.test.ts
@@ -42,13 +42,13 @@ describe("PrismaProjectService (Integration)", () => {
     });
   });
 
-  it("renames a project and synchronizes linked task categories", async () => {
+  it("renames a project without rewriting the stored legacy category column", async () => {
     const project = await projectService.create(TEST_USER_ID, {
       name: "Work / Client A",
     });
     const todo = await todoService.create(TEST_USER_ID, {
       title: "Ship report",
-      category: "Work / Client A",
+      projectId: project.id,
     });
 
     const updated = await projectService.update(TEST_USER_ID, project.id, {
@@ -66,6 +66,7 @@ describe("PrismaProjectService (Integration)", () => {
       where: { id: todo.id },
       include: { project: true },
     });
+    expect(dbTodo?.category).toBe("Work / Client A");
     expect(dbTodo?.project?.name).toBe("Work / Client B");
   });
 
@@ -85,7 +86,7 @@ describe("PrismaProjectService (Integration)", () => {
     const target = await projectService.create(TEST_USER_ID, { name: "Beta" });
     const todo = await todoService.create(TEST_USER_ID, {
       title: "Move me",
-      category: "Alpha",
+      projectId: source.id,
     });
 
     const deleted = await projectService.delete(
@@ -114,7 +115,7 @@ describe("PrismaProjectService (Integration)", () => {
     const source = await projectService.create(TEST_USER_ID, { name: "Alpha" });
     const todo = await todoService.create(TEST_USER_ID, {
       title: "Unassign me",
-      category: "Alpha",
+      projectId: source.id,
     });
 
     const deleted = await projectService.delete(

--- a/src/routes/todosRouter.ts
+++ b/src/routes/todosRouter.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { ITodoService } from "../interfaces/ITodoService";
+import { IProjectService } from "../interfaces/IProjectService";
 import {
   validateCreateTodo,
   validateUpdateTodo,
@@ -10,14 +11,17 @@ import {
   validateFindTodosQuery,
 } from "../validation/validation";
 import { PrismaTodoService } from "../services/prismaTodoService";
+import { applyLegacyCategoryProjectWriteCompatibility } from "../services/projectWriteCompatibility";
 
 interface TodoRouterDeps {
   todoService: ITodoService;
+  projectService?: IProjectService;
   resolveTodoUserId: (req: Request, res: Response) => string | null;
 }
 
 export function createTodosRouter({
   todoService,
+  projectService,
   resolveTodoUserId,
 }: TodoRouterDeps): Router {
   const router = Router();
@@ -189,7 +193,12 @@ export function createTodosRouter({
       const userId = resolveTodoUserId(req, res);
       if (!userId) return;
       const dto = validateCreateTodo(req.body);
-      const todo = await todoService.create(userId, dto);
+      const compatibleDto = await applyLegacyCategoryProjectWriteCompatibility(
+        userId,
+        dto,
+        projectService,
+      );
+      const todo = await todoService.create(userId, compatibleDto);
       res.status(201).json(todo);
     } catch (error) {
       if (
@@ -224,7 +233,13 @@ export function createTodosRouter({
         validateId(id);
 
         const dto = validateUpdateTodo(req.body);
-        const todo = await todoService.update(userId, id, dto);
+        const compatibleDto =
+          await applyLegacyCategoryProjectWriteCompatibility(
+            userId,
+            dto,
+            projectService,
+          );
+        const todo = await todoService.update(userId, id, compatibleDto);
 
         if (!todo) {
           return res.status(404).json({ error: "Todo not found" });

--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -23,6 +23,7 @@ import {
   PlanProjectResult,
   WeeklyReviewResult,
 } from "../types/plannerTypes";
+import { applyLegacyCategoryProjectWriteCompatibility } from "./projectWriteCompatibility";
 
 interface AgentServiceDeps {
   todoService: ITodoService;
@@ -85,7 +86,12 @@ export class AgentService {
   }
 
   async createTask(userId: string, dto: CreateTodoDto): Promise<Todo> {
-    return this.deps.todoService.create(userId, dto);
+    const compatibleDto = await applyLegacyCategoryProjectWriteCompatibility(
+      userId,
+      dto,
+      this.deps.projectService,
+    );
+    return this.deps.todoService.create(userId, compatibleDto);
   }
 
   async updateTask(
@@ -93,7 +99,12 @@ export class AgentService {
     id: string,
     dto: UpdateTodoDto,
   ): Promise<Todo | null> {
-    return this.deps.todoService.update(userId, id, dto);
+    const compatibleDto = await applyLegacyCategoryProjectWriteCompatibility(
+      userId,
+      dto,
+      this.deps.projectService,
+    );
+    return this.deps.todoService.update(userId, id, compatibleDto);
   }
 
   async completeTask(

--- a/src/services/aiApplyService.ts
+++ b/src/services/aiApplyService.ts
@@ -6,6 +6,7 @@ import {
   NormalizedTodoBoundSuggestion,
   NormalizedTodayPlanSuggestion,
 } from "./aiNormalizationService";
+import { applyLegacyCategoryProjectWriteCompatibility } from "./projectWriteCompatibility";
 
 // ── Result types ──
 
@@ -157,9 +158,16 @@ export async function applyTodoBoundSuggestion(params: {
         };
       }
 
-      const updated = await todoService.update(userId, inputTodoId, {
-        category: nextCategory,
-      });
+      const compatibleDto = await applyLegacyCategoryProjectWriteCompatibility(
+        userId,
+        { category: nextCategory },
+        projectService,
+      );
+      const updated = await todoService.update(
+        userId,
+        inputTodoId,
+        compatibleDto,
+      );
       if (!updated) {
         return { ok: false, status: 404, error: "Todo not found" };
       }

--- a/src/services/prismaTodoService.ts
+++ b/src/services/prismaTodoService.ts
@@ -45,30 +45,6 @@ export class PrismaTodoService implements ITodoService {
     return trimmed.length > 0 ? trimmed : null;
   }
 
-  private async ensureProjectId(
-    tx: Prisma.TransactionClient,
-    userId: string,
-    projectName: string,
-  ): Promise<string> {
-    const project = await tx.project.upsert({
-      where: {
-        userId_name: {
-          userId,
-          name: projectName,
-        },
-      },
-      create: {
-        name: projectName,
-        userId,
-      },
-      update: {},
-      select: {
-        id: true,
-      },
-    });
-    return project.id;
-  }
-
   private async findOwnedProject(
     tx: Prisma.TransactionClient,
     userId: string,
@@ -242,24 +218,50 @@ export class PrismaTodoService implements ITodoService {
       where.status = { in: query.statuses };
     }
     if (query?.category !== undefined) {
-      where.category = query.category;
+      and.push({
+        OR: [
+          { project: { is: { name: query.category } } },
+          {
+            AND: [{ projectId: null }, { category: query.category }],
+          },
+        ],
+      });
     }
     if (query?.projectId) {
       where.projectId = query.projectId;
     }
     if (query?.unsorted) {
       and.push({
-        OR: [{ category: null }, { category: "" }],
+        projectId: null,
       });
     }
     if (query?.project) {
       and.push({
         OR: [
-          { category: query.project },
           {
-            category: {
-              startsWith: `${query.project}${PROJECT_PATH_SEPARATOR}`,
+            project: { is: { name: query.project } },
+          },
+          {
+            project: {
+              is: {
+                name: {
+                  startsWith: `${query.project}${PROJECT_PATH_SEPARATOR}`,
+                },
+              },
             },
+          },
+          {
+            AND: [{ projectId: null }, { category: query.project }],
+          },
+          {
+            AND: [
+              { projectId: null },
+              {
+                category: {
+                  startsWith: `${query.project}${PROJECT_PATH_SEPARATOR}`,
+                },
+              },
+            ],
           },
         ],
       });
@@ -270,6 +272,13 @@ export class PrismaTodoService implements ITodoService {
           { title: { contains: query.search, mode: "insensitive" } },
           { description: { contains: query.search, mode: "insensitive" } },
           { notes: { contains: query.search, mode: "insensitive" } },
+          {
+            project: {
+              is: {
+                name: { contains: query.search, mode: "insensitive" },
+              },
+            },
+          },
           { category: { contains: query.search, mode: "insensitive" } },
           { waitingOn: { contains: query.search, mode: "insensitive" } },
         ],
@@ -381,9 +390,6 @@ export class PrismaTodoService implements ITodoService {
         category = project.name;
       } else {
         category = this.normalizeCategory(dto.category);
-        projectId = category
-          ? await this.ensureProjectId(tx, userId, category)
-          : null;
       }
       const headingId = await this.ensureHeadingId(
         tx,
@@ -578,26 +584,7 @@ export class PrismaTodoService implements ITodoService {
           }
         } else if (dto.category !== undefined) {
           const category = this.normalizeCategory(dto.category);
-          if (!category) {
-            nextProjectId = null;
-            projectChanged = currentTodo.projectId !== null;
-            updateData.category = null;
-            updateData.projectId = null;
-            updateData.headingId = null;
-          } else {
-            const ensuredProjectId = await this.ensureProjectId(
-              tx,
-              userId,
-              category,
-            );
-            nextProjectId = ensuredProjectId;
-            projectChanged = currentTodo.projectId !== ensuredProjectId;
-            updateData.category = category;
-            updateData.projectId = ensuredProjectId;
-            if (projectChanged && dto.headingId === undefined) {
-              updateData.headingId = null;
-            }
-          }
+          updateData.category = category;
         }
 
         if (dto.headingId !== undefined) {

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -261,14 +261,6 @@ export class PrismaProjectService implements IProjectService {
           },
         });
 
-        // Keep legacy category column synchronized until full API migration is complete.
-        if (dto.name !== undefined) {
-          await tx.todo.updateMany({
-            where: { userId, projectId },
-            data: { category: dto.name },
-          });
-        }
-
         const [count, openTodoCount, completedTaskCount] = await Promise.all([
           tx.todo.count({ where: { userId, projectId } }),
           tx.todo.count({

--- a/src/services/projectWriteCompatibility.ts
+++ b/src/services/projectWriteCompatibility.ts
@@ -1,0 +1,69 @@
+import { IProjectService } from "../interfaces/IProjectService";
+
+type TodoProjectWriteShape = {
+  projectId?: string | null;
+  category?: string | null;
+};
+
+function normalizeLegacyCategory(category?: string | null): string | null {
+  if (category === null || category === undefined) {
+    return null;
+  }
+
+  const trimmed = category.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function resolveProjectByName(
+  userId: string,
+  projectName: string,
+  projectService: IProjectService,
+) {
+  const findExisting = async () => {
+    const projects = await projectService.findAll(userId);
+    return projects.find((project) => project.name === projectName) ?? null;
+  };
+
+  const existing = await findExisting();
+  if (existing) {
+    return existing;
+  }
+
+  try {
+    return await projectService.create(userId, { name: projectName });
+  } catch (error) {
+    const createdByConcurrentRequest = await findExisting();
+    if (createdByConcurrentRequest) {
+      return createdByConcurrentRequest;
+    }
+    throw error;
+  }
+}
+
+export async function applyLegacyCategoryProjectWriteCompatibility<
+  T extends TodoProjectWriteShape,
+>(userId: string, dto: T, projectService?: IProjectService): Promise<T> {
+  if (
+    !projectService ||
+    dto.projectId !== undefined ||
+    dto.category === undefined
+  ) {
+    return dto;
+  }
+
+  const category = normalizeLegacyCategory(dto.category);
+  if (!category) {
+    return {
+      ...dto,
+      category: null,
+      projectId: null,
+    };
+  }
+
+  const project = await resolveProjectByName(userId, category, projectService);
+  return {
+    ...dto,
+    category: project.name,
+    projectId: project.id,
+  };
+}


### PR DESCRIPTION
## Why
The canonical Prisma todo/project services were still treating `category` as an authoritative project relationship. That kept legacy compatibility logic embedded in the core service layer and required project renames to rewrite stored task categories.

## What changed
- removed category-driven project creation and reassignment from the canonical Prisma todo service
- stopped project rename from rewriting stored task category values
- added a narrow compatibility adapter for legacy category-only writes in the REST `/todos` route, agent service, and AI apply flow
- updated project-aware query filtering to use canonical `projectId` / project name matching so renamed projects still filter correctly
- added regression coverage for canonical service behavior and legacy edge compatibility

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
- `npm run test:integration`

Closes #246
