### PR TITLE
feat(ui): Phase 3 — capture inbox view

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -288,6 +288,11 @@ import {
   renderHomeFocusDashboard,
 } from "./modules/homeDashboard.js";
 import {
+  renderInboxView,
+  loadInboxItems,
+  bindInboxHandlers,
+} from "./modules/inboxUi.js";
+import {
   getAiWorkspaceElements,
   getAiWorkspaceStatusLabel,
   updateAiWorkspaceStatusChip,
@@ -1541,6 +1546,8 @@ function bindDeclarativeHandlers() {
   hooks.renderTodayPlanPanel = TodayPlan.renderTodayPlanPanel;
   hooks.clearHomeFocusDashboard = clearHomeFocusDashboard;
   hooks.renderHomeDashboard = renderHomeDashboard;
+  hooks.renderInboxView = renderInboxView;
+  hooks.loadInboxItems = loadInboxItems;
   hooks.updateBulkActionsVisibility = updateBulkActionsVisibility;
   hooks.updateAiWorkspaceStatusChip = updateAiWorkspaceStatusChip;
   // projectsState → rail
@@ -1729,6 +1736,7 @@ function init() {
   renderSidebarNavigation();
   bindCriticalHandlers();
   bindTodoDrawerHandlers();
+  bindInboxHandlers();
   bindProjectsRailHandlers();
   bindCommandPaletteHandlers();
   bindTaskComposerHandlers();

--- a/client/index.html
+++ b/client/index.html
@@ -569,6 +569,34 @@
                         </button>
                         <button
                           type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="inbox"
+                          title="Inbox"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <polyline
+                              points="22 12 16 12 14 15 10 15 8 12 2 12"
+                            />
+                            <path
+                              d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                            />
+                          </svg>
+                          <span class="nav-label">Inbox</span>
+                        </button>
+                        <button
+                          type="button"
                           class="projects-rail-item projects-rail-projects-access"
                           id="projectsRailCollapsedProjectsButton"
                           title="Projects"
@@ -909,6 +937,34 @@
                             <path d="m9 12 2 2 4-4" />
                           </svg>
                           <span class="nav-label">Completed</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="inbox"
+                          title="Inbox"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <polyline
+                              points="22 12 16 12 14 15 10 15 8 12 2 12"
+                            />
+                            <path
+                              d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                            />
+                          </svg>
+                          <span class="nav-label">Inbox</span>
                         </button>
                       </nav>
                     </div>

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -157,6 +157,7 @@ function normalizeWorkspaceView(view) {
     "next_month",
     "someday",
     "completed",
+    "inbox",
     "project",
     "settings",
     "admin",
@@ -828,6 +829,19 @@ function renderTodos() {
         <button id="todosRetryLoadButton" class="mini-btn" data-onclick="retryLoadTodos()">Retry</button>
       </div>
     `;
+    hooks.syncTodoDrawerStateWithRender?.();
+    hooks.updateBulkActionsVisibility?.();
+    updateIcsExportButtonState();
+    assertNoHorizontalOverflow(scrollRegion);
+    return;
+  }
+
+  if (state.currentWorkspaceView === "inbox") {
+    updateHeaderFromVisibleTodos([]);
+    hooks.renderInboxView?.();
+    if (!state.inboxState.hasLoaded && !state.inboxState.loading) {
+      hooks.loadInboxItems?.();
+    }
     hooks.syncTodoDrawerStateWithRender?.();
     hooks.updateBulkActionsVisibility?.();
     updateIcsExportButtonState();

--- a/client/modules/inboxUi.js
+++ b/client/modules/inboxUi.js
@@ -1,0 +1,231 @@
+// =============================================================================
+// inboxUi.js — Capture inbox view: list, capture, triage, promote.
+// Uses callAgentAction for all API calls. Renders into #todosContent when
+// currentWorkspaceView === "inbox".
+// All user-provided content is passed through hooks.escapeHtml before
+// being assigned to innerHTML, consistent with the existing codebase pattern.
+// =============================================================================
+
+import { state, hooks } from "./store.js";
+import { applyAsyncAction } from "./stateActions.js";
+import { callAgentAction } from "./agentApiClient.js";
+
+// ---------------------------------------------------------------------------
+// Load inbox items from the agent API
+// ---------------------------------------------------------------------------
+
+export async function loadInboxItems() {
+  if (state.inboxState.loading) return;
+  applyAsyncAction("inbox/start");
+  renderInboxView();
+  try {
+    const data = await callAgentAction("/agent/read/list_inbox_items", {
+      lifecycle: "new",
+      limit: 100,
+    });
+    applyAsyncAction("inbox/success", {
+      items: Array.isArray(data?.items) ? data.items : [],
+    });
+  } catch (err) {
+    applyAsyncAction("inbox/failure", {
+      error: err.message || "Could not load inbox.",
+    });
+  }
+  renderInboxView();
+}
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function formatAge(date) {
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+function renderInboxItem(item) {
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+  const s = state.inboxState;
+  const isTriaging = s.triagingIds.has(item.id);
+  const age = item.capturedAt ? formatAge(new Date(item.capturedAt)) : "";
+
+  return `
+    <div class="inbox-item" data-capture-id="${escapeHtml(item.id)}">
+      <div class="inbox-item__body">
+        <p class="inbox-item__text">${escapeHtml(item.text || "")}</p>
+        ${age ? `<span class="inbox-item__age">${escapeHtml(age)}</span>` : ""}
+      </div>
+      <div class="inbox-item__actions">
+        ${
+          isTriaging
+            ? `<span class="inbox-item__spinner">Processing…</span>`
+            : `
+          <button type="button" class="inbox-btn inbox-btn--primary"
+            data-inbox-action="promote" data-capture-id="${escapeHtml(item.id)}">
+            Promote to task
+          </button>
+          <button type="button" class="inbox-btn inbox-btn--ghost"
+            data-inbox-action="discard" data-capture-id="${escapeHtml(item.id)}">
+            Discard
+          </button>
+        `
+        }
+      </div>
+    </div>
+  `;
+}
+
+export function renderInboxView() {
+  const container = document.getElementById("todosContent");
+  if (!container) return;
+  if (state.currentWorkspaceView !== "inbox") return;
+
+  const s = state.inboxState;
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+
+  let bodyHtml;
+
+  if (s.loading && !s.hasLoaded) {
+    bodyHtml = `<div class="inbox-view__loading" role="status" aria-live="polite">Loading inbox…</div>`;
+  } else if (s.error && s.items.length === 0) {
+    bodyHtml = `
+      <div class="inbox-view__error" role="status">
+        <p>${escapeHtml(s.error)}</p>
+        <button type="button" class="inbox-btn" data-inbox-action="reload">Retry</button>
+      </div>`;
+  } else if (!s.loading && s.hasLoaded && s.items.length === 0) {
+    bodyHtml = `<div class="inbox-view__empty"><p>Inbox is clear.</p></div>`;
+  } else {
+    const itemsHtml = s.items.map(renderInboxItem).join("");
+    bodyHtml = `
+      <div class="inbox-view__toolbar">
+        <span class="inbox-view__count">${s.items.length} item${s.items.length !== 1 ? "s" : ""}</span>
+        <button type="button" class="inbox-btn" data-inbox-action="reload">Refresh</button>
+      </div>
+      <div class="inbox-view__list">${itemsHtml}</div>`;
+  }
+
+  // All dynamic values passed through escapeHtml before innerHTML assignment.
+  container.innerHTML = `
+    <div class="inbox-view">
+      <div class="inbox-view__capture">
+        <form class="inbox-capture-form" data-inbox-action="capture-submit">
+          <input
+            type="text"
+            class="inbox-capture-input"
+            id="inboxCaptureInput"
+            placeholder="Capture something… (Enter to save)"
+            maxlength="2000"
+            autocomplete="off"
+          />
+          <button type="submit" class="inbox-btn inbox-btn--primary">Capture</button>
+        </form>
+      </div>
+      <div class="inbox-view__body">${bodyHtml}</div>
+    </div>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Action handlers
+// ---------------------------------------------------------------------------
+
+async function promoteItem(captureId) {
+  state.inboxState.triagingIds.add(captureId);
+  renderInboxView();
+  try {
+    await callAgentAction("/agent/write/promote_inbox_item", {
+      captureItemId: captureId,
+      type: "task",
+    });
+    state.inboxState.items = state.inboxState.items.filter(
+      (i) => i.id !== captureId,
+    );
+    if (typeof hooks.applyFiltersAndRender === "function") {
+      hooks.applyFiltersAndRender();
+    }
+  } catch (err) {
+    console.error("Inbox promote failed:", err);
+  } finally {
+    state.inboxState.triagingIds.delete(captureId);
+  }
+  renderInboxView();
+}
+
+async function discardItem(captureId) {
+  state.inboxState.triagingIds.add(captureId);
+  renderInboxView();
+  try {
+    await callAgentAction("/agent/write/triage_capture_item", {
+      captureItemId: captureId,
+      mode: "apply",
+    });
+    state.inboxState.items = state.inboxState.items.filter(
+      (i) => i.id !== captureId,
+    );
+  } catch (err) {
+    console.error("Inbox discard failed:", err);
+  } finally {
+    state.inboxState.triagingIds.delete(captureId);
+  }
+  renderInboxView();
+}
+
+async function captureItem(text) {
+  if (!text.trim()) return;
+  try {
+    await callAgentAction("/agent/write/capture_inbox_item", {
+      text: text.trim(),
+      source: "manual",
+    });
+    await loadInboxItems();
+  } catch (err) {
+    console.error("Inbox capture failed:", err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event binding (delegated, called once from app.js)
+// ---------------------------------------------------------------------------
+
+export function bindInboxHandlers() {
+  document.addEventListener("click", (event) => {
+    if (state.currentWorkspaceView !== "inbox") return;
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+
+    const actionEl = target.closest("[data-inbox-action]");
+    if (!(actionEl instanceof HTMLElement)) return;
+
+    const action = actionEl.getAttribute("data-inbox-action");
+    const captureId = actionEl.getAttribute("data-capture-id") || "";
+
+    if (action === "reload") {
+      loadInboxItems();
+    } else if (action === "promote" && captureId) {
+      promoteItem(captureId);
+    } else if (action === "discard" && captureId) {
+      discardItem(captureId);
+    }
+  });
+
+  document.addEventListener("submit", (event) => {
+    if (state.currentWorkspaceView !== "inbox") return;
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (!target.matches("[data-inbox-action='capture-submit']")) return;
+    event.preventDefault();
+    const input = document.getElementById("inboxCaptureInput");
+    if (input instanceof HTMLInputElement && input.value.trim()) {
+      const text = input.value;
+      input.value = "";
+      captureItem(text);
+    }
+  });
+}

--- a/client/styles.css
+++ b/client/styles.css
@@ -7253,3 +7253,138 @@ body.is-admin-user .projects-rail__footer--admin-only {
 .dm-backdrop {
   pointer-events: auto;
 }
+
+/* ── Inbox view ────────────────────────────────────────────────────────── */
+.inbox-view {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.inbox-capture-form {
+  display: flex;
+  gap: 8px;
+}
+
+.inbox-capture-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.inbox-capture-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--primary-color) 25%, transparent);
+}
+
+.inbox-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.inbox-btn:hover {
+  background: var(--hover-bg);
+}
+
+.inbox-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.inbox-btn--primary:hover {
+  filter: brightness(1.1);
+  background: var(--primary-color);
+}
+
+.inbox-btn--ghost {
+  background: transparent;
+}
+
+.inbox-view__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.inbox-view__count {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.inbox-view__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inbox-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+}
+
+.inbox-item__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.inbox-item__text {
+  margin: 0 0 4px;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.inbox-item__age {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.inbox-item__actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.inbox-item__spinner {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
+.inbox-view__loading,
+.inbox-view__error,
+.inbox-view__empty {
+  padding: 24px 0;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.inbox-view__error {
+  color: var(--danger-color, #dc2626);
+}


### PR DESCRIPTION
## Summary

- Add `inboxUi.js`: renders a capture inbox view in `#todosContent` when `currentWorkspaceView === "inbox"`
- Loads `list_inbox_items` (lifecycle=new) on first activation via `hooks.loadInboxItems`
- **Promote to task** button calls `promote_inbox_item` (type=task)
- **Discard** button calls `triage_capture_item` (mode=apply)
- Inline capture form at top calls `capture_inbox_item` (source=manual) then reloads
- Inbox nav item added to collapsed rail + expanded mobile sheet in `index.html`
- `inbox` registered as a valid workspace view in `normalizeWorkspaceView`
- `hooks.renderInboxView` + `hooks.loadInboxItems` wired in `app.js`
- CSS for `.inbox-view`, `.inbox-item`, `.inbox-btn`, `.inbox-capture-form`

## Test plan

- [ ] Click "Inbox" in sidebar → inbox view renders, items load from API
- [ ] Empty state shows "Inbox is clear." message
- [ ] Type text in capture form + Enter → item captured, list reloads
- [ ] "Promote to task" promotes item and removes it from list
- [ ] "Discard" discards item and removes it from list
- [ ] "Refresh" button reloads items
- [ ] Switching away and back does not double-load (loading guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)