### PR TITLE
feat(api): implement 8 agent API improvements (issues #313–#320)

### DIFF
--- a/agent-runner/Dockerfile
+++ b/agent-runner/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies first for better layer caching
+COPY agent-runner/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent-runner source
+COPY agent-runner/ .
+
+# Default command — overridden per Railway service via startCommand
+CMD ["python", "main.py", "daily"]

--- a/agent-runner/nixpacks.toml
+++ b/agent-runner/nixpacks.toml
@@ -1,0 +1,3 @@
+# Force Python provider — required because Nixpacks otherwise detects the
+# Node.js package.json at the repo root and skips Python setup entirely.
+providers = ["python"]

--- a/agent-runner/railway.json
+++ b/agent-runner/railway.json
@@ -2,10 +2,10 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "pip install -r agent-runner/requirements.txt"
+    "buildCommand": "pip install -r requirements.txt"
   },
   "deploy": {
-    "startCommand": "cd agent-runner && python main.py daily",
+    "startCommand": "python main.py daily",
     "restartPolicyType": "NEVER"
   }
 }

--- a/agent-runner/railway.json
+++ b/agent-runner/railway.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS",
-    "buildCommand": "pip install -r requirements.txt"
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "agent-runner/Dockerfile"
   },
   "deploy": {
     "startCommand": "python main.py daily",

--- a/prisma/migrations/20260316180000_agent_improvements/migration.sql
+++ b/prisma/migrations/20260316180000_agent_improvements/migration.sql
@@ -1,0 +1,64 @@
+-- Issue #317: Add job context columns to agent_action_audits
+ALTER TABLE "agent_action_audits"
+  ADD COLUMN "job_name"       VARCHAR(100),
+  ADD COLUMN "job_period_key" VARCHAR(20),
+  ADD COLUMN "triggered_by"   VARCHAR(20);
+
+CREATE INDEX "agent_action_audits_job_name_job_period_key_idx"
+  ON "agent_action_audits"("job_name", "job_period_key");
+
+-- Issue #314: Server-side job-run locking table
+CREATE TABLE "agent_job_runs" (
+  "id"            UUID NOT NULL DEFAULT gen_random_uuid(),
+  "user_id"       TEXT NOT NULL,
+  "job_name"      VARCHAR(100) NOT NULL,
+  "period_key"    VARCHAR(20) NOT NULL,
+  "status"        VARCHAR(20) NOT NULL,
+  "claimed_at"    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "completed_at"  TIMESTAMPTZ,
+  "failed_at"     TIMESTAMPTZ,
+  "error_message" VARCHAR(500),
+  "metadata"      JSONB,
+  "created_at"    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT "agent_job_runs_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "agent_job_runs_user_id_job_name_period_key_key"
+    UNIQUE ("user_id", "job_name", "period_key"),
+  CONSTRAINT "agent_job_runs_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "agent_job_runs_user_id_idx" ON "agent_job_runs"("user_id");
+CREATE INDEX "agent_job_runs_status_idx"  ON "agent_job_runs"("status");
+
+-- Issue #320: Dead-letter store for failed automation actions
+CREATE TABLE "failed_automation_actions" (
+  "id"            UUID NOT NULL DEFAULT gen_random_uuid(),
+  "user_id"       TEXT NOT NULL,
+  "job_name"      VARCHAR(100) NOT NULL,
+  "period_key"    VARCHAR(20) NOT NULL,
+  "action_type"   VARCHAR(100) NOT NULL,
+  "entity_type"   VARCHAR(50),
+  "entity_id"     VARCHAR(100),
+  "error_code"    VARCHAR(100),
+  "error_message" VARCHAR(1000),
+  "payload"       JSONB,
+  "retryable"     BOOLEAN NOT NULL DEFAULT FALSE,
+  "retry_count"   INTEGER NOT NULL DEFAULT 0,
+  "resolved_at"   TIMESTAMPTZ,
+  "resolution"    VARCHAR(20),
+  "created_at"    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT "failed_automation_actions_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "failed_automation_actions_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "failed_automation_actions_user_id_created_at_idx"
+  ON "failed_automation_actions"("user_id", "created_at");
+CREATE INDEX "failed_automation_actions_user_id_job_name_period_key_idx"
+  ON "failed_automation_actions"("user_id", "job_name", "period_key");
+CREATE INDEX "failed_automation_actions_resolved_at_idx"
+  ON "failed_automation_actions"("resolved_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,8 @@ model User {
   agentIdempotencyRecords AgentIdempotencyRecord[]
   agentActionAudits AgentActionAudit[]
   agentEnrollment   AgentEnrollment?
+  agentJobRuns      AgentJobRun[]
+  failedAutomationActions FailedAutomationAction[]
   aiSuggestions     AiSuggestion[]
   captureItems      CaptureItem[]
   areas             Area[]
@@ -242,6 +244,9 @@ model AgentActionAudit {
   idempotencyKey String?  @db.VarChar(255) @map("idempotency_key")
   replayed       Boolean  @default(false)
   errorCode      String?  @db.VarChar(100) @map("error_code")
+  jobName        String?  @db.VarChar(100) @map("job_name")
+  jobPeriodKey   String?  @db.VarChar(20) @map("job_period_key")
+  triggeredBy    String?  @db.VarChar(20) @map("triggered_by")
   metadata       Json?
   createdAt      DateTime @default(now()) @map("created_at")
 
@@ -251,6 +256,7 @@ model AgentActionAudit {
   @@index([userId, createdAt])
   @@index([requestId])
   @@index([action, createdAt])
+  @@index([jobName, jobPeriodKey])
 }
 
 model Project {
@@ -488,6 +494,54 @@ model AgentEnrollment {
 
   @@map("agent_enrollments")
   @@index([active])
+}
+
+model AgentJobRun {
+  id           String    @id @default(uuid()) @db.Uuid
+  userId       String    @map("user_id")
+  jobName      String    @db.VarChar(100) @map("job_name")
+  periodKey    String    @db.VarChar(20) @map("period_key")
+  status       String    @db.VarChar(20)
+  claimedAt    DateTime  @default(now()) @map("claimed_at")
+  completedAt  DateTime? @map("completed_at")
+  failedAt     DateTime? @map("failed_at")
+  errorMessage String?   @db.VarChar(500) @map("error_message")
+  metadata     Json?
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("agent_job_runs")
+  @@unique([userId, jobName, periodKey])
+  @@index([userId])
+  @@index([status])
+}
+
+model FailedAutomationAction {
+  id           String    @id @default(uuid()) @db.Uuid
+  userId       String    @map("user_id")
+  jobName      String    @db.VarChar(100) @map("job_name")
+  periodKey    String    @db.VarChar(20) @map("period_key")
+  actionType   String    @db.VarChar(100) @map("action_type")
+  entityType   String?   @db.VarChar(50) @map("entity_type")
+  entityId     String?   @db.VarChar(100) @map("entity_id")
+  errorCode    String?   @db.VarChar(100) @map("error_code")
+  errorMessage String?   @db.VarChar(1000) @map("error_message")
+  payload      Json?
+  retryable    Boolean   @default(false)
+  retryCount   Int       @default(0) @map("retry_count")
+  resolvedAt   DateTime? @map("resolved_at")
+  resolution   String?   @db.VarChar(20)
+  createdAt    DateTime  @default(now()) @map("created_at")
+  updatedAt    DateTime  @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("failed_automation_actions")
+  @@index([userId, createdAt])
+  @@index([userId, jobName, periodKey])
+  @@index([resolvedAt])
 }
 
 model UserPlanningPreferences {

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -1773,6 +1773,284 @@
       },
       "errorModel": "structured_agent_error",
       "idempotency": "not_applicable"
+    },
+    {
+      "name": "create_follow_up_for_waiting_task",
+      "description": "Create a follow-up next-action task for a task that is in 'waiting' status. Supports a cooldown window to avoid duplicate follow-ups and a suggest/apply mode.",
+      "method": "POST",
+      "path": "/write/create_follow_up_for_waiting_task",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["taskId"],
+        "properties": {
+          "taskId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the waiting task to create a follow-up for."
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["suggest", "apply"],
+            "description": "suggest returns a preview without writing; apply creates the task. Defaults to suggest."
+          },
+          "cooldownDays": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Skip creation if a follow-up was already created within this many days. Defaults to 7."
+          },
+          "title": {
+            "type": "string",
+            "description": "Override the generated follow-up title."
+          },
+          "priority": {
+            "type": "string",
+            "enum": ["low", "medium", "high", "urgent"],
+            "description": "Priority for the follow-up task. Defaults to medium."
+          }
+        }
+      },
+      "output": {
+        "description": "created boolean, task (when created), skipped/reason (when cooldown active), and waitingTaskId."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "supported"
+    },
+    {
+      "name": "claim_job_run",
+      "description": "Atomically claim a job run slot for a given jobName+periodKey combination. Returns claimed=false if already claimed (deduplication lock).",
+      "method": "POST",
+      "path": "/write/claim_job_run",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["jobName", "periodKey"],
+        "properties": {
+          "jobName": {
+            "type": "string",
+            "description": "Logical name of the scheduled job (e.g. 'daily_review')."
+          },
+          "periodKey": {
+            "type": "string",
+            "description": "Period identifier (e.g. '2026-03-16'). Combined with jobName for uniqueness."
+          }
+        }
+      },
+      "output": {
+        "description": "claimed boolean and run record when claimed."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "complete_job_run",
+      "description": "Mark a previously claimed job run as completed. Returns 404 if no matching running job run is found.",
+      "method": "POST",
+      "path": "/write/complete_job_run",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["jobName", "periodKey"],
+        "properties": {
+          "jobName": { "type": "string" },
+          "periodKey": { "type": "string" },
+          "metadata": {
+            "type": "object",
+            "description": "Optional JSON metadata to store with the completed run."
+          }
+        }
+      },
+      "output": {
+        "description": "completed boolean, jobName, and periodKey."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "fail_job_run",
+      "description": "Mark a previously claimed job run as failed. Returns 404 if no matching running job run is found.",
+      "method": "POST",
+      "path": "/write/fail_job_run",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["jobName", "periodKey", "errorMessage"],
+        "properties": {
+          "jobName": { "type": "string" },
+          "periodKey": { "type": "string" },
+          "errorMessage": {
+            "type": "string",
+            "description": "Error message describing why the job failed. Truncated to 500 characters."
+          }
+        }
+      },
+      "output": {
+        "description": "failed boolean, jobName, and periodKey."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "get_job_run_status",
+      "description": "Retrieve the status record for a specific jobName+periodKey combination.",
+      "method": "POST",
+      "path": "/read/get_job_run_status",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["jobName", "periodKey"],
+        "properties": {
+          "jobName": { "type": "string" },
+          "periodKey": { "type": "string" }
+        }
+      },
+      "output": {
+        "description": "run record or null if not found."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "list_job_runs",
+      "description": "List recent agent job run records for the authenticated user, optionally filtered by jobName or status.",
+      "method": "POST",
+      "path": "/read/list_job_runs",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "jobName": {
+            "type": "string",
+            "description": "Optional filter by job name."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["running", "completed", "failed"],
+            "description": "Optional filter by run status."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "description": "Maximum records to return. Defaults to 50."
+          }
+        }
+      },
+      "output": {
+        "description": "runs array and total count."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "record_failed_action",
+      "description": "Record a failed automation action to the dead-letter store for later inspection or retry.",
+      "method": "POST",
+      "path": "/write/record_failed_action",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["jobName", "periodKey", "actionType"],
+        "properties": {
+          "jobName": { "type": "string" },
+          "periodKey": { "type": "string" },
+          "actionType": {
+            "type": "string",
+            "description": "Logical action type that failed (e.g. 'create_follow_up')."
+          },
+          "entityType": {
+            "type": "string",
+            "description": "Optional entity type the action targeted (e.g. 'task')."
+          },
+          "entityId": {
+            "type": "string",
+            "description": "Optional entity ID the action targeted."
+          },
+          "errorCode": { "type": "string" },
+          "errorMessage": {
+            "type": "string",
+            "description": "Error message. Truncated to 1000 characters."
+          },
+          "payload": {
+            "type": "object",
+            "description": "Optional JSON payload for retry context."
+          },
+          "retryable": {
+            "type": "boolean",
+            "description": "Whether the action can be retried. Defaults to false."
+          }
+        }
+      },
+      "output": {
+        "description": "record object with the created failed-action entry."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "list_failed_actions",
+      "description": "List failed automation actions from the dead-letter store, optionally filtered by jobName, periodKey, or resolved status.",
+      "method": "POST",
+      "path": "/read/list_failed_actions",
+      "readOnly": true,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "jobName": { "type": "string" },
+          "periodKey": { "type": "string" },
+          "includeResolved": {
+            "type": "boolean",
+            "description": "Include already-resolved entries. Defaults to false."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200
+          }
+        }
+      },
+      "output": {
+        "description": "records array and total count."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
+    },
+    {
+      "name": "resolve_failed_action",
+      "description": "Resolve (dismiss or mark retried) a failed automation action in the dead-letter store.",
+      "method": "POST",
+      "path": "/write/resolve_failed_action",
+      "readOnly": false,
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "resolution"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the failed action record to resolve."
+          },
+          "resolution": {
+            "type": "string",
+            "enum": ["retried", "dismissed"],
+            "description": "How the failed action was resolved."
+          }
+        }
+      },
+      "output": {
+        "description": "resolved boolean indicating whether the record was found and updated."
+      },
+      "errorModel": "structured_agent_error",
+      "idempotency": "not_applicable"
     }
   ],
   "notes": [

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -1918,29 +1918,7 @@ export class AgentExecutor {
             );
           }
 
-          // Check cooldown: look for recent follow-ups created for this task
           const cooldown = cooldownDays ?? 7;
-          const cooldownDate = new Date(
-            Date.now() - cooldown * 24 * 60 * 60 * 1000,
-          );
-          const recentFollowUps = await this.agentService.listTasks(
-            context.userId,
-            {
-              statuses: ["inbox", "next", "in_progress"],
-              archived: false,
-              limit: 50,
-            },
-          );
-          const hasRecentFollowUp = recentFollowUps.some((t) => {
-            const createdAt =
-              t.createdAt instanceof Date
-                ? t.createdAt
-                : new Date(t.createdAt as unknown as string);
-            return (
-              t.createdByPrompt?.includes(taskId) && createdAt >= cooldownDate
-            );
-          });
-
           const followUpTitle = title ?? `Follow up: ${waitingTask.title}`;
           const followUp = {
             title: followUpTitle,
@@ -1952,17 +1930,6 @@ export class AgentExecutor {
             createdByPrompt: `follow_up:${taskId}`,
           };
 
-          if (hasRecentFollowUp) {
-            return this.success(action, readOnly, context, 200, {
-              created: false,
-              skipped: true,
-              reason: "cooldown_active",
-              cooldownDays: cooldown,
-              waitingTask: { id: waitingTask.id, title: waitingTask.title },
-              followUp,
-            });
-          }
-
           if (mode !== "apply") {
             return this.success(action, readOnly, context, 200, {
               created: false,
@@ -1972,11 +1939,46 @@ export class AgentExecutor {
             });
           }
 
+          // For apply mode, idempotency lookup fires first so retries with the
+          // same key replay the original success even if cooldown is now active.
           return await this.handleIdempotentWriteAction(
             action,
             context,
             input,
             async () => {
+              // Check cooldown inside the execute callback so idempotency replay
+              // bypasses this check on retries.
+              const cooldownDate = new Date(
+                Date.now() - cooldown * 24 * 60 * 60 * 1000,
+              );
+              const recentFollowUps = await this.agentService.listTasks(
+                context.userId,
+                {
+                  statuses: ["inbox", "next", "in_progress"],
+                  archived: false,
+                  limit: 50,
+                },
+              );
+              const hasRecentFollowUp = recentFollowUps.some((t) => {
+                const createdAt =
+                  t.createdAt instanceof Date
+                    ? t.createdAt
+                    : new Date(t.createdAt as unknown as string);
+                return (
+                  t.createdByPrompt?.includes(taskId) &&
+                  createdAt >= cooldownDate
+                );
+              });
+              if (hasRecentFollowUp) {
+                return {
+                  created: false,
+                  skipped: true,
+                  reason: "cooldown_active",
+                  cooldownDays: cooldown,
+                  waitingTask: { id: waitingTask.id, title: waitingTask.title },
+                  followUp,
+                };
+              }
               const task = await this.agentService.createTask(
                 context.userId,
                 followUp,
@@ -2007,12 +2009,21 @@ export class AgentExecutor {
         case "complete_job_run": {
           const { jobName, periodKey, metadata } =
             validateAgentCompleteJobRunInput(input);
-          await this.jobRunService.completeRun(
+          const completed = await this.jobRunService.completeRun(
             context.userId,
             jobName,
             periodKey,
             metadata,
           );
+          if (!completed) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND",
+              `No running job run found for jobName=${jobName} periodKey=${periodKey}`,
+              false,
+              "Ensure claim_job_run was called first for this job/period combination.",
+            );
+          }
           return this.success(action, readOnly, context, 200, {
             completed: true,
             jobName,
@@ -2022,12 +2033,21 @@ export class AgentExecutor {
         case "fail_job_run": {
           const { jobName, periodKey, errorMessage } =
             validateAgentFailJobRunInput(input);
-          await this.jobRunService.failRun(
+          const failed = await this.jobRunService.failRun(
             context.userId,
             jobName,
             periodKey,
             errorMessage,
           );
+          if (!failed) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND",
+              `No running job run found for jobName=${jobName} periodKey=${periodKey}`,
+              false,
+              "Ensure claim_job_run was called first for this job/period combination.",
+            );
+          }
           return this.success(action, readOnly, context, 200, {
             failed: true,
             jobName,

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -4,6 +4,8 @@ import { ITodoService } from "../interfaces/ITodoService";
 import agentManifest from "./agent-manifest.json";
 import { AgentIdempotencyService } from "../services/agentIdempotencyService";
 import { AgentAuditService } from "../services/agentAuditService";
+import { AgentJobRunService } from "../services/agentJobRunService";
+import { FailedAutomationActionService } from "../services/failedAutomationActionService";
 import { AgentService } from "../services/agentService";
 import { PrismaClient } from "@prisma/client";
 import { DryRunResult } from "../types";
@@ -54,6 +56,17 @@ import {
   validateAgentTriageInboxInput,
   validateAgentListAuditLogInput,
   validateAgentGetAvailabilityWindowsInput,
+  validateAgentWeeklyReviewWithSafeInput,
+  validateAgentCreateFollowUpInput,
+  validateAgentClaimJobRunInput,
+  validateAgentCompleteJobRunInput,
+  validateAgentFailJobRunInput,
+  validateAgentGetJobRunInput,
+  validateAgentListJobRunsInput,
+  validateAgentListAuditLogExtendedInput,
+  validateAgentListFailedActionsInput,
+  validateAgentResolveFailedActionInput,
+  validateAgentRecordFailedActionInput,
 } from "../validation/agentValidation";
 
 export type AgentActionName =
@@ -100,7 +113,16 @@ export type AgentActionName =
   | "triage_capture_item"
   | "triage_inbox"
   | "list_audit_log"
-  | "get_availability_windows";
+  | "get_availability_windows"
+  | "create_follow_up_for_waiting_task"
+  | "claim_job_run"
+  | "complete_job_run"
+  | "fail_job_run"
+  | "get_job_run_status"
+  | "list_job_runs"
+  | "list_failed_actions"
+  | "record_failed_action"
+  | "resolve_failed_action";
 
 interface AgentExecutorDeps {
   todoService: ITodoService;
@@ -183,6 +205,9 @@ const READ_ONLY_ACTIONS = new Set<AgentActionName>([
   "weekly_review_summary",
   "list_audit_log",
   "get_availability_windows",
+  "get_job_run_status",
+  "list_job_runs",
+  "list_failed_actions",
 ]);
 
 const IDEMPOTENT_PLANNER_APPLY_ACTIONS = new Set<AgentActionName>([
@@ -441,16 +466,27 @@ function triageCaptureText(text: string): {
   };
 }
 
+const SAFE_APPLY_ACTIONS = new Set([
+  "create_next_action",
+  "follow_up_waiting_task",
+]);
+
 export class AgentExecutor {
   private readonly agentService: AgentService;
   private readonly idempotencyService: AgentIdempotencyService;
   private readonly auditService: AgentAuditService;
+  private readonly jobRunService: AgentJobRunService;
+  private readonly failedActionService: FailedAutomationActionService;
 
   constructor(private readonly deps: AgentExecutorDeps) {
     this.idempotencyService = new AgentIdempotencyService(
       deps.persistencePrisma,
     );
     this.auditService = new AgentAuditService(deps.persistencePrisma);
+    this.jobRunService = new AgentJobRunService(deps.persistencePrisma);
+    this.failedActionService = new FailedAutomationActionService(
+      deps.persistencePrisma,
+    );
     this.agentService = new AgentService({
       todoService: deps.todoService,
       projectService: deps.projectService,
@@ -635,140 +671,186 @@ export class AgentExecutor {
               dryRunResult as unknown as Record<string, unknown>,
             );
           }
-          const task = await this.agentService.updateTask(
-            context.userId,
-            id,
-            changes,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const task = await this.agentService.updateTask(
+                context.userId,
+                id,
+                changes,
+              );
+              if (!task) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task not found",
+                  false,
+                  "Verify the task ID belongs to the authenticated user.",
+                );
+              }
+              return { task };
+            },
           );
-          if (!task) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task not found",
-              false,
-              "Verify the task ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { task });
         }
         case "complete_task": {
           const { id, completed } = validateAgentCompleteTaskInput(input);
-          const task = await this.agentService.completeTask(
-            context.userId,
-            id,
-            completed,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const task = await this.agentService.completeTask(
+                context.userId,
+                id,
+                completed,
+              );
+              if (!task) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task not found",
+                  false,
+                  "Verify the task ID belongs to the authenticated user.",
+                );
+              }
+              return { task };
+            },
           );
-          if (!task) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task not found",
-              false,
-              "Verify the task ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { task });
         }
         case "archive_task": {
           const { id, archived } = validateAgentArchiveTaskInput(input);
-          const task = await this.agentService.archiveTask(
-            context.userId,
-            id,
-            archived,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const task = await this.agentService.archiveTask(
+                context.userId,
+                id,
+                archived,
+              );
+              if (!task) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task not found",
+                  false,
+                  "Verify the task ID belongs to the authenticated user.",
+                );
+              }
+              return { task };
+            },
           );
-          if (!task) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task not found",
-              false,
-              "Verify the task ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { task });
         }
         case "delete_task": {
           const { id, hardDelete } = validateAgentDeleteTaskInput(input);
-          const result = await this.agentService.deleteTask(
-            context.userId,
-            id,
-            hardDelete,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const result = await this.agentService.deleteTask(
+                context.userId,
+                id,
+                hardDelete,
+              );
+              if (!result) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task not found",
+                  false,
+                  "Verify the task ID belongs to the authenticated user.",
+                );
+              }
+              return {
+                deleted: hardDelete === true,
+                archived: hardDelete === true ? false : true,
+                task: typeof result === "boolean" ? null : result,
+                taskId: id,
+              };
+            },
           );
-          if (!result) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task not found",
-              false,
-              "Verify the task ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, {
-            deleted: hardDelete === true,
-            archived: hardDelete === true ? false : true,
-            task: typeof result === "boolean" ? null : result,
-            taskId: id,
-          });
         }
         case "add_subtask": {
           const { taskId, changes } = validateAgentAddSubtaskInput(input);
-          const subtask = await this.agentService.addSubtask(
-            context.userId,
-            taskId,
-            changes,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const subtask = await this.agentService.addSubtask(
+                context.userId,
+                taskId,
+                changes,
+              );
+              if (!subtask) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task not found",
+                  false,
+                  "Verify the parent task ID belongs to the authenticated user.",
+                );
+              }
+              return { subtask };
+            },
+            201,
           );
-          if (!subtask) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task not found",
-              false,
-              "Verify the parent task ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 201, { subtask });
         }
         case "update_subtask": {
           const { taskId, subtaskId, changes } =
             validateAgentUpdateSubtaskInput(input);
-          const subtask = await this.agentService.updateSubtask(
-            context.userId,
-            taskId,
-            subtaskId,
-            changes,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const subtask = await this.agentService.updateSubtask(
+                context.userId,
+                taskId,
+                subtaskId,
+                changes,
+              );
+              if (!subtask) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task or subtask not found",
+                  false,
+                  "Verify the task ID and subtask ID belong to the authenticated user.",
+                );
+              }
+              return { subtask };
+            },
           );
-          if (!subtask) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task or subtask not found",
-              false,
-              "Verify the task ID and subtask ID belong to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { subtask });
         }
         case "delete_subtask": {
           const { taskId, subtaskId } = validateAgentDeleteSubtaskInput(input);
-          const deleted = await this.agentService.deleteSubtask(
-            context.userId,
-            taskId,
-            subtaskId,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const deleted = await this.agentService.deleteSubtask(
+                context.userId,
+                taskId,
+                subtaskId,
+              );
+              if (!deleted) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task or subtask not found",
+                  false,
+                  "Verify the task ID and subtask ID belong to the authenticated user.",
+                );
+              }
+              return { deleted: true, taskId, subtaskId };
+            },
           );
-          if (!deleted) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task or subtask not found",
-              false,
-              "Verify the task ID and subtask ID belong to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, {
-            deleted: true,
-            taskId,
-            subtaskId,
-          });
         }
         case "list_projects": {
           const filters = validateAgentListProjectsInput(input);
@@ -784,121 +866,154 @@ export class AgentExecutor {
         }
         case "update_project": {
           const { id, changes } = validateAgentUpdateProjectInput(input);
-          const project = await this.agentService.updateProject(
-            context.userId,
-            id,
-            changes,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const project = await this.agentService.updateProject(
+                context.userId,
+                id,
+                changes,
+              );
+              if (!project) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Project not found",
+                  false,
+                  "Verify the project ID belongs to the authenticated user.",
+                );
+              }
+              return { project };
+            },
           );
-          if (!project) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Project not found",
-              false,
-              "Verify the project ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { project });
         }
         case "rename_project": {
           const { id, name } = validateAgentRenameProjectInput(input);
-          const project = await this.agentService.renameProject(
-            context.userId,
-            id,
-            name,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const project = await this.agentService.renameProject(
+                context.userId,
+                id,
+                name,
+              );
+              if (!project) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Project not found",
+                  false,
+                  "Verify the project ID belongs to the authenticated user.",
+                );
+              }
+              return { project };
+            },
           );
-          if (!project) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Project not found",
-              false,
-              "Verify the project ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { project });
         }
         case "delete_project": {
           const { id, moveTasksToProjectId, archiveInstead } =
             validateAgentDeleteProjectInput(input);
-          if (archiveInstead) {
-            const project = await this.agentService.archiveProject(
-              context.userId,
-              id,
-              true,
-            );
-            if (!project) {
-              throw new AgentExecutionError(
-                404,
-                "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-                "Project not found",
-                false,
-                "Verify the project ID belongs to the authenticated user.",
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              if (archiveInstead) {
+                const project = await this.agentService.archiveProject(
+                  context.userId,
+                  id,
+                  true,
+                );
+                if (!project) {
+                  throw new AgentExecutionError(
+                    404,
+                    "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                    "Project not found",
+                    false,
+                    "Verify the project ID belongs to the authenticated user.",
+                  );
+                }
+                return { deleted: false, archived: true, project };
+              }
+              const deleted = await this.agentService.deleteProject(
+                context.userId,
+                id,
+                moveTasksToProjectId,
               );
-            }
-            return this.success(action, readOnly, context, 200, {
-              deleted: false,
-              archived: true,
-              project,
-            });
-          }
-          const deleted = await this.agentService.deleteProject(
-            context.userId,
-            id,
-            moveTasksToProjectId,
+              if (!deleted) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Project not found",
+                  false,
+                  "Verify the source and target project IDs belong to the authenticated user.",
+                );
+              }
+              return {
+                deleted: true,
+                projectId: id,
+                movedTasksToProjectId: moveTasksToProjectId,
+                taskDisposition: moveTasksToProjectId
+                  ? "reassigned"
+                  : "unassigned",
+              };
+            },
           );
-          if (!deleted) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Project not found",
-              false,
-              "Verify the source and target project IDs belong to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, {
-            deleted: true,
-            projectId: id,
-            movedTasksToProjectId: moveTasksToProjectId,
-            taskDisposition: moveTasksToProjectId ? "reassigned" : "unassigned",
-          });
         }
         case "move_task_to_project": {
           const { taskId, projectId } =
             validateAgentMoveTaskToProjectInput(input);
-          const task = await this.agentService.moveTaskToProject(
-            context.userId,
-            taskId,
-            projectId,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const task = await this.agentService.moveTaskToProject(
+                context.userId,
+                taskId,
+                projectId,
+              );
+              if (!task) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Task or project not found",
+                  false,
+                  "Verify the task ID and target project ID belong to the authenticated user.",
+                );
+              }
+              return { task };
+            },
           );
-          if (!task) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Task or project not found",
-              false,
-              "Verify the task ID and target project ID belong to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { task });
         }
         case "archive_project": {
           const { id, archived } = validateAgentArchiveProjectInput(input);
-          const project = await this.agentService.archiveProject(
-            context.userId,
-            id,
-            archived,
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const project = await this.agentService.archiveProject(
+                context.userId,
+                id,
+                archived,
+              );
+              if (!project) {
+                throw new AgentExecutionError(
+                  404,
+                  "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+                  "Project not found",
+                  false,
+                  "Verify the project ID belongs to the authenticated user.",
+                );
+              }
+              return { project };
+            },
           );
-          if (!project) {
-            throw new AgentExecutionError(
-              404,
-              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
-              "Project not found",
-              false,
-              "Verify the project ID belongs to the authenticated user.",
-            );
-          }
-          return this.success(action, readOnly, context, 200, { project });
         }
         case "list_today": {
           const filters = validateAgentListTodayInput(input);
@@ -1033,11 +1148,88 @@ export class AgentExecutor {
           );
         }
         case "weekly_review": {
-          const plannerInput = validateAgentWeeklyReviewInput(input);
+          const plannerInput = validateAgentWeeklyReviewWithSafeInput(input);
+
+          // apply_safe: run suggest, then server-side apply allowlisted actions
+          if (plannerInput.mode === "apply_safe") {
+            return await this.handleIdempotentWriteAction(
+              action,
+              context,
+              plannerInput,
+              async () => {
+                const review = await this.agentService.weeklyReviewForUser(
+                  context.userId,
+                  {
+                    mode: "suggest",
+                    includeArchived: plannerInput.includeArchived,
+                  },
+                );
+                const appliedActions: Array<Record<string, unknown>> = [];
+                const skippedActions: Array<Record<string, unknown>> = [];
+                const errors: Array<Record<string, unknown>> = [];
+
+                for (const recAction of review.recommendedActions ?? []) {
+                  const rec = recAction as unknown as Record<string, unknown>;
+                  const actionType = rec.type as string;
+                  if (!SAFE_APPLY_ACTIONS.has(actionType)) {
+                    skippedActions.push({ ...rec, reason: "not_in_allowlist" });
+                    continue;
+                  }
+                  try {
+                    if (actionType === "create_next_action") {
+                      const pId = rec.projectId as string | undefined;
+                      if (pId) {
+                        await this.agentService.ensureNextActionForUser(
+                          context.userId,
+                          { projectId: pId, mode: "apply" },
+                        );
+                        appliedActions.push(rec);
+                      }
+                    } else if (actionType === "follow_up_waiting_task") {
+                      const tId = rec.taskId as string | undefined;
+                      if (tId) {
+                        await this.agentService.createTask(context.userId, {
+                          title:
+                            (rec.title as string) ||
+                            "Follow up on waiting task",
+                          status: "next" as import("../types").TaskStatus,
+                          priority:
+                            (rec.priority as import("../types").Priority) ??
+                            "medium",
+                          source: "automation" as import("../types").TaskSource,
+                          createdByPrompt:
+                            "Created automatically by weekly_review apply_safe mode",
+                        });
+                        appliedActions.push(rec);
+                      }
+                    }
+                  } catch (err) {
+                    errors.push({
+                      ...rec,
+                      error: err instanceof Error ? err.message : String(err),
+                    });
+                  }
+                }
+
+                return {
+                  review: {
+                    ...review,
+                    appliedActions,
+                    skippedActions,
+                    errors,
+                  },
+                };
+              },
+            );
+          }
+
           const executeWeeklyReview = async () => {
             const review = await this.agentService.weeklyReviewForUser(
               context.userId,
-              plannerInput,
+              {
+                mode: plannerInput.mode as "suggest" | "apply" | undefined,
+                includeArchived: plannerInput.includeArchived,
+              },
             );
             return { review };
           };
@@ -1259,11 +1451,25 @@ export class AgentExecutor {
           const { availableMinutes, energy, date } =
             validateAgentPlanTodayInput(input);
           const today = date ?? new Date().toISOString().slice(0, 10);
-          const allTasks = await this.agentService.listTasks(context.userId, {
-            statuses: ["inbox", "next", "in_progress", "scheduled"],
-            archived: false,
-            limit: 200,
-          });
+
+          // Fetch all data in parallel (Issue #318: delivery-ready payload)
+          const [allTasks, waitingTasks, missingNextActionProjects] =
+            await Promise.all([
+              this.agentService.listTasks(context.userId, {
+                statuses: ["inbox", "next", "in_progress", "scheduled"],
+                archived: false,
+                limit: 200,
+              }),
+              this.agentService.listWaitingOn(context.userId, {}),
+              this.deps.projectService
+                ? this.agentService
+                    .listProjectsWithoutNextAction(context.userId, {
+                      includeOnHold: false,
+                    })
+                    .catch(() => [] as import("../types").Project[])
+                : Promise.resolve([] as import("../types").Project[]),
+            ]);
+
           const PRIORITY_SCORE: Record<string, number> = {
             urgent: 40,
             high: 20,
@@ -1303,17 +1509,38 @@ export class AgentExecutor {
               usedMinutes += item.effort;
             }
           }
+
+          const recommendedTasks = selected.map((s) => ({
+            ...s.task,
+            estimatedMinutes: s.effort,
+            score: s.score,
+          }));
+
           return this.success(action, readOnly, context, 200, {
-            date: today,
-            availableMinutes: budget,
-            energy: energy ?? null,
-            selectedTasks: selected.map((s) => ({
-              ...s.task,
-              estimatedMinutes: s.effort,
-              score: s.score,
-            })),
-            totalMinutes: usedMinutes,
-            remainingMinutes: budget - usedMinutes,
+            plan: {
+              date: today,
+              timezone: null,
+              headline: {
+                recommendedTaskCount: recommendedTasks.length,
+                waitingCount: waitingTasks.length,
+                projectsNeedingAttention: missingNextActionProjects.length,
+              },
+              recommendedTasks,
+              waitingTasks: waitingTasks.slice(0, 10).map((t) => ({
+                id: t.id,
+                title: t.title,
+                waitingOn: t.waitingOn ?? null,
+                dueDate: t.dueDate ?? null,
+                projectId: t.projectId ?? null,
+              })),
+              projectsNeedingAttention: missingNextActionProjects
+                .slice(0, 10)
+                .map((p) => ({ id: p.id, name: p.name })),
+              availableMinutes: budget,
+              energy: energy ?? null,
+              totalMinutes: usedMinutes,
+              remainingMinutes: budget - usedMinutes,
+            },
           });
         }
         case "break_down_task": {
@@ -1615,8 +1842,14 @@ export class AgentExecutor {
           );
         }
         case "list_audit_log": {
-          const { limit, since, actionFilter } =
-            validateAgentListAuditLogInput(input);
+          const {
+            limit,
+            since,
+            actionFilter,
+            jobName,
+            periodKey,
+            triggeredBy,
+          } = validateAgentListAuditLogExtendedInput(input);
           if (!this.deps.persistencePrisma) {
             return this.success(action, readOnly, context, 200, {
               entries: [],
@@ -1628,6 +1861,9 @@ export class AgentExecutor {
               userId: context.userId,
               ...(actionFilter ? { action: actionFilter } : {}),
               ...(since ? { createdAt: { gte: new Date(since) } } : {}),
+              ...(jobName ? { jobName } : {}),
+              ...(periodKey ? { jobPeriodKey: periodKey } : {}),
+              ...(triggeredBy ? { triggeredBy } : {}),
             };
           const entries =
             await this.deps.persistencePrisma.agentActionAudit.findMany({
@@ -1642,6 +1878,9 @@ export class AgentExecutor {
                 status: true,
                 createdAt: true,
                 surface: true,
+                jobName: true,
+                jobPeriodKey: true,
+                triggeredBy: true,
               },
             });
           const total =
@@ -1649,6 +1888,216 @@ export class AgentExecutor {
           return this.success(action, readOnly, context, 200, {
             entries,
             total,
+          });
+        }
+
+        // ── Issue #316: create_follow_up_for_waiting_task ──────────────────────
+        case "create_follow_up_for_waiting_task": {
+          const { taskId, mode, cooldownDays, title, priority } =
+            validateAgentCreateFollowUpInput(input);
+          const waitingTask = await this.agentService.getTask(
+            context.userId,
+            taskId,
+          );
+          if (!waitingTask) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Task not found",
+              false,
+              "Verify the task ID belongs to the authenticated user.",
+            );
+          }
+          if (waitingTask.status !== "waiting") {
+            throw new AgentExecutionError(
+              400,
+              "INVALID_INPUT",
+              "Task is not in waiting status",
+              false,
+              "Only tasks with status 'waiting' can have follow-ups created.",
+            );
+          }
+
+          // Check cooldown: look for recent follow-ups created for this task
+          const cooldown = cooldownDays ?? 7;
+          const cooldownDate = new Date(
+            Date.now() - cooldown * 24 * 60 * 60 * 1000,
+          );
+          const recentFollowUps = await this.agentService.listTasks(
+            context.userId,
+            {
+              statuses: ["inbox", "next", "in_progress"],
+              archived: false,
+              limit: 50,
+            },
+          );
+          const hasRecentFollowUp = recentFollowUps.some((t) => {
+            const createdAt =
+              t.createdAt instanceof Date
+                ? t.createdAt
+                : new Date(t.createdAt as unknown as string);
+            return (
+              t.createdByPrompt?.includes(taskId) && createdAt >= cooldownDate
+            );
+          });
+
+          const followUpTitle = title ?? `Follow up: ${waitingTask.title}`;
+          const followUp = {
+            title: followUpTitle,
+            status: "next" as import("../types").TaskStatus,
+            priority:
+              (priority as import("../types").Priority | undefined) ?? "medium",
+            projectId: waitingTask.projectId ?? undefined,
+            source: "automation" as import("../types").TaskSource,
+            createdByPrompt: `follow_up:${taskId}`,
+          };
+
+          if (hasRecentFollowUp) {
+            return this.success(action, readOnly, context, 200, {
+              created: false,
+              skipped: true,
+              reason: "cooldown_active",
+              cooldownDays: cooldown,
+              waitingTask: { id: waitingTask.id, title: waitingTask.title },
+              followUp,
+            });
+          }
+
+          if (mode !== "apply") {
+            return this.success(action, readOnly, context, 200, {
+              created: false,
+              mode: "suggest",
+              waitingTask: { id: waitingTask.id, title: waitingTask.title },
+              followUp,
+            });
+          }
+
+          return await this.handleIdempotentWriteAction(
+            action,
+            context,
+            input,
+            async () => {
+              const task = await this.agentService.createTask(
+                context.userId,
+                followUp,
+              );
+              return {
+                created: true,
+                task,
+                waitingTaskId: taskId,
+              };
+            },
+            201,
+          );
+        }
+
+        // ── Issue #314: job-run locking ────────────────────────────────────────
+        case "claim_job_run": {
+          const { jobName, periodKey } = validateAgentClaimJobRunInput(input);
+          const { claimed, run } = await this.jobRunService.claimRun(
+            context.userId,
+            jobName,
+            periodKey,
+          );
+          return this.success(action, readOnly, context, 200, {
+            claimed,
+            run,
+          });
+        }
+        case "complete_job_run": {
+          const { jobName, periodKey, metadata } =
+            validateAgentCompleteJobRunInput(input);
+          await this.jobRunService.completeRun(
+            context.userId,
+            jobName,
+            periodKey,
+            metadata,
+          );
+          return this.success(action, readOnly, context, 200, {
+            completed: true,
+            jobName,
+            periodKey,
+          });
+        }
+        case "fail_job_run": {
+          const { jobName, periodKey, errorMessage } =
+            validateAgentFailJobRunInput(input);
+          await this.jobRunService.failRun(
+            context.userId,
+            jobName,
+            periodKey,
+            errorMessage,
+          );
+          return this.success(action, readOnly, context, 200, {
+            failed: true,
+            jobName,
+            periodKey,
+          });
+        }
+        case "get_job_run_status": {
+          const { jobName, periodKey } = validateAgentGetJobRunInput(input);
+          const run = await this.jobRunService.getRunStatus(
+            context.userId,
+            jobName,
+            periodKey,
+          );
+          return this.success(action, readOnly, context, 200, { run });
+        }
+        case "list_job_runs": {
+          const filters = validateAgentListJobRunsInput(input);
+          const runs = await this.jobRunService.listRuns(
+            context.userId,
+            filters,
+          );
+          return this.success(action, readOnly, context, 200, {
+            runs,
+            total: runs.length,
+          });
+        }
+
+        // ── Issue #320: dead-letter store ──────────────────────────────────────
+        case "record_failed_action": {
+          const recordInput = validateAgentRecordFailedActionInput(input);
+          const record = await this.failedActionService.record({
+            ...recordInput,
+            userId: context.userId,
+          });
+          return this.success(action, readOnly, context, 201, {
+            record,
+          });
+        }
+        case "list_failed_actions": {
+          const filters = validateAgentListFailedActionsInput(input);
+          const actions = await this.failedActionService.list(
+            context.userId,
+            filters,
+          );
+          return this.success(action, readOnly, context, 200, {
+            actions,
+            total: actions.length,
+          });
+        }
+        case "resolve_failed_action": {
+          const { id, resolution } =
+            validateAgentResolveFailedActionInput(input);
+          const resolved = await this.failedActionService.resolve(
+            context.userId,
+            id,
+            resolution,
+          );
+          if (!resolved) {
+            throw new AgentExecutionError(
+              404,
+              "RESOURCE_NOT_FOUND_OR_FORBIDDEN",
+              "Failed action not found or already resolved",
+              false,
+              "Verify the ID belongs to the authenticated user and the action is unresolved.",
+            );
+          }
+          return this.success(action, readOnly, context, 200, {
+            resolved: true,
+            id,
+            resolution,
           });
         }
         case "get_availability_windows": {

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -120,7 +120,18 @@ function minimumRequiredScopesForAction(
       return [TASK_READ_SCOPE, PROJECT_READ_SCOPE];
     case "triage_capture_item":
     case "triage_inbox":
+    case "create_follow_up_for_waiting_task":
       return [TASK_WRITE_SCOPE];
+    case "claim_job_run":
+    case "complete_job_run":
+    case "fail_job_run":
+    case "record_failed_action":
+    case "resolve_failed_action":
+      return [TASK_WRITE_SCOPE];
+    case "get_job_run_status":
+    case "list_job_runs":
+    case "list_failed_actions":
+      return [TASK_READ_SCOPE];
   }
 }
 

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -254,5 +254,50 @@ export function createAgentRouter({
     createAgentActionHandler(agentExecutor, "get_availability_windows"),
   );
 
+  // Issue #316: follow-up for waiting tasks
+  router.post(
+    "/write/create_follow_up_for_waiting_task",
+    createAgentActionHandler(
+      agentExecutor,
+      "create_follow_up_for_waiting_task",
+    ),
+  );
+
+  // Issue #314: server-side job-run locking
+  router.post(
+    "/write/claim_job_run",
+    createAgentActionHandler(agentExecutor, "claim_job_run"),
+  );
+  router.post(
+    "/write/complete_job_run",
+    createAgentActionHandler(agentExecutor, "complete_job_run"),
+  );
+  router.post(
+    "/write/fail_job_run",
+    createAgentActionHandler(agentExecutor, "fail_job_run"),
+  );
+  router.post(
+    "/read/get_job_run_status",
+    createAgentActionHandler(agentExecutor, "get_job_run_status"),
+  );
+  router.post(
+    "/read/list_job_runs",
+    createAgentActionHandler(agentExecutor, "list_job_runs"),
+  );
+
+  // Issue #320: dead-letter store
+  router.post(
+    "/write/record_failed_action",
+    createAgentActionHandler(agentExecutor, "record_failed_action"),
+  );
+  router.post(
+    "/read/list_failed_actions",
+    createAgentActionHandler(agentExecutor, "list_failed_actions"),
+  );
+  router.post(
+    "/write/resolve_failed_action",
+    createAgentActionHandler(agentExecutor, "resolve_failed_action"),
+  );
+
   return router;
 }

--- a/src/services/agentAuditService.ts
+++ b/src/services/agentAuditService.ts
@@ -13,6 +13,9 @@ interface AgentAuditRecordInput {
   idempotencyKey?: string;
   replayed?: boolean;
   errorCode?: string;
+  jobName?: string;
+  jobPeriodKey?: string;
+  triggeredBy?: "user" | "automation" | "agent";
 }
 
 export class AgentAuditService {
@@ -76,6 +79,9 @@ export class AgentAuditService {
         idempotencyKey: input.idempotencyKey,
         replayed: input.replayed || false,
         errorCode: input.errorCode,
+        jobName: input.jobName,
+        jobPeriodKey: input.jobPeriodKey,
+        triggeredBy: input.triggeredBy,
         metadata,
       },
     });

--- a/src/services/agentJobRunService.ts
+++ b/src/services/agentJobRunService.ts
@@ -1,0 +1,122 @@
+import { PrismaClient } from "@prisma/client";
+
+export interface JobRunRecord {
+  id: string;
+  jobName: string;
+  periodKey: string;
+  status: string;
+  claimedAt: Date;
+  completedAt: Date | null;
+  failedAt: Date | null;
+  errorMessage: string | null;
+  metadata: unknown;
+}
+
+export class AgentJobRunService {
+  constructor(private readonly prisma?: PrismaClient) {}
+
+  async claimRun(
+    userId: string,
+    jobName: string,
+    periodKey: string,
+  ): Promise<{ claimed: boolean; run: JobRunRecord | null }> {
+    if (!this.prisma) {
+      return { claimed: true, run: null };
+    }
+
+    try {
+      const run = await this.prisma.agentJobRun.create({
+        data: { userId, jobName, periodKey, status: "running" },
+      });
+      return { claimed: true, run: this.toRecord(run) };
+    } catch (err: unknown) {
+      // Unique constraint violation means already claimed
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "code" in err &&
+        (err as { code: string }).code === "P2002"
+      ) {
+        return { claimed: false, run: null };
+      }
+      throw err;
+    }
+  }
+
+  async completeRun(
+    userId: string,
+    jobName: string,
+    periodKey: string,
+    metadata?: unknown,
+  ): Promise<void> {
+    if (!this.prisma) return;
+    await this.prisma.agentJobRun.updateMany({
+      where: { userId, jobName, periodKey },
+      data: {
+        status: "completed",
+        completedAt: new Date(),
+        metadata: metadata as import("@prisma/client").Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  async failRun(
+    userId: string,
+    jobName: string,
+    periodKey: string,
+    errorMessage: string,
+  ): Promise<void> {
+    if (!this.prisma) return;
+    await this.prisma.agentJobRun.updateMany({
+      where: { userId, jobName, periodKey },
+      data: {
+        status: "failed",
+        failedAt: new Date(),
+        errorMessage: errorMessage.slice(0, 500),
+      },
+    });
+  }
+
+  async getRunStatus(
+    userId: string,
+    jobName: string,
+    periodKey: string,
+  ): Promise<JobRunRecord | null> {
+    if (!this.prisma) return null;
+    const run = await this.prisma.agentJobRun.findUnique({
+      where: { userId_jobName_periodKey: { userId, jobName, periodKey } },
+    });
+    return run ? this.toRecord(run) : null;
+  }
+
+  async listRuns(
+    userId: string,
+    filters: { jobName?: string; status?: string; limit?: number },
+  ): Promise<JobRunRecord[]> {
+    if (!this.prisma) return [];
+    const runs = await this.prisma.agentJobRun.findMany({
+      where: {
+        userId,
+        ...(filters.jobName ? { jobName: filters.jobName } : {}),
+        ...(filters.status ? { status: filters.status } : {}),
+      },
+      orderBy: { claimedAt: "desc" },
+      take: filters.limit ?? 50,
+    });
+    return runs.map((r) => this.toRecord(r));
+  }
+
+  private toRecord(run: import("@prisma/client").AgentJobRun): JobRunRecord {
+    return {
+      id: run.id,
+      jobName: run.jobName,
+      periodKey: run.periodKey,
+      status: run.status,
+      claimedAt: run.claimedAt,
+      completedAt: run.completedAt,
+      failedAt: run.failedAt,
+      errorMessage: run.errorMessage,
+      metadata: run.metadata,
+    };
+  }
+}

--- a/src/services/agentJobRunService.ts
+++ b/src/services/agentJobRunService.ts
@@ -48,9 +48,9 @@ export class AgentJobRunService {
     jobName: string,
     periodKey: string,
     metadata?: unknown,
-  ): Promise<void> {
-    if (!this.prisma) return;
-    await this.prisma.agentJobRun.updateMany({
+  ): Promise<boolean> {
+    if (!this.prisma) return true;
+    const result = await this.prisma.agentJobRun.updateMany({
       where: { userId, jobName, periodKey },
       data: {
         status: "completed",
@@ -58,6 +58,7 @@ export class AgentJobRunService {
         metadata: metadata as import("@prisma/client").Prisma.InputJsonValue,
       },
     });
+    return result.count > 0;
   }
 
   async failRun(
@@ -65,9 +66,9 @@ export class AgentJobRunService {
     jobName: string,
     periodKey: string,
     errorMessage: string,
-  ): Promise<void> {
-    if (!this.prisma) return;
-    await this.prisma.agentJobRun.updateMany({
+  ): Promise<boolean> {
+    if (!this.prisma) return true;
+    const result = await this.prisma.agentJobRun.updateMany({
       where: { userId, jobName, periodKey },
       data: {
         status: "failed",
@@ -75,6 +76,7 @@ export class AgentJobRunService {
         errorMessage: errorMessage.slice(0, 500),
       },
     });
+    return result.count > 0;
   }
 
   async getRunStatus(

--- a/src/services/failedAutomationActionService.ts
+++ b/src/services/failedAutomationActionService.ts
@@ -1,0 +1,124 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+
+export interface FailedActionRecord {
+  id: string;
+  jobName: string;
+  periodKey: string;
+  actionType: string;
+  entityType: string | null;
+  entityId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  payload: unknown;
+  retryable: boolean;
+  retryCount: number;
+  resolvedAt: Date | null;
+  resolution: string | null;
+  createdAt: Date;
+}
+
+export interface RecordFailedActionInput {
+  userId: string;
+  jobName: string;
+  periodKey: string;
+  actionType: string;
+  entityType?: string;
+  entityId?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  payload?: unknown;
+  retryable?: boolean;
+}
+
+export class FailedAutomationActionService {
+  constructor(private readonly prisma?: PrismaClient) {}
+
+  async record(
+    input: RecordFailedActionInput,
+  ): Promise<FailedActionRecord | null> {
+    if (!this.prisma) return null;
+
+    const row = await this.prisma.failedAutomationAction.create({
+      data: {
+        userId: input.userId,
+        jobName: input.jobName,
+        periodKey: input.periodKey,
+        actionType: input.actionType,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        errorCode: input.errorCode,
+        errorMessage: input.errorMessage?.slice(0, 1000),
+        payload: input.payload as Prisma.InputJsonValue,
+        retryable: input.retryable ?? false,
+      },
+    });
+    return this.toRecord(row);
+  }
+
+  async list(
+    userId: string,
+    filters: {
+      jobName?: string;
+      periodKey?: string;
+      includeResolved?: boolean;
+      limit?: number;
+    },
+  ): Promise<FailedActionRecord[]> {
+    if (!this.prisma) return [];
+
+    const rows = await this.prisma.failedAutomationAction.findMany({
+      where: {
+        userId,
+        ...(filters.jobName ? { jobName: filters.jobName } : {}),
+        ...(filters.periodKey ? { periodKey: filters.periodKey } : {}),
+        ...(filters.includeResolved ? {} : { resolvedAt: null }),
+      },
+      orderBy: { createdAt: "desc" },
+      take: filters.limit ?? 50,
+    });
+    return rows.map((r) => this.toRecord(r));
+  }
+
+  async resolve(
+    userId: string,
+    id: string,
+    resolution: "retried" | "dismissed",
+  ): Promise<boolean> {
+    if (!this.prisma) return false;
+
+    const result = await this.prisma.failedAutomationAction.updateMany({
+      where: { id, userId, resolvedAt: null },
+      data: { resolvedAt: new Date(), resolution },
+    });
+    return result.count > 0;
+  }
+
+  async incrementRetryCount(userId: string, id: string): Promise<void> {
+    if (!this.prisma) return;
+    await this.prisma.failedAutomationAction.updateMany({
+      where: { id, userId },
+      data: { retryCount: { increment: 1 } },
+    });
+  }
+
+  private toRecord(
+    row: import("@prisma/client").FailedAutomationAction,
+  ): FailedActionRecord {
+    return {
+      id: row.id,
+      jobName: row.jobName,
+      periodKey: row.periodKey,
+      actionType: row.actionType,
+      entityType: row.entityType,
+      entityId: row.entityId,
+      errorCode: row.errorCode,
+      errorMessage: row.errorMessage,
+      payload: row.payload,
+      retryable: row.retryable,
+      retryCount: row.retryCount,
+      resolvedAt: row.resolvedAt,
+      resolution: row.resolution,
+      createdAt: row.createdAt,
+    };
+  }
+}

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -71,6 +71,7 @@ const TASK_FIELD_KEYS = [
   "category",
   "headingId",
   "dueDate",
+  "doDate",
   "startDate",
   "scheduledDate",
   "reviewDate",
@@ -86,6 +87,9 @@ const TASK_FIELD_KEYS = [
   "source",
   "createdByPrompt",
   "notes",
+  "blockedReason",
+  "effortScore",
+  "confidenceScore",
 ];
 const LIST_TASK_KEYS = [
   "completed",
@@ -1279,5 +1283,264 @@ export function validateAgentGetAvailabilityWindowsInput(data: unknown): {
   rejectUnknownKeys(body, GET_AVAILABILITY_WINDOWS_KEYS, "Agent action input");
   return {
     date: parseOptionalString(body.date, "date", 10),
+  };
+}
+
+// ── Issue #315: weekly_review apply_safe mode ─────────────────────────────────
+
+export function validateAgentWeeklyReviewWithSafeInput(data: unknown): {
+  mode?: "suggest" | "apply" | "apply_safe";
+  includeArchived?: boolean;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, WEEKLY_REVIEW_KEYS, "Agent action input");
+  const modeVal = parseOptionalString(body.mode, "mode", 20);
+  if (
+    modeVal !== undefined &&
+    modeVal !== "suggest" &&
+    modeVal !== "apply" &&
+    modeVal !== "apply_safe"
+  ) {
+    throw new ValidationError(
+      'mode must be "suggest", "apply", or "apply_safe"',
+    );
+  }
+  return {
+    mode: modeVal as "suggest" | "apply" | "apply_safe" | undefined,
+    includeArchived: parseOptionalBoolean(
+      body.includeArchived,
+      "includeArchived",
+    ),
+  };
+}
+
+// ── Issue #316: create_follow_up_for_waiting_task ─────────────────────────────
+
+const CREATE_FOLLOW_UP_KEYS = [
+  "taskId",
+  "mode",
+  "cooldownDays",
+  "title",
+  "priority",
+];
+
+export function validateAgentCreateFollowUpInput(data: unknown): {
+  taskId: string;
+  mode?: "suggest" | "apply";
+  cooldownDays?: number;
+  title?: string;
+  priority?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, CREATE_FOLLOW_UP_KEYS, "Agent action input");
+  const modeVal = parseOptionalString(body.mode, "mode", 10);
+  if (modeVal !== undefined && modeVal !== "suggest" && modeVal !== "apply") {
+    throw new ValidationError('mode must be "suggest" or "apply"');
+  }
+  return {
+    taskId: parseRequiredId(body, "taskId"),
+    mode: modeVal as "suggest" | "apply" | undefined,
+    cooldownDays: parseOptionalPositiveInt(
+      body.cooldownDays,
+      "cooldownDays",
+      365,
+    ),
+    title: parseOptionalString(body.title, "title", 200),
+    priority: parseOptionalPriority(body.priority),
+  };
+}
+
+// ── Issue #314: job-run locking ───────────────────────────────────────────────
+
+const CLAIM_JOB_RUN_KEYS = ["jobName", "periodKey"];
+const COMPLETE_JOB_RUN_KEYS = ["jobName", "periodKey", "metadata"];
+const FAIL_JOB_RUN_KEYS = ["jobName", "periodKey", "errorMessage"];
+const GET_JOB_RUN_KEYS = ["jobName", "periodKey"];
+const LIST_JOB_RUNS_KEYS = ["jobName", "status", "limit"];
+
+export function validateAgentClaimJobRunInput(data: unknown): {
+  jobName: string;
+  periodKey: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, CLAIM_JOB_RUN_KEYS, "Agent action input");
+  const jobName = parseOptionalString(body.jobName, "jobName", 100);
+  if (!jobName) throw new ValidationError("jobName is required");
+  const periodKey = parseOptionalString(body.periodKey, "periodKey", 20);
+  if (!periodKey) throw new ValidationError("periodKey is required");
+  return { jobName, periodKey };
+}
+
+export function validateAgentCompleteJobRunInput(data: unknown): {
+  jobName: string;
+  periodKey: string;
+  metadata?: unknown;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, COMPLETE_JOB_RUN_KEYS, "Agent action input");
+  const jobName = parseOptionalString(body.jobName, "jobName", 100);
+  if (!jobName) throw new ValidationError("jobName is required");
+  const periodKey = parseOptionalString(body.periodKey, "periodKey", 20);
+  if (!periodKey) throw new ValidationError("periodKey is required");
+  return { jobName, periodKey, metadata: body.metadata };
+}
+
+export function validateAgentFailJobRunInput(data: unknown): {
+  jobName: string;
+  periodKey: string;
+  errorMessage: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, FAIL_JOB_RUN_KEYS, "Agent action input");
+  const jobName = parseOptionalString(body.jobName, "jobName", 100);
+  if (!jobName) throw new ValidationError("jobName is required");
+  const periodKey = parseOptionalString(body.periodKey, "periodKey", 20);
+  if (!periodKey) throw new ValidationError("periodKey is required");
+  const errorMessage =
+    parseOptionalString(body.errorMessage, "errorMessage", 500) ?? "";
+  return { jobName, periodKey, errorMessage };
+}
+
+export function validateAgentGetJobRunInput(data: unknown): {
+  jobName: string;
+  periodKey: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, GET_JOB_RUN_KEYS, "Agent action input");
+  const jobName = parseOptionalString(body.jobName, "jobName", 100);
+  if (!jobName) throw new ValidationError("jobName is required");
+  const periodKey = parseOptionalString(body.periodKey, "periodKey", 20);
+  if (!periodKey) throw new ValidationError("periodKey is required");
+  return { jobName, periodKey };
+}
+
+export function validateAgentListJobRunsInput(data: unknown): {
+  jobName?: string;
+  status?: string;
+  limit?: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, LIST_JOB_RUNS_KEYS, "Agent action input");
+  return {
+    jobName: parseOptionalString(body.jobName, "jobName", 100),
+    status: parseOptionalString(body.status, "status", 20),
+    limit: parseOptionalPositiveInt(body.limit, "limit", 200),
+  };
+}
+
+// ── Issue #317: list_audit_log with job filter ─────────────────────────────────
+
+const LIST_AUDIT_LOG_EXTENDED_KEYS = [
+  "limit",
+  "since",
+  "action",
+  "jobName",
+  "periodKey",
+  "triggeredBy",
+];
+
+export function validateAgentListAuditLogExtendedInput(data: unknown): {
+  limit?: number;
+  since?: string;
+  actionFilter?: string;
+  jobName?: string;
+  periodKey?: string;
+  triggeredBy?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, LIST_AUDIT_LOG_EXTENDED_KEYS, "Agent action input");
+  return {
+    limit: parseOptionalPositiveInt(body.limit, "limit", 200) ?? undefined,
+    since: parseOptionalString(body.since, "since", 30),
+    actionFilter: parseOptionalString(body.action, "action", 60),
+    jobName: parseOptionalString(body.jobName, "jobName", 100),
+    periodKey: parseOptionalString(body.periodKey, "periodKey", 20),
+    triggeredBy: parseOptionalString(body.triggeredBy, "triggeredBy", 20),
+  };
+}
+
+// ── Issue #320: dead-letter store ─────────────────────────────────────────────
+
+const LIST_FAILED_ACTIONS_KEYS = [
+  "jobName",
+  "periodKey",
+  "includeResolved",
+  "limit",
+];
+const RESOLVE_FAILED_ACTION_KEYS = ["id", "resolution"];
+const RECORD_FAILED_ACTION_KEYS = [
+  "jobName",
+  "periodKey",
+  "actionType",
+  "entityType",
+  "entityId",
+  "errorCode",
+  "errorMessage",
+  "payload",
+  "retryable",
+];
+
+export function validateAgentListFailedActionsInput(data: unknown): {
+  jobName?: string;
+  periodKey?: string;
+  includeResolved?: boolean;
+  limit?: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, LIST_FAILED_ACTIONS_KEYS, "Agent action input");
+  return {
+    jobName: parseOptionalString(body.jobName, "jobName", 100),
+    periodKey: parseOptionalString(body.periodKey, "periodKey", 20),
+    includeResolved: parseOptionalBoolean(
+      body.includeResolved,
+      "includeResolved",
+    ),
+    limit: parseOptionalPositiveInt(body.limit, "limit", 200),
+  };
+}
+
+export function validateAgentResolveFailedActionInput(data: unknown): {
+  id: string;
+  resolution: "retried" | "dismissed";
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, RESOLVE_FAILED_ACTION_KEYS, "Agent action input");
+  const id = parseId(body);
+  const resolution = parseOptionalString(body.resolution, "resolution", 20);
+  if (resolution !== "retried" && resolution !== "dismissed") {
+    throw new ValidationError('resolution must be "retried" or "dismissed"');
+  }
+  return { id, resolution };
+}
+
+export function validateAgentRecordFailedActionInput(data: unknown): {
+  jobName: string;
+  periodKey: string;
+  actionType: string;
+  entityType?: string;
+  entityId?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  payload?: unknown;
+  retryable?: boolean;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, RECORD_FAILED_ACTION_KEYS, "Agent action input");
+  const jobName = parseOptionalString(body.jobName, "jobName", 100);
+  if (!jobName) throw new ValidationError("jobName is required");
+  const periodKey = parseOptionalString(body.periodKey, "periodKey", 20);
+  if (!periodKey) throw new ValidationError("periodKey is required");
+  const actionType = parseOptionalString(body.actionType, "actionType", 100);
+  if (!actionType) throw new ValidationError("actionType is required");
+  return {
+    jobName,
+    periodKey,
+    actionType,
+    entityType: parseOptionalString(body.entityType, "entityType", 50),
+    entityId: parseOptionalString(body.entityId, "entityId", 100),
+    errorCode: parseOptionalString(body.errorCode, "errorCode", 100),
+    errorMessage: parseOptionalString(body.errorMessage, "errorMessage", 1000),
+    payload: body.payload,
+    retryable: parseOptionalBoolean(body.retryable, "retryable"),
   };
 }


### PR DESCRIPTION
## Summary

Implements all 8 open GitHub issues for agent API improvements in a single batch:

- **#313** — Idempotency on all write actions: `update_task`, `complete_task`, `archive_task`, `delete_task`, all subtask mutations, all project mutations, `move_task_to_project` now all use `handleIdempotentWriteAction` — safe retry on network errors
- **#314** — Server-side job-run locking: new `AgentJobRun` model + `AgentJobRunService`; actions `claim_job_run`, `complete_job_run`, `fail_job_run`, `get_job_run_status`, `list_job_runs`
- **#315** — `weekly_review` `apply_safe` mode: server-side execution of allowlisted actions (`create_next_action`, `follow_up_waiting_task`) with applied/skipped/error breakdowns
- **#316** — `create_follow_up_for_waiting_task`: suggest/apply modes, configurable cooldown (default 7 days), dedup via `createdByPrompt`
- **#317** — Durable audit log with job context: `jobName`, `jobPeriodKey`, `triggeredBy` columns on `agent_action_audits`; `list_audit_log` gains matching filters
- **#318** — `plan_today` delivery-ready payload: single call now returns `plan.headline`, `plan.waitingTasks`, `plan.projectsNeedingAttention` — no more multi-call orchestration needed
- **#319** — Task schema normalization: `blockedReason`, `effortScore`, `confidenceScore`, `doDate` added to `TASK_FIELD_KEYS` so `create_task`/`update_task` accept them
- **#320** — Dead-letter store: `FailedAutomationAction` model + service; actions `record_failed_action`, `list_failed_actions`, `resolve_failed_action`

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:unit` — 296 tests pass
- [x] `npm run lint:html && npm run lint:css` — clean
- [ ] Integration tests on deploy (migration applies `agent_job_runs`, `failed_automation_actions` tables and `agent_action_audits` columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)