### PR TITLE
feat(api): friction tracker and per-action policy engine (closes #338, #339)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todos-api",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "main": "index.js",
   "scripts": {
     "start": "npx prisma migrate deploy && node dist/server.js",

--- a/prisma/migrations/20260317140000_agent_config_action_policies/migration.sql
+++ b/prisma/migrations/20260317140000_agent_config_action_policies/migration.sql
@@ -1,0 +1,3 @@
+-- Migration: add action_policies_json column to agent_configs
+ALTER TABLE "agent_configs"
+  ADD COLUMN IF NOT EXISTS "action_policies_json" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -568,6 +568,7 @@ model AgentConfig {
   plannerWeightEnergyMatch Float    @default(1.0) @map("planner_weight_energy_match")
   plannerWeightEstimateFit Float    @default(1.0) @map("planner_weight_estimate_fit")
   plannerWeightFreshness   Float    @default(1.0) @map("planner_weight_freshness")
+  actionPoliciesJson       Json?    @map("action_policies_json")
   createdAt                DateTime @default(now()) @map("created_at")
   updatedAt                DateTime @updatedAt @map("updated_at")
 

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.4",
+  "version": "1.6.0",
   "surface": "agent_accessibility_v2",
   "basePath": "/agent",
   "description": "Expanded machine-usable task and project contract for the Todos app. This surface stays thin over the existing server-side todo and project services.",
@@ -3965,6 +3965,108 @@
           "configUpdated": {
             "type": "boolean",
             "description": "Whether AgentConfig was modified."
+          }
+        }
+      },
+      "readOnly": false
+    },
+    {
+      "name": "list_friction_patterns",
+      "namespace": "review",
+      "category": "Diagnostics",
+      "lifecycle": "derived_read",
+      "audience": "agent",
+      "description": "Surface recurring friction signals: tasks deferred repeatedly, recommendations ignored, follow-up churn, and stalled projects. Defaults to the last 30 days.",
+      "method": "POST",
+      "path": "/agent/read/list_friction_patterns",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "since": {
+            "type": "string",
+            "description": "ISO date (YYYY-MM-DD). Defaults to 30 days ago."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "description": "Max patterns to return (default 20)."
+          }
+        }
+      },
+      "output": {
+        "properties": {
+          "patterns": {
+            "type": "array",
+            "description": "Array of FrictionPattern objects (repeated_deferral, ignored_recommendation, follow_up_churn, project_stall)."
+          },
+          "totalPatterns": {
+            "type": "integer"
+          }
+        }
+      },
+      "readOnly": true
+    },
+    {
+      "name": "get_action_policies",
+      "namespace": "automation",
+      "category": "Automation Runtime",
+      "lifecycle": "primitive_read",
+      "audience": "operator",
+      "description": "Return per-action auto-apply policies and confidence thresholds for the current user.",
+      "method": "GET",
+      "path": "/agent/read/get_action_policies",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {}
+      },
+      "output": {
+        "properties": {
+          "policies": {
+            "type": "object",
+            "description": "Map of actionName → { autoApply, minConfidence }."
+          }
+        }
+      },
+      "readOnly": true
+    },
+    {
+      "name": "update_action_policy",
+      "namespace": "automation",
+      "category": "Automation Runtime",
+      "lifecycle": "mutating",
+      "audience": "operator",
+      "description": "Update the auto-apply policy and confidence threshold for a specific action.",
+      "method": "POST",
+      "path": "/agent/write/update_action_policy",
+      "inputSchema": {
+        "type": "object",
+        "required": ["actionName"],
+        "additionalProperties": false,
+        "properties": {
+          "actionName": {
+            "type": "string",
+            "description": "The agent action name to update policy for."
+          },
+          "autoApply": {
+            "type": "boolean",
+            "description": "Whether this action may be auto-applied."
+          },
+          "minConfidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Minimum confidence score required for auto-apply."
+          }
+        }
+      },
+      "output": {
+        "properties": {
+          "policies": {
+            "type": "object",
+            "description": "Updated full policies map."
           }
         }
       },

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -19,6 +19,8 @@ import {
 import { WeeklyExecutiveSummaryService } from "../services/weeklyExecutiveSummaryService";
 import { EvaluationService } from "../services/evaluationService";
 import { LearningRecommendationService } from "../services/learningRecommendationService";
+import { FrictionService } from "../services/frictionService";
+import { ActionPolicyService } from "../services/actionPolicyService";
 import { AgentService } from "../services/agentService";
 import { PrismaClient } from "@prisma/client";
 import { DryRunResult } from "../types";
@@ -101,6 +103,9 @@ import {
   validateAgentRecordLearningRecInput,
   validateAgentListLearningRecsInput,
   validateAgentApplyLearningRecInput,
+  validateAgentListFrictionPatternsInput,
+  validateAgentGetActionPoliciesInput,
+  validateAgentUpdateActionPolicyInput,
 } from "../validation/agentValidation";
 import { CaptureService } from "../services/captureService";
 
@@ -178,7 +183,10 @@ export type AgentActionName =
   | "evaluate_weekly_system"
   | "record_learning_recommendation"
   | "list_learning_recommendations"
-  | "apply_learning_recommendation";
+  | "apply_learning_recommendation"
+  | "list_friction_patterns"
+  | "get_action_policies"
+  | "update_action_policy";
 
 interface AgentExecutorDeps {
   todoService: ITodoService;
@@ -276,6 +284,8 @@ const READ_ONLY_ACTIONS = new Set<AgentActionName>([
   "evaluate_daily_plan",
   "evaluate_weekly_system",
   "list_learning_recommendations",
+  "list_friction_patterns",
+  "get_action_policies",
 ]);
 
 const IDEMPOTENT_PLANNER_APPLY_ACTIONS = new Set<AgentActionName>([
@@ -553,6 +563,8 @@ export class AgentExecutor {
   private readonly captureService: CaptureService | null;
   private readonly learningRecommendationService: LearningRecommendationService;
   private readonly evaluationService: EvaluationService;
+  private readonly frictionService: FrictionService;
+  private readonly actionPolicyService: ActionPolicyService;
 
   constructor(private readonly deps: AgentExecutorDeps) {
     this.idempotencyService = new AgentIdempotencyService(
@@ -579,6 +591,8 @@ export class AgentExecutor {
     this.learningRecommendationService = new LearningRecommendationService(
       deps.persistencePrisma,
     );
+    this.frictionService = new FrictionService(deps.persistencePrisma);
+    this.actionPolicyService = new ActionPolicyService(deps.persistencePrisma);
     this.agentService = new AgentService({
       todoService: deps.todoService,
       projectService: deps.projectService,
@@ -1204,6 +1218,13 @@ export class AgentExecutor {
         }
         case "ensure_next_action": {
           const plannerInput = validateAgentEnsureNextActionInput(input);
+          const enaPolicies = await this.actionPolicyService.getPolicies(
+            context.userId,
+          );
+          const enaActionMeta = this.actionPolicyService.buildActionMeta(
+            "ensure_next_action",
+            enaPolicies,
+          );
           const executeEnsureNextAction = async () => {
             const result = await this.agentService.ensureNextActionForUser(
               context.userId,
@@ -1218,7 +1239,7 @@ export class AgentExecutor {
                 "Verify the project ID belongs to the authenticated user.",
               );
             }
-            return { result };
+            return { result, actionMeta: enaActionMeta };
           };
           if (
             IDEMPOTENT_PLANNER_APPLY_ACTIONS.has(action) &&
@@ -1918,10 +1939,17 @@ export class AgentExecutor {
             });
             applied = true;
           }
+          const triagePolicies = await this.actionPolicyService.getPolicies(
+            context.userId,
+          );
           return this.success(action, readOnly, context, 200, {
             captureItemId,
             recommendation,
             applied,
+            actionMeta: this.actionPolicyService.buildActionMeta(
+              "triage_capture_item",
+              triagePolicies,
+            ),
           });
         }
         case "triage_inbox": {
@@ -2164,12 +2192,21 @@ export class AgentExecutor {
             createdByPrompt: `follow_up:${taskId}`,
           };
 
+          const followUpPolicies = await this.actionPolicyService.getPolicies(
+            context.userId,
+          );
+          const followUpActionMeta = this.actionPolicyService.buildActionMeta(
+            "create_follow_up_for_waiting_task",
+            followUpPolicies,
+          );
+
           if (mode !== "apply") {
             return this.success(action, readOnly, context, 200, {
               created: false,
               mode: "suggest",
               waitingTask: { id: waitingTask.id, title: waitingTask.title },
               followUp,
+              actionMeta: followUpActionMeta,
             });
           }
 
@@ -2211,6 +2248,7 @@ export class AgentExecutor {
                   cooldownDays: cooldown,
                   waitingTask: { id: waitingTask.id, title: waitingTask.title },
                   followUp,
+                  actionMeta: followUpActionMeta,
                 };
               }
               const task = await this.agentService.createTask(
@@ -2221,6 +2259,7 @@ export class AgentExecutor {
                 created: true,
                 task,
                 waitingTaskId: taskId,
+                actionMeta: followUpActionMeta,
               };
             },
             201,
@@ -2802,6 +2841,43 @@ export class AgentExecutor {
             scheduledTasks: tasksForDate,
             totalAvailableMinutes,
           });
+        }
+
+        // ── Issue #338: list_friction_patterns ────────────────────────────────
+        case "list_friction_patterns": {
+          const { since, limit } =
+            validateAgentListFrictionPatternsInput(input);
+          const result = await this.frictionService.listPatterns(
+            context.userId,
+            { since, limit },
+          );
+          return this.success(
+            action,
+            readOnly,
+            context,
+            200,
+            result as unknown as Record<string, unknown>,
+          );
+        }
+
+        // ── Issue #339: action policies ───────────────────────────────────────
+        case "get_action_policies": {
+          validateAgentGetActionPoliciesInput(input);
+          const policies = await this.actionPolicyService.getPolicies(
+            context.userId,
+          );
+          return this.success(action, readOnly, context, 200, { policies });
+        }
+
+        case "update_action_policy": {
+          const { actionName, autoApply, minConfidence } =
+            validateAgentUpdateActionPolicyInput(input);
+          const policies = await this.actionPolicyService.updatePolicy(
+            context.userId,
+            actionName,
+            { autoApply, minConfidence },
+          );
+          return this.success(action, readOnly, context, 200, { policies });
         }
       }
     } catch (error) {

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -136,6 +136,7 @@ function minimumRequiredScopesForAction(
     case "set_day_context":
     case "record_learning_recommendation":
     case "apply_learning_recommendation":
+    case "update_action_policy":
       return [TASK_WRITE_SCOPE];
     case "get_job_run_status":
     case "list_job_runs":
@@ -152,6 +153,8 @@ function minimumRequiredScopesForAction(
     case "evaluate_daily_plan":
     case "evaluate_weekly_system":
     case "list_learning_recommendations":
+    case "list_friction_patterns":
+    case "get_action_policies":
       return [TASK_READ_SCOPE];
   }
 }

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -393,5 +393,21 @@ export function createAgentRouter({
     createAgentActionHandler(agentExecutor, "apply_learning_recommendation"),
   );
 
+  // Friction patterns (#338)
+  router.post(
+    "/read/list_friction_patterns",
+    createAgentActionHandler(agentExecutor, "list_friction_patterns"),
+  );
+
+  // Action policies (#339)
+  router.get(
+    "/read/get_action_policies",
+    createAgentActionHandler(agentExecutor, "get_action_policies"),
+  );
+  router.post(
+    "/write/update_action_policy",
+    createAgentActionHandler(agentExecutor, "update_action_policy"),
+  );
+
   return router;
 }

--- a/src/services/actionPolicyService.ts
+++ b/src/services/actionPolicyService.ts
@@ -1,0 +1,134 @@
+import { PrismaClient } from "@prisma/client";
+
+export type BlastRadius =
+  | "single_entity"
+  | "project_scope"
+  | "cross_project"
+  | "account_wide";
+
+export interface ActionPolicy {
+  autoApply: boolean;
+  minConfidence: number;
+}
+
+export type ActionPoliciesMap = Record<string, ActionPolicy>;
+
+export interface ActionMeta {
+  confidence: number;
+  reversible: boolean;
+  blastRadius: BlastRadius;
+  autoApplied: boolean;
+  policyUsed: string;
+}
+
+// Static action metadata — confidence and blast radius are intrinsic to the action type.
+const ACTION_STATIC_META: Record<
+  string,
+  { confidence: number; reversible: boolean; blastRadius: BlastRadius }
+> = {
+  create_follow_up_for_waiting_task: {
+    confidence: 0.85,
+    reversible: true,
+    blastRadius: "single_entity",
+  },
+  ensure_next_action: {
+    confidence: 0.87,
+    reversible: false,
+    blastRadius: "project_scope",
+  },
+  triage_capture_item: {
+    confidence: 0.9,
+    reversible: false,
+    blastRadius: "single_entity",
+  },
+};
+
+// Default per-action policy used when no explicit override is stored.
+const DEFAULT_POLICIES: ActionPoliciesMap = {
+  create_follow_up_for_waiting_task: { autoApply: true, minConfidence: 0.8 },
+  ensure_next_action: { autoApply: true, minConfidence: 0.85 },
+  triage_capture_item: { autoApply: true, minConfidence: 0.9 },
+  archive_task: { autoApply: false, minConfidence: 1.0 },
+};
+
+export class ActionPolicyService {
+  constructor(private readonly prisma?: PrismaClient) {}
+
+  async getPolicies(userId: string): Promise<ActionPoliciesMap> {
+    if (!this.prisma) return { ...DEFAULT_POLICIES };
+    const config = await this.prisma.agentConfig.findUnique({
+      where: { userId },
+      select: { actionPoliciesJson: true },
+    });
+    const stored = (config?.actionPoliciesJson ??
+      {}) as unknown as ActionPoliciesMap;
+    return { ...DEFAULT_POLICIES, ...stored };
+  }
+
+  async updatePolicy(
+    userId: string,
+    actionName: string,
+    policy: Partial<ActionPolicy>,
+  ): Promise<ActionPoliciesMap> {
+    if (!this.prisma) {
+      return {
+        ...DEFAULT_POLICIES,
+        [actionName]: { ...DEFAULT_POLICIES[actionName], ...policy },
+      };
+    }
+    const current = await this.getPolicies(userId);
+    const updated: ActionPoliciesMap = {
+      ...current,
+      [actionName]: {
+        autoApply: policy.autoApply ?? current[actionName]?.autoApply ?? false,
+        minConfidence:
+          policy.minConfidence ?? current[actionName]?.minConfidence ?? 1.0,
+      },
+    };
+    // Persist only the overrides (delta from defaults)
+    const overrides: ActionPoliciesMap = {};
+    for (const [k, v] of Object.entries(updated)) {
+      const def = DEFAULT_POLICIES[k];
+      if (
+        !def ||
+        def.autoApply !== v.autoApply ||
+        def.minConfidence !== v.minConfidence
+      ) {
+        overrides[k] = v;
+      }
+    }
+    await this.prisma.agentConfig.upsert({
+      where: { userId },
+      create: {
+        userId,
+        actionPoliciesJson:
+          overrides as unknown as import("@prisma/client").Prisma.JsonObject,
+      },
+      update: {
+        actionPoliciesJson:
+          overrides as unknown as import("@prisma/client").Prisma.JsonObject,
+      },
+    });
+    return updated;
+  }
+
+  buildActionMeta(actionName: string, policies: ActionPoliciesMap): ActionMeta {
+    const staticMeta = ACTION_STATIC_META[actionName];
+    const policy = policies[actionName];
+    const confidence = staticMeta?.confidence ?? 1.0;
+    const autoApplied = policy
+      ? policy.autoApply && confidence >= policy.minConfidence
+      : false;
+    return {
+      confidence,
+      reversible: staticMeta?.reversible ?? true,
+      blastRadius: staticMeta?.blastRadius ?? "single_entity",
+      autoApplied,
+      policyUsed: actionName,
+    };
+  }
+
+  getDefaultPolicies(): ActionPoliciesMap {
+    return { ...DEFAULT_POLICIES };
+  }
+}

--- a/src/services/frictionService.ts
+++ b/src/services/frictionService.ts
@@ -1,0 +1,249 @@
+import { PrismaClient } from "@prisma/client";
+
+export type FrictionPatternType =
+  | "repeated_deferral"
+  | "ignored_recommendation"
+  | "follow_up_churn"
+  | "project_stall";
+
+export interface FrictionPattern {
+  type: FrictionPatternType;
+  taskId?: string;
+  taskTitle?: string;
+  projectId?: string;
+  projectName?: string;
+  count: number;
+  staleDays?: number;
+  firstSeenAt?: string;
+  insight: string;
+}
+
+export interface ListFrictionPatternsResult {
+  patterns: FrictionPattern[];
+  totalPatterns: number;
+}
+
+export class FrictionService {
+  constructor(private readonly prisma?: PrismaClient) {}
+
+  async listPatterns(
+    userId: string,
+    opts: { since?: string; limit?: number },
+  ): Promise<ListFrictionPatternsResult> {
+    if (!this.prisma) return { patterns: [], totalPatterns: 0 };
+
+    const limit = opts.limit ?? 20;
+    const sinceDate = opts.since
+      ? new Date(`${opts.since}T00:00:00Z`)
+      : new Date(Date.now() - 30 * 86400000);
+
+    const [deferralPatterns, ignoredPatterns, churnPatterns, stallPatterns] =
+      await Promise.all([
+        this.repeatedDeferralPatterns(userId, sinceDate),
+        this.ignoredRecommendationPatterns(userId, sinceDate),
+        this.followUpChurnPatterns(userId, sinceDate),
+        this.projectStallPatterns(userId, sinceDate),
+      ]);
+
+    const all = [
+      ...deferralPatterns,
+      ...ignoredPatterns,
+      ...churnPatterns,
+      ...stallPatterns,
+    ]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, limit);
+
+    return { patterns: all, totalPatterns: all.length };
+  }
+
+  // Tasks recommended by the planner on ≥3 distinct days but never completed.
+  private async repeatedDeferralPatterns(
+    userId: string,
+    since: Date,
+  ): Promise<FrictionPattern[]> {
+    const rows = await this.prisma!.agentMetricEvent.groupBy({
+      by: ["entityId"],
+      where: {
+        userId,
+        metricType: "planner.recommend_task",
+        recordedAt: { gte: since },
+        entityId: { not: null },
+      },
+      _count: { entityId: true },
+      _min: { recordedAt: true },
+      having: { entityId: { _count: { gte: 3 } } },
+    });
+
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((r) => r.entityId as string);
+    const tasks = await this.prisma!.todo.findMany({
+      where: {
+        userId,
+        id: { in: ids },
+        status: { notIn: ["done", "cancelled"] },
+        archived: false,
+      },
+      select: { id: true, title: true, doDate: true },
+    });
+    const taskMap = new Map(tasks.map((t) => [t.id, t]));
+
+    return rows
+      .filter((r) => taskMap.has(r.entityId as string))
+      .map((r) => {
+        const task = taskMap.get(r.entityId as string)!;
+        const count = r._count.entityId;
+        const firstSeenAt = r._min.recordedAt
+          ? r._min.recordedAt.toISOString().slice(0, 10)
+          : undefined;
+        return {
+          type: "repeated_deferral" as const,
+          taskId: task.id,
+          taskTitle: task.title,
+          count,
+          firstSeenAt,
+          insight: `Planned ${count} times since ${firstSeenAt ?? "recently"} without being completed. Consider delegating, breaking it down, or dropping it.`,
+        };
+      });
+  }
+
+  // Tasks with ≥3 "ignored" signals in TaskRecommendationFeedback.
+  private async ignoredRecommendationPatterns(
+    userId: string,
+    since: Date,
+  ): Promise<FrictionPattern[]> {
+    const rows = await this.prisma!.taskRecommendationFeedback.groupBy({
+      by: ["taskId"],
+      where: {
+        userId,
+        signal: "ignored",
+        recordedAt: { gte: since },
+      },
+      _count: { taskId: true },
+      _min: { recordedAt: true },
+      having: { taskId: { _count: { gte: 3 } } },
+    });
+
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((r) => r.taskId);
+    const tasks = await this.prisma!.todo.findMany({
+      where: { userId, id: { in: ids } },
+      select: { id: true, title: true },
+    });
+    const taskMap = new Map(tasks.map((t) => [t.id, t]));
+
+    return rows
+      .filter((r) => taskMap.has(r.taskId))
+      .map((r) => {
+        const task = taskMap.get(r.taskId)!;
+        const count = r._count.taskId;
+        return {
+          type: "ignored_recommendation" as const,
+          taskId: task.id,
+          taskTitle: task.title,
+          count,
+          insight: `Recommended ${count} times and skipped each time. Consider rescheduling, delegating, or archiving.`,
+        };
+      });
+  }
+
+  // Waiting tasks with ≥2 follow-up events that are still not done.
+  private async followUpChurnPatterns(
+    userId: string,
+    since: Date,
+  ): Promise<FrictionPattern[]> {
+    const rows = await this.prisma!.agentMetricEvent.groupBy({
+      by: ["entityId"],
+      where: {
+        userId,
+        metricType: "automation.followup.created",
+        recordedAt: { gte: since },
+        entityId: { not: null },
+      },
+      _count: { entityId: true },
+      having: { entityId: { _count: { gte: 2 } } },
+    });
+
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((r) => r.entityId as string);
+    const tasks = await this.prisma!.todo.findMany({
+      where: {
+        userId,
+        id: { in: ids },
+        status: { notIn: ["done", "cancelled"] },
+        archived: false,
+      },
+      select: { id: true, title: true },
+    });
+    const taskMap = new Map(tasks.map((t) => [t.id, t]));
+
+    return rows
+      .filter((r) => taskMap.has(r.entityId as string))
+      .map((r) => {
+        const task = taskMap.get(r.entityId as string)!;
+        const count = r._count.entityId;
+        return {
+          type: "follow_up_churn" as const,
+          taskId: task.id,
+          taskTitle: task.title,
+          count,
+          insight: `${count} follow-ups generated but the task is still waiting. Consider escalating or closing it out.`,
+        };
+      });
+  }
+
+  // Projects with no task completed in the since window and all tasks untouched for 14+ days.
+  private async projectStallPatterns(
+    userId: string,
+    since: Date,
+  ): Promise<FrictionPattern[]> {
+    const staleThreshold = new Date(Date.now() - 14 * 86400000);
+
+    const stalledProjects = await this.prisma!.project.findMany({
+      where: {
+        userId,
+        archived: false,
+        status: { notIn: ["completed", "archived"] },
+      },
+      select: {
+        id: true,
+        name: true,
+        todos: {
+          where: { archived: false, status: { notIn: ["done", "cancelled"] } },
+          select: { id: true, updatedAt: true, completedAt: true },
+        },
+      },
+    });
+
+    const patterns: FrictionPattern[] = [];
+    for (const project of stalledProjects) {
+      const todos = project.todos;
+      if (todos.length === 0) continue;
+      const allStale = todos.every((t) => t.updatedAt < staleThreshold);
+      const anyCompletedRecently = todos.some(
+        (t) => t.completedAt && t.completedAt >= since,
+      );
+      if (!allStale || anyCompletedRecently) continue;
+
+      const oldestUpdated = todos.reduce((min, t) =>
+        t.updatedAt < min.updatedAt ? t : min,
+      );
+      const staleDays = Math.floor(
+        (Date.now() - oldestUpdated.updatedAt.getTime()) / 86400000,
+      );
+      patterns.push({
+        type: "project_stall" as const,
+        projectId: project.id,
+        projectName: project.name,
+        count: todos.length,
+        staleDays,
+        insight: `${todos.length} open task(s) untouched for ${staleDays}+ days with no recent completions. Consider a weekly review to unstick this project.`,
+      });
+    }
+
+    return patterns;
+  }
+}

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -2124,6 +2124,57 @@ export function validateAgentPromoteInboxItemInput(data: unknown): {
   };
 }
 
+// ── Issue #338: friction patterns ─────────────────────────────────────────────
+
+const LIST_FRICTION_PATTERNS_KEYS = ["since", "limit"];
+
+export function validateAgentListFrictionPatternsInput(data: unknown): {
+  since?: string;
+  limit?: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, LIST_FRICTION_PATTERNS_KEYS, "Agent action input");
+  return {
+    since: parseOptionalString(body.since, "since", 10),
+    limit: parseOptionalPositiveInt(body.limit, "limit", 200) ?? undefined,
+  };
+}
+
+// ── Issue #339: action policies ───────────────────────────────────────────────
+
+const UPDATE_ACTION_POLICY_KEYS = ["actionName", "autoApply", "minConfidence"];
+
+export function validateAgentGetActionPoliciesInput(
+  _data: unknown,
+): Record<string, never> {
+  return {};
+}
+
+export function validateAgentUpdateActionPolicyInput(data: unknown): {
+  actionName: string;
+  autoApply?: boolean;
+  minConfidence?: number;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, UPDATE_ACTION_POLICY_KEYS, "Agent action input");
+  const actionName = parseOptionalString(body.actionName, "actionName", 100);
+  if (!actionName) throw new ValidationError("actionName is required");
+  const result: {
+    actionName: string;
+    autoApply?: boolean;
+    minConfidence?: number;
+  } = { actionName };
+  if (body.autoApply !== undefined)
+    result.autoApply = parseOptionalBoolean(body.autoApply, "autoApply");
+  if (body.minConfidence !== undefined) {
+    const raw = Number(body.minConfidence);
+    if (isNaN(raw) || raw < 0 || raw > 1)
+      throw new ValidationError("minConfidence must be between 0 and 1");
+    result.minConfidence = raw;
+  }
+  return result;
+}
+
 // ── Issue #337: weekly executive summary ──────────────────────────────────────
 
 const WEEKLY_EXEC_SUMMARY_KEYS = ["weekOffset"];


### PR DESCRIPTION
## Summary
- **#338 `list_friction_patterns`**: Derives four friction signal types from existing tables — `repeated_deferral` (tasks planned ≥3× without completion), `ignored_recommendation` (≥3 feedback signals), `follow_up_churn` (≥2 follow-ups on still-waiting tasks), `project_stall` (all tasks untouched 14+ days). No schema migration needed.
- **#339 Action policy engine**: `actionPoliciesJson` column on `AgentConfig` stores per-action `{ autoApply, minConfidence }` overrides. `get_action_policies` and `update_action_policy` endpoints expose this. `actionMeta` (confidence, reversible, blastRadius, autoApplied, policyUsed) is now included in `create_follow_up_for_waiting_task`, `ensure_next_action`, and `triage_capture_item` responses.
- Manifest bumped to v1.6.0, package.json to 1.6.0.

## Test plan
- [ ] `POST /agent/read/list_friction_patterns` returns patterns array (empty on fresh user)
- [ ] `GET /agent/read/get_action_policies` returns default policy map
- [ ] `POST /agent/write/update_action_policy` with `{ actionName: "archive_task", autoApply: true, minConfidence: 0.9 }` persists override
- [ ] `create_follow_up_for_waiting_task` response includes `actionMeta` with `policyUsed: "create_follow_up_for_waiting_task"`
- [ ] Unit + integration CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)