### PR TITLE
feat(api): add onboarding progress fields and endpoints to users

### DIFF
--- a/prisma/migrations/20260318000000_add_onboarding_fields/migration.sql
+++ b/prisma/migrations/20260318000000_add_onboarding_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "onboarding_step" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "users" ADD COLUMN "onboarding_completed_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,8 @@ model User {
   resetTokenExpiry  DateTime?      @map("reset_token_expiry")
   role              UserRole       @default(user)
   plan              UserPlan       @default(free)
+  onboardingStep        Int       @default(0) @map("onboarding_step")
+  onboardingCompletedAt DateTime? @map("onboarding_completed_at")
   mcpRevokedAfter   DateTime?      @map("mcp_revoked_after")
   createdAt         DateTime       @default(now()) @map("created_at")
   updatedAt         DateTime       @updatedAt @map("updated_at")

--- a/src/routes/usersRouter.ts
+++ b/src/routes/usersRouter.ts
@@ -82,5 +82,54 @@ export function createUsersRouter({ authService }: UsersRouterDeps): Router {
     }
   });
 
+  // PATCH /users/me/onboarding/step — save mid-flow progress
+  router.patch(
+    "/me/onboarding/step",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!authService)
+        return res.status(501).json({ error: "Auth not configured" });
+      try {
+        const userId = req.user?.userId;
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+        const step = Number(req.body?.step);
+        if (!Number.isInteger(step) || step < 0 || step > 10) {
+          return res
+            .status(400)
+            .json({ error: "step must be an integer 0-10" });
+        }
+
+        await authService.updateOnboarding(userId, { step });
+        return res.json({ ok: true, step });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // POST /users/me/onboarding/complete — mark onboarding done, return updated user
+  router.post(
+    "/me/onboarding/complete",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!authService)
+        return res.status(501).json({ error: "Auth not configured" });
+      try {
+        const userId = req.user?.userId;
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+        await authService.updateOnboarding(userId, {
+          step: 4,
+          completedAt: new Date(),
+        });
+
+        const user = await authService.getUserById(userId);
+        if (!user) return res.status(404).json({ error: "User not found" });
+        return res.json(user);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
   return router;
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -441,6 +441,8 @@ export class AuthService {
         isVerified: true,
         role: true,
         plan: true,
+        onboardingStep: true,
+        onboardingCompletedAt: true,
         createdAt: true,
         updatedAt: true,
       },
@@ -530,6 +532,18 @@ export class AuthService {
     }
 
     return updatedUser;
+  }
+
+  async updateOnboarding(
+    userId: string,
+    patch: { step?: number; completedAt?: Date | null },
+  ): Promise<void> {
+    const data: Record<string, unknown> = {};
+    if (patch.step !== undefined) data["onboardingStep"] = patch.step;
+    if ("completedAt" in patch)
+      data["onboardingCompletedAt"] = patch.completedAt;
+    if (Object.keys(data).length === 0) return;
+    await this.prisma.user.update({ where: { id: userId }, data });
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds two fields to the `User` model and three new endpoints to support a first-time user onboarding flow (Task A of two sequential tasks — frontend in follow-up PR).

## Schema changes

```prisma
onboardingStep        Int       @default(0) @map("onboarding_step")
onboardingCompletedAt DateTime? @map("onboarding_completed_at")
```

## New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `PATCH` | `/users/me/onboarding/step` | Save mid-flow step progress (0–10); returns `{ ok, step }` |
| `POST` | `/users/me/onboarding/complete` | Set step=4 + completedAt=now; returns full updated user |

`GET /users/me` response now also includes `onboardingStep` and `onboardingCompletedAt`.

## Test plan

- [ ] `npx tsc --noEmit` — ✅ clean
- [ ] `npm run format:check` — ✅ clean
- [ ] `npm run test:unit` — ✅ 296 passed
- [ ] Manual: `GET /users/me` includes `onboardingStep: 0, onboardingCompletedAt: null` for new user
- [ ] Manual: `PATCH /users/me/onboarding/step` with `{ step: 2 }` → `{ ok: true, step: 2 }`
- [ ] Manual: `PATCH /users/me/onboarding/step` with `{ step: -1 }` → 400
- [ ] Manual: `POST /users/me/onboarding/complete` → user object with `onboardingCompletedAt` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)