### PR TITLE
feat(ui): Phase 4 — Day Plan agent panel on Today view

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -293,6 +293,10 @@ import {
   bindInboxHandlers,
 } from "./modules/inboxUi.js";
 import {
+  renderDayPlanAgentPanel,
+  bindDayPlanAgentHandlers,
+} from "./modules/planTodayAgent.js";
+import {
   getAiWorkspaceElements,
   getAiWorkspaceStatusLabel,
   updateAiWorkspaceStatusChip,
@@ -1544,6 +1548,7 @@ function bindDeclarativeHandlers() {
   hooks.renderProjectsRail = renderProjectsRail;
   hooks.patchProjectsRailView = patchProjectsRailView;
   hooks.renderTodayPlanPanel = TodayPlan.renderTodayPlanPanel;
+  hooks.renderDayPlanAgentPanel = renderDayPlanAgentPanel;
   hooks.clearHomeFocusDashboard = clearHomeFocusDashboard;
   hooks.renderHomeDashboard = renderHomeDashboard;
   hooks.renderInboxView = renderInboxView;
@@ -1737,6 +1742,7 @@ function init() {
   bindCriticalHandlers();
   bindTodoDrawerHandlers();
   bindInboxHandlers();
+  bindDayPlanAgentHandlers();
   bindProjectsRailHandlers();
   bindCommandPaletteHandlers();
   bindTaskComposerHandlers();

--- a/client/index.html
+++ b/client/index.html
@@ -1918,6 +1918,11 @@
                         data-testid="today-plan-panel"
                         hidden
                       ></section>
+                      <section
+                        id="dayPlanAgentPanel"
+                        class="day-plan-agent-panel"
+                        hidden
+                      ></section>
 
                       <div id="todosContent">
                         <div class="loading">

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -766,6 +766,7 @@ function renderTodos() {
 
   hooks.patchProjectsRailView?.();
   hooks.renderTodayPlanPanel?.();
+  hooks.renderDayPlanAgentPanel?.();
   const scrollRegion = document.getElementById("todosScrollRegion");
 
   if (state.todosLoadState !== "loading" && state.todos.length > 0) {

--- a/client/modules/planTodayAgent.js
+++ b/client/modules/planTodayAgent.js
@@ -1,0 +1,182 @@
+// =============================================================================
+// planTodayAgent.js — Day Plan panel using the real plan_today agent action.
+// Renders into #dayPlanAgentPanel when the "today" date view is active.
+// All user-provided content is passed through hooks.escapeHtml before
+// being assigned to innerHTML, consistent with the existing codebase pattern.
+// =============================================================================
+
+import { state, hooks } from "./store.js";
+import { callAgentAction } from "./agentApiClient.js";
+
+const PANEL_ID = "dayPlanAgentPanel";
+
+// ---------------------------------------------------------------------------
+// Local state (module-level, not in shared store — this panel is lightweight)
+// ---------------------------------------------------------------------------
+
+const planState = {
+  loading: false,
+  error: "",
+  tasks: [], // [{ taskId, title, estimatedMinutes, reason }]
+  totalMinutes: 0,
+  remainingMinutes: 0,
+  availableMinutes: 480,
+  energy: "medium",
+};
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function getPanelEl() {
+  return document.getElementById(PANEL_ID);
+}
+
+function isTodayViewActive() {
+  return state.currentDateView === "today";
+}
+
+export function renderDayPlanAgentPanel() {
+  const panel = getPanelEl();
+  if (!panel) return;
+
+  if (!isTodayViewActive()) {
+    panel.hidden = true;
+    panel.innerHTML = "";
+    return;
+  }
+
+  panel.hidden = false;
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+
+  let bodyHtml;
+  if (planState.loading) {
+    bodyHtml = `<p class="day-plan-agent__loading">Planning your day…</p>`;
+  } else if (planState.error) {
+    bodyHtml = `<p class="day-plan-agent__error">${escapeHtml(planState.error)}</p>`;
+  } else if (planState.tasks.length > 0) {
+    const taskRows = planState.tasks
+      .map(
+        (t) => `
+        <div class="day-plan-agent__task">
+          <div class="day-plan-agent__task-title">${escapeHtml(t.title)}</div>
+          ${t.estimatedMinutes ? `<span class="day-plan-agent__task-mins">${t.estimatedMinutes}m</span>` : ""}
+          ${t.reason ? `<div class="day-plan-agent__task-reason">${escapeHtml(t.reason)}</div>` : ""}
+        </div>`,
+      )
+      .join("");
+    const totals =
+      planState.totalMinutes > 0
+        ? `<div class="day-plan-agent__totals">${planState.totalMinutes}m planned · ${planState.remainingMinutes}m remaining</div>`
+        : "";
+    bodyHtml = `${totals}<div class="day-plan-agent__task-list">${taskRows}</div>`;
+  } else {
+    bodyHtml = "";
+  }
+
+  // All dynamic values are passed through escapeHtml before innerHTML assignment.
+  panel.innerHTML = `
+    <div class="day-plan-agent__header">
+      <span class="day-plan-agent__title">Day plan</span>
+      <div class="day-plan-agent__controls">
+        <label class="sr-only" for="dayPlanMinutes">Available minutes</label>
+        <input
+          type="number"
+          id="dayPlanMinutes"
+          class="day-plan-agent__input"
+          min="30" max="1440" step="30"
+          value="${planState.availableMinutes}"
+          aria-label="Available minutes"
+        />
+        <label class="sr-only" for="dayPlanEnergy">Energy level</label>
+        <select id="dayPlanEnergy" class="day-plan-agent__select" aria-label="Energy level">
+          <option value="low" ${planState.energy === "low" ? "selected" : ""}>Low energy</option>
+          <option value="medium" ${planState.energy === "medium" ? "selected" : ""}>Medium energy</option>
+          <option value="high" ${planState.energy === "high" ? "selected" : ""}>High energy</option>
+        </select>
+        <button
+          type="button"
+          class="mini-btn"
+          data-day-plan-action="generate"
+          ${planState.loading ? "disabled" : ""}
+        >
+          ${planState.loading ? "Planning…" : "Plan day"}
+        </button>
+        ${planState.tasks.length > 0 ? `<button type="button" class="mini-btn mini-btn--ghost" data-day-plan-action="clear">Clear</button>` : ""}
+      </div>
+    </div>
+    ${bodyHtml ? `<div class="day-plan-agent__body">${bodyHtml}</div>` : ""}
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+async function generateDayPlan() {
+  planState.loading = true;
+  planState.error = "";
+  planState.tasks = [];
+  renderDayPlanAgentPanel();
+
+  try {
+    const data = await callAgentAction("/agent/read/plan_today", {
+      availableMinutes: planState.availableMinutes,
+      energy: planState.energy,
+    });
+    planState.tasks = Array.isArray(data?.selectedTasks)
+      ? data.selectedTasks.map((t) => ({
+          taskId: t.taskId || t.id || "",
+          title: t.title || "",
+          estimatedMinutes: t.estimatedMinutes || 0,
+          reason: t.reason || "",
+        }))
+      : [];
+    planState.totalMinutes = data?.totalMinutes || 0;
+    planState.remainingMinutes = data?.remainingMinutes || 0;
+    planState.error = "";
+  } catch (err) {
+    planState.error = err.message || "Could not generate day plan.";
+  } finally {
+    planState.loading = false;
+  }
+  renderDayPlanAgentPanel();
+}
+
+function clearDayPlan() {
+  planState.tasks = [];
+  planState.error = "";
+  planState.totalMinutes = 0;
+  planState.remainingMinutes = 0;
+  renderDayPlanAgentPanel();
+}
+
+// ---------------------------------------------------------------------------
+// Event binding (delegated, called once from app.js)
+// ---------------------------------------------------------------------------
+
+export function bindDayPlanAgentHandlers() {
+  document.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const actionEl = target.closest("[data-day-plan-action]");
+    if (!(actionEl instanceof HTMLElement)) return;
+    const action = actionEl.getAttribute("data-day-plan-action");
+    if (action === "generate") {
+      generateDayPlan();
+    } else if (action === "clear") {
+      clearDayPlan();
+    }
+  });
+
+  document.addEventListener("change", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (target.id === "dayPlanEnergy") {
+      planState.energy = target.value || "medium";
+    } else if (target.id === "dayPlanMinutes") {
+      const v = parseInt(target.value, 10);
+      if (!isNaN(v) && v >= 30 && v <= 1440) planState.availableMinutes = v;
+    }
+  });
+}

--- a/client/styles.css
+++ b/client/styles.css
@@ -7388,3 +7388,118 @@ body.is-admin-user .projects-rail__footer--admin-only {
 .inbox-view__error {
   color: var(--danger-color, #dc2626);
 }
+
+/* ── Day Plan Agent panel ───────────────────────────────────────────────── */
+.day-plan-agent-panel {
+  margin-bottom: 12px;
+}
+
+.day-plan-agent__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--surface-bg, var(--input-bg));
+}
+
+.day-plan-agent__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.day-plan-agent__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  flex: 1;
+  justify-content: flex-end;
+}
+
+.day-plan-agent__input {
+  width: 72px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+}
+
+.day-plan-agent__select {
+  padding: 4px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+}
+
+.day-plan-agent__body {
+  border: 1px solid var(--border-color);
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  padding: 10px 12px;
+  background: var(--surface-bg, var(--input-bg));
+}
+
+.day-plan-agent__loading,
+.day-plan-agent__error {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.day-plan-agent__error {
+  color: var(--danger-color, #dc2626);
+}
+
+.day-plan-agent__totals {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+}
+
+.day-plan-agent__task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.day-plan-agent__task {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px 8px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.day-plan-agent__task:last-child {
+  border-bottom: none;
+}
+
+.day-plan-agent__task-title {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  grid-column: 1;
+}
+
+.day-plan-agent__task-mins {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  grid-column: 2;
+  grid-row: 1;
+  white-space: nowrap;
+}
+
+.day-plan-agent__task-reason {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  grid-column: 1 / -1;
+}


### PR DESCRIPTION
## Summary

- Add `planTodayAgent.js`: renders `#dayPlanAgentPanel` when date view is **today**
- Calls `/agent/read/plan_today` with user-set `availableMinutes` (default 480) and `energy` (low/medium/high)
- Shows recommended tasks with `estimatedMinutes` and `reason` per task
- Totals row: total minutes planned + remaining minutes
- Panel auto-hides when navigating away from Today view
- Wire `hooks.renderDayPlanAgentPanel` in `app.js` + `filterLogic.js`
- Add `#dayPlanAgentPanel` section to `index.html` after the existing today plan panel
- CSS for `.day-plan-agent-panel` and all sub-elements

## Test plan

- [ ] Navigate to Today view → "Day plan" panel appears with energy selector + minutes input
- [ ] Click "Plan day" → loading state → task list with reasons and minute estimates appears
- [ ] Totals row shows total/remaining minutes
- [ ] Change energy to "high", click again → different recommendations
- [ ] Click "Clear" → task list disappears
- [ ] Navigate away from Today → panel hides; navigate back → panel shows (empty, ready to generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)