### PR TITLE
ci: notify harness failures

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -39,3 +39,7 @@ jobs:
         with:
           name: harness-cleanup-report
           path: artifacts/harness/cleanup-report
+
+      - name: Notify harness regression
+        if: failure()
+        run: node scripts/harness/issue-alert.mjs

--- a/scripts/harness/issue-alert.mjs
+++ b/scripts/harness/issue-alert.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+const repo = process.env.GITHUB_REPOSITORY;
+const workflow = process.env.GITHUB_WORKFLOW ?? 'harness';
+const runId = process.env.GITHUB_RUN_ID;
+const sha = process.env.GITHUB_SHA?.slice(0, 7) ?? 'unknown';
+const ref = process.env.GITHUB_REF ?? 'unknown';
+const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
+const title = `Harness regression: ${workflow} failed (${sha})`;
+const body = `## Harness regression\n- workflow: ${workflow}\n- run: ${runUrl}\n- branch: ${ref}\n- commit: ${sha}\n\nView logs: ${runUrl}`;
+
+function run(cmd, input = '') {
+  return execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'inherit'], input }).trim();
+}
+
+let issueNumber = '';
+try {
+  issueNumber = run("gh issue list --label harness-alert --state open --json number --jq '.[0].number' || true");
+  if (!issueNumber) issueNumber = '';
+} catch (error) {
+  issueNumber = '';
+}
+
+if (issueNumber) {
+  run(`gh issue comment ${issueNumber}`, body);
+} else {
+  run(`gh issue create --title "${title.replace(/"/g, '')}" --label harness-alert --label type:ci-alert`, body);
+}


### PR DESCRIPTION
## Why
We need a lightweight failure path so harness regressions automatically open or update a tracker.

## What
- add a harness workflow step that, on failure, runs `scripts/harness/issue-alert.mjs`
- the script uses `gh issue` to comment/update an open `harness-alert` issue or create one when absent

## Verification
- `npm run harness:cleanup-report`
- `npm run eval:all`
- `npx tsc --noEmit`, `npm run format:check`, `npm run lint:html`, `npm run lint:css`, `npm run test:unit`, `CI=1 npm run test:ui:fast`
