### PR TITLE
feat(api): add 12 AI agent actions (anti-entropy, planning, triage, eval harness)

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -2,6 +2,7 @@ const base = require("./jest.config");
 
 module.exports = {
   ...base,
+  roots: ["<rootDir>/src", "<rootDir>/tests/eval"],
   testMatch: [
     "**/src/app.test.ts",
     "**/src/authValidation.test.ts",
@@ -19,5 +20,6 @@ module.exports = {
     "**/src/mcpOAuthService.test.ts",
     "**/src/agentIdempotencyService.test.ts",
     "**/src/ai/recommendationSchema.test.ts",
+    "**/tests/eval/recommendation-quality.test.ts",
   ],
 };

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -1465,6 +1465,314 @@
       },
       "errorModel": "structured_agent_error",
       "idempotency": "not_applicable"
+    },
+    {
+      "name": "analyze_task_quality",
+      "description": "Analyze open tasks for quality issues: missing action verbs, vague language, multi-action titles, excessive length.",
+      "method": "POST",
+      "path": "/read/analyze_task_quality",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "taskIds": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Optional list of task IDs to analyze. Defaults to all open tasks."
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Optional: filter to tasks in this project."
+          }
+        }
+      },
+      "output": {
+        "dataKey": "results",
+        "type": "array",
+        "description": "Quality analysis result for each task."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "find_duplicate_tasks",
+      "description": "Detect exact, normalized, and near-duplicate open tasks using title similarity.",
+      "method": "POST",
+      "path": "/read/find_duplicate_tasks",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "projectId": {
+            "type": "string",
+            "description": "Optional: scope to a single project."
+          },
+          "scope": {
+            "type": "string",
+            "description": "Optional scope hint (e.g. 'active'). Reserved for future use."
+          }
+        }
+      },
+      "output": {
+        "dataKey": "groups",
+        "type": "array",
+        "description": "Groups of potentially duplicate tasks with confidence and suggested action."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "find_stale_items",
+      "description": "Find tasks and projects not updated within a configurable number of days.",
+      "method": "POST",
+      "path": "/read/find_stale_items",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "staleDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 365,
+            "description": "Threshold in days. Items not updated in this many days are stale. Default 30."
+          }
+        }
+      },
+      "output": {
+        "description": "staleTasks and staleProjects arrays, plus the effective staleDays and threshold date."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "taxonomy_cleanup_suggestions",
+      "description": "Suggest project hygiene improvements: similar project names and projects with very few tasks.",
+      "method": "POST",
+      "path": "/read/taxonomy_cleanup_suggestions",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      },
+      "output": {
+        "description": "similarProjects pairs and smallProjects list."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "plan_today",
+      "description": "Build a deterministic day plan by selecting tasks that fit within available time, weighted by priority, due dates, and energy.",
+      "method": "POST",
+      "path": "/read/plan_today",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "availableMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1440,
+            "description": "Total available minutes for the day. Default 480."
+          },
+          "energy": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Current energy level, used to weight task effort."
+          },
+          "date": {
+            "type": "string",
+            "description": "ISO date (YYYY-MM-DD). Defaults to today."
+          }
+        }
+      },
+      "output": {
+        "description": "selectedTasks array with estimatedMinutes, plus totalMinutes and remainingMinutes."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "break_down_task",
+      "description": "Suggest subtask decompositions for a task using heuristic patterns based on the task title.",
+      "method": "POST",
+      "path": "/read/break_down_task",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["taskId"],
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the task to decompose."
+          },
+          "maxSubtasks": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Maximum number of suggested subtasks. Default 5."
+          }
+        }
+      },
+      "output": {
+        "description": "suggestedSubtasks array with title and order, plus decompositionBasis."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "suggest_next_actions",
+      "description": "Return prioritized actionable tasks for a project, ordered by status and priority.",
+      "method": "POST",
+      "path": "/read/suggest_next_actions",
+      "readOnly": true,
+      "availability": { "requires": ["project_service"] },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["projectId"],
+        "properties": {
+          "projectId": { "type": "string", "format": "uuid" },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 50 }
+        }
+      },
+      "output": {
+        "description": "suggestedActions task array with projectName and total count."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "weekly_review_summary",
+      "description": "Read-only summary of the current week: tasks completed, created, stale, waiting, inbox count, and projects with no active tasks.",
+      "method": "POST",
+      "path": "/read/weekly_review_summary",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "weekStart": {
+            "type": "string",
+            "description": "ISO date for week start (YYYY-MM-DD). Defaults to the current Monday."
+          }
+        }
+      },
+      "output": {
+        "description": "weekStart, weekEnd, completed, created, stale, waiting, inboxCount, projectsWithNoActive."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "triage_capture_item",
+      "description": "Analyze a single capture item and suggest how to convert it to a task, note, or discard it. Pass mode='apply' to mark it as triaged.",
+      "method": "POST",
+      "path": "/write/triage_capture_item",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["captureItemId"],
+        "properties": {
+          "captureItemId": { "type": "string", "format": "uuid" },
+          "mode": {
+            "type": "string",
+            "enum": ["suggest", "apply"],
+            "description": "suggest (default) returns recommendations only; apply marks the item as triaged."
+          }
+        }
+      },
+      "output": {
+        "description": "recommendation object with kind, confidence, why, proposedAction, and applied boolean."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "triage_inbox",
+      "description": "Batch-triage capture items with lifecycle='new'. Returns recommendations for each. Pass mode='apply' to mark them as triaged.",
+      "method": "POST",
+      "path": "/write/triage_inbox",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "description": "Max items to process. Default 20."
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["suggest", "apply"],
+            "description": "suggest (default) or apply."
+          }
+        }
+      },
+      "output": {
+        "description": "triaged array, totalProcessed, and mode."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "list_audit_log",
+      "description": "Return recent agent operation audit log entries for the authenticated user.",
+      "method": "POST",
+      "path": "/read/list_audit_log",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "since": {
+            "type": "string",
+            "description": "ISO timestamp — return only entries after this date."
+          },
+          "action": {
+            "type": "string",
+            "description": "Optional filter by action name."
+          }
+        }
+      },
+      "output": {
+        "description": "entries array and total count."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "get_availability_windows",
+      "description": "Return time availability windows for a given day, based on planning preferences. Also returns tasks already scheduled for that day.",
+      "method": "POST",
+      "path": "/read/get_availability_windows",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "ISO date (YYYY-MM-DD). Defaults to today."
+          }
+        }
+      },
+      "output": {
+        "description": "windows array with start/end/minutes, scheduledTasks, and totalAvailableMinutes."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
     }
   ],
   "notes": [

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -7,6 +7,8 @@ import { AgentAuditService } from "../services/agentAuditService";
 import { AgentService } from "../services/agentService";
 import { PrismaClient } from "@prisma/client";
 import { DryRunResult } from "../types";
+import { analyzeTaskQuality } from "../ai/taskQualityAnalyzer";
+import { findDuplicates } from "../ai/duplicateDetector";
 import {
   validateAgentAddSubtaskInput,
   validateAgentAnalyzeProjectHealthInput,
@@ -40,6 +42,18 @@ import {
   validateAgentUpdateProjectInput,
   validateAgentUpdateTaskInput,
   validateAgentWeeklyReviewInput,
+  validateAgentAnalyzeTaskQualityInput,
+  validateAgentFindDuplicateTasksInput,
+  validateAgentFindStaleItemsInput,
+  validateAgentTaxonomyCleanupInput,
+  validateAgentPlanTodayInput,
+  validateAgentBreakDownTaskInput,
+  validateAgentSuggestNextActionsInput,
+  validateAgentWeeklyReviewSummaryInput,
+  validateAgentTriageCaptureItemInput,
+  validateAgentTriageInboxInput,
+  validateAgentListAuditLogInput,
+  validateAgentGetAvailabilityWindowsInput,
 } from "../validation/agentValidation";
 
 export type AgentActionName =
@@ -74,7 +88,19 @@ export type AgentActionName =
   | "weekly_review"
   | "decide_next_work"
   | "analyze_project_health"
-  | "analyze_work_graph";
+  | "analyze_work_graph"
+  | "analyze_task_quality"
+  | "find_duplicate_tasks"
+  | "find_stale_items"
+  | "taxonomy_cleanup_suggestions"
+  | "plan_today"
+  | "break_down_task"
+  | "suggest_next_actions"
+  | "weekly_review_summary"
+  | "triage_capture_item"
+  | "triage_inbox"
+  | "list_audit_log"
+  | "get_availability_windows";
 
 interface AgentExecutorDeps {
   todoService: ITodoService;
@@ -147,6 +173,16 @@ const READ_ONLY_ACTIONS = new Set<AgentActionName>([
   "decide_next_work",
   "analyze_project_health",
   "analyze_work_graph",
+  "analyze_task_quality",
+  "find_duplicate_tasks",
+  "find_stale_items",
+  "taxonomy_cleanup_suggestions",
+  "plan_today",
+  "break_down_task",
+  "suggest_next_actions",
+  "weekly_review_summary",
+  "list_audit_log",
+  "get_availability_windows",
 ]);
 
 const IDEMPOTENT_PLANNER_APPLY_ACTIONS = new Set<AgentActionName>([
@@ -352,6 +388,56 @@ function toAgentError(error: unknown): {
       retryable: true,
       hint: "Retry the action. If the error persists, inspect server logs for the request ID.",
     },
+  };
+}
+
+const ACTION_VERB_RE =
+  /^(buy|call|send|write|read|review|schedule|book|fix|update|check|draft|prepare|submit|complete|finish|create|build|test|deploy|refactor|add|remove|delete|merge|close|open|contact|email|research|investigate|plan|organize|clean|sort|discuss|confirm|follow|set|get|make|find|move|copy|install|configure|document|upload|download|publish|cancel|archive|approve|reject|invite|register|verify|report|analyze|design|implement|request|order|pay|sign|file|print|record|backup|restore|monitor|notify|present|remind|track|coordinate|attend|join)\b/i;
+
+function triageCaptureText(text: string): {
+  kind: "create_task" | "discard" | "convert_to_note";
+  confidence: number;
+  why: string;
+  proposedAction: { title: string; status: string } | null;
+} {
+  const trimmed = text.trim();
+  // URL / reference — check before word count
+  if (/^https?:\/\//.test(trimmed)) {
+    return {
+      kind: "convert_to_note",
+      confidence: 0.8,
+      why: "Looks like a URL reference, better stored as a note",
+      proposedAction: {
+        title: `Review: ${trimmed.slice(0, 60)}`,
+        status: "inbox",
+      },
+    };
+  }
+  // Very short, no verb → discard candidate
+  const wordCount = trimmed.split(/\s+/).length;
+  if (wordCount < 3 && !ACTION_VERB_RE.test(trimmed)) {
+    return {
+      kind: "discard",
+      confidence: 0.6,
+      why: "Very short text with no action verb — likely noise or incomplete thought",
+      proposedAction: null,
+    };
+  }
+  // Starts with action verb → create task
+  if (ACTION_VERB_RE.test(trimmed)) {
+    return {
+      kind: "create_task",
+      confidence: 0.85,
+      why: "Starts with a clear action verb — actionable task",
+      proposedAction: { title: trimmed, status: "inbox" },
+    };
+  }
+  // Ambiguous — suggest as task but lower confidence
+  return {
+    kind: "create_task",
+    confidence: 0.5,
+    why: "No clear action verb but text may be actionable — review before adding",
+    proposedAction: { title: trimmed, status: "inbox" },
   };
 }
 
@@ -1015,6 +1101,628 @@ export class AgentExecutor {
             );
           }
           return this.success(action, readOnly, context, 200, { graph });
+        }
+        case "analyze_task_quality": {
+          const { taskIds, projectId } =
+            validateAgentAnalyzeTaskQualityInput(input);
+          const tasks = await this.agentService.listTasks(context.userId, {
+            ...(projectId ? { projectId } : {}),
+            archived: false,
+            limit: 200,
+          });
+          const filtered = taskIds
+            ? tasks.filter((t) => taskIds.includes(t.id))
+            : tasks;
+          const results = filtered.map((t) =>
+            analyzeTaskQuality(t.id, t.title),
+          );
+          return this.success(action, readOnly, context, 200, {
+            results,
+            totalAnalyzed: filtered.length,
+          });
+        }
+        case "find_duplicate_tasks": {
+          const { projectId } = validateAgentFindDuplicateTasksInput(input);
+          const tasks = await this.agentService.listTasks(context.userId, {
+            ...(projectId ? { projectId } : {}),
+            archived: false,
+            limit: 500,
+          });
+          const groups = findDuplicates(
+            tasks.map((t) => ({
+              id: t.id,
+              title: t.title,
+              status: t.status ?? "inbox",
+              projectId: t.projectId ?? null,
+            })),
+          );
+          return this.success(action, readOnly, context, 200, {
+            groups,
+            totalTasks: tasks.length,
+          });
+        }
+        case "find_stale_items": {
+          const { staleDays } = validateAgentFindStaleItemsInput(input);
+          const threshold = new Date(
+            Date.now() - staleDays * 24 * 60 * 60 * 1000,
+          );
+          const staleTasks = await this.agentService.listTasks(context.userId, {
+            statuses: ["inbox", "next", "someday"],
+            updatedBefore: threshold,
+            archived: false,
+            limit: 200,
+          });
+          const staleTaskDtos = staleTasks.map((t) => ({
+            id: t.id,
+            title: t.title,
+            status: t.status,
+            lastUpdated: t.updatedAt,
+            projectId: t.projectId ?? null,
+          }));
+          let staleProjects: Array<{
+            id: string;
+            name: string;
+            lastUpdated: Date;
+          }> = [];
+          if (this.deps.projectService) {
+            const allProjects = await this.deps.projectService.findAll(
+              context.userId,
+            );
+            staleProjects = allProjects
+              .filter(
+                (p) =>
+                  !p.archived &&
+                  p.status === "active" &&
+                  new Date(p.updatedAt) < threshold,
+              )
+              .map((p) => ({
+                id: p.id,
+                name: p.name,
+                lastUpdated: p.updatedAt,
+              }));
+          }
+          return this.success(action, readOnly, context, 200, {
+            staleTasks: staleTaskDtos,
+            staleProjects,
+            staleDays,
+            threshold: threshold.toISOString(),
+          });
+        }
+        case "taxonomy_cleanup_suggestions": {
+          validateAgentTaxonomyCleanupInput(input);
+          if (!this.deps.projectService) {
+            return this.success(action, readOnly, context, 200, {
+              similarProjects: [],
+              smallProjects: [],
+            });
+          }
+          const allProjects = await this.deps.projectService.findAll(
+            context.userId,
+          );
+          const activeProjects = allProjects.filter((p) => !p.archived);
+          // Find projects with 0–1 open tasks
+          const smallProjects = activeProjects
+            .filter((p) => (p.openTaskCount ?? p.openTodoCount ?? 0) <= 1)
+            .map((p) => ({
+              id: p.id,
+              name: p.name,
+              taskCount: p.openTaskCount ?? p.openTodoCount ?? 0,
+            }));
+          // Find pairs with similar names via Levenshtein
+          const similarProjects: Array<{
+            projectAId: string;
+            projectAName: string;
+            projectBId: string;
+            projectBName: string;
+            editDistance: number;
+          }> = [];
+          for (let i = 0; i < activeProjects.length; i++) {
+            for (let j = i + 1; j < activeProjects.length; j++) {
+              const a = activeProjects[i].name.toLowerCase();
+              const b = activeProjects[j].name.toLowerCase();
+              if (Math.abs(a.length - b.length) > 5) continue;
+              const m = a.length,
+                n = b.length;
+              const dp = Array.from({ length: m + 1 }, (_, r) =>
+                Array.from({ length: n + 1 }, (_, c) =>
+                  r === 0 ? c : c === 0 ? r : 0,
+                ),
+              );
+              for (let r = 1; r <= m; r++) {
+                for (let c = 1; c <= n; c++) {
+                  dp[r][c] =
+                    a[r - 1] === b[c - 1]
+                      ? dp[r - 1][c - 1]
+                      : 1 +
+                        Math.min(dp[r - 1][c], dp[r][c - 1], dp[r - 1][c - 1]);
+                }
+              }
+              const dist = dp[m][n];
+              if (dist <= 3 && Math.max(m, n) >= 4) {
+                similarProjects.push({
+                  projectAId: activeProjects[i].id,
+                  projectAName: activeProjects[i].name,
+                  projectBId: activeProjects[j].id,
+                  projectBName: activeProjects[j].name,
+                  editDistance: dist,
+                });
+              }
+            }
+          }
+          return this.success(action, readOnly, context, 200, {
+            similarProjects,
+            smallProjects,
+            totalProjects: activeProjects.length,
+          });
+        }
+        case "plan_today": {
+          const { availableMinutes, energy, date } =
+            validateAgentPlanTodayInput(input);
+          const today = date ?? new Date().toISOString().slice(0, 10);
+          const allTasks = await this.agentService.listTasks(context.userId, {
+            statuses: ["inbox", "next", "in_progress", "scheduled"],
+            archived: false,
+            limit: 200,
+          });
+          const PRIORITY_SCORE: Record<string, number> = {
+            urgent: 40,
+            high: 20,
+            medium: 10,
+            low: 0,
+          };
+          const scored = allTasks.map((t) => {
+            let score = PRIORITY_SCORE[t.priority ?? "medium"] ?? 10;
+            if (t.doDate) {
+              const d =
+                t.doDate instanceof Date
+                  ? t.doDate.toISOString().slice(0, 10)
+                  : String(t.doDate).slice(0, 10);
+              if (d < today) score += 50;
+              else if (d === today) score += 30;
+            }
+            if (t.dueDate) {
+              const d =
+                t.dueDate instanceof Date
+                  ? t.dueDate.toISOString().slice(0, 10)
+                  : String(t.dueDate).slice(0, 10);
+              if (d < today) score += 40;
+              else if (d === today) score += 20;
+            }
+            const effort = t.effortScore ?? 30;
+            if (energy === "low" && effort > 60) score -= 20;
+            if (energy === "high" && effort < 15) score -= 5;
+            return { task: t, score, effort };
+          });
+          scored.sort((a, b) => b.score - a.score);
+          const selected: typeof scored = [];
+          let usedMinutes = 0;
+          const budget = availableMinutes ?? 480;
+          for (const item of scored) {
+            if (usedMinutes + item.effort <= budget) {
+              selected.push(item);
+              usedMinutes += item.effort;
+            }
+          }
+          return this.success(action, readOnly, context, 200, {
+            date: today,
+            availableMinutes: budget,
+            energy: energy ?? null,
+            selectedTasks: selected.map((s) => ({
+              ...s.task,
+              estimatedMinutes: s.effort,
+              score: s.score,
+            })),
+            totalMinutes: usedMinutes,
+            remainingMinutes: budget - usedMinutes,
+          });
+        }
+        case "break_down_task": {
+          const { taskId, maxSubtasks } =
+            validateAgentBreakDownTaskInput(input);
+          const task = await this.agentService.getTask(context.userId, taskId);
+          if (!task) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Task not found",
+              false,
+              "Verify the task ID belongs to the authenticated user.",
+            );
+          }
+          const title = task.title;
+          const lower = title.toLowerCase();
+          const limit = maxSubtasks ?? 5;
+          let suggestedSubtasks: Array<{ title: string; order: number }> = [];
+          let decompositionBasis = "generic";
+          if (/\bwrite\b/.test(lower)) {
+            suggestedSubtasks = [
+              { title: `Draft outline for: ${title}`, order: 1 },
+              { title: `Write first draft: ${title}`, order: 2 },
+              { title: `Review and edit: ${title}`, order: 3 },
+            ];
+            decompositionBasis = "write-workflow";
+          } else if (/\breview\b/.test(lower)) {
+            suggestedSubtasks = [
+              { title: `Read through: ${title}`, order: 1 },
+              { title: `Note issues in: ${title}`, order: 2 },
+              { title: `Write review summary: ${title}`, order: 3 },
+            ];
+            decompositionBasis = "review-workflow";
+          } else if (/\bsetup|configure|install\b/.test(lower)) {
+            suggestedSubtasks = [
+              { title: `Research options for: ${title}`, order: 1 },
+              { title: `Install and configure: ${title}`, order: 2 },
+              { title: `Test setup: ${title}`, order: 3 },
+              { title: `Document configuration: ${title}`, order: 4 },
+            ];
+            decompositionBasis = "setup-workflow";
+          } else if (/\bfix\b/.test(lower)) {
+            suggestedSubtasks = [
+              { title: `Reproduce issue: ${title}`, order: 1 },
+              { title: `Identify root cause: ${title}`, order: 2 },
+              { title: `Implement fix: ${title}`, order: 3 },
+              { title: `Add test for: ${title}`, order: 4 },
+            ];
+            decompositionBasis = "bugfix-workflow";
+          } else if (/ and /.test(lower) || title.includes(",")) {
+            const parts = title.split(/, | and /i).filter(Boolean);
+            suggestedSubtasks = parts
+              .slice(0, limit)
+              .map((p, i) => ({ title: p.trim(), order: i + 1 }));
+            decompositionBasis = "split-compound";
+          } else {
+            suggestedSubtasks = [
+              { title: `Plan: ${title}`, order: 1 },
+              { title: `Execute: ${title}`, order: 2 },
+              { title: `Review and complete: ${title}`, order: 3 },
+            ];
+            decompositionBasis = "generic";
+          }
+          return this.success(action, readOnly, context, 200, {
+            taskId,
+            taskTitle: title,
+            suggestedSubtasks: suggestedSubtasks.slice(0, limit),
+            decompositionBasis,
+          });
+        }
+        case "suggest_next_actions": {
+          const { projectId, limit } =
+            validateAgentSuggestNextActionsInput(input);
+          if (!this.deps.projectService) {
+            throw new AgentExecutionError(
+              501,
+              "PROJECTS_NOT_CONFIGURED",
+              "Projects not configured",
+              false,
+              "Configure the project service before calling project actions.",
+            );
+          }
+          const project = await this.deps.projectService.findById(
+            context.userId,
+            projectId,
+          );
+          if (!project) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Project not found",
+              false,
+              "Verify the project ID belongs to the authenticated user.",
+            );
+          }
+          const tasks = await this.agentService.listTasks(context.userId, {
+            projectId,
+            statuses: ["in_progress", "next", "inbox"],
+            archived: false,
+            limit: 100,
+          });
+          const STATUS_ORDER: Record<string, number> = {
+            in_progress: 0,
+            next: 1,
+            inbox: 2,
+          };
+          const PRIORITY_ORDER: Record<string, number> = {
+            urgent: 0,
+            high: 1,
+            medium: 2,
+            low: 3,
+          };
+          tasks.sort((a, b) => {
+            const sA = STATUS_ORDER[a.status ?? "inbox"] ?? 2;
+            const sB = STATUS_ORDER[b.status ?? "inbox"] ?? 2;
+            if (sA !== sB) return sA - sB;
+            const pA = PRIORITY_ORDER[a.priority ?? "medium"] ?? 2;
+            const pB = PRIORITY_ORDER[b.priority ?? "medium"] ?? 2;
+            return pA - pB;
+          });
+          return this.success(action, readOnly, context, 200, {
+            projectId,
+            projectName: project.name,
+            suggestedActions: tasks.slice(0, limit ?? 5),
+            total: tasks.length,
+          });
+        }
+        case "weekly_review_summary": {
+          const { weekStart } = validateAgentWeeklyReviewSummaryInput(input);
+          const now = new Date();
+          let weekStartDate: Date;
+          if (weekStart) {
+            weekStartDate = new Date(weekStart);
+          } else {
+            // Start of current week (Monday)
+            weekStartDate = new Date(now);
+            const day = weekStartDate.getDay();
+            const diff = day === 0 ? -6 : 1 - day;
+            weekStartDate.setDate(weekStartDate.getDate() + diff);
+            weekStartDate.setHours(0, 0, 0, 0);
+          }
+          const weekEndDate = new Date(weekStartDate);
+          weekEndDate.setDate(weekEndDate.getDate() + 7);
+          const completedTasks = await this.agentService.listTasks(
+            context.userId,
+            {
+              statuses: ["done"],
+              updatedAfter: weekStartDate,
+              updatedBefore: weekEndDate,
+              limit: 200,
+            },
+          );
+          const createdTasks = await this.agentService.listTasks(
+            context.userId,
+            {
+              archived: false,
+              limit: 200,
+            },
+          );
+          const createdThisWeek = createdTasks.filter((t) => {
+            const created =
+              t.createdAt instanceof Date
+                ? t.createdAt
+                : new Date(t.createdAt as unknown as string);
+            return created >= weekStartDate && created < weekEndDate;
+          });
+          const staleCutoff = new Date(
+            now.getTime() - 14 * 24 * 60 * 60 * 1000,
+          );
+          const staleTasks = await this.agentService.listTasks(context.userId, {
+            statuses: ["inbox", "next"],
+            updatedBefore: staleCutoff,
+            archived: false,
+            limit: 200,
+          });
+          const waitingTasks = await this.agentService.listTasks(
+            context.userId,
+            {
+              statuses: ["waiting"],
+              archived: false,
+              limit: 200,
+            },
+          );
+          const inboxTasks = await this.agentService.listTasks(context.userId, {
+            statuses: ["inbox"],
+            archived: false,
+            limit: 200,
+          });
+          let projectsWithNoActive: Array<{ id: string; name: string }> = [];
+          if (this.deps.projectService) {
+            const allProjects = await this.deps.projectService.findAll(
+              context.userId,
+            );
+            projectsWithNoActive = allProjects
+              .filter(
+                (p) =>
+                  !p.archived &&
+                  p.status === "active" &&
+                  (p.openTaskCount ?? p.openTodoCount ?? 0) === 0,
+              )
+              .map((p) => ({ id: p.id, name: p.name }));
+          }
+          return this.success(action, readOnly, context, 200, {
+            weekStart: weekStartDate.toISOString(),
+            weekEnd: weekEndDate.toISOString(),
+            completed: completedTasks.length,
+            created: createdThisWeek.length,
+            stale: staleTasks.length,
+            waiting: waitingTasks.length,
+            inboxCount: inboxTasks.length,
+            projectsWithNoActive,
+          });
+        }
+        case "triage_capture_item": {
+          const { captureItemId, mode } =
+            validateAgentTriageCaptureItemInput(input);
+          if (!this.deps.persistencePrisma) {
+            throw new AgentExecutionError(
+              501,
+              "NOT_CONFIGURED",
+              "Persistence layer not available",
+              false,
+            );
+          }
+          const item = await this.deps.persistencePrisma.captureItem.findFirst({
+            where: { id: captureItemId, userId: context.userId },
+          });
+          if (!item) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Capture item not found",
+              false,
+              "Verify the capture item ID belongs to the authenticated user.",
+            );
+          }
+          const recommendation = triageCaptureText(item.text);
+          let applied = false;
+          if (mode === "apply") {
+            await this.deps.persistencePrisma.captureItem.updateMany({
+              where: { id: captureItemId, userId: context.userId },
+              data: {
+                lifecycle: "triaged",
+                triageResult:
+                  recommendation as unknown as import("@prisma/client").Prisma.JsonObject,
+              },
+            });
+            applied = true;
+          }
+          return this.success(action, readOnly, context, 200, {
+            captureItemId,
+            recommendation,
+            applied,
+          });
+        }
+        case "triage_inbox": {
+          const { limit, mode } = validateAgentTriageInboxInput(input);
+          if (!this.deps.persistencePrisma) {
+            throw new AgentExecutionError(
+              501,
+              "NOT_CONFIGURED",
+              "Persistence layer not available",
+              false,
+            );
+          }
+          const items = await this.deps.persistencePrisma.captureItem.findMany({
+            where: { userId: context.userId, lifecycle: "new" },
+            orderBy: { capturedAt: "asc" },
+            take: limit ?? 20,
+          });
+          const triaged = items.map((item) => ({
+            captureItemId: item.id,
+            recommendation: triageCaptureText(item.text),
+          }));
+          if (mode === "apply" && items.length > 0) {
+            for (const item of items) {
+              const rec = triaged.find((t) => t.captureItemId === item.id);
+              await this.deps.persistencePrisma.captureItem.updateMany({
+                where: { id: item.id, userId: context.userId },
+                data: {
+                  lifecycle: "triaged",
+                  triageResult:
+                    rec?.recommendation as unknown as import("@prisma/client").Prisma.JsonObject,
+                },
+              });
+            }
+          }
+          return this.success(
+            action,
+            readOnly,
+            context,
+            mode === "apply" ? 200 : 200,
+            {
+              triaged,
+              totalProcessed: items.length,
+              mode: mode ?? "suggest",
+            },
+          );
+        }
+        case "list_audit_log": {
+          const { limit, since, actionFilter } =
+            validateAgentListAuditLogInput(input);
+          if (!this.deps.persistencePrisma) {
+            return this.success(action, readOnly, context, 200, {
+              entries: [],
+              total: 0,
+            });
+          }
+          const where: import("@prisma/client").Prisma.AgentActionAuditWhereInput =
+            {
+              userId: context.userId,
+              ...(actionFilter ? { action: actionFilter } : {}),
+              ...(since ? { createdAt: { gte: new Date(since) } } : {}),
+            };
+          const entries =
+            await this.deps.persistencePrisma.agentActionAudit.findMany({
+              where,
+              orderBy: { createdAt: "desc" },
+              take: limit ?? 50,
+              select: {
+                id: true,
+                action: true,
+                outcome: true,
+                readOnly: true,
+                status: true,
+                createdAt: true,
+                surface: true,
+              },
+            });
+          const total =
+            await this.deps.persistencePrisma.agentActionAudit.count({ where });
+          return this.success(action, readOnly, context, 200, {
+            entries,
+            total,
+          });
+        }
+        case "get_availability_windows": {
+          const { date } = validateAgentGetAvailabilityWindowsInput(input);
+          const today = date ?? new Date().toISOString().slice(0, 10);
+          let windows: Array<{ start: string; end: string; minutes: number }> =
+            [
+              { start: "09:00", end: "12:00", minutes: 180 },
+              { start: "14:00", end: "17:00", minutes: 180 },
+            ];
+          if (this.deps.persistencePrisma) {
+            const prefs =
+              await this.deps.persistencePrisma.userPlanningPreferences.findUnique(
+                { where: { userId: context.userId } },
+              );
+            if (prefs) {
+              const startH =
+                (
+                  prefs as unknown as {
+                    workStartTime?: string | null;
+                  }
+                ).workStartTime ?? "09:00";
+              const endH =
+                (
+                  prefs as unknown as {
+                    workEndTime?: string | null;
+                  }
+                ).workEndTime ?? "17:00";
+              const [sh, sm] = startH.split(":").map(Number);
+              const [eh, em] = endH.split(":").map(Number);
+              const totalMin = eh * 60 + em - (sh * 60 + sm);
+              const midMin = Math.floor(totalMin / 2);
+              const midH = sh * 60 + sm + midMin;
+              const midHH = String(Math.floor(midH / 60)).padStart(2, "0");
+              const midMM = String(midH % 60).padStart(2, "0");
+              windows = [
+                {
+                  start: startH,
+                  end: `${midHH}:${midMM}`,
+                  minutes: midMin,
+                },
+                {
+                  start: `${midHH}:${midMM}`,
+                  end: endH,
+                  minutes: totalMin - midMin,
+                },
+              ];
+            }
+          }
+          const scheduledTasks = await this.agentService.listTasks(
+            context.userId,
+            {
+              archived: false,
+              limit: 100,
+            },
+          );
+          const tasksForDate = scheduledTasks.filter((t) => {
+            if (!t.doDate) return false;
+            const d =
+              t.doDate instanceof Date
+                ? t.doDate.toISOString().slice(0, 10)
+                : String(t.doDate).slice(0, 10);
+            return d === today;
+          });
+          const totalAvailableMinutes = windows.reduce(
+            (sum, w) => sum + w.minutes,
+            0,
+          );
+          return this.success(action, readOnly, context, 200, {
+            date: today,
+            windows,
+            scheduledTasks: tasksForDate,
+            totalAvailableMinutes,
+          });
         }
       }
     } catch (error) {

--- a/src/anti-entropy.integration.test.ts
+++ b/src/anti-entropy.integration.test.ts
@@ -1,0 +1,245 @@
+import request from "supertest";
+import type { Express } from "express";
+import { createApp } from "./app";
+import { TodoService } from "./services/todoService";
+import type { IProjectService } from "./interfaces/IProjectService";
+import type {
+  CreateProjectDto,
+  Project,
+  ProjectTaskDisposition,
+  UpdateProjectDto,
+} from "./types";
+
+const USER_ID = "default-user";
+
+function makeProject(
+  id: string,
+  name: string,
+  overrides: Partial<Project> = {},
+): Project {
+  return {
+    id,
+    name,
+    status: "active",
+    archived: false,
+    userId: USER_ID,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+    taskCount: 0,
+    openTaskCount: 0,
+    completedTaskCount: 0,
+    todoCount: 0,
+    openTodoCount: 0,
+    ...overrides,
+  };
+}
+
+function createProjectServiceMock(
+  projects: Project[],
+): jest.Mocked<IProjectService> {
+  return {
+    findAll: jest
+      .fn<Promise<Project[]>, [string]>()
+      .mockResolvedValue(projects),
+    findById: jest
+      .fn<Promise<Project | null>, [string, string]>()
+      .mockImplementation(
+        async (_userId, id) =>
+          projects.find((project) => project.id === id) ?? null,
+      ),
+    create: jest.fn<Promise<Project>, [string, CreateProjectDto]>(),
+    update: jest.fn<
+      Promise<Project | null>,
+      [string, string, UpdateProjectDto]
+    >(),
+    setArchived: jest.fn<Promise<Project | null>, [string, string, boolean]>(),
+    delete: jest.fn<
+      Promise<boolean>,
+      [string, string, ProjectTaskDisposition, (string | null)?]
+    >(),
+  };
+}
+
+describe("Anti-entropy analyzers", () => {
+  let app: Express;
+  let todoService: TodoService;
+  let projectService: jest.Mocked<IProjectService>;
+
+  beforeEach(() => {
+    todoService = new TodoService();
+    projectService = createProjectServiceMock([]);
+    app = createApp(
+      todoService,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      projectService,
+    );
+  });
+
+  describe("analyze_task_quality", () => {
+    it("returns results array in structured envelope", async () => {
+      await request(app)
+        .post("/todos")
+        .send({ title: "Fix the login bug" })
+        .expect(201);
+
+      const response = await request(app)
+        .post("/agent/read/analyze_task_quality")
+        .send({})
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.action).toBe("analyze_task_quality");
+      expect(response.body.readOnly).toBe(true);
+      expect(Array.isArray(response.body.data.results)).toBe(true);
+    });
+
+    it("flags a vague task title without an action verb", async () => {
+      const created = await request(app)
+        .post("/todos")
+        .send({ title: "The login situation" })
+        .expect(201);
+
+      const response = await request(app)
+        .post("/agent/read/analyze_task_quality")
+        .send({ taskIds: [created.body.id] })
+        .expect(200);
+
+      const results = response.body.data.results as Array<{
+        id: string;
+        qualityScore: number;
+        issues: string[];
+      }>;
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.qualityScore).toBeLessThan(5);
+      expect(result.issues.length).toBeGreaterThan(0);
+      expect(result.issues.some((i) => i.includes("action verb"))).toBe(true);
+    });
+
+    it("gives a good score to a well-formed task", async () => {
+      const created = await request(app)
+        .post("/todos")
+        .send({ title: "Review quarterly report" })
+        .expect(201);
+
+      const response = await request(app)
+        .post("/agent/read/analyze_task_quality")
+        .send({ taskIds: [created.body.id] })
+        .expect(200);
+
+      const results = response.body.data.results as Array<{
+        qualityScore: number;
+      }>;
+      expect(results[0].qualityScore).toBeGreaterThanOrEqual(4);
+    });
+
+    it("rejects taskIds that are not strings", async () => {
+      const response = await request(app)
+        .post("/agent/read/analyze_task_quality")
+        .send({ taskIds: [123] })
+        .expect(400);
+
+      expect(response.body.ok).toBe(false);
+    });
+  });
+
+  describe("find_duplicate_tasks", () => {
+    it("returns groups array in structured envelope", async () => {
+      const response = await request(app)
+        .post("/agent/read/find_duplicate_tasks")
+        .send({})
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.action).toBe("find_duplicate_tasks");
+      expect(response.body.readOnly).toBe(true);
+      expect(Array.isArray(response.body.data.groups)).toBe(true);
+    });
+
+    it("finds exact duplicate tasks", async () => {
+      await request(app)
+        .post("/todos")
+        .send({ title: "Buy groceries" })
+        .expect(201);
+      await request(app)
+        .post("/todos")
+        .send({ title: "Buy groceries" })
+        .expect(201);
+
+      const response = await request(app)
+        .post("/agent/read/find_duplicate_tasks")
+        .send({ scope: "active" })
+        .expect(200);
+
+      const groups = response.body.data.groups as Array<{
+        confidence: number;
+        reason: string;
+        tasks: Array<{ id: string; title: string }>;
+        suggestedAction: string;
+      }>;
+
+      expect(groups.length).toBeGreaterThanOrEqual(1);
+      const exactMatch = groups.find((g) => g.confidence === 1.0);
+      expect(exactMatch).toBeDefined();
+      expect(exactMatch?.reason).toBe("Exact title match");
+      expect(exactMatch?.suggestedAction).toBe("archive-older");
+    });
+
+    it("scopes to active tasks by default", async () => {
+      await request(app)
+        .post("/todos")
+        .send({ title: "Call dentist" })
+        .expect(201);
+      await request(app)
+        .post("/todos")
+        .send({ title: "Call dentist" })
+        .expect(201);
+
+      // default scope = active — should still find duplicates
+      const response = await request(app)
+        .post("/agent/read/find_duplicate_tasks")
+        .send({})
+        .expect(200);
+
+      expect(response.body.data.groups.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("find_stale_items", () => {
+    it("returns correct structure in envelope", async () => {
+      const response = await request(app)
+        .post("/agent/read/find_stale_items")
+        .send({})
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.action).toBe("find_stale_items");
+      expect(response.body.readOnly).toBe(true);
+      // Without prisma, throws "Projects not configured"
+      // but structure is validated in agentService; here test just checks route responds
+      // In environments without prisma the call returns error envelope
+      // So we just check the envelope contract exists
+      expect(typeof response.body.ok).toBe("boolean");
+    });
+  });
+
+  describe("taxonomy_cleanup_suggestions", () => {
+    it("returns correct structure in envelope", async () => {
+      const response = await request(app)
+        .post("/agent/read/taxonomy_cleanup_suggestions")
+        .send({})
+        .expect(200);
+
+      expect(response.body.ok).toBe(true);
+      expect(response.body.action).toBe("taxonomy_cleanup_suggestions");
+      expect(response.body.readOnly).toBe(true);
+      // Without prisma, throws "Projects not configured"
+      // Similar to find_stale_items; check envelope contract
+      expect(typeof response.body.ok).toBe("boolean");
+    });
+  });
+});

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -106,6 +106,21 @@ function minimumRequiredScopesForAction(
     case "delete_project":
     case "archive_project":
       return [PROJECT_WRITE_SCOPE];
+    case "analyze_task_quality":
+    case "find_duplicate_tasks":
+    case "find_stale_items":
+    case "taxonomy_cleanup_suggestions":
+    case "weekly_review_summary":
+    case "list_audit_log":
+    case "get_availability_windows":
+      return [TASK_READ_SCOPE];
+    case "plan_today":
+    case "break_down_task":
+    case "suggest_next_actions":
+      return [TASK_READ_SCOPE, PROJECT_READ_SCOPE];
+    case "triage_capture_item":
+    case "triage_inbox":
+      return [TASK_WRITE_SCOPE];
   }
 }
 

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -200,5 +200,59 @@ export function createAgentRouter({
     createAgentActionHandler(agentExecutor, "weekly_review"),
   );
 
+  // Anti-entropy
+  router.post(
+    "/read/analyze_task_quality",
+    createAgentActionHandler(agentExecutor, "analyze_task_quality"),
+  );
+  router.post(
+    "/read/find_duplicate_tasks",
+    createAgentActionHandler(agentExecutor, "find_duplicate_tasks"),
+  );
+  router.post(
+    "/read/find_stale_items",
+    createAgentActionHandler(agentExecutor, "find_stale_items"),
+  );
+  router.post(
+    "/read/taxonomy_cleanup_suggestions",
+    createAgentActionHandler(agentExecutor, "taxonomy_cleanup_suggestions"),
+  );
+
+  // Planning
+  router.post(
+    "/read/plan_today",
+    createAgentActionHandler(agentExecutor, "plan_today"),
+  );
+  router.post(
+    "/read/break_down_task",
+    createAgentActionHandler(agentExecutor, "break_down_task"),
+  );
+  router.post(
+    "/read/suggest_next_actions",
+    createAgentActionHandler(agentExecutor, "suggest_next_actions"),
+  );
+  router.post(
+    "/read/weekly_review_summary",
+    createAgentActionHandler(agentExecutor, "weekly_review_summary"),
+  );
+
+  // Triage / audit / availability
+  router.post(
+    "/write/triage_capture_item",
+    createAgentActionHandler(agentExecutor, "triage_capture_item"),
+  );
+  router.post(
+    "/write/triage_inbox",
+    createAgentActionHandler(agentExecutor, "triage_inbox"),
+  );
+  router.post(
+    "/read/list_audit_log",
+    createAgentActionHandler(agentExecutor, "list_audit_log"),
+  );
+  router.post(
+    "/read/get_availability_windows",
+    createAgentActionHandler(agentExecutor, "get_availability_windows"),
+  );
+
   return router;
 }

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -1100,3 +1100,184 @@ export function validateAgentAnalyzeWorkGraphInput(data: unknown): {
     projectId: parseRequiredId(body, "projectId"),
   };
 }
+
+// ─── Anti-entropy ────────────────────────────────────────────────────────────
+
+const ANALYZE_TASK_QUALITY_KEYS = ["taskIds", "projectId"];
+const FIND_DUPLICATE_TASKS_KEYS = ["projectId", "scope"];
+const FIND_STALE_ITEMS_KEYS = ["staleDays"];
+const TAXONOMY_CLEANUP_KEYS: string[] = [];
+
+export function validateAgentAnalyzeTaskQualityInput(data: unknown): {
+  taskIds?: string[];
+  projectId?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, ANALYZE_TASK_QUALITY_KEYS, "Agent action input");
+  if (body.taskIds !== undefined) {
+    if (!Array.isArray(body.taskIds)) {
+      throw new ValidationError("taskIds must be an array of strings");
+    }
+    for (const id of body.taskIds) {
+      if (typeof id !== "string") {
+        throw new ValidationError("taskIds must be an array of strings");
+      }
+    }
+  }
+  return {
+    taskIds: body.taskIds as string[] | undefined,
+    projectId: body.projectId ? parseRequiredId(body, "projectId") : undefined,
+  };
+}
+
+export function validateAgentFindDuplicateTasksInput(data: unknown): {
+  projectId?: string;
+  scope?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, FIND_DUPLICATE_TASKS_KEYS, "Agent action input");
+  return {
+    projectId: body.projectId ? parseRequiredId(body, "projectId") : undefined,
+    scope: parseOptionalString(body.scope, "scope", 20),
+  };
+}
+
+export function validateAgentFindStaleItemsInput(data: unknown): {
+  staleDays: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, FIND_STALE_ITEMS_KEYS, "Agent action input");
+  return {
+    staleDays: parseOptionalPositiveInt(body.staleDays, "staleDays", 365) ?? 30,
+  };
+}
+
+export function validateAgentTaxonomyCleanupInput(data: unknown): void {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, TAXONOMY_CLEANUP_KEYS, "Agent action input");
+}
+
+// ─── Planning ─────────────────────────────────────────────────────────────────
+
+const PLAN_TODAY_KEYS = ["availableMinutes", "energy", "date"];
+const BREAK_DOWN_TASK_KEYS = ["taskId", "maxSubtasks"];
+const SUGGEST_NEXT_ACTIONS_KEYS = ["projectId", "limit"];
+const WEEKLY_REVIEW_SUMMARY_KEYS = ["weekStart"];
+
+export function validateAgentPlanTodayInput(data: unknown): {
+  availableMinutes?: number;
+  energy?: Energy;
+  date?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, PLAN_TODAY_KEYS, "Agent action input");
+  return {
+    availableMinutes:
+      parseOptionalPositiveInt(
+        body.availableMinutes,
+        "availableMinutes",
+        1440,
+      ) ?? undefined,
+    energy: parseOptionalEnergy(body.energy) ?? undefined,
+    date: parseOptionalString(body.date, "date", 10),
+  };
+}
+
+export function validateAgentBreakDownTaskInput(data: unknown): {
+  taskId: string;
+  maxSubtasks?: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, BREAK_DOWN_TASK_KEYS, "Agent action input");
+  return {
+    taskId: parseRequiredId(body, "taskId"),
+    maxSubtasks:
+      parseOptionalPositiveInt(body.maxSubtasks, "maxSubtasks", 10) ??
+      undefined,
+  };
+}
+
+export function validateAgentSuggestNextActionsInput(data: unknown): {
+  projectId: string;
+  limit?: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, SUGGEST_NEXT_ACTIONS_KEYS, "Agent action input");
+  return {
+    projectId: parseRequiredId(body, "projectId"),
+    limit: parseOptionalPositiveInt(body.limit, "limit", 50) ?? undefined,
+  };
+}
+
+export function validateAgentWeeklyReviewSummaryInput(data: unknown): {
+  weekStart?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, WEEKLY_REVIEW_SUMMARY_KEYS, "Agent action input");
+  return {
+    weekStart: parseOptionalString(body.weekStart, "weekStart", 10),
+  };
+}
+
+// ─── Triage / audit / availability ───────────────────────────────────────────
+
+const TRIAGE_CAPTURE_ITEM_KEYS = ["captureItemId", "mode"];
+const TRIAGE_INBOX_KEYS = ["limit", "mode"];
+const LIST_AUDIT_LOG_KEYS = ["limit", "since", "action"];
+const GET_AVAILABILITY_WINDOWS_KEYS = ["date"];
+
+export function validateAgentTriageCaptureItemInput(data: unknown): {
+  captureItemId: string;
+  mode?: "suggest" | "apply";
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, TRIAGE_CAPTURE_ITEM_KEYS, "Agent action input");
+  const modeVal = parseOptionalString(body.mode, "mode", 10);
+  if (modeVal !== undefined && modeVal !== "suggest" && modeVal !== "apply") {
+    throw new ValidationError('mode must be "suggest" or "apply"');
+  }
+  return {
+    captureItemId: parseRequiredId(body, "captureItemId"),
+    mode: modeVal as "suggest" | "apply" | undefined,
+  };
+}
+
+export function validateAgentTriageInboxInput(data: unknown): {
+  limit?: number;
+  mode?: "suggest" | "apply";
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, TRIAGE_INBOX_KEYS, "Agent action input");
+  const modeVal = parseOptionalString(body.mode, "mode", 10);
+  if (modeVal !== undefined && modeVal !== "suggest" && modeVal !== "apply") {
+    throw new ValidationError('mode must be "suggest" or "apply"');
+  }
+  return {
+    limit: parseOptionalPositiveInt(body.limit, "limit", 100) ?? undefined,
+    mode: modeVal as "suggest" | "apply" | undefined,
+  };
+}
+
+export function validateAgentListAuditLogInput(data: unknown): {
+  limit?: number;
+  since?: string;
+  actionFilter?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, LIST_AUDIT_LOG_KEYS, "Agent action input");
+  return {
+    limit: parseOptionalPositiveInt(body.limit, "limit", 200) ?? undefined,
+    since: parseOptionalString(body.since, "since", 30),
+    actionFilter: parseOptionalString(body.action, "action", 60),
+  };
+}
+
+export function validateAgentGetAvailabilityWindowsInput(data: unknown): {
+  date?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, GET_AVAILABILITY_WINDOWS_KEYS, "Agent action input");
+  return {
+    date: parseOptionalString(body.date, "date", 10),
+  };
+}

--- a/tests/eval/recommendation-quality.test.ts
+++ b/tests/eval/recommendation-quality.test.ts
@@ -1,0 +1,119 @@
+import { analyzeTaskQuality } from "../../src/ai/taskQualityAnalyzer";
+import { findDuplicates } from "../../src/ai/duplicateDetector";
+import type { TaskForDuplication } from "../../src/ai/duplicateDetector";
+import taskQualityFixtures from "../fixtures/ai-workflows/task-quality.json";
+import duplicateFixtures from "../fixtures/ai-workflows/duplicate-tasks.json";
+import captureTriageFixtures from "../fixtures/ai-workflows/capture-triage.json";
+
+// ---------------------------------------------------------------------------
+// Inline the triage helper (same logic as agentExecutor.triageCaptureText)
+// ---------------------------------------------------------------------------
+
+const ACTION_VERB_RE =
+  /^(buy|call|send|write|read|review|schedule|book|fix|update|check|draft|prepare|submit|complete|finish|create|build|test|deploy|refactor|add|remove|delete|merge|close|open|contact|email|research|investigate|plan|organize|clean|sort|discuss|confirm|follow|set|get|make|find|move|copy|install|configure|document|upload|download|publish|cancel|archive|approve|reject|invite|register|verify|report|analyze|design|implement|request|order|pay|sign|file|print|record|backup|restore|monitor|notify|present|remind|track|coordinate|attend|join)\b/i;
+
+function triageCaptureText(text: string): {
+  kind: "create_task" | "discard" | "convert_to_note";
+  confidence: number;
+} {
+  const trimmed = text.trim();
+  if (/^https?:\/\//.test(trimmed)) {
+    return { kind: "convert_to_note", confidence: 0.8 };
+  }
+  const wordCount = trimmed.split(/\s+/).length;
+  if (wordCount < 3 && !ACTION_VERB_RE.test(trimmed)) {
+    return { kind: "discard", confidence: 0.6 };
+  }
+  if (ACTION_VERB_RE.test(trimmed)) {
+    return { kind: "create_task", confidence: 0.85 };
+  }
+  return { kind: "create_task", confidence: 0.5 };
+}
+
+// ---------------------------------------------------------------------------
+// Task quality eval
+// ---------------------------------------------------------------------------
+
+describe("Eval: task quality analyzer", () => {
+  for (const fixture of taskQualityFixtures) {
+    it(fixture.description, () => {
+      const result = analyzeTaskQuality(fixture.input.id, fixture.input.title);
+
+      if ("qualityScore" in fixture.expected) {
+        expect(result.qualityScore).toBe(fixture.expected.qualityScore);
+      }
+      if ("qualityScoreMax" in fixture.expected) {
+        expect(result.qualityScore).toBeLessThanOrEqual(
+          fixture.expected.qualityScoreMax as number,
+        );
+      }
+      if ("issueCount" in fixture.expected) {
+        expect(result.issues).toHaveLength(
+          fixture.expected.issueCount as number,
+        );
+      }
+      if ("issueContains" in fixture.expected) {
+        const issueContains = fixture.expected.issueContains as string;
+        const found = result.issues.some((i) =>
+          i.toLowerCase().includes(issueContains.toLowerCase()),
+        );
+        expect(found).toBe(true);
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Duplicate detection eval
+// ---------------------------------------------------------------------------
+
+describe("Eval: duplicate task detector", () => {
+  for (const fixture of duplicateFixtures) {
+    it(fixture.description, () => {
+      const tasks = fixture.input as TaskForDuplication[];
+      const groups = findDuplicates(tasks);
+
+      expect(groups).toHaveLength(fixture.expected.groupCount);
+
+      if (fixture.expected.groupCount > 0) {
+        const first = groups[0];
+        if ("firstGroupConfidence" in fixture.expected) {
+          expect(first.confidence).toBe(fixture.expected.firstGroupConfidence);
+        }
+        if ("firstGroupConfidenceMin" in fixture.expected) {
+          expect(first.confidence).toBeGreaterThanOrEqual(
+            fixture.expected.firstGroupConfidenceMin as number,
+          );
+        }
+        if ("firstGroupAction" in fixture.expected) {
+          expect(first.suggestedAction).toBe(fixture.expected.firstGroupAction);
+        }
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Capture triage eval
+// ---------------------------------------------------------------------------
+
+describe("Eval: capture triage heuristic", () => {
+  for (const fixture of captureTriageFixtures) {
+    it(fixture.description, () => {
+      const result = triageCaptureText(fixture.input.text);
+
+      expect(result.kind).toBe(fixture.expected.kind);
+
+      if ("confidenceMin" in fixture.expected) {
+        expect(result.confidence).toBeGreaterThanOrEqual(
+          fixture.expected.confidenceMin as number,
+        );
+      }
+      if ("confidenceMax" in fixture.expected) {
+        expect(result.confidence).toBeLessThanOrEqual(
+          fixture.expected.confidenceMax as number,
+        );
+      }
+    });
+  }
+});

--- a/tests/fixtures/ai-workflows/capture-triage.json
+++ b/tests/fixtures/ai-workflows/capture-triage.json
@@ -1,0 +1,27 @@
+[
+  {
+    "description": "Clear action verb — should suggest create_task",
+    "input": { "text": "Call dentist to schedule appointment" },
+    "expected": { "kind": "create_task", "confidenceMin": 0.8 }
+  },
+  {
+    "description": "URL — should suggest convert_to_note",
+    "input": { "text": "https://example.com/article-about-planning" },
+    "expected": { "kind": "convert_to_note", "confidenceMin": 0.7 }
+  },
+  {
+    "description": "Very short without verb — should suggest discard",
+    "input": { "text": "um" },
+    "expected": { "kind": "discard", "confidenceMin": 0.5 }
+  },
+  {
+    "description": "Ambiguous text without clear verb — lower confidence task",
+    "input": { "text": "the quarterly planning meeting agenda" },
+    "expected": { "kind": "create_task", "confidenceMax": 0.7 }
+  },
+  {
+    "description": "Write action verb — should be create_task",
+    "input": { "text": "Write up the design doc for auth refactor" },
+    "expected": { "kind": "create_task", "confidenceMin": 0.8 }
+  }
+]

--- a/tests/fixtures/ai-workflows/duplicate-tasks.json
+++ b/tests/fixtures/ai-workflows/duplicate-tasks.json
@@ -1,0 +1,86 @@
+[
+  {
+    "description": "Exact duplicate pair",
+    "input": [
+      {
+        "id": "a",
+        "title": "Buy groceries",
+        "status": "inbox",
+        "projectId": null
+      },
+      {
+        "id": "b",
+        "title": "Buy groceries",
+        "status": "inbox",
+        "projectId": null
+      }
+    ],
+    "expected": {
+      "groupCount": 1,
+      "firstGroupConfidence": 1.0,
+      "firstGroupAction": "archive-older"
+    }
+  },
+  {
+    "description": "Normalized duplicate (articles/punctuation differ)",
+    "input": [
+      {
+        "id": "a",
+        "title": "Review the quarterly report",
+        "status": "inbox",
+        "projectId": null
+      },
+      {
+        "id": "b",
+        "title": "Review quarterly report",
+        "status": "inbox",
+        "projectId": null
+      }
+    ],
+    "expected": {
+      "groupCount": 1,
+      "firstGroupConfidenceMin": 0.85
+    }
+  },
+  {
+    "description": "Near-duplicate in same project",
+    "input": [
+      {
+        "id": "a",
+        "title": "Setup CI pipeline",
+        "status": "next",
+        "projectId": "proj-1"
+      },
+      {
+        "id": "b",
+        "title": "Set up CI pipeline",
+        "status": "next",
+        "projectId": "proj-1"
+      }
+    ],
+    "expected": {
+      "groupCount": 1,
+      "firstGroupConfidenceMin": 0.6
+    }
+  },
+  {
+    "description": "No duplicates — distinct tasks",
+    "input": [
+      {
+        "id": "a",
+        "title": "Write unit tests",
+        "status": "inbox",
+        "projectId": null
+      },
+      {
+        "id": "b",
+        "title": "Deploy to production",
+        "status": "next",
+        "projectId": null
+      }
+    ],
+    "expected": {
+      "groupCount": 0
+    }
+  }
+]

--- a/tests/fixtures/ai-workflows/planning-scenarios.json
+++ b/tests/fixtures/ai-workflows/planning-scenarios.json
@@ -1,0 +1,63 @@
+[
+  {
+    "description": "High energy, 4 hours — prefers urgent/high priority tasks",
+    "input": {
+      "availableMinutes": 240,
+      "energy": "high",
+      "tasks": [
+        {
+          "id": "t1",
+          "title": "Fix critical login bug",
+          "priority": "urgent",
+          "effortScore": 60,
+          "status": "next"
+        },
+        {
+          "id": "t2",
+          "title": "Update documentation",
+          "priority": "low",
+          "effortScore": 30,
+          "status": "inbox"
+        },
+        {
+          "id": "t3",
+          "title": "Review PR",
+          "priority": "high",
+          "effortScore": 30,
+          "status": "next"
+        }
+      ]
+    },
+    "expected": {
+      "firstTaskId": "t1",
+      "selectedMinMaxCount": [2, 3]
+    }
+  },
+  {
+    "description": "Low energy, 1 hour — avoids high-effort tasks",
+    "input": {
+      "availableMinutes": 60,
+      "energy": "low",
+      "tasks": [
+        {
+          "id": "t1",
+          "title": "Refactor authentication module",
+          "priority": "high",
+          "effortScore": 120,
+          "status": "next"
+        },
+        {
+          "id": "t2",
+          "title": "Reply to emails",
+          "priority": "medium",
+          "effortScore": 15,
+          "status": "inbox"
+        }
+      ]
+    },
+    "expected": {
+      "selectedContainsId": "t2",
+      "selectedDoesNotContainId": "t1"
+    }
+  }
+]

--- a/tests/fixtures/ai-workflows/task-quality.json
+++ b/tests/fixtures/ai-workflows/task-quality.json
@@ -1,0 +1,42 @@
+[
+  {
+    "description": "Task with clear action verb — should score high",
+    "input": { "id": "task-1", "title": "Review quarterly report" },
+    "expected": { "qualityScore": 5, "issueCount": 0 }
+  },
+  {
+    "description": "Task without action verb — should flag missing verb",
+    "input": { "id": "task-2", "title": "The login situation" },
+    "expected": {
+      "qualityScoreMax": 4,
+      "issueContains": "action verb"
+    }
+  },
+  {
+    "description": "Task with vague phrase — should flag vague verb",
+    "input": { "id": "task-3", "title": "Handle the deployment issue" },
+    "expected": {
+      "qualityScoreMax": 4,
+      "issueContains": "vague phrase"
+    }
+  },
+  {
+    "description": "Task with multiple actions — should flag compound",
+    "input": {
+      "id": "task-4",
+      "title": "Write report and review results and update dashboard"
+    },
+    "expected": {
+      "qualityScoreMax": 4,
+      "issueContains": "multiple actions"
+    }
+  },
+  {
+    "description": "Task with vague placeholder words",
+    "input": { "id": "task-5", "title": "Fix stuff in the auth module" },
+    "expected": {
+      "qualityScoreMax": 4,
+      "issueContains": "placeholder"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- Adds 12 new agent actions wired across `agentExecutor.ts`, `agentValidation.ts`, `agentRouter.ts`, `agent-manifest.json`, and `mcpToolCatalog.ts`
- **Anti-entropy** (4 actions): `analyze_task_quality`, `find_duplicate_tasks`, `find_stale_items`, `taxonomy_cleanup_suggestions`
- **Planning** (4 actions): `plan_today`, `break_down_task`, `suggest_next_actions`, `weekly_review_summary`
- **Triage / audit / availability** (4 actions): `triage_capture_item`, `triage_inbox`, `list_audit_log`, `get_availability_windows`
- Adds eval harness (`tests/eval/recommendation-quality.test.ts`) driven by JSON fixtures in `tests/fixtures/ai-workflows/`

Closes #290, #292, #293, #294, #295, #296, #297, #298, #301, #302, #303, #306, #307, #308

## Test plan

- [ ] `npx tsc --noEmit` — passes
- [ ] `npm run test:unit` — all unit/eval tests pass
- [ ] `npm run format:check` — passes
- [ ] Anti-entropy integration tests pass against Postgres
- [ ] Agent manifest endpoint returns all 12 new actions
- [ ] All 12 routes respond 200 with valid input, 400 with invalid input

🤖 Generated with [Claude Code](https://claude.com/claude-code)