### PR TITLE
docs(planner): align runtime docs with projectId-only matching

### DIFF
--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -90,7 +90,7 @@ That split is reflected in both code and the manifest metadata.
 
 - Agent actions reuse the existing `todoService` and `projectService` implementations.
 - Existing server-side validation remains the source of truth for create/update rules.
-- The first pass preserves the current project/category compatibility path already used by the server. `projectId` is the canonical project relationship, while `category` remains available for backward compatibility and transition.
+- `projectId` is the canonical project relationship for planner and agent matching. `category` still exists only as backward-compatibility debt in the underlying service layer until that transition is fully retired.
 - Project deletion defaults to unassigning linked tasks unless a target project ID is provided for reassignment.
 - Task deletion defaults to archival unless `hardDelete=true` is explicitly requested.
 - Project archiving is metadata-only in this pass. Archived projects still appear in list responses with `archived: true`.
@@ -146,7 +146,7 @@ This is enough for operational debugging without introducing a separate analytic
 ## Known Gaps / Follow-Up
 
 - extend idempotency beyond create flows and planner apply flows if retry semantics are needed for more writes
-- decide when the project/category compatibility path can be retired in favor of `projectId` only
+- retire the remaining service-layer `category` compatibility path once the transition can be completed safely
 - add destructive confirmation patterns before exposing broader delete or bulk write actions
 - add richer audit reporting or revocation UI if operational needs outgrow the current trace tables
 - keep the new MCP assistant-session revoke APIs aligned with any future in-app assistant management UI

--- a/docs/planner-runtime.md
+++ b/docs/planner-runtime.md
@@ -63,8 +63,11 @@ task/project business-logic stack.
   planning engine
 - `weekly_review` apply mode only performs safe starter actions such as
   creating a next action
-- the runtime still carries the repo's temporary `projectId` / `category`
-  compatibility bridge until that migration follow-up is retired
+- planner and agent project matching are `projectId`-only now; any remaining
+  `category` compatibility debt lives in the canonical task/project services,
+  not inside the planner runtime
 - Home keeps its deterministic client fallback when the planner-backed AI path
   abstains or fails; the reuse today is in backend focus suggestion generation,
   not a full dashboard rewrite
+- broader UI surfaces can reuse this runtime later, but are not yet routed
+  through it


### PR DESCRIPTION
## Why
The planner/runtime docs still described planner and agent matching as carrying a temporary `category` bridge after the codebase moved those paths to `projectId`-only matching.

## What changed
- updated the planner runtime doc to reflect the current `projectId`-only planner/agent matching behavior
- clarified that any remaining `category` compatibility debt lives in the canonical service layer, not the planner runtime
- kept the newer Home planner-runtime reuse note intact

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

Closes #245