### PR TITLE
feat(ui): add workflow filter views, projectId writes, and next-actions tile

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -355,6 +355,20 @@
                           >
                             Someday
                           </button>
+                          <button
+                            class="date-view-tab"
+                            id="dateViewWaiting"
+                            data-onclick="setDateView('waiting')"
+                          >
+                            Waiting
+                          </button>
+                          <button
+                            class="date-view-tab"
+                            id="dateViewScheduled"
+                            data-onclick="setDateView('scheduled')"
+                          >
+                            Scheduled
+                          </button>
                         </div>
                         <div class="more-filters-actions">
                           <button
@@ -971,6 +985,20 @@
                             data-onclick="setDateView('someday')"
                           >
                             Someday
+                          </button>
+                          <button
+                            class="date-view-tab"
+                            id="dateViewWaitingSheet"
+                            data-onclick="setDateView('waiting')"
+                          >
+                            Waiting
+                          </button>
+                          <button
+                            class="date-view-tab"
+                            id="dateViewScheduledSheet"
+                            data-onclick="setDateView('scheduled')"
+                          >
+                            Scheduled
                           </button>
                         </div>
                         <div class="more-filters-actions">

--- a/client/modules/drawerUi.js
+++ b/client/modules/drawerUi.js
@@ -766,7 +766,14 @@ export function onDrawerProjectChange(event) {
   const normalizeProjectPath = hooks.normalizeProjectPath || ((v) => v);
   const project = normalizeProjectPath(String(event?.target?.value || ""));
   updateDrawerDraftField("project", project || "");
-  saveDrawerPatch({ category: project || null });
+  const patch = { category: project || null, projectId: null };
+  if (project) {
+    const projectRecord = hooks.getProjectRecordByName?.(project);
+    if (projectRecord?.id) {
+      patch.projectId = projectRecord.id;
+    }
+  }
+  saveDrawerPatch(patch);
 }
 
 export function onDrawerPriorityChange(event) {
@@ -905,7 +912,14 @@ export function onDrawerCategoryBlur() {
   );
   updateDrawerDraftField("project", normalized || "");
   updateDrawerDraftField("categoryDetail", normalized || "");
-  saveDrawerPatch({ category: normalized || null });
+  const patch = { category: normalized || null, projectId: null };
+  if (normalized) {
+    const projectRecord = hooks.getProjectRecordByName?.(normalized);
+    if (projectRecord?.id) {
+      patch.projectId = projectRecord.id;
+    }
+  }
+  saveDrawerPatch(patch);
 }
 
 // ---------------------------------------------------------------------------

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -48,6 +48,8 @@ function setDateView(view, { skipApply = false } = {}) {
     upcoming: "dateViewUpcoming",
     next_month: "dateViewNextMonth",
     someday: "dateViewSomeday",
+    waiting: "dateViewWaiting",
+    scheduled: "dateViewScheduled",
     completed: "",
   };
   const suffixes = ["", "Sheet"];
@@ -181,6 +183,12 @@ function isSameLocalDay(a, b) {
 function matchesDateView(todo) {
   if (state.currentDateView === "all") return true;
   if (state.currentDateView === "completed") return !!todo.completed;
+  if (state.currentDateView === "waiting")
+    return (
+      !todo.completed && String(todo.status || "").toLowerCase() === "waiting"
+    );
+  if (state.currentDateView === "scheduled")
+    return !todo.completed && !!todo.scheduledDate;
 
   const dueDate = todo.dueDate ? new Date(todo.dueDate) : null;
   const now = new Date();
@@ -469,6 +477,8 @@ function getCurrentDateViewLabel() {
     completed: "Completed",
     next_month: "Next month",
     someday: "Someday",
+    waiting: "Waiting",
+    scheduled: "Scheduled",
   };
   return labels[state.currentDateView] || "";
 }

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -297,6 +297,32 @@ export function getScheduledTodos(limit = 6) {
     .slice(0, limit);
 }
 
+export function getNextActionTodos(limit = 6) {
+  return getOpenTodos()
+    .filter((todo) => String(todo.status || "").toLowerCase() === "next")
+    .sort((a, b) => {
+      const aPriority =
+        a.priority === "urgent"
+          ? 0
+          : a.priority === "high"
+            ? 1
+            : a.priority === "medium"
+              ? 2
+              : 3;
+      const bPriority =
+        b.priority === "urgent"
+          ? 0
+          : b.priority === "high"
+            ? 1
+            : b.priority === "medium"
+              ? 2
+              : 3;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return String(a.title || "").localeCompare(String(b.title || ""));
+    })
+    .slice(0, limit);
+}
+
 function isProjectReviewOverdue(projectRecord) {
   if (!projectRecord?.reviewCadence || !projectRecord?.lastReviewedAt)
     return false;
@@ -407,6 +433,11 @@ export function getHomeDashboardModel({ topFocusItems = [] } = {}) {
     6,
     usedTodoIds,
   );
+  const nextActionTodos = takeExclusiveTodos(
+    getNextActionTodos(12),
+    6,
+    usedTodoIds,
+  );
   return {
     dueSoon,
     dueSoonGroups: buildHomeDueSoonGroups(dueSoon),
@@ -414,6 +445,7 @@ export function getHomeDashboardModel({ topFocusItems = [] } = {}) {
     quickWins,
     waitingTodos,
     scheduledTodos,
+    nextActionTodos,
     projectsToNudge: getProjectsToNudge(4),
     topFocusFallback: getTopFocusFallbackTodos(3),
   };
@@ -426,6 +458,7 @@ export function buildHomeTileListByKey(key) {
   if (key === "quick_wins") return model.quickWins;
   if (key === "waiting") return model.waitingTodos;
   if (key === "scheduled") return model.scheduledTodos;
+  if (key === "next_actions") return model.nextActionTodos;
   return [];
 }
 
@@ -745,6 +778,17 @@ export function renderHomeDashboard() {
               title: "Scheduled",
               items: model.scheduledTodos,
               emptyText: "Nothing scheduled.",
+              showSeeAll: false,
+            })
+          : ""
+      }
+      ${
+        model.nextActionTodos.length > 0
+          ? renderHomeTaskTile({
+              key: "next_actions",
+              title: "Next Actions",
+              items: model.nextActionTodos,
+              emptyText: "No next actions.",
               showSeeAll: false,
             })
           : ""

--- a/client/modules/todosService.js
+++ b/client/modules/todosService.js
@@ -102,6 +102,10 @@ function buildVisibleTodosQueryParams() {
     params.dueDateBefore = monthAfterNextStart.toISOString();
   } else if (state.currentDateView === "someday") {
     params.dueDateIsNull = true;
+  } else if (state.currentDateView === "waiting") {
+    params.status = "waiting";
+  } else if (state.currentDateView === "scheduled") {
+    params.scheduledDateIsNotNull = true;
   }
 
   return params;


### PR DESCRIPTION
## Summary

- **#274 (category → projectId)**: Task drawer project change now writes `projectId` alongside `category` (canonical dual-write pattern), completing the client-side migration
- **#273 (filter parity)**: Added "Waiting" and "Scheduled" filter tabs to the date-view pipeline for both desktop and mobile sheet; backed by `matchesDateView` status/scheduledDate logic and server-side params
- **#275 (home dashboard)**: Added `getNextActionTodos()` and a "Next Actions" home tile showing tasks with `status="next"`, sorted by priority
- **#272 (project metadata)**: Already fully implemented in prior work — project edit drawer round-trips all canonical fields (description, status, priority, area, goal, targetDate, reviewCadence, archive/unarchive)

Closes #272, #273, #274, #275

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test:unit` — 282 tests pass
- [ ] `npm run format:check` passes
- [ ] `npm run lint:html` passes
- [ ] `npm run lint:css` passes
- [ ] Waiting/Scheduled filter tabs appear in the filter panel and correctly filter tasks
- [ ] Changing project in task drawer now sends `projectId` to the API
- [ ] Home dashboard shows "Next Actions" tile when tasks with `status="next"` exist
- [ ] Project edit drawer saves all metadata fields (description, status, priority, etc.)
- [ ] Archive/Unarchive project works from the edit drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)