### PR TITLE
feat(ai): prewarm home priorities snapshot

### DIFF
--- a/agent-runner/jobs/prewarm.py
+++ b/agent-runner/jobs/prewarm.py
@@ -1,0 +1,106 @@
+"""
+Home focus prewarm job — prepares a recent Home AI snapshot before the user opens the app.
+
+Called from main.py once per enrolled user. Runs daily using the user's local date.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import pytz
+
+from mcp_client import AgentApiError, AgentClient
+
+logger = logging.getLogger(__name__)
+
+JOB_NAME = "home_focus_prewarm"
+DEFAULT_FRESHNESS_HOURS = 18
+
+
+def run_prewarm_for_user(
+    client: AgentClient,
+    user_id: str,
+    timezone: str,
+    *args: Any,
+    **kwargs: Any,
+) -> str:
+    """
+    Generate or reuse a fresh home_focus snapshot for a single user.
+    Returns outcome: 'success' | 'error'
+    """
+    tz = pytz.timezone(timezone)
+    now = datetime.now(tz)
+    period_key = now.strftime("%Y-%m-%d")
+
+    logger.info(
+        "prewarm user=%s period=%s tz=%s", user_id[:8], period_key, timezone
+    )
+
+    try:
+        claim_resp = client.write(
+            "claim_job_run",
+            {"jobName": JOB_NAME, "periodKey": period_key},
+        )
+        claimed = bool(claim_resp.get("data", {}).get("claimed"))
+        if not claimed:
+            logger.info(
+                "prewarm already claimed/completed user=%s period=%s",
+                user_id[:8],
+                period_key,
+            )
+            return "success"
+
+        prewarm_resp = client.write(
+            "prewarm_home_focus",
+            {
+                "topN": 3,
+                "freshnessHours": DEFAULT_FRESHNESS_HOURS,
+                "timezone": timezone,
+                "periodKey": period_key,
+            },
+        )
+        prewarm = prewarm_resp.get("data", {}).get("prewarm", {})
+        logger.info(
+            "prewarm user=%s status=%s suggestionId=%s count=%s ageHours=%s",
+            user_id[:8],
+            prewarm.get("status"),
+            prewarm.get("suggestionId"),
+            prewarm.get("suggestionCount"),
+            prewarm.get("ageHours"),
+        )
+
+        client.write(
+            "complete_job_run",
+            {
+                "jobName": JOB_NAME,
+                "periodKey": period_key,
+                "metadata": {
+                    "status": prewarm.get("status"),
+                    "suggestionId": prewarm.get("suggestionId"),
+                    "createdAt": prewarm.get("createdAt"),
+                    "freshUntil": prewarm.get("freshUntil"),
+                    "ageHours": prewarm.get("ageHours"),
+                    "suggestionCount": prewarm.get("suggestionCount"),
+                    "mustAbstain": prewarm.get("mustAbstain"),
+                    "timezone": timezone,
+                },
+            },
+        )
+        return "success"
+
+    except Exception as exc:
+        logger.exception("prewarm failed user=%s: %s", user_id[:8], exc)
+        try:
+            client.write(
+                "fail_job_run",
+                {
+                    "jobName": JOB_NAME,
+                    "periodKey": period_key,
+                    "errorMessage": str(exc)[:500],
+                },
+            )
+        except AgentApiError:
+            pass
+        return "error"

--- a/agent-runner/main.py
+++ b/agent-runner/main.py
@@ -8,6 +8,7 @@ Usage:
     python main.py inbox       # Inbox triage: classify + apply capture items
     python main.py watchdog    # Aging watchdog: stale tasks + waiting follow-ups
     python main.py decomposer  # Project decomposer: stuck projects + next actions
+    python main.py prewarm     # Home AI prewarm: generate/reuse Home focus snapshot
 
 For each enrolled user the runner:
   1. Reads their enrollment row (refresh token + settings) from Postgres.
@@ -40,7 +41,7 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-COMMANDS = ("daily", "weekly", "inbox", "watchdog", "decomposer", "evaluator_daily", "evaluator_weekly")
+COMMANDS = ("daily", "weekly", "inbox", "watchdog", "decomposer", "prewarm", "evaluator_daily", "evaluator_weekly")
 USAGE = f"Usage: python main.py <{'|'.join(COMMANDS)}>"
 
 
@@ -92,6 +93,9 @@ def main() -> None:
     elif command == "decomposer":
         from jobs.decomposer import run_decomposer_for_user as run_for_user
         eligible = [e for e in enrollments if e.weekly_enabled]  # same gate as weekly
+    elif command == "prewarm":
+        from jobs.prewarm import run_prewarm_for_user as run_for_user
+        eligible = [e for e in enrollments if e.daily_enabled]
     elif command == "evaluator_daily":
         from jobs.evaluator_daily import run_evaluator_daily_for_user as run_for_user
         eligible = [e for e in enrollments if e.daily_enabled]

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -2200,6 +2200,72 @@
       "audience": "user"
     },
     {
+      "name": "prewarm_home_focus",
+      "description": "Generate or reuse a fresh Home AI focus snapshot so Home can render a recent suggestion set before the user opens the app.",
+      "readOnly": false,
+      "method": "POST",
+      "path": "/agent/write/prewarm_home_focus",
+      "availability": {
+        "requires": []
+      },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "topN": {
+            "type": "integer",
+            "enum": [3, 5]
+          },
+          "freshnessHours": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 48
+          },
+          "force": {
+            "type": "boolean"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "periodKey": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "dataKey": "prewarm",
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["generated", "reused"]
+          },
+          "suggestionId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "freshUntil": {
+            "type": "string"
+          },
+          "ageHours": {
+            "type": "number"
+          },
+          "suggestionCount": {
+            "type": "integer"
+          },
+          "mustAbstain": {
+            "type": "boolean"
+          }
+        }
+      },
+      "namespace": "automation",
+      "category": "Automation",
+      "lifecycle": "mutating",
+      "audience": "automation"
+    },
+    {
       "name": "decide_next_work",
       "description": "Rank the best next tasks for the current user based on urgency, effort, energy, and dependencies.",
       "readOnly": true,

--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -24,6 +24,8 @@ import { ActionPolicyService } from "../services/actionPolicyService";
 import { AgentService } from "../services/agentService";
 import { PrismaClient } from "@prisma/client";
 import { DryRunResult } from "../types";
+import { AiPlannerService } from "../services/aiService";
+import type { IAiSuggestionStore } from "../services/aiSuggestionStore";
 import { analyzeTaskQuality } from "../ai/taskQualityAnalyzer";
 import { findDuplicates } from "../ai/duplicateDetector";
 import {
@@ -106,8 +108,10 @@ import {
   validateAgentListFrictionPatternsInput,
   validateAgentGetActionPoliciesInput,
   validateAgentUpdateActionPolicyInput,
+  validateAgentPrewarmHomeFocusInput,
 } from "../validation/agentValidation";
 import { CaptureService } from "../services/captureService";
+import { HomeFocusPrewarmService } from "../services/homeFocusPrewarmService";
 
 export type AgentActionName =
   | "list_tasks"
@@ -186,12 +190,15 @@ export type AgentActionName =
   | "apply_learning_recommendation"
   | "list_friction_patterns"
   | "get_action_policies"
-  | "update_action_policy";
+  | "update_action_policy"
+  | "prewarm_home_focus";
 
 interface AgentExecutorDeps {
   todoService: ITodoService;
   projectService?: IProjectService;
   persistencePrisma?: PrismaClient;
+  aiPlannerService?: AiPlannerService;
+  suggestionStore?: IAiSuggestionStore;
 }
 
 export interface AgentExecutionContext {
@@ -565,6 +572,7 @@ export class AgentExecutor {
   private readonly evaluationService: EvaluationService;
   private readonly frictionService: FrictionService;
   private readonly actionPolicyService: ActionPolicyService;
+  private readonly homeFocusPrewarmService: HomeFocusPrewarmService | null;
 
   constructor(private readonly deps: AgentExecutorDeps) {
     this.idempotencyService = new AgentIdempotencyService(
@@ -593,6 +601,13 @@ export class AgentExecutor {
     );
     this.frictionService = new FrictionService(deps.persistencePrisma);
     this.actionPolicyService = new ActionPolicyService(deps.persistencePrisma);
+    this.homeFocusPrewarmService =
+      deps.aiPlannerService && deps.suggestionStore
+        ? new HomeFocusPrewarmService(
+            deps.aiPlannerService,
+            deps.suggestionStore,
+          )
+        : null;
     this.agentService = new AgentService({
       todoService: deps.todoService,
       projectService: deps.projectService,
@@ -675,9 +690,12 @@ export class AgentExecutor {
       },
       actions: agentManifest.actions.map((action) => ({
         ...action,
+        availability: action.availability,
         enabled:
-          !action.availability?.requires?.includes("project_service") ||
-          this.hasProjectService(),
+          !(
+            (action.availability?.requires as readonly string[] | undefined) ||
+            []
+          ).includes("project_service") || this.hasProjectService(),
       })),
     };
   }
@@ -2264,6 +2282,54 @@ export class AgentExecutor {
             },
             201,
           );
+        }
+
+        case "prewarm_home_focus": {
+          if (!this.homeFocusPrewarmService) {
+            throw new AgentExecutionError(
+              501,
+              "NOT_CONFIGURED",
+              "Home focus prewarm not configured",
+              false,
+              "Provide AI planner and suggestion store dependencies before calling this action.",
+            );
+          }
+          const prewarmInput = validateAgentPrewarmHomeFocusInput(input);
+          const periodKey =
+            prewarmInput.periodKey ?? new Date().toISOString().slice(0, 10);
+          const prewarm = await this.homeFocusPrewarmService.prewarmForUser(
+            context.userId,
+            prewarmInput,
+          );
+          await this.metricsService.record(context.userId, {
+            jobName: "home_focus_prewarm",
+            periodKey,
+            metricType:
+              prewarm.status === "generated"
+                ? "automation.home_focus.generated"
+                : "automation.home_focus.reused",
+            value: 1,
+            metadata: {
+              suggestionId: prewarm.suggestionId,
+              createdAt: prewarm.createdAt,
+              freshUntil: prewarm.freshUntil,
+              ageHours: prewarm.ageHours,
+              suggestionCount: prewarm.suggestionCount,
+              mustAbstain: prewarm.mustAbstain,
+              timezone: prewarmInput.timezone ?? null,
+            },
+          });
+          await this.metricsService.record(context.userId, {
+            jobName: "home_focus_prewarm",
+            periodKey,
+            metricType: "automation.home_focus.snapshot_age_hours",
+            value: prewarm.ageHours,
+            metadata: {
+              suggestionId: prewarm.suggestionId,
+              status: prewarm.status,
+            },
+          });
+          return this.success(action, readOnly, context, 200, { prewarm });
         }
 
         // ── Issue #314: job-run locking ────────────────────────────────────────

--- a/src/ai.api.integration.test.ts
+++ b/src/ai.api.integration.test.ts
@@ -258,6 +258,89 @@ describe("AI API Integration", () => {
     );
   });
 
+  it("prewarms home_focus and serves the stored snapshot from latest", async () => {
+    await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        title: "Finalize travel dates",
+        priority: "high",
+        dueDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .expect(201);
+    await request(app)
+      .post("/todos")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        title: "Book ferry tickets",
+        priority: "medium",
+        dueDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+      })
+      .expect(201);
+
+    const prewarm = await request(app)
+      .post("/agent/write/prewarm_home_focus")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        topN: 3,
+        freshnessHours: 18,
+        timezone: "America/New_York",
+        periodKey: "2026-03-19",
+      })
+      .expect(200);
+
+    expect(prewarm.body.data.prewarm.status).toBe("generated");
+    expect(prewarm.body.data.prewarm.suggestionId).toBeDefined();
+
+    const latest = await request(app)
+      .get("/ai/suggestions/latest?surface=home_focus")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(latest.body.aiSuggestionId).toBe(
+      prewarm.body.data.prewarm.suggestionId,
+    );
+    expect(latest.body.outputEnvelope.surface).toBe("home_focus");
+    expect(Array.isArray(latest.body.outputEnvelope.suggestions)).toBe(true);
+    expect(latest.body.outputEnvelope.suggestions.length).toBeGreaterThan(0);
+
+    const brief = await request(app)
+      .get("/ai/priorities-brief")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(brief.body.prewarmed).toBe(true);
+    expect(String(brief.body.html || "")).toContain("Next priorities");
+
+    const reused = await request(app)
+      .post("/agent/write/prewarm_home_focus")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        topN: 3,
+        freshnessHours: 18,
+        timezone: "America/New_York",
+        periodKey: "2026-03-19",
+      })
+      .expect(200);
+
+    expect(reused.body.data.prewarm.status).toBe("reused");
+    expect(reused.body.data.prewarm.suggestionId).toBe(
+      prewarm.body.data.prewarm.suggestionId,
+    );
+
+    const suggestions = await request(app)
+      .get("/ai/suggestions")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(
+      suggestions.body.filter(
+        (record: { input?: { surface?: string } }) =>
+          record.input?.surface === "home_focus",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("throttles decision-assist generation after repeated rejects", async () => {
     const todoId = await createTaskDrawerTodo("reject burst throttle");
     for (let i = 0; i < 3; i += 1) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,11 @@ import { createAiRouter } from "./routes/aiRouter";
 import { createPrioritiesBriefRouter } from "./routes/prioritiesBriefRouter";
 import { createAgentRouter } from "./routes/agentRouter";
 import { createMcpRouter } from "./routes/mcpRouter";
-import { IAiSuggestionStore } from "./services/aiSuggestionStore";
+import {
+  IAiSuggestionStore,
+  InMemoryAiSuggestionStore,
+  PrismaAiSuggestionStore,
+} from "./services/aiSuggestionStore";
 import { AiPlannerService } from "./services/aiService";
 import { UserPlan } from "./routes/aiRouter";
 import { createProjectsRouter } from "./routes/projectsRouter";
@@ -57,10 +61,23 @@ export function createApp(
     authService instanceof AuthService
       ? authService.getPrismaClient()
       : undefined;
+  const runtimeAiSuggestionStore =
+    aiSuggestionStore ||
+    (persistencePrisma
+      ? new PrismaAiSuggestionStore(persistencePrisma)
+      : new InMemoryAiSuggestionStore());
+  const runtimeAiPlannerService =
+    aiPlannerService ||
+    new AiPlannerService({
+      todoService,
+      projectService,
+    });
   const agentExecutor = new AgentExecutor({
     todoService,
     projectService,
     persistencePrisma,
+    aiPlannerService: runtimeAiPlannerService,
+    suggestionStore: runtimeAiSuggestionStore,
   });
   const mcpOAuthService = new McpOAuthService(persistencePrisma);
   const mcpClientService = new McpClientService();
@@ -248,8 +265,8 @@ export function createApp(
     createAiRouter({
       todoService,
       resolveAiUserId,
-      suggestionStore: aiSuggestionStore,
-      aiPlannerService,
+      suggestionStore: runtimeAiSuggestionStore,
+      aiPlannerService: runtimeAiPlannerService,
       aiDailySuggestionLimit,
       aiDailySuggestionLimitByPlan,
       resolveAiUserPlan,
@@ -263,6 +280,7 @@ export function createApp(
       todoService,
       projectService,
       resolveUserId: resolveAiUserId,
+      suggestionStore: runtimeAiSuggestionStore,
     }),
   );
   app.use(

--- a/src/homeFocusPrewarmService.test.ts
+++ b/src/homeFocusPrewarmService.test.ts
@@ -1,0 +1,67 @@
+import { InMemoryAiSuggestionStore } from "./services/aiSuggestionStore";
+import { HomeFocusPrewarmService } from "./services/homeFocusPrewarmService";
+import { AiPlannerService } from "./services/aiService";
+
+function buildHomeFocusOutput() {
+  return {
+    requestId: "req-home-focus",
+    surface: "home_focus" as const,
+    must_abstain: false,
+    suggestions: [
+      {
+        type: "focus_task" as const,
+        confidence: 0.91,
+        rationale:
+          "This is overdue and should be resolved before more work slips.",
+        suggestionId: "home-focus-1",
+        payload: {
+          taskId: "todo-1",
+          todoId: "todo-1",
+          title: "Finalize travel dates",
+          summary:
+            "This is overdue and should be resolved before more work slips.",
+          reason:
+            "This is overdue and should be resolved before more work slips.",
+          source: "deterministic",
+        },
+      },
+    ],
+  };
+}
+
+describe("HomeFocusPrewarmService", () => {
+  it("generates a snapshot once and reuses it while it is still fresh", async () => {
+    const suggestionStore = new InMemoryAiSuggestionStore();
+    const aiPlannerService = {
+      generateDecisionAssistStub: jest
+        .fn()
+        .mockResolvedValue(buildHomeFocusOutput()),
+    } as unknown as AiPlannerService;
+
+    const service = new HomeFocusPrewarmService(
+      aiPlannerService,
+      suggestionStore,
+    );
+
+    const first = await service.prewarmForUser("user-1", {
+      topN: 3,
+      freshnessHours: 18,
+      periodKey: "2026-03-19",
+      timezone: "America/New_York",
+    });
+    const second = await service.prewarmForUser("user-1", {
+      topN: 3,
+      freshnessHours: 18,
+      periodKey: "2026-03-19",
+      timezone: "America/New_York",
+    });
+
+    expect(first.status).toBe("generated");
+    expect(first.suggestionCount).toBe(1);
+    expect(second.status).toBe("reused");
+    expect(second.suggestionId).toBe(first.suggestionId);
+    expect(
+      (aiPlannerService.generateDecisionAssistStub as jest.Mock).mock.calls,
+    ).toHaveLength(1);
+  });
+});

--- a/src/mcp/mcpToolCatalog.ts
+++ b/src/mcp/mcpToolCatalog.ts
@@ -125,6 +125,7 @@ function minimumRequiredScopesForAction(
     case "list_waiting_on":
     case "list_upcoming":
     case "list_stale_tasks":
+    case "prewarm_home_focus":
       return [TASK_READ_SCOPE];
     case "create_task":
     case "update_task":
@@ -280,7 +281,9 @@ function buildCatalog(): ToolCatalogEntry[] {
         ? "suggest"
         : undefined,
       requiresProjectService: Boolean(
-        action.availability?.requires?.includes("project_service"),
+        (
+          (action.availability?.requires as readonly string[] | undefined) || []
+        ).includes("project_service"),
       ),
     };
   });

--- a/src/prioritiesBriefRouter.test.ts
+++ b/src/prioritiesBriefRouter.test.ts
@@ -1,0 +1,68 @@
+import express from "express";
+import request from "supertest";
+import { InMemoryAiSuggestionStore } from "./services/aiSuggestionStore";
+import { createPrioritiesBriefRouter } from "./routes/prioritiesBriefRouter";
+
+function buildHomeFocusOutput() {
+  return {
+    requestId: "req-home-focus",
+    surface: "home_focus" as const,
+    must_abstain: false,
+    suggestions: [
+      {
+        type: "focus_task" as const,
+        confidence: 0.91,
+        rationale:
+          "This is overdue and should be resolved before more work slips.",
+        suggestionId: "home-focus-1",
+        payload: {
+          taskId: "todo-1",
+          todoId: "todo-1",
+          title: "Finalize travel dates",
+          summary:
+            "This is overdue and should be resolved before more work slips.",
+          reason:
+            "This is overdue and should be resolved before more work slips.",
+          source: "deterministic",
+        },
+      },
+    ],
+  };
+}
+
+describe("prioritiesBriefRouter", () => {
+  it("uses a recent prewarmed home_focus snapshot before calling the LLM route", async () => {
+    const suggestionStore = new InMemoryAiSuggestionStore();
+    const suggestion = await suggestionStore.create({
+      userId: "user-1",
+      type: "task_critic",
+      input: {
+        surface: "home_focus",
+        source: "automation_prewarm",
+      },
+      output: buildHomeFocusOutput() as unknown as Record<string, unknown>,
+    });
+
+    const app = express();
+    app.use(
+      createPrioritiesBriefRouter({
+        todoService: {
+          findAll: jest.fn().mockResolvedValue([]),
+        } as any,
+        projectService: {
+          findAll: jest.fn().mockResolvedValue([]),
+        } as any,
+        suggestionStore,
+        resolveUserId: () => "user-1",
+      }),
+    );
+
+    const response = await request(app).get("/priorities-brief").expect(200);
+
+    expect(response.body.prewarmed).toBe(true);
+    expect(response.body.cached).toBe(true);
+    expect(response.body.generatedAt).toBe(suggestion.createdAt.toISOString());
+    expect(String(response.body.html || "")).toContain("Next priorities");
+    expect(String(response.body.html || "")).toContain("Finalize travel dates");
+  });
+});

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -199,6 +199,10 @@ export function createAgentRouter({
     "/write/weekly_review",
     createAgentActionHandler(agentExecutor, "weekly_review"),
   );
+  router.post(
+    "/write/prewarm_home_focus",
+    createAgentActionHandler(agentExecutor, "prewarm_home_focus"),
+  );
 
   // Anti-entropy
   router.post(

--- a/src/routes/prioritiesBriefRouter.ts
+++ b/src/routes/prioritiesBriefRouter.ts
@@ -8,11 +8,17 @@ import { Router, Request, Response } from "express";
 import { callLlm, LlmProviderNotConfiguredError } from "../services/llmService";
 import { ITodoService } from "../interfaces/ITodoService";
 import { IProjectService } from "../interfaces/IProjectService";
+import type { IAiSuggestionStore } from "../services/aiSuggestionStore";
+import {
+  findLatestPendingHomeFocusSuggestion,
+  normalizeHomeFocusEnvelope,
+} from "../services/aiNormalizationService";
 
 interface PrioritiesBriefRouterDeps {
   todoService: ITodoService;
   projectService?: IProjectService;
   resolveUserId: (req: Request, res: Response) => string | null;
+  suggestionStore?: IAiSuggestionStore;
 }
 
 interface CacheEntry {
@@ -23,11 +29,62 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+const HOME_FOCUS_FALLBACK_FRESHNESS_MS = 18 * 60 * 60 * 1000;
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderHomeFocusFallbackHtml(output: Record<string, unknown>): string {
+  const envelope = normalizeHomeFocusEnvelope(output);
+  const suggestions = envelope.suggestions
+    .slice(0, 3)
+    .map((item) => ({
+      title: String((item as { title?: unknown }).title || "").trim(),
+      summary: String((item as { summary?: unknown }).summary || "").trim(),
+    }))
+    .filter((item) => item.title && item.summary);
+  if (!suggestions.length) {
+    return `
+      <div class="lbl">Next priorities</div>
+      <div class="card">
+        <div class="row">
+          <span class="rn">&#8594;</span>
+          <div>
+            <div class="rt">No priorities yet</div>
+            <div class="rb">Add or schedule tasks to generate a Home focus snapshot.</div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  return [
+    `<div class="lbl">Next priorities</div>`,
+    ...suggestions.map(
+      (item) => `
+        <div class="card">
+          <div class="row">
+            <span class="rn">&#8594;</span>
+            <div>
+              <div class="rt">${escapeHtml(item.title)}</div>
+              <div class="rb">${escapeHtml(item.summary)}</div>
+            </div>
+          </div>
+        </div>`,
+    ),
+  ].join("");
+}
 
 export function createPrioritiesBriefRouter({
   todoService,
   projectService,
   resolveUserId,
+  suggestionStore,
 }: PrioritiesBriefRouterDeps): Router {
   const router = Router();
 
@@ -44,6 +101,39 @@ export function createPrioritiesBriefRouter({
           generatedAt: cached.generatedAt,
           cached: true,
         });
+      }
+
+      if (suggestionStore) {
+        const latestHomeFocus = await findLatestPendingHomeFocusSuggestion(
+          suggestionStore,
+          userId,
+        );
+        if (
+          latestHomeFocus &&
+          Date.now() - latestHomeFocus.createdAt.getTime() <=
+            HOME_FOCUS_FALLBACK_FRESHNESS_MS
+        ) {
+          try {
+            const html = renderHomeFocusFallbackHtml(latestHomeFocus.output);
+            const generatedAt = latestHomeFocus.createdAt.toISOString();
+            cache.set(userId, {
+              html,
+              generatedAt,
+              expiresAt: Date.now() + CACHE_TTL_MS,
+            });
+            return res.json({
+              html,
+              generatedAt,
+              cached: true,
+              prewarmed: true,
+            });
+          } catch (error) {
+            console.warn(
+              "priorities-brief home_focus fallback normalization failed:",
+              error,
+            );
+          }
+        }
       }
 
       // Fetch tasks and projects in parallel; tolerate individual failures

--- a/src/services/homeFocusPrewarmService.ts
+++ b/src/services/homeFocusPrewarmService.ts
@@ -1,0 +1,121 @@
+import { AiPlannerService } from "./aiService";
+import type { IAiSuggestionStore } from "./aiSuggestionStore";
+import {
+  findLatestPendingHomeFocusSuggestion,
+  normalizeHomeFocusEnvelope,
+} from "./aiNormalizationService";
+
+export const DEFAULT_HOME_FOCUS_PREWARM_TOP_N = 3;
+export const DEFAULT_HOME_FOCUS_PREWARM_FRESHNESS_HOURS = 18;
+
+export interface HomeFocusPrewarmInput {
+  topN?: 3 | 5;
+  freshnessHours?: number;
+  force?: boolean;
+  timezone?: string;
+  periodKey?: string;
+}
+
+export interface HomeFocusPrewarmResult {
+  status: "generated" | "reused";
+  suggestionId: string;
+  createdAt: string;
+  freshUntil: string;
+  ageHours: number;
+  suggestionCount: number;
+  mustAbstain: boolean;
+}
+
+export class HomeFocusPrewarmService {
+  constructor(
+    private readonly aiPlannerService: AiPlannerService,
+    private readonly suggestionStore: IAiSuggestionStore,
+  ) {}
+
+  async prewarmForUser(
+    userId: string,
+    input: HomeFocusPrewarmInput = {},
+  ): Promise<HomeFocusPrewarmResult> {
+    const topN = input.topN ?? DEFAULT_HOME_FOCUS_PREWARM_TOP_N;
+    const freshnessHours =
+      input.freshnessHours ?? DEFAULT_HOME_FOCUS_PREWARM_FRESHNESS_HOURS;
+    const now = new Date();
+    const latest = await findLatestPendingHomeFocusSuggestion(
+      this.suggestionStore,
+      userId,
+    );
+
+    if (!input.force && latest) {
+      const existing = this.tryBuildResult(latest, freshnessHours, now);
+      if (existing && existing.ageHours < freshnessHours) {
+        return { ...existing, status: "reused" };
+      }
+    }
+
+    const output = await this.aiPlannerService.generateDecisionAssistStub(
+      {
+        surface: "home_focus",
+        topN,
+      },
+      { userId },
+    );
+
+    const created = await this.suggestionStore.create({
+      userId,
+      type: "task_critic",
+      input: {
+        surface: "home_focus",
+        topN,
+        source: "automation_prewarm",
+        ...(typeof input.timezone === "string" && input.timezone
+          ? { timezone: input.timezone }
+          : {}),
+        ...(typeof input.periodKey === "string" && input.periodKey
+          ? { periodKey: input.periodKey }
+          : {}),
+      },
+      output: output as unknown as Record<string, unknown>,
+    });
+
+    const result = this.tryBuildResult(created, freshnessHours, now);
+    if (!result) {
+      throw new Error("Failed to normalize generated home focus snapshot");
+    }
+    return { ...result, status: "generated" };
+  }
+
+  private tryBuildResult(
+    record: {
+      id: string;
+      createdAt: Date;
+      output: Record<string, unknown>;
+    },
+    freshnessHours: number,
+    now: Date,
+  ): Omit<HomeFocusPrewarmResult, "status"> | null {
+    try {
+      const envelope = normalizeHomeFocusEnvelope(record.output);
+      const createdAt = record.createdAt.toISOString();
+      const ageHours = this.roundHours(
+        (now.getTime() - record.createdAt.getTime()) / (60 * 60 * 1000),
+      );
+      return {
+        suggestionId: record.id,
+        createdAt,
+        freshUntil: new Date(
+          record.createdAt.getTime() + freshnessHours * 60 * 60 * 1000,
+        ).toISOString(),
+        ageHours,
+        suggestionCount: envelope.suggestions.length,
+        mustAbstain: envelope.must_abstain || envelope.suggestions.length === 0,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private roundHours(value: number): number {
+    if (!Number.isFinite(value)) return 0;
+    return Math.max(0, Math.round(value * 100) / 100);
+  }
+}

--- a/src/services/metricRegistry.ts
+++ b/src/services/metricRegistry.ts
@@ -16,6 +16,9 @@ export const CANONICAL_METRIC_TYPES = [
   "review.action.rejected",
   "automation.followup.created",
   "automation.next_action.created",
+  "automation.home_focus.generated",
+  "automation.home_focus.reused",
+  "automation.home_focus.snapshot_age_hours",
 
   // ── Outcome events ─────────────────────────────────────────────────────────
   "task.completed_after_recommendation",

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -2143,11 +2143,55 @@ export function validateAgentListFrictionPatternsInput(data: unknown): {
 // ── Issue #339: action policies ───────────────────────────────────────────────
 
 const UPDATE_ACTION_POLICY_KEYS = ["actionName", "autoApply", "minConfidence"];
+const PREWARM_HOME_FOCUS_KEYS = [
+  "topN",
+  "freshnessHours",
+  "force",
+  "timezone",
+  "periodKey",
+];
 
 export function validateAgentGetActionPoliciesInput(
   _data: unknown,
 ): Record<string, never> {
   return {};
+}
+
+export function validateAgentPrewarmHomeFocusInput(data: unknown): {
+  topN?: 3 | 5;
+  freshnessHours?: number;
+  force?: boolean;
+  timezone?: string;
+  periodKey?: string;
+} {
+  const body = ensureObject(data, "Agent action input");
+  rejectUnknownKeys(body, PREWARM_HOME_FOCUS_KEYS, "Agent action input");
+
+  let topN: 3 | 5 | undefined;
+  if (body.topN !== undefined) {
+    const parsedTopN = Number(body.topN);
+    if (parsedTopN !== 3 && parsedTopN !== 5) {
+      throw new ValidationError("topN must be 3 or 5");
+    }
+    topN = parsedTopN;
+  }
+
+  let freshnessHours: number | undefined;
+  if (body.freshnessHours !== undefined) {
+    const parsedHours = Number(body.freshnessHours);
+    if (!Number.isFinite(parsedHours) || parsedHours <= 0 || parsedHours > 48) {
+      throw new ValidationError("freshnessHours must be between 1 and 48");
+    }
+    freshnessHours = Math.round(parsedHours);
+  }
+
+  return {
+    topN,
+    freshnessHours,
+    force: parseOptionalBoolean(body.force, "force"),
+    timezone: parseOptionalString(body.timezone, "timezone", 50),
+    periodKey: parseOptionalString(body.periodKey, "periodKey", 20),
+  };
 }
 
 export function validateAgentUpdateActionPolicyInput(data: unknown): {


### PR DESCRIPTION
## Summary
- add a dedicated prewarm_home_focus automation action and runner job
- persist/reuse fresh home_focus snapshots and expose job-run metrics
- let priorities-brief fall back to a recent prewarmed snapshot so Home can render immediately

Closes #375