### PR TITLE
fix(mcp): bump serverInfo.version to 1.1.0 to expose new tools to MCP clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todos-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "scripts": {
     "start": "npx prisma migrate deploy && node dist/server.js",


### PR DESCRIPTION
## Summary

- Bumps `package.json` version `1.0.0` → `1.1.0`
- This changes the `serverInfo.version` returned in the MCP `initialize` handshake, forcing MCP hosts that cache tool schemas by `(serverUrl, serverInfo.version)` to invalidate their cache and re-fetch `tools/list`

## Root cause analysis

After PR #322 added 9 new agent actions (`plan_today`, `claim_job_run`, `complete_job_run`, `fail_job_run`, `get_job_run_status`, `list_job_runs`, `record_failed_action`, `list_failed_actions`, `resolve_failed_action`), MCP clients that connected before the deploy — and cached the tool list by server version — continued serving the stale schema without the new tools.

**What was verified (no code changes needed):**
- All 53 actions are in `agent-manifest.json` ✓
- `mcpToolCatalog.ts` builds the catalog from the full manifest — no namespace or path filtering ✓
- `minimumRequiredScopesForAction()` switch covers all 9 new actions ✓
- Production is running the latest code (confirmed via Railway deployment meta) ✓
- No `/todos/*` namespace filtering exists anywhere in the MCP router or catalog ✓

**Scope requirements for full visibility** (separate from this fix — the MCP token must have adequate scopes):
- Read-only tools (`plan_today`, `get_job_run_status`, `list_job_runs`, `list_failed_actions`): need `tasks.read` + `projects.read` (default scopes)
- Write tools (`claim_job_run`, `complete_job_run`, `fail_job_run`, `record_failed_action`, `resolve_failed_action`, `create_follow_up_for_waiting_task`): additionally need `tasks.write`
- Use the `"write"` scope alias when creating the MCP token to get all four scopes at once

## Test plan
- [ ] After deploy: reconnect MCP client — `plan_today` appears in tool list
- [ ] Invoke `plan_today` with `{ "availableMinutes": 120 }` — returns structured plan
- [ ] Invoke `claim_job_run` with `{ "jobName": "daily_review", "periodKey": "daily-2026-03-17" }` — returns `claimed: true`
- [ ] Invoke same again — returns `claimed: false` (deduplication)
- [ ] Invoke `complete_job_run` with same `jobName`/`periodKey` — returns `completed: true`
- [ ] Invoke `get_job_run_status` — returns completed run record

🤖 Generated with [Claude Code](https://claude.com/claude-code)