### PR TITLE
docs(harness): add session docs and templates

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,16 @@
+# .codex/
+
+Worktree-local harness session files live here.
+
+- `context-ack.json` is the machine-readable record that the current session
+  loaded the required docs and constraints before editing code.
+- `progress.md` is a local run log for the current worktree session.
+- `feature-checklist.json` is the local execution checklist for the current
+  task or issue.
+
+These files are intentionally ignored by git and should not be used as the
+source of truth for task state. GitHub Issues and GitHub Projects remain the
+authoritative task queue.
+
+Use the committed templates under `.codex/templates/` to initialize them in a
+fresh worktree.

--- a/.codex/templates/context-ack.json
+++ b/.codex/templates/context-ack.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "issue": "",
+  "branch": "",
+  "worktree": "",
+  "startedAt": "",
+  "docsRead": [
+    "AGENTS.md",
+    "docs/WORKFLOW.md",
+    "docs/architecture/AGENT_RULES.md",
+    "docs/harness/README.md",
+    "docs/harness/SESSION_FLOW.md",
+    "docs/harness/INVARIANT_MATRIX.md"
+  ],
+  "acknowledgedInvariants": [],
+  "notes": ""
+}

--- a/.codex/templates/feature-checklist.json
+++ b/.codex/templates/feature-checklist.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "issue": "",
+  "title": "",
+  "branch": "",
+  "checks": [
+    {
+      "id": "understand-scope",
+      "label": "Understand scope and current architecture",
+      "done": false
+    },
+    {
+      "id": "implement",
+      "label": "Implement the smallest coherent change",
+      "done": false
+    },
+    {
+      "id": "verify",
+      "label": "Run the required verification commands",
+      "done": false
+    },
+    {
+      "id": "handoff",
+      "label": "Prepare PR and handoff summary",
+      "done": false
+    }
+  ],
+  "notes": []
+}

--- a/.codex/templates/progress.md
+++ b/.codex/templates/progress.md
@@ -1,0 +1,25 @@
+# Session Progress
+
+## Context
+
+- Issue:
+- Branch:
+- Worktree:
+- Goal:
+
+## Progress Log
+
+- Session started:
+
+## Verification
+
+- [ ] `npx tsc --noEmit`
+- [ ] `npm run format:check`
+- [ ] `npm run lint:html`
+- [ ] `npm run lint:css`
+- [ ] `npm run test:unit`
+- [ ] `CI=1 npm run test:ui:fast`
+
+## Open Questions / Risks
+
+- None recorded yet.

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ test-results/
 blob-report/
 .playwright/.auth/
 client/vendor/chrono-node/
+.codex/context-ack.json
+.codex/progress.md
+.codex/feature-checklist.json
 
 /src/generated/prisma

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Navigation map for this directory.
 | `assistant-mcp.md`       | Remote MCP adapter for assistant clients                                      |
 | `remote-mcp-auth.md`     | Account linking, auth, scopes, and local testing for the remote MCP surface   |
 | `planner-runtime.md`     | Planner runtime architecture and tool-to-engine mapping                       |
+| `harness/`               | Repo harness docs: session flow, evals, and invariant matrix                  |
 | `ops/railway-remote-mcp-deploy.md` | Railway deployment runbook for the public MCP surface            |
 | `ops/connector-smoke-checklist.md` | Manual ChatGPT / Claude connector smoke checklist                  |
 | `ops/refresh-token-fallback-removal.md` | Refresh-token cutover and legacy cleanup step               |

--- a/docs/harness/EVALS.md
+++ b/docs/harness/EVALS.md
@@ -1,0 +1,62 @@
+# Evals
+
+Current harness direction for evals in this repo.
+
+## Purpose
+
+Evals are capability and regression checks for agent-facing behavior that sit
+alongside the normal unit, integration, and UI suites.
+
+They are not meant to replace the existing test stack. The harness should use
+the existing stack as the substrate and add eval runners where they provide a
+clearer signal about agent quality, planner quality, MCP behavior, or output
+contract drift.
+
+## First-pass principles
+
+- keep the harness script-first and repo-native
+- prefer code-based graders first
+- isolate each trial from the next
+- separate regression suites from capability suites
+- emit machine-readable artifacts
+
+## Existing building blocks already in the repo
+
+- contract fixtures and validation tests under `src/`
+- planner tests and deterministic planners under `src/services/planner/`
+- MCP and agent route coverage under `src/mcpRouter.test.ts`,
+  `src/mcpPublicRouter.test.ts`, and `src/agentRouter.test.ts`
+- deterministic UI readiness helpers under `tests/ui/helpers/todos-view.ts`
+- decision-assist telemetry under `src/services/decisionAssistTelemetry.ts`
+
+## Eval artifact expectations
+
+The harness should eventually emit artifacts under `artifacts/evals/`, such as:
+
+- machine-readable result summaries
+- per-trial traces or transcripts
+- screenshots when a UI flow is part of grading
+- structured failure reasons
+
+## Planned suite split
+
+- decision-assist evals
+- planner evals
+- agent evals
+- MCP evals
+- UI smoke evals where a browser-grade artifact is valuable
+
+## Grading guidance
+
+Use code-based graders first:
+
+- final DB state
+- HTTP/API response shape
+- tool-call sequence
+- forbidden-action checks
+- telemetry emission
+- UI assertions
+
+LLM-judge grading can be added later only for areas where deterministic grading
+cannot reasonably capture quality, such as rationale quality or prioritization
+quality.

--- a/docs/harness/INVARIANT_MATRIX.md
+++ b/docs/harness/INVARIANT_MATRIX.md
@@ -1,0 +1,29 @@
+# Invariant Matrix
+
+Map of load-bearing repo rules to their current enforcement points.
+
+| Invariant | Source | Current enforcement | Gap / follow-up |
+| --------- | ------ | ------------------- | --------------- |
+| Work only in a fresh worktree per issue | `AGENTS.md` | manual today | session bootstrap script and drift check planned |
+| Run `git status --porcelain` before start and before rebase/merge | `AGENTS.md` | manual today | session-start script planned |
+| Event delegation only for dynamic UI | `AGENTS.md`, `docs/architecture/AGENT_RULES.md` | review + existing app architecture | no mechanical check yet |
+| `#categoryFilter` + `filterTodos()` is the canonical filter path | `AGENTS.md`, `docs/architecture/AGENT_RULES.md` | review + regression tests | add drift check later |
+| Always use `setSelectedProjectKey(...)` for project selection | `AGENTS.md`, `docs/architecture/AGENT_RULES.md` | review + UI regression coverage | add drift check later |
+| No `page.waitForTimeout()` in UI tests | `AGENTS.md` | review today | add mechanical check later |
+| No native browser prompts in app code | repo issue direction, UI conventions | review today | add mechanical check later |
+| Fast UI suite is the CI gate | `AGENTS.md`, `package.json` | `CI=1 npm run test:ui:fast` | keep explicit in harness smoke |
+| MCP and agent behavior should stay aligned with docs/contracts | `docs/agent-accessibility.md`, `docs/assistant-mcp.md`, `src/api.contract.test.ts` | contract tests + route tests | add stronger drift checks later |
+| Task state lives in GitHub, not markdown docs | `docs/WORKFLOW.md` | docs + issue templates | local `.codex/` files must remain session-only |
+| Session context should be acknowledged before edits | harness issue scope | none yet | local context ack file and later drift check |
+
+## Usage
+
+Use this matrix as the single place to answer:
+
+- what invariant exists
+- where it is documented
+- how it is currently enforced
+- what still needs to become mechanical
+
+When a new guard or test lands, update this matrix so the harness map stays
+current.

--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -1,0 +1,41 @@
+# Harness Guide
+
+Canonical map for the repo harness.
+
+The harness exists to make long-running agent work repeatable and checkable.
+It does not replace GitHub Issues or GitHub Projects as the source of task
+state.
+
+## What lives here
+
+| Path                          | Purpose |
+| ----------------------------- | ------- |
+| `docs/harness/README.md`      | Harness doc map and scope |
+| `docs/harness/SESSION_FLOW.md`| Required flow for starting and running a worktree session |
+| `docs/harness/EVALS.md`       | Eval strategy, current runners, and artifact expectations |
+| `docs/harness/INVARIANT_MATRIX.md` | Matrix of repo invariants, enforcement points, and gaps |
+
+## Session artifacts
+
+Each worktree should keep local harness artifacts under `.codex/`:
+
+- `.codex/context-ack.json`
+- `.codex/progress.md`
+- `.codex/feature-checklist.json`
+
+These files are intentionally gitignored. They are local run state, not task
+tracking. Initialize them from `.codex/templates/`.
+
+## Source of truth split
+
+- GitHub Issues and GitHub Projects hold task state.
+- `docs/` holds durable guidance.
+- `.codex/` holds worktree-local session state.
+
+## Current harness boundaries
+
+- The harness is script-first and repo-native.
+- The repo continues to use Node, Jest, Playwright, Prisma, and shell scripts.
+- External harness platforms are intentionally out of scope for the first pass.
+
+See `docs/harness/SESSION_FLOW.md` for how a session should use these files.

--- a/docs/harness/SESSION_FLOW.md
+++ b/docs/harness/SESSION_FLOW.md
@@ -1,0 +1,89 @@
+# Session Flow
+
+Required flow for a code-changing harness session.
+
+## 1. Create a fresh worktree
+
+Use the repo-required worktree flow from `AGENTS.md`. One branch and one
+worktree should correspond to one issue or PR.
+
+## 2. Get bearings before editing
+
+At the start of a session:
+
+1. run `git status --porcelain`
+2. confirm the current working directory and branch
+3. read:
+   - `AGENTS.md`
+   - `docs/WORKFLOW.md`
+   - `docs/architecture/AGENT_RULES.md`
+   - this harness directory
+4. inspect recent relevant git history if the area has moved recently
+5. initialize local `.codex/` session artifacts from `.codex/templates/`
+
+## 3. Create local session artifacts
+
+Every code-changing session should have:
+
+- `.codex/context-ack.json`
+- `.codex/progress.md`
+- `.codex/feature-checklist.json`
+
+Minimum expectations:
+
+- `context-ack.json` records the docs/invariants that were acknowledged
+- `progress.md` records what happened during the run
+- `feature-checklist.json` captures the execution checklist for the current
+  issue or slice
+
+These are local harness artifacts, not durable task tracking.
+
+## 4. Establish a baseline
+
+Before editing code, establish whether the current worktree is healthy.
+
+The harness baseline should include:
+
+- typecheck
+- formatting check
+- HTML validation
+- CSS lint
+- fast unit tests when relevant to the area
+- a deterministic UI/browser smoke when the task touches the app surface
+
+The upcoming session scripts should automate this, but the flow is mandatory
+even before those scripts exist.
+
+## 5. Make the smallest coherent change
+
+- keep changes scoped to the current issue
+- reuse canonical services and route patterns
+- do not create parallel business-logic paths
+- update durable docs when the behavior or operating model changes
+
+## 6. Re-run required verification
+
+For code changes, run the repo-required checks:
+
+- `npx tsc --noEmit`
+- `npm run format:check`
+- `npm run lint:html`
+- `npm run lint:css`
+- `npm run test:unit`
+- `CI=1 npm run test:ui:fast`
+
+If a failure is unrelated, record that explicitly in the local progress log and
+handoff instead of silently working around it.
+
+## 7. Prepare handoff
+
+The final handoff should include:
+
+- branch name and head SHA
+- changed files
+- what was implemented
+- verification results
+- PR creation URL
+
+The local `.codex/` artifacts can support that handoff, but GitHub remains the
+durable task record.

--- a/docs/memory/index/INDEX.md
+++ b/docs/memory/index/INDEX.md
@@ -10,6 +10,7 @@ Quick-reference to find things. Keep this flat and current.
 | Claude project config    | `CLAUDE.md` (root)                      |
 | Operational guardrails   | `docs/SAFETY_GUARDRAILS.md`             |
 | Architecture invariants  | `docs/architecture/AGENT_RULES.md`      |
+| Harness docs             | `docs/harness/README.md`                |
 | Dual-agent protocol      | `docs/agent-ops/DUAL_AGENT_PROTOCOL.md` |
 
 ## Task Management
@@ -55,8 +56,12 @@ Quick-reference to find things. Keep this flat and current.
 | Assistant MCP       | `docs/assistant-mcp.md`        |
 | Remote MCP auth     | `docs/remote-mcp-auth.md`      |
 | Planner runtime     | `docs/planner-runtime.md`      |
+| Harness session flow | `docs/harness/SESSION_FLOW.md` |
+| Harness evals        | `docs/harness/EVALS.md`        |
+| Harness invariants   | `docs/harness/INVARIANT_MATRIX.md` |
 | MCP deploy runbook  | `docs/ops/railway-remote-mcp-deploy.md` |
 | Connector smoke     | `docs/ops/connector-smoke-checklist.md` |
 | Codex task prompts  | `docs/codex-prompts.md`        |
 | Codex task config   | `.codex/tasks/ui-testing.md`   |
+| Local session templates | `.codex/templates/`         |
 | Dual-agent runner   | `scripts/dual-agent-runner.sh` |


### PR DESCRIPTION
## Why
The repo has strong guidance and tests already, but it does not yet have a single harness doc map or a standard shape for worktree-local session artifacts. This adds the first harness layer without changing the task-state model.

## What changed
- added `docs/harness/README.md`, `SESSION_FLOW.md`, `EVALS.md`, and `INVARIANT_MATRIX.md`
- added tracked `.codex/templates/` and a `.codex/README.md` for worktree-local session artifacts
- ignored the live local session files in `.gitignore`
- updated the main docs map and memory index to point to the new harness docs

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

Closes #258