### PR TITLE
feat(ui): Phase 5 — Weekly Review view with suggest/apply workflow

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -297,6 +297,10 @@ import {
   bindDayPlanAgentHandlers,
 } from "./modules/planTodayAgent.js";
 import {
+  renderWeeklyReviewView,
+  bindWeeklyReviewHandlers,
+} from "./modules/weeklyReviewUi.js";
+import {
   getAiWorkspaceElements,
   getAiWorkspaceStatusLabel,
   updateAiWorkspaceStatusChip,
@@ -1553,6 +1557,7 @@ function bindDeclarativeHandlers() {
   hooks.renderHomeDashboard = renderHomeDashboard;
   hooks.renderInboxView = renderInboxView;
   hooks.loadInboxItems = loadInboxItems;
+  hooks.renderWeeklyReviewView = renderWeeklyReviewView;
   hooks.updateBulkActionsVisibility = updateBulkActionsVisibility;
   hooks.updateAiWorkspaceStatusChip = updateAiWorkspaceStatusChip;
   // projectsState → rail
@@ -1743,6 +1748,7 @@ function init() {
   bindTodoDrawerHandlers();
   bindInboxHandlers();
   bindDayPlanAgentHandlers();
+  bindWeeklyReviewHandlers();
   bindProjectsRailHandlers();
   bindCommandPaletteHandlers();
   bindTaskComposerHandlers();

--- a/client/index.html
+++ b/client/index.html
@@ -597,6 +597,40 @@
                         </button>
                         <button
                           type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="weekly-review"
+                          title="Weekly review"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect
+                              x="3"
+                              y="4"
+                              width="18"
+                              height="18"
+                              rx="2"
+                              ry="2"
+                            />
+                            <line x1="16" y1="2" x2="16" y2="6" />
+                            <line x1="8" y1="2" x2="8" y2="6" />
+                            <line x1="3" y1="10" x2="21" y2="10" />
+                            <path d="m9 16 2 2 4-4" />
+                          </svg>
+                          <span class="nav-label">Review</span>
+                        </button>
+                        <button
+                          type="button"
                           class="projects-rail-item projects-rail-projects-access"
                           id="projectsRailCollapsedProjectsButton"
                           title="Projects"
@@ -965,6 +999,40 @@
                             />
                           </svg>
                           <span class="nav-label">Inbox</span>
+                        </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item workspace-view-item"
+                          data-workspace-view="weekly-review"
+                          title="Weekly review"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect
+                              x="3"
+                              y="4"
+                              width="18"
+                              height="18"
+                              rx="2"
+                              ry="2"
+                            />
+                            <line x1="16" y1="2" x2="16" y2="6" />
+                            <line x1="8" y1="2" x2="8" y2="6" />
+                            <line x1="3" y1="10" x2="21" y2="10" />
+                            <path d="m9 16 2 2 4-4" />
+                          </svg>
+                          <span class="nav-label">Review</span>
                         </button>
                       </nav>
                     </div>

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -158,6 +158,7 @@ function normalizeWorkspaceView(view) {
     "someday",
     "completed",
     "inbox",
+    "weekly-review",
     "project",
     "settings",
     "admin",
@@ -843,6 +844,16 @@ function renderTodos() {
     if (!state.inboxState.hasLoaded && !state.inboxState.loading) {
       hooks.loadInboxItems?.();
     }
+    hooks.syncTodoDrawerStateWithRender?.();
+    hooks.updateBulkActionsVisibility?.();
+    updateIcsExportButtonState();
+    assertNoHorizontalOverflow(scrollRegion);
+    return;
+  }
+
+  if (state.currentWorkspaceView === "weekly-review") {
+    updateHeaderFromVisibleTodos([]);
+    hooks.renderWeeklyReviewView?.();
     hooks.syncTodoDrawerStateWithRender?.();
     hooks.updateBulkActionsVisibility?.();
     updateIcsExportButtonState();

--- a/client/modules/weeklyReviewUi.js
+++ b/client/modules/weeklyReviewUi.js
@@ -1,0 +1,182 @@
+// =============================================================================
+// weeklyReviewUi.js — Weekly Review view: suggest mode → show findings &
+// recommended actions → apply mode with confirmation.
+// Renders into #todosContent when currentWorkspaceView === "weekly-review".
+// All user-provided content is passed through hooks.escapeHtml before
+// being assigned to innerHTML, consistent with the existing codebase pattern.
+// =============================================================================
+
+import { state, hooks } from "./store.js";
+import { applyAsyncAction } from "./stateActions.js";
+import { callAgentAction } from "./agentApiClient.js";
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+function renderFindingRow(f) {
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+  const label = f.type ? f.type.replace(/_/g, " ") : "finding";
+  const subject = f.taskTitle || f.projectName || "";
+  return `
+    <div class="wr-finding">
+      <span class="wr-finding__type">${escapeHtml(label)}</span>
+      ${subject ? `<span class="wr-finding__subject">${escapeHtml(subject)}</span>` : ""}
+      ${f.reason ? `<p class="wr-finding__reason">${escapeHtml(f.reason)}</p>` : ""}
+    </div>`;
+}
+
+function renderActionRow(a) {
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+  const label = a.type ? a.type.replace(/_/g, " ") : "action";
+  return `
+    <div class="wr-action">
+      <span class="wr-action__type">${escapeHtml(label)}</span>
+      ${a.title ? `<span class="wr-action__title">${escapeHtml(a.title)}</span>` : ""}
+      ${a.reason ? `<p class="wr-action__reason">${escapeHtml(a.reason)}</p>` : ""}
+    </div>`;
+}
+
+function renderSummaryBadges(summary) {
+  if (!summary) return "";
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+  const badges = [
+    {
+      label: "projects without next action",
+      value: summary.projectsWithoutNextAction,
+    },
+    { label: "stale tasks", value: summary.staleTasks },
+    { label: "waiting", value: summary.waitingTasks },
+    { label: "upcoming", value: summary.upcomingTasks },
+  ]
+    .filter((b) => b.value !== undefined && b.value !== null)
+    .map(
+      (b) =>
+        `<span class="wr-badge"><strong>${escapeHtml(String(b.value))}</strong> ${escapeHtml(b.label)}</span>`,
+    )
+    .join("");
+  return badges ? `<div class="wr-summary">${badges}</div>` : "";
+}
+
+export function renderWeeklyReviewView() {
+  const container = document.getElementById("todosContent");
+  if (!container) return;
+  if (state.currentWorkspaceView !== "weekly-review") return;
+
+  const s = state.weeklyReviewState;
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+
+  let bodyHtml;
+
+  if (s.loading) {
+    bodyHtml = `<div class="wr-loading" role="status" aria-live="polite">Running weekly review…</div>`;
+  } else if (s.error) {
+    bodyHtml = `
+      <div class="wr-error">${escapeHtml(s.error)}</div>
+      <button type="button" class="wr-btn" data-wr-action="suggest">Retry</button>`;
+  } else if (s.hasRun) {
+    const findingsHtml =
+      s.findings.length > 0
+        ? `<section class="wr-section">
+            <h3 class="wr-section__title">Findings (${s.findings.length})</h3>
+            ${s.findings.map(renderFindingRow).join("")}
+          </section>`
+        : "";
+
+    const actionsHtml =
+      s.actions.length > 0
+        ? `<section class="wr-section">
+            <h3 class="wr-section__title">Recommended actions (${s.actions.length})</h3>
+            ${s.actions.map(renderActionRow).join("")}
+            ${
+              s.mode === "suggest"
+                ? `<div class="wr-apply-row">
+                    <button type="button" class="wr-btn wr-btn--primary" data-wr-action="apply">
+                      Apply all actions
+                    </button>
+                  </div>`
+                : `<p class="wr-applied-msg">Actions applied.</p>`
+            }
+          </section>`
+        : `<p class="wr-empty">No recommended actions this week.</p>`;
+
+    bodyHtml = `${renderSummaryBadges(s.summary)}${findingsHtml}${actionsHtml}`;
+  } else {
+    bodyHtml = `<p class="wr-intro">Run the weekly review to surface stale tasks, projects without a next action, and get recommendations.</p>`;
+  }
+
+  // All dynamic values are passed through escapeHtml before innerHTML assignment.
+  container.innerHTML = `
+    <div class="wr-view">
+      <div class="wr-toolbar">
+        <h2 class="wr-title">Weekly review</h2>
+        <button
+          type="button"
+          class="wr-btn wr-btn--primary"
+          data-wr-action="suggest"
+          ${s.loading ? "disabled" : ""}
+        >
+          ${s.loading ? "Running…" : s.hasRun ? "Re-run" : "Run review"}
+        </button>
+      </div>
+      <div class="wr-body">${bodyHtml}</div>
+    </div>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+async function runWeeklyReview(mode = "suggest") {
+  applyAsyncAction("weeklyReview/start");
+  if (mode === "apply") {
+    applyAsyncAction("weeklyReview/mode:set", { mode: "apply" });
+  }
+  renderWeeklyReviewView();
+
+  try {
+    const data = await callAgentAction("/agent/write/weekly_review", { mode });
+    const review = data?.review || data;
+    applyAsyncAction("weeklyReview/success", {
+      summary: review?.summary || null,
+      findings: Array.isArray(review?.findings) ? review.findings : [],
+      actions: Array.isArray(review?.recommendedActions)
+        ? review.recommendedActions
+        : Array.isArray(review?.appliedActions)
+          ? review.appliedActions
+          : [],
+    });
+    if (mode === "apply") {
+      applyAsyncAction("weeklyReview/mode:set", { mode: "apply" });
+      if (typeof hooks.applyFiltersAndRender === "function") {
+        hooks.applyFiltersAndRender();
+      }
+    }
+  } catch (err) {
+    applyAsyncAction("weeklyReview/failure", {
+      error: err.message || "Could not run weekly review.",
+    });
+  }
+  renderWeeklyReviewView();
+}
+
+// ---------------------------------------------------------------------------
+// Event binding (delegated, called once from app.js)
+// ---------------------------------------------------------------------------
+
+export function bindWeeklyReviewHandlers() {
+  document.addEventListener("click", (event) => {
+    if (state.currentWorkspaceView !== "weekly-review") return;
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const actionEl = target.closest("[data-wr-action]");
+    if (!(actionEl instanceof HTMLElement)) return;
+    const action = actionEl.getAttribute("data-wr-action");
+    if (action === "suggest") {
+      runWeeklyReview("suggest");
+    } else if (action === "apply") {
+      runWeeklyReview("apply");
+    }
+  });
+}

--- a/client/styles.css
+++ b/client/styles.css
@@ -7503,3 +7503,153 @@ body.is-admin-user .projects-rail__footer--admin-only {
   color: var(--text-secondary);
   grid-column: 1 / -1;
 }
+
+/* ── Weekly Review view ─────────────────────────────────────────────────── */
+.wr-view {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.wr-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.wr-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.wr-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.wr-btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.wr-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.wr-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.wr-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+  background: var(--primary-color);
+}
+
+.wr-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.wr-badge {
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  background: var(--input-bg);
+}
+
+.wr-badge strong {
+  color: var(--text-primary);
+}
+
+.wr-section {
+  margin-bottom: 20px;
+}
+
+.wr-section__title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 10px;
+}
+
+.wr-finding,
+.wr-action {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.wr-finding:last-of-type,
+.wr-action:last-of-type {
+  border-bottom: none;
+}
+
+.wr-finding__type,
+.wr-action__type {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  padding-top: 2px;
+}
+
+.wr-finding__subject,
+.wr-action__title {
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.wr-finding__reason,
+.wr-action__reason {
+  grid-column: 1 / -1;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.wr-apply-row {
+  padding-top: 12px;
+}
+
+.wr-applied-msg,
+.wr-empty,
+.wr-intro {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.wr-loading {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  padding: 24px 0;
+  text-align: center;
+}
+
+.wr-error {
+  font-size: 0.875rem;
+  color: var(--danger-color, #dc2626);
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary

- Add `weeklyReviewUi.js`: renders a Weekly Review page when `currentWorkspaceView === "weekly-review"`
- **Suggest mode**: calls `/agent/write/weekly_review` with `mode=suggest` → shows summary badges, findings, and recommended actions
- **Apply mode**: "Apply all actions" button re-runs with `mode=apply` → refreshes the todos list
- Summary badges: projects without next action, stale tasks, waiting tasks, upcoming tasks
- Each finding/action shows type label + subject title + reason text
- "Re-run" button to refresh the review
- "Review" nav item added to both rail nav sections in `index.html`
- `weekly-review` registered as a valid workspace view in `normalizeWorkspaceView`
- `hooks.renderWeeklyReviewView` wired in `app.js` + `filterLogic.js`
- CSS for `.wr-view`, `.wr-toolbar`, `.wr-badge`, `.wr-finding`, `.wr-action`

## Test plan

- [ ] Click "Review" in sidebar → view renders with "Run review" button
- [ ] Click "Run review" → loading state → findings + recommendations appear
- [ ] Summary badges show counts from API response
- [ ] Click "Apply all actions" → re-runs with apply mode, actions section changes to "Applied"
- [ ] After apply, todos reload (stale task updates visible in All view)
- [ ] "Re-run" button runs suggest again

🤖 Generated with [Claude Code](https://claude.com/claude-code)