### PR TITLE
feat(harness): add session bootstrap scripts

### DIFF
--- a/docs/harness/README.md
+++ b/docs/harness/README.md
@@ -14,6 +14,7 @@ state.
 | `docs/harness/SESSION_FLOW.md`| Required flow for starting and running a worktree session |
 | `docs/harness/EVALS.md`       | Eval strategy, current runners, and artifact expectations |
 | `docs/harness/INVARIANT_MATRIX.md` | Matrix of repo invariants, enforcement points, and gaps |
+| `scripts/harness/`            | Bootstrap, session-start, and smoke scripts |
 
 ## Session artifacts
 

--- a/docs/harness/SESSION_FLOW.md
+++ b/docs/harness/SESSION_FLOW.md
@@ -7,6 +7,10 @@ Required flow for a code-changing harness session.
 Use the repo-required worktree flow from `AGENTS.md`. One branch and one
 worktree should correspond to one issue or PR.
 
+The harness bootstrap script should automate that flow:
+
+- `scripts/harness/bootstrap-worktree.sh <issue-number> <short-feature-name>`
+
 ## 2. Get bearings before editing
 
 At the start of a session:
@@ -20,6 +24,10 @@ At the start of a session:
    - this harness directory
 4. inspect recent relevant git history if the area has moved recently
 5. initialize local `.codex/` session artifacts from `.codex/templates/`
+
+The harness session-start script should automate this:
+
+- `scripts/harness/session-start.sh <issue-number>`
 
 ## 3. Create local session artifacts
 
@@ -51,8 +59,12 @@ The harness baseline should include:
 - fast unit tests when relevant to the area
 - a deterministic UI/browser smoke when the task touches the app surface
 
-The upcoming session scripts should automate this, but the flow is mandatory
-even before those scripts exist.
+The smoke script should automate the minimal baseline:
+
+- `scripts/harness/smoke.sh`
+
+It should stay small and reuse the repo’s existing deterministic checks rather
+than inventing a second CI stack.
 
 ## 5. Make the smallest coherent change
 

--- a/scripts/harness/bootstrap-worktree.sh
+++ b/scripts/harness/bootstrap-worktree.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <issue-number> <short-feature-name> [base-branch]" >&2
+  echo "Example: $0 259 harness-scripts" >&2
+  exit 1
+fi
+
+ISSUE_NUMBER="$1"
+SHORT_NAME="$2"
+BASE_BRANCH="${3:-origin/master}"
+BRANCH_NAME="codex/issue-${ISSUE_NUMBER}-${SHORT_NAME}"
+WORKTREE_DIR="/private/tmp/todos-api-issue-${ISSUE_NUMBER}-${SHORT_NAME}"
+
+cd "${REPO_ROOT}"
+
+echo "==> repo root: ${REPO_ROOT}"
+git status --porcelain
+git fetch origin
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+  echo "Local branch already exists: ${BRANCH_NAME}" >&2
+  exit 1
+fi
+
+if [[ -e "${WORKTREE_DIR}" ]]; then
+  echo "Worktree path already exists: ${WORKTREE_DIR}" >&2
+  exit 1
+fi
+
+echo "==> creating worktree ${WORKTREE_DIR} on ${BRANCH_NAME} from ${BASE_BRANCH}"
+git worktree add "${WORKTREE_DIR}" -b "${BRANCH_NAME}" "${BASE_BRANCH}"
+
+cd "${WORKTREE_DIR}"
+echo "==> installing dependencies"
+npm ci
+
+echo "==> starting session harness"
+HARNESS_REPO_ROOT="${WORKTREE_DIR}" "${SCRIPT_DIR}/session-start.sh" "${ISSUE_NUMBER}"

--- a/scripts/harness/session-start.sh
+++ b/scripts/harness/session-start.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${HARNESS_REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+cd "${REPO_ROOT}"
+
+ISSUE_NUMBER="${1:-}"
+BRANCH_NAME="$(git branch --show-current)"
+WORKTREE_DIR="$(pwd)"
+CODEX_DIR="${REPO_ROOT}/.codex"
+TEMPLATE_DIR="${CODEX_DIR}/templates"
+CONTEXT_ACK="${CODEX_DIR}/context-ack.json"
+PROGRESS_LOG="${CODEX_DIR}/progress.md"
+FEATURE_CHECKLIST="${CODEX_DIR}/feature-checklist.json"
+DOCS=(
+  "AGENTS.md"
+  "docs/WORKFLOW.md"
+  "docs/architecture/AGENT_RULES.md"
+  "docs/harness/README.md"
+  "docs/harness/SESSION_FLOW.md"
+  "docs/harness/EVALS.md"
+  "docs/harness/INVARIANT_MATRIX.md"
+)
+
+echo "==> harness session start"
+echo "pwd: ${WORKTREE_DIR}"
+echo "branch: ${BRANCH_NAME}"
+echo "issue: ${ISSUE_NUMBER:-unassigned}"
+echo
+
+echo "==> git status --porcelain"
+git status --porcelain
+echo
+
+echo "==> recent history"
+git log --oneline -5
+echo
+
+mkdir -p "${CODEX_DIR}"
+
+if [[ ! -f "${CONTEXT_ACK}" ]]; then
+  cp "${TEMPLATE_DIR}/context-ack.json" "${CONTEXT_ACK}"
+fi
+if [[ ! -f "${PROGRESS_LOG}" ]]; then
+  cp "${TEMPLATE_DIR}/progress.md" "${PROGRESS_LOG}"
+fi
+if [[ ! -f "${FEATURE_CHECKLIST}" ]]; then
+  cp "${TEMPLATE_DIR}/feature-checklist.json" "${FEATURE_CHECKLIST}"
+fi
+
+python3 - <<'PY' "${CONTEXT_ACK}" "${ISSUE_NUMBER}" "${BRANCH_NAME}" "${WORKTREE_DIR}"
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+path = pathlib.Path(sys.argv[1])
+issue = sys.argv[2]
+branch = sys.argv[3]
+worktree = sys.argv[4]
+
+data = json.loads(path.read_text())
+data["issue"] = issue
+data["branch"] = branch
+data["worktree"] = worktree
+if not data.get("startedAt"):
+    data["startedAt"] = datetime.now(timezone.utc).isoformat()
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+python3 - <<'PY' "${FEATURE_CHECKLIST}" "${ISSUE_NUMBER}" "${BRANCH_NAME}"
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+issue = sys.argv[2]
+branch = sys.argv[3]
+
+data = json.loads(path.read_text())
+data["issue"] = issue
+data["branch"] = branch
+if not data.get("title"):
+    data["title"] = f"Issue {issue}" if issue else "Unassigned session"
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+
+python3 - <<'PY' "${PROGRESS_LOG}" "${ISSUE_NUMBER}" "${BRANCH_NAME}" "${WORKTREE_DIR}"
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+path = pathlib.Path(sys.argv[1])
+issue = sys.argv[2]
+branch = sys.argv[3]
+worktree = sys.argv[4]
+text = path.read_text()
+text = text.replace("- Issue:", f"- Issue: {issue}" if issue else "- Issue: unassigned", 1)
+text = text.replace("- Branch:", f"- Branch: {branch}", 1)
+text = text.replace("- Worktree:", f"- Worktree: {worktree}", 1)
+text = text.replace("- Session started:", f"- Session started: {datetime.now(timezone.utc).isoformat()}", 1)
+path.write_text(text)
+PY
+
+echo "==> required docs"
+for doc in "${DOCS[@]}"; do
+  echo "--- ${doc}"
+  sed -n '1,40p' "${doc}"
+  echo
+done
+
+echo "==> local session artifacts"
+echo "- ${CONTEXT_ACK}"
+echo "- ${PROGRESS_LOG}"
+echo "- ${FEATURE_CHECKLIST}"
+echo
+echo "--- feature checklist"
+cat "${FEATURE_CHECKLIST}"
+echo
+
+echo "==> running harness smoke"
+"${SCRIPT_DIR}/smoke.sh"

--- a/scripts/harness/smoke.sh
+++ b/scripts/harness/smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+echo "==> typecheck"
+npx tsc --noEmit
+
+echo "==> visual tagging guard"
+npm run test:ui:check-visual-tags
+
+echo "==> harness browser smoke"
+PLAYWRIGHT_AUTH_DIR=.playwright/.auth npx playwright test tests/ui/harness-smoke.spec.ts --project=chromium

--- a/tests/ui/harness-smoke.spec.ts
+++ b/tests/ui/harness-smoke.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+import { bootstrapTodosContext } from "./helpers/todos-view";
+
+test("Harness session smoke bootstraps Todos and reaches idle state", async ({
+  browser,
+}) => {
+  const { context, page } = await bootstrapTodosContext(browser);
+
+  await expect(page.locator("#todosView")).toHaveClass(/active/);
+  await expect(page.locator("#todosContent")).toBeVisible();
+  await expect(page.locator("#todosListHeaderTitle")).toHaveText("All tasks");
+
+  await context.close();
+});


### PR DESCRIPTION
## Why
The harness docs are in place, but the repo still needs a repeatable session bootstrap flow so every agent worktree starts from the same bearings and baseline checks.

Closes #259.

## What changed
- added `scripts/harness/bootstrap-worktree.sh` to create a new issue worktree, install deps, and launch the harness session flow
- added `scripts/harness/session-start.sh` to gather bearings, initialize local `.codex/` session artifacts, and run the harness smoke baseline
- added `scripts/harness/smoke.sh` plus a small Playwright smoke spec that reuses the repo's deterministic todos-view helpers
- updated the harness docs to point at the new bootstrap/session/smoke scripts

## Verification
- `scripts/harness/session-start.sh 259`
- `scripts/harness/bootstrap-worktree.sh 999 harness-bootstrap-smoke codex/issue-259-harness-scripts`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
