### PR TITLE
feat(api): extend durable idempotency to additional MCP write flows

### DIFF
--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -110,10 +110,14 @@ This keeps the existing app routes unchanged while making the agent surface pred
 
 ## Idempotency
 
-The first pass adds idempotency for create flows through the optional `Idempotency-Key` header on:
+Durable idempotency is implemented through the optional `Idempotency-Key`
+header on:
 
 - `create_task`
 - `create_project`
+- `plan_project` when `mode=apply`
+- `ensure_next_action` when `mode=apply`
+- `weekly_review` when `mode=apply`
 
 Current behavior:
 
@@ -123,7 +127,7 @@ Current behavior:
 
 Current limitation:
 
-- idempotency is still only implemented for the create flows that currently need safe retries
+- idempotency is still only implemented for create flows and the planner apply flows where duplicate task creation is the main retry risk
 
 ## Traceability
 
@@ -141,7 +145,7 @@ This is enough for operational debugging without introducing a separate analytic
 
 ## Known Gaps / Follow-Up
 
-- extend idempotency beyond create flows if retry semantics are needed for more writes
+- extend idempotency beyond create flows and planner apply flows if retry semantics are needed for more writes
 - decide when the project/category compatibility path can be retired in favor of `projectId` only
 - add destructive confirmation patterns before exposing broader delete or bulk write actions
 - add richer audit reporting or revocation UI if operational needs outgrow the current trace tables

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -165,7 +165,14 @@ The delegated internal agent execution still emits its own action trace with `su
 
 ## Idempotency
 
-First-pass idempotency is implemented for `create_task` via an optional `idempotencyKey` tool argument.
+Durable idempotency is implemented through an optional `idempotencyKey` tool
+argument on:
+
+- `create_task`
+- `create_project`
+- `plan_project` when `mode="apply"`
+- `ensure_next_action` when `mode="apply"`
+- `weekly_review` when `mode="apply"`
 
 Current behavior:
 
@@ -190,6 +197,6 @@ Those docs also record what remains manual from this sandboxed environment.
 ## Current Limitations
 
 - revocation/session management exists as API routes, but there is still no polished in-app assistant management UI
-- idempotency is implemented for `create_task` and `create_project`
+- idempotency is implemented for `create_task`, `create_project`, and the planner apply flows that can create duplicate tasks on retry
 - persisted audit records are lightweight operational traces, not a full analytics platform
 - the public deployment and real ChatGPT/Claude connector validation must be completed from a networked environment with Railway access

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -219,6 +219,10 @@ For the planner tools above, `tools/list` exposes the minimum scopes needed to
 run the default `mode: "suggest"` behavior, plus mode-scoped requirements for
 `apply`.
 
+For `create_task`, `create_project`, and the planner tools that support
+`mode: "apply"`, MCP callers can also send an optional `idempotencyKey`
+argument to make safe retries replay the original success response.
+
 The planner-runtime architecture behind these tools is documented in
 `docs/planner-runtime.md`.
 

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.2.1",
   "surface": "agent_accessibility_v2",
   "basePath": "/agent",
   "description": "Expanded machine-usable task and project contract for the Todos app. This surface stays thin over the existing server-side todo and project services.",
@@ -26,7 +26,7 @@
     {
       "name": "Idempotency-Key",
       "requiredWhen": "optional",
-      "description": "Optional idempotency key for create actions. Replays return the original successful response for matching input, backed by durable storage in the normal server runtime."
+      "description": "Optional idempotency key for supported create actions and planner apply flows. Replays return the original successful response for matching input, backed by durable storage in the normal server runtime."
     }
   ],
   "responseEnvelope": {
@@ -1208,7 +1208,7 @@
         }
       },
       "errorModel": "structured_agent_error",
-      "idempotency": "not_applicable"
+      "idempotency": "optional_header_for_apply_flow"
     },
     {
       "name": "ensure_next_action",
@@ -1250,7 +1250,7 @@
         }
       },
       "errorModel": "structured_agent_error",
-      "idempotency": "not_applicable"
+      "idempotency": "optional_header_for_apply_flow"
     },
     {
       "name": "weekly_review",
@@ -1327,7 +1327,7 @@
         }
       },
       "errorModel": "structured_agent_error",
-      "idempotency": "not_applicable"
+      "idempotency": "optional_header_for_apply_flow"
     },
     {
       "name": "decide_next_work",

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -148,6 +148,12 @@ const READ_ONLY_ACTIONS = new Set<AgentActionName>([
   "analyze_work_graph",
 ]);
 
+const IDEMPOTENT_PLANNER_APPLY_ACTIONS = new Set<AgentActionName>([
+  "plan_project",
+  "ensure_next_action",
+  "weekly_review",
+]);
+
 function buildTrace(
   context: AgentExecutionContext,
   extras: Record<string, unknown> = {},
@@ -798,45 +804,105 @@ export class AgentExecutor {
         }
         case "plan_project": {
           const plannerInput = validateAgentPlanProjectInput(input);
-          const plan = await this.agentService.planProjectForUser(
-            context.userId,
-            plannerInput,
-          );
-          if (!plan) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Project not found",
-              false,
-              "Verify the project ID belongs to the authenticated user.",
+          const executePlanProject = async () => {
+            const plan = await this.agentService.planProjectForUser(
+              context.userId,
+              plannerInput,
+            );
+            if (!plan) {
+              throw new AgentExecutionError(
+                404,
+                "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                "Project not found",
+                false,
+                "Verify the project ID belongs to the authenticated user.",
+              );
+            }
+            return { plan };
+          };
+          if (
+            IDEMPOTENT_PLANNER_APPLY_ACTIONS.has(action) &&
+            plannerInput.mode === "apply"
+          ) {
+            return await this.handleIdempotentWriteAction(
+              action,
+              context,
+              plannerInput,
+              executePlanProject,
             );
           }
-          return this.success(action, readOnly, context, 200, { plan });
+          return this.success(
+            action,
+            readOnly,
+            context,
+            200,
+            await executePlanProject(),
+          );
         }
         case "ensure_next_action": {
           const plannerInput = validateAgentEnsureNextActionInput(input);
-          const result = await this.agentService.ensureNextActionForUser(
-            context.userId,
-            plannerInput,
-          );
-          if (!result) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Project not found",
-              false,
-              "Verify the project ID belongs to the authenticated user.",
+          const executeEnsureNextAction = async () => {
+            const result = await this.agentService.ensureNextActionForUser(
+              context.userId,
+              plannerInput,
+            );
+            if (!result) {
+              throw new AgentExecutionError(
+                404,
+                "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                "Project not found",
+                false,
+                "Verify the project ID belongs to the authenticated user.",
+              );
+            }
+            return { result };
+          };
+          if (
+            IDEMPOTENT_PLANNER_APPLY_ACTIONS.has(action) &&
+            plannerInput.mode === "apply"
+          ) {
+            return await this.handleIdempotentWriteAction(
+              action,
+              context,
+              plannerInput,
+              executeEnsureNextAction,
             );
           }
-          return this.success(action, readOnly, context, 200, { result });
+          return this.success(
+            action,
+            readOnly,
+            context,
+            200,
+            await executeEnsureNextAction(),
+          );
         }
         case "weekly_review": {
           const plannerInput = validateAgentWeeklyReviewInput(input);
-          const review = await this.agentService.weeklyReviewForUser(
-            context.userId,
-            plannerInput,
+          const executeWeeklyReview = async () => {
+            const review = await this.agentService.weeklyReviewForUser(
+              context.userId,
+              plannerInput,
+            );
+            return { review };
+          };
+          if (
+            IDEMPOTENT_PLANNER_APPLY_ACTIONS.has(action) &&
+            plannerInput.mode === "apply"
+          ) {
+            return await this.handleIdempotentWriteAction(
+              action,
+              context,
+              plannerInput,
+              executeWeeklyReview,
+            );
+          }
+          return this.success(
+            action,
+            readOnly,
+            context,
+            200,
+            await executeWeeklyReview(),
           );
-          return this.success(action, readOnly, context, 200, { review });
         }
         case "decide_next_work": {
           const plannerInput = validateAgentDecideNextWorkInput(input);
@@ -1032,6 +1098,83 @@ export class AgentExecutor {
     });
     return {
       status: 201,
+      body: response,
+    };
+  }
+
+  private async handleIdempotentWriteAction(
+    action: AgentActionName,
+    context: AgentExecutionContext,
+    input: unknown,
+    execute: () => Promise<Record<string, unknown>>,
+    successStatus = 200,
+  ): Promise<AgentExecutionResult> {
+    const readOnly = false;
+    const idempotencyKey = context.idempotencyKey;
+
+    if (idempotencyKey) {
+      const lookup = await this.idempotencyService.lookup(
+        action,
+        context.userId,
+        idempotencyKey,
+        input,
+      );
+      if (lookup.kind === "conflict") {
+        throw new AgentExecutionError(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency key already used for different input",
+          false,
+          "Reuse the original payload or supply a new idempotency key.",
+        );
+      }
+      if (lookup.kind === "replay") {
+        const replayed = lookup.body as AgentSuccessEnvelope;
+        const response = {
+          ...replayed,
+          trace: buildTrace(context, {
+            replayed: true,
+            originalRequestId: replayed.trace.requestId,
+          }),
+        };
+        this.persistActionAudit(context, {
+          action,
+          readOnly,
+          status: lookup.status,
+          outcome: "success",
+          replayed: true,
+        });
+        return {
+          status: lookup.status,
+          body: response,
+        };
+      }
+    }
+
+    const response = this.buildSuccessBody(
+      action,
+      readOnly,
+      context,
+      await execute(),
+    );
+    if (idempotencyKey) {
+      await this.idempotencyService.store(
+        action,
+        context.userId,
+        idempotencyKey,
+        input,
+        successStatus,
+        response,
+      );
+    }
+    this.persistActionAudit(context, {
+      action,
+      readOnly,
+      status: successStatus,
+      outcome: "success",
+    });
+    return {
+      status: successStatus,
       body: response,
     };
   }

--- a/src/agentRouter.test.ts
+++ b/src/agentRouter.test.ts
@@ -279,6 +279,128 @@ describe("Agent router", () => {
     expect(replayResponse.body.trace.replayed).toBe(true);
   });
 
+  it("replays ensure_next_action apply responses for matching idempotency keys", async () => {
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000051",
+      name: "Ops",
+      status: "active",
+      archived: false,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project);
+
+    const firstResponse = await request(app)
+      .post("/agent/write/ensure_next_action")
+      .set("Idempotency-Key", "planner-ensure-1")
+      .send({
+        projectId: "00000000-0000-1000-8000-000000000051",
+        mode: "apply",
+      })
+      .expect(200);
+
+    const replayResponse = await request(app)
+      .post("/agent/write/ensure_next_action")
+      .set("Idempotency-Key", "planner-ensure-1")
+      .send({
+        projectId: "00000000-0000-1000-8000-000000000051",
+        mode: "apply",
+      })
+      .expect(200);
+
+    const tasks = await todoService.findAll("default-user", {
+      archived: false,
+    });
+
+    expect(firstResponse.body.data.result.created).toBe(true);
+    expect(replayResponse.body.trace.replayed).toBe(true);
+    expect(replayResponse.body.data.result.task.id).toBe(
+      firstResponse.body.data.result.task.id,
+    );
+    expect(tasks).toHaveLength(1);
+  });
+
+  it("returns a structured idempotency conflict for mismatched plan_project apply payloads", async () => {
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000052",
+      name: "Vacation",
+      goal: "Plan trip",
+      status: "active",
+      archived: false,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project);
+
+    await request(app)
+      .post("/agent/write/plan_project")
+      .set("Idempotency-Key", "planner-plan-1")
+      .send({
+        projectId: "00000000-0000-1000-8000-000000000052",
+        goal: "Plan vacation",
+        mode: "apply",
+      })
+      .expect(200);
+
+    const response = await request(app)
+      .post("/agent/write/plan_project")
+      .set("Idempotency-Key", "planner-plan-1")
+      .send({
+        projectId: "00000000-0000-1000-8000-000000000052",
+        goal: "Plan a different vacation",
+        mode: "apply",
+      })
+      .expect(409);
+
+    expect(response.body.ok).toBe(false);
+    expect(response.body.action).toBe("plan_project");
+    expect(response.body.error.code).toBe("IDEMPOTENCY_CONFLICT");
+  });
+
+  it("replays weekly_review apply responses without duplicating created tasks", async () => {
+    const reviewProject = {
+      id: "00000000-0000-1000-8000-000000000053",
+      name: "Admin",
+      status: "active",
+      archived: false,
+      userId: "default-user",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    } as Project;
+    projectService.findAll.mockResolvedValue([reviewProject]);
+    projectService.findById.mockResolvedValue(reviewProject);
+
+    const firstResponse = await request(app)
+      .post("/agent/write/weekly_review")
+      .set("Idempotency-Key", "planner-review-1")
+      .send({
+        mode: "apply",
+      })
+      .expect(200);
+
+    const replayResponse = await request(app)
+      .post("/agent/write/weekly_review")
+      .set("Idempotency-Key", "planner-review-1")
+      .send({
+        mode: "apply",
+      })
+      .expect(200);
+
+    const tasks = await todoService.findAll("default-user", {
+      archived: false,
+    });
+
+    expect(firstResponse.body.data.review.appliedActions).toHaveLength(1);
+    expect(replayResponse.body.trace.replayed).toBe(true);
+    expect(tasks).toHaveLength(1);
+  });
+
   it("plans a project through the write surface", async () => {
     projectService.findById.mockResolvedValue({
       id: "00000000-0000-1000-8000-000000000041",

--- a/src/api.contract.test.ts
+++ b/src/api.contract.test.ts
@@ -219,6 +219,27 @@ describe("API Contract", () => {
           "analyze_work_graph",
         ]),
       );
+
+      const actionsByName = new Map<
+        string,
+        { name: string; idempotency?: string }
+      >(
+        response.body.data.manifest.actions.map(
+          (action: { name: string; idempotency?: string }) => [
+            action.name,
+            action,
+          ],
+        ),
+      );
+      expect(actionsByName.get("plan_project")?.idempotency).toBe(
+        "optional_header_for_apply_flow",
+      );
+      expect(actionsByName.get("ensure_next_action")?.idempotency).toBe(
+        "optional_header_for_apply_flow",
+      );
+      expect(actionsByName.get("weekly_review")?.idempotency).toBe(
+        "optional_header_for_apply_flow",
+      );
     });
   });
 

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -32,6 +32,14 @@ const PLANNER_MODE_SCOPED_ACTIONS = new Set<AgentActionName>([
   "weekly_review",
 ]);
 
+const MCP_IDEMPOTENCY_KEY_ACTIONS = new Set<AgentActionName>([
+  "create_task",
+  "create_project",
+  "plan_project",
+  "ensure_next_action",
+  "weekly_review",
+]);
+
 const PLANNER_SUGGEST_SCOPES: McpScope[] = [
   PROJECT_READ_SCOPE,
   TASK_READ_SCOPE,
@@ -47,6 +55,12 @@ function isPlannerModeScopedAction(
   actionName: AgentActionName,
 ): actionName is "plan_project" | "ensure_next_action" | "weekly_review" {
   return PLANNER_MODE_SCOPED_ACTIONS.has(actionName);
+}
+
+export function supportsMcpIdempotencyKey(
+  actionName: AgentActionName,
+): boolean {
+  return MCP_IDEMPOTENCY_KEY_ACTIONS.has(actionName);
 }
 
 function minimumRequiredScopesForAction(
@@ -131,7 +145,7 @@ function buildCatalog(): ToolCatalogEntry[] {
       action.inputSchema as Record<string, unknown>,
     );
 
-    if (action.name === "create_task" || action.name === "create_project") {
+    if (supportsMcpIdempotencyKey(action.name as AgentActionName)) {
       const properties =
         (inputSchema.properties as Record<string, unknown> | undefined) || {};
       inputSchema.properties = {
@@ -139,7 +153,9 @@ function buildCatalog(): ToolCatalogEntry[] {
         idempotencyKey: {
           type: "string",
           maxLength: 200,
-          description: `Optional first-pass retry guard for ${action.name}. Reuse the same key with the same input to replay the original success response.`,
+          description: isPlannerModeScopedAction(action.name as AgentActionName)
+            ? `Optional durable retry guard for ${action.name} when mode="apply". Reuse the same key with the same input to replay the original success response.`
+            : `Optional durable retry guard for ${action.name}. Reuse the same key with the same input to replay the original success response.`,
         },
       };
     }
@@ -184,8 +200,7 @@ export function listMcpTools(input: {
       readOnlyHint: tool.readOnly,
       destructiveHint:
         tool.name === "delete_project" || tool.name === "delete_task",
-      idempotentHint:
-        tool.name === "create_task" || tool.name === "create_project",
+      idempotentHint: supportsMcpIdempotencyKey(tool.name),
       openWorldHint: false,
     },
     auth: {

--- a/src/mcpRouter.test.ts
+++ b/src/mcpRouter.test.ts
@@ -570,6 +570,12 @@ describe("Remote MCP router auth and scopes", () => {
       suggest: ["projects.read", "tasks.read"],
       apply: ["projects.read", "tasks.read", "tasks.write"],
     });
+    expect(ensureNextActionTool.inputSchema.properties.idempotencyKey).toEqual(
+      expect.objectContaining({
+        type: "string",
+      }),
+    );
+    expect(ensureNextActionTool.annotations.idempotentHint).toBe(true);
 
     const decideNextWorkTool = response.body.result.tools.find(
       (tool: { name: string }) => tool.name === "decide_next_work",
@@ -824,6 +830,68 @@ describe("Remote MCP router auth and scopes", () => {
     );
 
     logSpy.mockRestore();
+  });
+
+  it("replays planner apply calls through the MCP surface when idempotencyKey is reused", async () => {
+    currentSession = buildMcpSession("user-1", [
+      "projects.read",
+      "tasks.read",
+      "tasks.write",
+    ]);
+    projectService.findById.mockResolvedValue({
+      id: "00000000-0000-1000-8000-000000000032",
+      name: "Ops",
+      status: "active",
+      archived: false,
+      userId: "user-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      todoCount: 0,
+      openTodoCount: 0,
+    });
+
+    const firstResponse = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer task-write-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 8.1,
+        method: "tools/call",
+        params: {
+          name: "ensure_next_action",
+          arguments: {
+            projectId: "00000000-0000-1000-8000-000000000032",
+            mode: "apply",
+            idempotencyKey: "mcp-ensure-1",
+          },
+        },
+      })
+      .expect(200);
+
+    const replayResponse = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer task-write-token")
+      .send({
+        jsonrpc: "2.0",
+        id: 8.2,
+        method: "tools/call",
+        params: {
+          name: "ensure_next_action",
+          arguments: {
+            projectId: "00000000-0000-1000-8000-000000000032",
+            mode: "apply",
+            idempotencyKey: "mcp-ensure-1",
+          },
+        },
+      })
+      .expect(200);
+
+    expect(replayResponse.body.result.structuredContent.trace.replayed).toBe(
+      true,
+    );
+    expect(
+      replayResponse.body.result.structuredContent.data.result.task.id,
+    ).toBe(firstResponse.body.result.structuredContent.data.result.task.id);
   });
 
   it("moves a task to a project through the MCP surface", async () => {

--- a/src/routes/mcpRouter.ts
+++ b/src/routes/mcpRouter.ts
@@ -15,6 +15,7 @@ import {
   listMcpTools,
   MCP_PROTOCOL_VERSION,
   requiredScopesForToolCall,
+  supportsMcpIdempotencyKey,
 } from "../mcp/mcpToolCatalog";
 import { AuthService } from "../services/authService";
 import { McpOAuthService } from "../services/mcpOAuthService";
@@ -593,7 +594,7 @@ export function createMcpRouter({
 
         const toolArguments = { ...normalized.args };
         const idempotencyKey =
-          tool.name === "create_task" &&
+          supportsMcpIdempotencyKey(tool.name as AgentActionName) &&
           typeof toolArguments.idempotencyKey === "string" &&
           toolArguments.idempotencyKey.trim()
             ? toolArguments.idempotencyKey.trim()


### PR DESCRIPTION
## Why
Planner apply flows still retried unsafely compared with the existing durable create-task path. This extends the current MCP/agent idempotency layer so repeated apply-mode planner calls replay cleanly instead of duplicating work.

Closes #249

## What changed
- extended durable idempotency to `plan_project`, `ensure_next_action`, and `weekly_review` when they run in `mode=apply`
- exposed optional `idempotencyKey` support for those planner tools in MCP metadata and schemas
- kept suggest mode read-only and non-idempotent
- added route, MCP, agent, and manifest coverage for replay and conflict handling
- updated MCP/agent docs to reflect the broader durable idempotency surface

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`