### PR TITLE
fix(api): decouple audit log writes and add MCP debug scripts

### DIFF
--- a/scripts/stress-test-mcp.ts
+++ b/scripts/stress-test-mcp.ts
@@ -1,0 +1,266 @@
+import http from "http";
+import { randomUUID } from "crypto";
+
+const API_BASE = "http://localhost:3000";
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function mcpCall(
+  token: string,
+  method: string,
+  args: any,
+  id: number | string,
+) {
+  const start = Date.now();
+  const res = await fetch(`${API_BASE}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: {
+        name: method,
+        arguments: args,
+      },
+    }),
+  });
+
+  const end = Date.now();
+  const data: any = await res.json();
+  return { timeMs: end - start, data, status: res.status };
+}
+
+async function runTest() {
+  console.log(`1. Waiting for server to start on ${API_BASE}...`);
+
+  let ready = false;
+  for (let i = 0; i < 20; i++) {
+    try {
+      const res = await fetch(`${API_BASE}/healthz`);
+      if (res.ok) {
+        ready = true;
+        break;
+      }
+    } catch (e) {
+      // ignore
+    }
+    await delay(1000);
+  }
+
+  if (!ready) throw new Error("Server did not become ready");
+
+  const email = `stress-${randomUUID().slice(0, 8)}@example.com`;
+  const password = "Password123!";
+
+  console.log(`2. Registering and obtaining MCP token for ${email}...`);
+  await fetch(`${API_BASE}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password, name: "Stress Tester" }),
+  });
+
+  const loginRes = await fetch(`${API_BASE}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  const loginData: any = await loginRes.json();
+  const appToken = loginData.token;
+
+  const mcpTokenRes = await fetch(`${API_BASE}/auth/mcp/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${appToken}`,
+    },
+    body: JSON.stringify({
+      scopes: ["tasks.read", "tasks.write", "projects.read", "projects.write"],
+      assistantName: "StressTestBot",
+      clientId: "stress-client",
+    }),
+  });
+  const mcpTokenData: any = await mcpTokenRes.json();
+  const mcpToken = mcpTokenData.token;
+
+  console.log(
+    "3. Connecting to MCP SSE endpoint (simulating client connection)...",
+  );
+  const req = http.get(`${API_BASE}/mcp`, {
+    headers: {
+      Authorization: `Bearer ${mcpToken}`,
+      Accept: "text/event-stream",
+    },
+  });
+
+  const connected = new Promise((resolve, reject) => {
+    req.on("response", (res) => {
+      res.on("data", (chunk) => {
+        if (chunk.toString().includes(": connected")) resolve(true);
+      });
+    });
+    req.on("error", reject);
+  });
+
+  await connected;
+  console.log("   SSE Connected.");
+
+  console.log("\n--- SCENARIO 1: Bulk Project Creation (10 Concurrent) ---");
+  let reqId = 1000;
+  const projectPromises = [];
+  for (let i = 0; i < 10; i++) {
+    projectPromises.push(
+      mcpCall(
+        mcpToken,
+        "create_project",
+        {
+          name: `Stress Project ${i}`,
+          goal: "Testing system capacity",
+        },
+        reqId++,
+      ),
+    );
+  }
+
+  const projectResults = await Promise.all(projectPromises);
+  const avgProjTime =
+    projectResults.reduce((sum, r) => sum + r.timeMs, 0) /
+    projectResults.length;
+  console.log(`   Created 10 projects. Avg Time: ${avgProjTime.toFixed(2)}ms`);
+
+  const projectIds = projectResults
+    .map((r) => r.data.result?.structuredContent?.data?.project?.id)
+    .filter(Boolean);
+
+  console.log("\n--- SCENARIO 2: Bulk Task Creation (50 Concurrent) ---");
+  const taskPromises = [];
+  for (let i = 0; i < 50; i++) {
+    const projectId = projectIds[i % projectIds.length];
+    taskPromises.push(
+      mcpCall(
+        mcpToken,
+        "create_task",
+        {
+          title: `Stress Task ${i}`,
+          status: i % 2 === 0 ? "todo" : "doing",
+          projectId,
+        },
+        reqId++,
+      ),
+    );
+  }
+
+  const taskResults = await Promise.all(taskPromises);
+  const avgTaskTime =
+    taskResults.reduce((sum, r) => sum + r.timeMs, 0) / taskResults.length;
+  console.log(`   Created 50 tasks. Avg Time: ${avgTaskTime.toFixed(2)}ms`);
+
+  const taskIds = taskResults
+    .map((r) => r.data.result?.structuredContent?.data?.result?.id)
+    .filter(Boolean);
+
+  console.log("\n--- SCENARIO 3: Creating Subtasks (Depth testing) ---");
+  if (taskIds.length > 0) {
+    const parentId = taskIds[0];
+    const subtaskRes = await mcpCall(
+      mcpToken,
+      "add_subtask",
+      {
+        taskId: parentId,
+        title: "Level 1 Subtask",
+      },
+      reqId++,
+    );
+    console.log(`   L1 Subtask created in ${subtaskRes.timeMs}ms`);
+
+    // Some systems allow deep nesting, some dont. Let's see if we can nest a subtask inside a subtask
+    const subtaskId =
+      subtaskRes.data.result?.structuredContent?.data?.subtask?.id;
+    if (subtaskId) {
+      const subtaskRes2 = await mcpCall(
+        mcpToken,
+        "add_subtask",
+        {
+          taskId: subtaskId, // Trying to attach to a subtask
+          title: "Level 2 Subtask",
+        },
+        reqId++,
+      );
+
+      console.log(
+        `   L2 Subtask Attempt:`,
+        subtaskRes2.data.result?.isError
+          ? subtaskRes2.data.result?.structuredContent?.error?.message ||
+              "Failed"
+          : "Success",
+      );
+    }
+  }
+
+  console.log(
+    "\n--- SCENARIO 4: Test Edge Cases (Pagination, Invalid Data) ---",
+  );
+  const listRes = await mcpCall(
+    mcpToken,
+    "list_tasks",
+    { limit: 100 },
+    reqId++,
+  );
+  console.log(
+    `   list_tasks (100 limit) returned ${listRes.data.result?.structuredContent?.data?.tasks?.length || 0} items in ${listRes.timeMs}ms`,
+  );
+
+  const badRes = await mcpCall(mcpToken, "create_task", { title: "" }, reqId++); // Empty title
+  console.log(
+    `   Empty title handled: ${badRes.data.result?.isError ? "Yes (Rejected)" : "No (Accepted)"} - Error: ${badRes.data.result?.structuredContent?.error?.code}`,
+  );
+
+  console.log(
+    "\n--- SCENARIO 5: AI Planner Functionality (plan_project, analyze_work_graph) ---",
+  );
+  if (projectIds.length > 0) {
+    const pId = projectIds[0];
+    const planRes = await mcpCall(
+      mcpToken,
+      "plan_project",
+      { projectId: pId, mode: "suggest" },
+      reqId++,
+    );
+    console.log(
+      `   plan_project call took ${planRes.timeMs}ms (Enabled/Working: ${planRes.data.result?.isError ? "No, " + planRes.data.result?.structuredContent?.error?.message : "Yes"})`,
+    );
+
+    const analyzeRes = await mcpCall(
+      mcpToken,
+      "analyze_work_graph",
+      {},
+      reqId++,
+    );
+    console.log(
+      `   analyze_work_graph took ${analyzeRes.timeMs}ms (Enabled/Working: ${analyzeRes.data.result?.isError ? "No, " + analyzeRes.data.result?.structuredContent?.error?.message : "Yes"})`,
+    );
+
+    const weeklyRes = await mcpCall(
+      mcpToken,
+      "weekly_review",
+      { mode: "suggest" },
+      reqId++,
+    );
+    console.log(
+      `   weekly_review took ${weeklyRes.timeMs}ms (Enabled/Working: ${weeklyRes.data.result?.isError ? "No, " + weeklyRes.data.result?.structuredContent?.error?.message : "Yes"})`,
+    );
+  }
+
+  console.log("\n--- Stress Test Completed Successfully ---");
+  process.exit(0);
+}
+
+runTest().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/test-mcp-manual.ts
+++ b/scripts/test-mcp-manual.ts
@@ -1,0 +1,140 @@
+import http from "http";
+import { randomUUID } from "crypto";
+
+const API_BASE = `http://localhost:${process.env.PORT ?? 3000}`;
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function runTest() {
+  const port = process.env.PORT || 3000;
+  const apiBase = `http://localhost:${port}`;
+
+  console.log(`1. Waiting for server to start on ${apiBase}...`);
+
+  let ready = false;
+  for (let i = 0; i < 20; i++) {
+    try {
+      const res = await fetch(`${apiBase}/healthz`);
+      if (res.ok) {
+        ready = true;
+        break;
+      }
+    } catch (e) {
+      // ignore
+    }
+    await delay(1000);
+  }
+
+  if (!ready) {
+    throw new Error("Server did not become ready");
+  }
+
+  const email = `testmcp-${randomUUID().slice(0, 8)}@example.com`;
+  const password = "Password123!";
+
+  console.log(`2. Registering user: ${email}...`);
+  const registerRes = await fetch(`${apiBase}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password, name: "MCP Tester" }),
+  });
+
+  if (!registerRes.ok) {
+    const err = await registerRes.text();
+    throw new Error(`Registration failed: ${err}`);
+  }
+
+  const loginRes = await fetch(`${apiBase}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  const loginData: any = await loginRes.json();
+  const appToken = loginData.token;
+
+  console.log("3. Fetching MCP token...");
+  const mcpTokenRes = await fetch(`${apiBase}/auth/mcp/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${appToken}`,
+    },
+    body: JSON.stringify({
+      scopes: ["tasks.read", "tasks.write", "projects.read", "projects.write"],
+      assistantName: "TestScript",
+      clientId: "test-client",
+    }),
+  });
+
+  if (!mcpTokenRes.ok) {
+    const err = await mcpTokenRes.text();
+    throw new Error(`Failed to get MCP token: ${err}`);
+  }
+
+  const mcpTokenData: any = await mcpTokenRes.json();
+  const mcpToken = mcpTokenData.token;
+
+  console.log("4. Connecting to MCP SSE endpoint...");
+  const req = http.get(`${apiBase}/mcp`, {
+    headers: {
+      Authorization: `Bearer ${mcpToken}`,
+      Accept: "text/event-stream",
+    },
+  });
+
+  req.on("response", (res) => {
+    console.log(`SSE Status: ${res.statusCode}`);
+
+    res.on("data", async (chunk) => {
+      const str = chunk.toString();
+      console.log(`SSE Message Received: ${str.trim()}`);
+
+      if (str.includes(": connected")) {
+        console.log("5. Sending POST /mcp (tools/list)...");
+
+        try {
+          const mcpPostRes = await fetch(`${apiBase}/mcp`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${mcpToken}`,
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/list",
+            }),
+          });
+
+          const mcpPostData: any = await mcpPostRes.json();
+          console.log(
+            `Tools Response:\n${JSON.stringify(
+              mcpPostData.result.tools.map((t: any) => t.name),
+              null,
+              2,
+            )}`,
+          );
+
+          console.log("\n--- SUCCESS! Test Completed. ---");
+          process.exit(0);
+        } catch (e) {
+          console.error(e);
+          process.exit(1);
+        }
+      }
+    });
+  });
+
+  req.on("error", (e) => {
+    console.error("SSE Error:", e);
+    process.exit(1);
+  });
+}
+
+runTest().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/services/agentAuditService.ts
+++ b/src/services/agentAuditService.ts
@@ -41,20 +41,28 @@ export class AgentAuditService {
       rationale: rationaleMetadata as unknown as Prisma.InputJsonObject,
     };
 
-    await this.prisma.agentActionAudit.create({
-      data: {
-        surface: ctx.surface as "agent" | "mcp",
-        action,
-        readOnly: false,
-        outcome,
-        status: outcome === "success" ? 200 : 500,
-        userId: ctx.userId,
-        requestId: ctx.requestId,
-        actor: ctx.actor,
-        replayed: false,
-        metadata,
-      },
-    });
+    // Fire and forget to avoid blocking or crashing on high concurrency
+    this.prisma.agentActionAudit
+      .create({
+        data: {
+          surface: ctx.surface as "agent" | "mcp",
+          action,
+          readOnly: false,
+          outcome,
+          status: outcome === "success" ? 200 : 500,
+          userId: ctx.userId,
+          requestId: ctx.requestId,
+          actor: ctx.actor,
+          replayed: false,
+          metadata,
+        },
+      })
+      .catch((err) => {
+        console.error(
+          "Non-fatal error auditing agent action with rationale:",
+          err,
+        );
+      });
   }
 
   async record(input: AgentAuditRecordInput): Promise<void> {
@@ -66,24 +74,29 @@ export class AgentAuditService {
       ts: new Date().toISOString(),
     };
 
-    await this.prisma.agentActionAudit.create({
-      data: {
-        surface: input.surface,
-        action: input.action,
-        readOnly: input.readOnly,
-        outcome: input.outcome,
-        status: input.status,
-        userId: input.userId,
-        requestId: input.requestId,
-        actor: input.actor,
-        idempotencyKey: input.idempotencyKey,
-        replayed: input.replayed || false,
-        errorCode: input.errorCode,
-        jobName: input.jobName,
-        jobPeriodKey: input.jobPeriodKey,
-        triggeredBy: input.triggeredBy,
-        metadata,
-      },
-    });
+    // Fire and forget to avoid blocking or crashing on high concurrency
+    this.prisma.agentActionAudit
+      .create({
+        data: {
+          surface: input.surface,
+          action: input.action,
+          readOnly: input.readOnly,
+          outcome: input.outcome,
+          status: input.status,
+          userId: input.userId,
+          requestId: input.requestId,
+          actor: input.actor,
+          idempotencyKey: input.idempotencyKey,
+          replayed: input.replayed || false,
+          errorCode: input.errorCode,
+          jobName: input.jobName,
+          jobPeriodKey: input.jobPeriodKey,
+          triggeredBy: input.triggeredBy,
+          metadata,
+        },
+      })
+      .catch((err) => {
+        console.error("Non-fatal error auditing agent action:", err);
+      });
   }
 }


### PR DESCRIPTION
## Summary

- **`agentAuditService`**: both `record()` and `logWithRationale()` are now fire-and-forget. The `await` was removed and a `.catch()` handler logs failures as non-fatal errors. Audit inserts no longer sit in the critical path of every agent/MCP request, eliminating a class of latency spikes and crashes under bulk tool usage.
- **`scripts/stress-test-mcp.ts`**: end-to-end stress script — registers a user, mints an MCP token, runs 5 scenarios: 10 concurrent project creates, 50 concurrent task creates, subtask depth probing, edge-case validation (empty title, 100-item list), and planner tool smoke checks.
- **`scripts/test-mcp-manual.ts`**: lightweight smoke script — registers, logs in, mints MCP token, connects to SSE endpoint, calls `tools/list`, prints tool names.

> **Not included**: the `20260317130040_schema_sync` migration from the Codex handoff branch. Its SQL content (dropping UUID defaults, altering FK constraints) did not match the stated intent ("add job_name column") and its timestamp would have conflicted with already-applied migrations in the production history.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test:unit` passes (296 tests)
- [ ] Run `npx ts-node scripts/test-mcp-manual.ts` against a local server — should print tool list and exit 0
- [ ] MCP tool calls no longer block on audit DB writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)