### PR TITLE
[codex] keep home priorities visible while refreshing

### DIFF
--- a/client/modules/homePrioritiesTile.js
+++ b/client/modules/homePrioritiesTile.js
@@ -4,25 +4,193 @@
 // Shell renders immediately on home load; content swaps in asynchronously.
 // =============================================================================
 
+import { STORAGE_KEYS } from "../utils/storageKeys.js";
 import { hooks } from "./store.js";
 
 const TILE_BODY_ID = "homePrioritiesTileBody";
+const STALE_REFRESH_RETRY_MS = 1500;
+const MAX_STALE_REFRESH_POLLS = 3;
 
 // Session-scoped state — not in shared store
-let _status = "idle"; // idle | loading | loaded | error
+let _status = "idle"; // idle | loading | refreshing | loaded | error
 let _html = "";
 let _generatedAt = null;
+let _expiresAt = null;
+let _isStale = false;
+let _refreshInFlight = false;
 let _error = "";
+let _cacheHydrated = false;
+let _loadToken = 0;
+let _staleRefreshTimer = null;
+let _staleRefreshPolls = 0;
+
+function _readCachedBrief() {
+  try {
+    const raw = window.localStorage.getItem(
+      STORAGE_KEYS.HOME_PRIORITIES_BRIEF_CACHE,
+    );
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const html = typeof parsed.html === "string" ? parsed.html.trim() : "";
+    if (!html) return null;
+    return {
+      html,
+      generatedAt:
+        typeof parsed.generatedAt === "string" ? parsed.generatedAt : null,
+      expiresAt: typeof parsed.expiresAt === "string" ? parsed.expiresAt : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function _writeCachedBrief() {
+  if (!_html) return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEYS.HOME_PRIORITIES_BRIEF_CACHE,
+      JSON.stringify({
+        html: _html,
+        generatedAt: _generatedAt,
+        expiresAt: _expiresAt,
+      }),
+    );
+  } catch {
+    // Ignore storage failures; the tile still works for the current session.
+  }
+}
+
+function _hydrateFromCache() {
+  if (_cacheHydrated) return;
+  _cacheHydrated = true;
+  const cached = _readCachedBrief();
+  if (!cached) return;
+  _html = cached.html;
+  _generatedAt = cached.generatedAt;
+  _expiresAt = cached.expiresAt;
+  _isStale = true;
+  _refreshInFlight = false;
+  _status = "loaded";
+  _error = "";
+}
+
+function _clearStaleRefreshTimer() {
+  if (_staleRefreshTimer) {
+    window.clearTimeout(_staleRefreshTimer);
+    _staleRefreshTimer = null;
+  }
+}
+
+function _scheduleFollowUpRefresh() {
+  if (_staleRefreshPolls >= MAX_STALE_REFRESH_POLLS) return;
+  _clearStaleRefreshTimer();
+  _staleRefreshPolls += 1;
+  _staleRefreshTimer = window.setTimeout(() => {
+    _staleRefreshTimer = null;
+    void loadPrioritiesBrief({ background: true });
+  }, STALE_REFRESH_RETRY_MS);
+}
+
+function _formatTimestamp(value) {
+  if (!value) return "";
+  const ts = new Date(value);
+  if (Number.isNaN(ts.getTime())) return "";
+  return ts.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function _buildMetaHtml() {
+  const timestamp = _formatTimestamp(_generatedAt);
+  const stampHtml = timestamp
+    ? `<div class="home-priorities-timestamp">Updated ${timestamp}</div>`
+    : "";
+
+  if (_status === "refreshing") {
+    return `
+      <div class="home-priorities-status" aria-live="polite">
+        Refreshing priorities…
+      </div>
+      ${stampHtml}`;
+  }
+
+  if (_error && _html) {
+    return `
+      <div class="home-priorities-status home-priorities-status--warning" aria-live="polite">
+        Showing the last update.
+        <button type="button" class="mini-btn" data-onclick="refreshPrioritiesTile()">Retry</button>
+      </div>
+      ${stampHtml}`;
+  }
+
+  if (_isStale) {
+    return `
+      <div class="home-priorities-status" aria-live="polite">
+        Updating priorities in the background…
+      </div>
+      ${stampHtml}`;
+  }
+
+  return stampHtml;
+}
+
+function _buildBodyHtml() {
+  if (_status === "idle" || (_status === "loading" && !_html)) {
+    return `<div class="home-priorities-state" aria-live="polite">Loading priorities&#8230;</div>`;
+  }
+
+  if (_status === "error" && !_html) {
+    return `
+      <div class="home-priorities-state home-priorities-state--error">
+        Could not load priorities.
+        <button type="button" class="mini-btn" data-onclick="refreshPrioritiesTile()">Retry</button>
+      </div>`;
+  }
+
+  return `${_html}${_buildMetaHtml()}`;
+}
+
+function _patchBody() {
+  const body = document.getElementById(TILE_BODY_ID);
+  if (!(body instanceof HTMLElement)) return;
+  body.innerHTML = _buildBodyHtml();
+}
+
+function _applyResponsePayload(data) {
+  _html = String(data?.html || "").trim();
+  _generatedAt =
+    typeof data?.generatedAt === "string" ? data.generatedAt : null;
+  _expiresAt = typeof data?.expiresAt === "string" ? data.expiresAt : null;
+  _isStale = !!data?.isStale;
+  _refreshInFlight = !!data?.refreshInFlight;
+  _status = "loaded";
+  _error = "";
+  if (_html) {
+    _writeCachedBrief();
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Fetch
 // ---------------------------------------------------------------------------
 
-export async function loadPrioritiesBrief({ force = false } = {}) {
-  if (!force && (_status === "loaded" || _status === "loading")) return;
+export async function loadPrioritiesBrief({
+  force = false,
+  background = false,
+} = {}) {
+  _hydrateFromCache();
 
-  _status = "loading";
+  if (!force && (_status === "loading" || _status === "refreshing")) return;
+
+  const hasVisibleContent = !!_html;
+  _status = hasVisibleContent ? "refreshing" : "loading";
+  _error = "";
   _patchBody();
+
+  _clearStaleRefreshTimer();
+  const requestToken = ++_loadToken;
 
   try {
     if (force) {
@@ -42,20 +210,34 @@ export async function loadPrioritiesBrief({ force = false } = {}) {
     }
 
     const data = await response.json();
-    _html = String(data.html || "");
-    _generatedAt = data.generatedAt || null;
-    _status = "loaded";
-    _error = "";
+    if (requestToken !== _loadToken) return;
+
+    _applyResponsePayload(data);
+
+    if (_refreshInFlight || (_isStale && !background)) {
+      _scheduleFollowUpRefresh();
+    } else {
+      _staleRefreshPolls = 0;
+    }
   } catch (err) {
-    _status = "error";
-    _error = String(err?.message || "Could not load priorities");
+    if (requestToken !== _loadToken) return;
+    if (_html) {
+      _status = "loaded";
+      _error = String(err?.message || "Could not refresh priorities");
+      _isStale = true;
+      _refreshInFlight = false;
+    } else {
+      _status = "error";
+      _error = String(err?.message || "Could not load priorities");
+    }
   }
 
   _patchBody();
 }
 
 export function refreshPrioritiesTile() {
-  loadPrioritiesBrief({ force: true });
+  _staleRefreshPolls = 0;
+  void loadPrioritiesBrief({ force: true });
 }
 
 // ---------------------------------------------------------------------------
@@ -63,6 +245,8 @@ export function refreshPrioritiesTile() {
 // ---------------------------------------------------------------------------
 
 export function renderPrioritiesTileShell() {
+  _hydrateFromCache();
+
   return `
     <section class="home-tile home-tile--priorities" data-testid="home-priorities-tile">
       <div class="home-tile__header">
@@ -76,42 +260,7 @@ export function renderPrioritiesTileShell() {
                 title="Refresh">&#8635;</button>
       </div>
       <div class="home-tile__body home-priorities-body" id="${TILE_BODY_ID}">
-        <div class="home-priorities-state" aria-live="polite">Loading&#8230;</div>
+        ${_buildBodyHtml()}
       </div>
     </section>`;
-}
-
-function _patchBody() {
-  const body = document.getElementById(TILE_BODY_ID);
-  if (!(body instanceof HTMLElement)) return;
-
-  if (_status === "idle" || _status === "loading") {
-    body.innerHTML = `<div class="home-priorities-state" aria-live="polite">Loading priorities&#8230;</div>`;
-    return;
-  }
-
-  if (_status === "error") {
-    body.innerHTML = `
-      <div class="home-priorities-state home-priorities-state--error">
-        Could not load priorities.
-        <button type="button" class="mini-btn" data-onclick="refreshPrioritiesTile()">Retry</button>
-      </div>`;
-    return;
-  }
-
-  // Server-generated HTML from configured LLM using app's own CSS classes.
-  // Content originates from the server's prioritiesBriefRouter which formats
-  // user task data into HTML using a structured system prompt with a closed
-  // set of CSS class names. No user-controlled HTML reaches this path.
-  body.innerHTML = _html; // trusted server-generated HTML
-
-  if (_generatedAt) {
-    const ts = new Date(_generatedAt);
-    if (!isNaN(ts.getTime())) {
-      const stamp = document.createElement("div");
-      stamp.className = "home-priorities-timestamp";
-      stamp.textContent = `Updated ${ts.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}`;
-      body.appendChild(stamp);
-    }
-  }
 }

--- a/client/styles.css
+++ b/client/styles.css
@@ -5719,6 +5719,19 @@ body.is-todos-view .projects-rail-item__count {
   align-items: center;
   gap: 8px;
 }
+.home-priorities-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 0.5px solid var(--color-border-tertiary);
+}
+.home-priorities-status--warning {
+  color: var(--color-warning-strong, #8a5a00);
+}
 .home-priorities-refresh-btn {
   font-size: 14px;
   padding: 2px 8px;
@@ -5728,8 +5741,9 @@ body.is-todos-view .projects-rail-item__count {
   font-size: 11px;
   color: var(--color-text-tertiary);
   margin-top: 12px;
-  padding-top: 8px;
-  border-top: 0.5px solid var(--color-border-tertiary);
+}
+.home-priorities-status + .home-priorities-timestamp {
+  margin-top: 6px;
 }
 
 .lbl {

--- a/client/utils/storageKeys.js
+++ b/client/utils/storageKeys.js
@@ -6,6 +6,7 @@ export const STORAGE_KEYS = {
   AI_WORKSPACE_VISIBLE: "todos:ai-visible",
   QUICK_ENTRY_PROPERTIES_OPEN: "todos:quick-entry-properties-open",
   HOME_TOP_FOCUS_CACHE: "todos:home-top-focus-cache",
+  HOME_PRIORITIES_BRIEF_CACHE: "todos:home-priorities-brief-cache",
   AI_ON_CREATE_DISMISSED: "todos:ai-on-create-dismissed",
   FEATURE_ENHANCED_TASK_CRITIC: "feature.enhancedTaskCritic",
   FEATURE_TASK_DRAWER_ASSIST: "feature.taskDrawerDecisionAssist",

--- a/src/prioritiesBriefRouter.test.ts
+++ b/src/prioritiesBriefRouter.test.ts
@@ -1,0 +1,141 @@
+import express from "express";
+import request from "supertest";
+import { createPrioritiesBriefRouter } from "./routes/prioritiesBriefRouter";
+
+const callLlmMock = jest.fn();
+
+jest.mock("./services/llmService", () => {
+  class TestLlmProviderNotConfiguredError extends Error {}
+  return {
+    callLlm: (...args: unknown[]) => callLlmMock(...args),
+    LlmProviderNotConfiguredError: TestLlmProviderNotConfiguredError,
+  };
+});
+
+function createTestApp(userId = "user-1") {
+  const app = express();
+  app.use(
+    "/ai",
+    createPrioritiesBriefRouter({
+      todoService: {
+        findAll: jest.fn().mockResolvedValue([
+          {
+            id: "todo-1",
+            title: "Ship priorities tile",
+            completed: false,
+            category: "Work",
+            dueDate: "2026-03-20T14:00:00.000Z",
+            priority: "high",
+          },
+        ]),
+      } as any,
+      projectService: {
+        findAll: jest.fn().mockResolvedValue([
+          {
+            id: "project-1",
+            name: "Work",
+            area: "ops",
+            openTaskCount: 3,
+          },
+        ]),
+      } as any,
+      resolveUserId: () => userId,
+    }),
+  );
+  return app;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("prioritiesBriefRouter", () => {
+  beforeEach(() => {
+    callLlmMock.mockReset();
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("serves cached fresh content without regenerating", async () => {
+    const app = createTestApp("user-fresh");
+    callLlmMock.mockResolvedValue("<div>Fresh priorities</div>");
+
+    const first = await request(app).get("/ai/priorities-brief").expect(200);
+    expect(first.body).toMatchObject({
+      html: "<div>Fresh priorities</div>",
+      cached: false,
+      isStale: false,
+      refreshInFlight: false,
+    });
+    expect(first.body.generatedAt).toEqual(expect.any(String));
+    expect(first.body.expiresAt).toEqual(expect.any(String));
+
+    const second = await request(app).get("/ai/priorities-brief").expect(200);
+    expect(second.body).toMatchObject({
+      html: "<div>Fresh priorities</div>",
+      cached: true,
+      isStale: false,
+      refreshInFlight: false,
+    });
+    expect(callLlmMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns stale cached content while a background refresh is running", async () => {
+    const app = createTestApp("user-stale");
+    const refreshDeferred = createDeferred<string>();
+
+    callLlmMock.mockResolvedValueOnce("<div>Cached priorities</div>");
+    await request(app).get("/ai/priorities-brief").expect(200);
+
+    callLlmMock.mockImplementationOnce(() => refreshDeferred.promise);
+    await request(app).post("/ai/priorities-brief/refresh").expect(200);
+
+    const stale = await request(app).get("/ai/priorities-brief").expect(200);
+    expect(stale.body).toMatchObject({
+      html: "<div>Cached priorities</div>",
+      cached: true,
+      isStale: true,
+      refreshInFlight: true,
+    });
+
+    refreshDeferred.resolve("<div>Fresh priorities</div>");
+    await refreshDeferred.promise;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const fresh = await request(app).get("/ai/priorities-brief").expect(200);
+    expect(fresh.body).toMatchObject({
+      html: "<div>Fresh priorities</div>",
+      cached: true,
+      isStale: false,
+      refreshInFlight: false,
+    });
+  });
+
+  it("keeps serving stale cached content when a background refresh fails", async () => {
+    const app = createTestApp("user-failed-refresh");
+
+    callLlmMock.mockResolvedValueOnce("<div>Last good priorities</div>");
+    await request(app).get("/ai/priorities-brief").expect(200);
+
+    callLlmMock.mockRejectedValueOnce(new Error("llm down"));
+    await request(app).post("/ai/priorities-brief/refresh").expect(200);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const stale = await request(app).get("/ai/priorities-brief").expect(200);
+    expect(stale.body).toMatchObject({
+      html: "<div>Last good priorities</div>",
+      cached: true,
+      isStale: true,
+      refreshInFlight: true,
+    });
+  });
+});

--- a/src/routes/prioritiesBriefRouter.ts
+++ b/src/routes/prioritiesBriefRouter.ts
@@ -1,7 +1,7 @@
 // =============================================================================
 // prioritiesBriefRouter.ts — GET /ai/priorities-brief
 // Generates an opinionated HTML priorities digest using the configured LLM.
-// Response is cached per-user for 4 hours. POST /refresh busts the cache.
+// Response is cached per-user for 4 hours and served stale-while-refresh.
 // =============================================================================
 
 import { Router, Request, Response } from "express";
@@ -19,10 +19,33 @@ interface CacheEntry {
   html: string;
   generatedAt: string;
   expiresAt: number;
+  refreshPromise: Promise<void> | null;
 }
 
 const cache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+function getCacheResponse(
+  entry: CacheEntry,
+  {
+    cached,
+    isStale,
+    refreshInFlight,
+  }: {
+    cached: boolean;
+    isStale: boolean;
+    refreshInFlight: boolean;
+  },
+) {
+  return {
+    html: entry.html,
+    generatedAt: entry.generatedAt,
+    expiresAt: new Date(entry.expiresAt).toISOString(),
+    cached,
+    isStale,
+    refreshInFlight,
+  };
+}
 
 export function createPrioritiesBriefRouter({
   todoService,
@@ -31,66 +54,50 @@ export function createPrioritiesBriefRouter({
 }: PrioritiesBriefRouterDeps): Router {
   const router = Router();
 
-  router.get("/priorities-brief", async (req: Request, res: Response) => {
-    try {
-      const userId = resolveUserId(req, res);
-      if (!userId) return;
+  async function generateBriefEntry(userId: string): Promise<CacheEntry> {
+    const [todosResult, projectsResult] = await Promise.allSettled([
+      todoService.findAll(userId, { completed: false }),
+      projectService ? projectService.findAll(userId) : Promise.resolve([]),
+    ]);
 
-      // Serve from cache if still fresh
-      const cached = cache.get(userId);
-      if (cached && cached.expiresAt > Date.now()) {
-        return res.json({
-          html: cached.html,
-          generatedAt: cached.generatedAt,
-          cached: true,
-        });
-      }
+    const todos = todosResult.status === "fulfilled" ? todosResult.value : [];
+    const projects =
+      projectsResult.status === "fulfilled" ? projectsResult.value : [];
 
-      // Fetch tasks and projects in parallel; tolerate individual failures
-      const [todosResult, projectsResult] = await Promise.allSettled([
-        todoService.findAll(userId, { completed: false }),
-        projectService ? projectService.findAll(userId) : Promise.resolve([]),
-      ]);
+    const todayISO = new Date().toISOString().split("T")[0];
 
-      const todos = todosResult.status === "fulfilled" ? todosResult.value : [];
-      const projects =
-        projectsResult.status === "fulfilled" ? projectsResult.value : [];
+    const taskLines = (Array.isArray(todos) ? todos : [])
+      .slice(0, 40)
+      .map((t: any) => {
+        const parts: string[] = [
+          `"${String(t.title || "").replace(/"/g, "'")}"`,
+        ];
+        if (t.priority) parts.push(`priority:${t.priority}`);
+        if (t.dueDate) parts.push(`due:${String(t.dueDate).split("T")[0]}`);
+        if (t.estimateMinutes) parts.push(`est:${t.estimateMinutes}m`);
+        if (t.waitingOn)
+          parts.push(`waiting_on:${String(t.waitingOn).slice(0, 60)}`);
+        if (t.status) parts.push(`status:${t.status}`);
+        if (t.category)
+          parts.push(`project:${String(t.category).slice(0, 40)}`);
+        return `- ${parts.join(" ")}`;
+      })
+      .join("\n");
 
-      const todayISO = new Date().toISOString().split("T")[0];
+    const projectLines = (Array.isArray(projects) ? projects : [])
+      .map((p: any) => {
+        const open = Number(p.openTaskCount ?? p.taskCount ?? 0);
+        const parts: string[] = [
+          `"${String(p.name || "").replace(/"/g, "'")}"`,
+        ];
+        parts.push(`area:${p.area ?? "none"}`);
+        parts.push(`open_tasks:${open}`);
+        if (p.goal) parts.push(`goal:${String(p.goal).slice(0, 80)}`);
+        return `- ${parts.join(" ")}`;
+      })
+      .join("\n");
 
-      // Build compact task context (<=40 tasks to keep token count low)
-      const taskLines = (Array.isArray(todos) ? todos : [])
-        .slice(0, 40)
-        .map((t: any) => {
-          const parts: string[] = [
-            `"${String(t.title || "").replace(/"/g, "'")}"`,
-          ];
-          if (t.priority) parts.push(`priority:${t.priority}`);
-          if (t.dueDate) parts.push(`due:${String(t.dueDate).split("T")[0]}`);
-          if (t.estimateMinutes) parts.push(`est:${t.estimateMinutes}m`);
-          if (t.waitingOn)
-            parts.push(`waiting_on:${String(t.waitingOn).slice(0, 60)}`);
-          if (t.status) parts.push(`status:${t.status}`);
-          if (t.category)
-            parts.push(`project:${String(t.category).slice(0, 40)}`);
-          return `- ${parts.join(" ")}`;
-        })
-        .join("\n");
-
-      const projectLines = (Array.isArray(projects) ? projects : [])
-        .map((p: any) => {
-          const open = Number(p.openTaskCount ?? p.taskCount ?? 0);
-          const parts: string[] = [
-            `"${String(p.name || "").replace(/"/g, "'")}"`,
-          ];
-          parts.push(`area:${p.area ?? "none"}`);
-          parts.push(`open_tasks:${open}`);
-          if (p.goal) parts.push(`goal:${String(p.goal).slice(0, 80)}`);
-          return `- ${parts.join(" ")}`;
-        })
-        .join("\n");
-
-      const systemPrompt = `You are a personal productivity assistant generating an HTML priorities digest.
+    const systemPrompt = `You are a personal productivity assistant generating an HTML priorities digest.
 Output ONLY the inner HTML — no outer wrapper, no markdown fences, no explanation.
 Use only these CSS classes (already defined in the app's stylesheet):
 
@@ -124,22 +131,87 @@ Rules:
 - Estimate labels in .item rows: format (30m) or (1h).
 - Today is ${todayISO}.`;
 
-      const userPrompt = `Open tasks:\n${taskLines || "(none)"}\n\nProjects:\n${projectLines || "(none)"}`;
+    const userPrompt = `Open tasks:\n${taskLines || "(none)"}\n\nProjects:\n${projectLines || "(none)"}`;
 
-      const html = await callLlm({
-        systemPrompt,
-        userPrompt,
-        maxTokens: 1500,
-        temperature: 0.3,
-      });
-      const generatedAt = new Date().toISOString();
+    const html = await callLlm({
+      systemPrompt,
+      userPrompt,
+      maxTokens: 1500,
+      temperature: 0.3,
+    });
+    const generatedAt = new Date().toISOString();
 
-      cache.set(userId, {
-        html,
-        generatedAt,
-        expiresAt: Date.now() + CACHE_TTL_MS,
-      });
-      return res.json({ html, generatedAt, cached: false });
+    return {
+      html,
+      generatedAt,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+      refreshPromise: null,
+    };
+  }
+
+  function startBackgroundRefresh(userId: string, existingEntry: CacheEntry) {
+    if (existingEntry.refreshPromise) return existingEntry.refreshPromise;
+
+    const refreshPromise = (async () => {
+      try {
+        const nextEntry = await generateBriefEntry(userId);
+        cache.set(userId, nextEntry);
+      } catch (err) {
+        const current = cache.get(userId);
+        if (current) {
+          cache.set(userId, {
+            ...current,
+            refreshPromise: null,
+          });
+        }
+        console.error("priorities-brief background refresh error:", err);
+      }
+    })();
+
+    cache.set(userId, {
+      ...existingEntry,
+      refreshPromise,
+    });
+
+    return refreshPromise;
+  }
+
+  router.get("/priorities-brief", async (req: Request, res: Response) => {
+    try {
+      const userId = resolveUserId(req, res);
+      if (!userId) return;
+
+      const cached = cache.get(userId);
+      if (cached && cached.expiresAt > Date.now()) {
+        return res.json(
+          getCacheResponse(cached, {
+            cached: true,
+            isStale: false,
+            refreshInFlight: !!cached.refreshPromise,
+          }),
+        );
+      }
+
+      if (cached) {
+        startBackgroundRefresh(userId, cached);
+        return res.json(
+          getCacheResponse(cached, {
+            cached: true,
+            isStale: true,
+            refreshInFlight: true,
+          }),
+        );
+      }
+
+      const freshEntry = await generateBriefEntry(userId);
+      cache.set(userId, freshEntry);
+      return res.json(
+        getCacheResponse(freshEntry, {
+          cached: false,
+          isStale: false,
+          refreshInFlight: false,
+        }),
+      );
     } catch (err) {
       if (err instanceof LlmProviderNotConfiguredError) {
         return res.status(503).json({ error: err.message });
@@ -151,12 +223,22 @@ Rules:
     }
   });
 
-  // Cache-bust endpoint
   router.post("/priorities-brief/refresh", (req: Request, res: Response) => {
     const userId = resolveUserId(req, res);
     if (!userId) return;
-    cache.delete(userId);
-    return res.json({ ok: true });
+
+    const cached = cache.get(userId);
+    if (!cached) {
+      return res.json({ ok: true, refreshInFlight: false });
+    }
+
+    const staleEntry = {
+      ...cached,
+      expiresAt: 0,
+    };
+    cache.set(userId, staleEntry);
+    startBackgroundRefresh(userId, staleEntry);
+    return res.json({ ok: true, refreshInFlight: true });
   });
 
   return router;

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -22,6 +22,16 @@ type SeedTodo = {
   }>;
 };
 
+type PrioritiesBriefMockResponse = {
+  html?: string;
+  generatedAt?: string;
+  isStale?: boolean;
+  refreshInFlight?: boolean;
+  delayMs?: number;
+  status?: number;
+  error?: string;
+};
+
 function isoDaysFromNow(days: number, hour = 10) {
   const dt = new Date();
   dt.setDate(dt.getDate() + days);
@@ -42,6 +52,7 @@ async function installHomeFocusMockApi(
     aiDecisionAssistStatus = 500,
     aiTopFocus = null,
     homeFocusSequences = null,
+    prioritiesBriefResponses = null,
     seedTodos,
   }: {
     aiDecisionAssistStatus?: number;
@@ -49,6 +60,7 @@ async function installHomeFocusMockApi(
     homeFocusSequences?: Array<
       Array<{ todoId: string; summary?: string; reason?: string }>
     > | null;
+    prioritiesBriefResponses?: PrioritiesBriefMockResponse[] | null;
     seedTodos: SeedTodo[];
   },
 ) {
@@ -68,6 +80,7 @@ async function installHomeFocusMockApi(
   let todoSeq = 1000;
   let homeFocusSeq = 1;
   let homeFocusGenerateSeq = 0;
+  let prioritiesBriefGetSeq = 0;
 
   const nowIso = () => new Date().toISOString();
   const json = (route: Route, status: number, body: unknown) =>
@@ -190,6 +203,22 @@ async function installHomeFocusMockApi(
         </div>
       </div>
     `;
+  };
+
+  const getPrioritiesBriefResponse = () => {
+    if (
+      Array.isArray(prioritiesBriefResponses) &&
+      prioritiesBriefResponses.length > 0
+    ) {
+      const index = Math.min(
+        prioritiesBriefGetSeq,
+        prioritiesBriefResponses.length - 1,
+      );
+      prioritiesBriefGetSeq += 1;
+      return prioritiesBriefResponses[index] || {};
+    }
+    prioritiesBriefGetSeq += 1;
+    return {};
   };
 
   await page.route("**/*", async (route) => {
@@ -324,15 +353,28 @@ async function installHomeFocusMockApi(
       return json(route, 200, []);
     }
     if (pathname === "/ai/priorities-brief" && method === "GET") {
-      return json(route, 200, {
-        html: buildPrioritiesBriefHtml(),
-        generatedAt: nowIso(),
+      const mock = getPrioritiesBriefResponse();
+      if (mock.delayMs && mock.delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, mock.delayMs));
+      }
+      if ((mock.status || 200) >= 400) {
+        return json(route, mock.status || 500, {
+          error: mock.error || "Priorities brief failed",
+        });
+      }
+      return json(route, mock.status || 200, {
+        html: mock.html || buildPrioritiesBriefHtml(),
+        generatedAt: mock.generatedAt || nowIso(),
+        expiresAt: new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString(),
+        cached: prioritiesBriefGetSeq > 1,
+        isStale: !!mock.isStale,
+        refreshInFlight: !!mock.refreshInFlight,
       });
     }
     if (pathname === "/ai/priorities-brief/refresh" && method === "POST") {
       return json(route, 200, {
-        html: buildPrioritiesBriefHtml(),
-        generatedAt: nowIso(),
+        ok: true,
+        refreshInFlight: true,
       });
     }
     if (pathname === "/ai/suggestions/latest" && method === "GET") {
@@ -645,6 +687,16 @@ function buildSeedTodos(): SeedTodo[] {
   ];
 }
 
+function buildPrioritiesBriefMarkup(title: string) {
+  return `
+    <div class="home-priorities-brief">
+      <div class="home-priorities-brief__item">
+        <strong>${title}</strong>
+      </div>
+    </div>
+  `;
+}
+
 test.describe("Home focus dashboard + sheet composer", () => {
   test.beforeEach(async ({ page }) => {
     await installHomeFocusMockApi(page, {
@@ -734,5 +786,87 @@ test.describe("Home focus dashboard + sheet composer", () => {
       "Upcoming",
     );
     await expectListOrEmptyState(page);
+  });
+});
+
+test.describe("Home priorities stale refresh", () => {
+  test("Home renders cached priorities immediately and swaps in the refreshed tile", async ({
+    page,
+  }) => {
+    await installHomeFocusMockApi(page, {
+      seedTodos: buildSeedTodos(),
+      prioritiesBriefResponses: [
+        {
+          html: buildPrioritiesBriefMarkup("Initial priorities"),
+          generatedAt: "2026-03-20T10:55:00.000Z",
+          isStale: false,
+          refreshInFlight: false,
+        },
+        {
+          html: buildPrioritiesBriefMarkup("Cached priorities"),
+          generatedAt: "2026-03-20T11:00:00.000Z",
+          isStale: true,
+          refreshInFlight: true,
+          delayMs: 300,
+        },
+        {
+          html: buildPrioritiesBriefMarkup("Fresh priorities"),
+          generatedAt: "2026-03-20T11:05:00.000Z",
+          isStale: false,
+          refreshInFlight: false,
+        },
+      ],
+    });
+
+    await openHomeApp(page);
+    await page.evaluate(
+      (payload) => {
+        window.localStorage.setItem(
+          "todos:home-priorities-brief-cache",
+          JSON.stringify(payload),
+        );
+      },
+      {
+        html: buildPrioritiesBriefMarkup("Cached priorities"),
+        generatedAt: "2026-03-20T11:00:00.000Z",
+        expiresAt: "2026-03-20T15:00:00.000Z",
+      },
+    );
+    await page.reload();
+
+    const tile = page.locator('[data-testid="home-priorities-tile"]');
+    await expect(tile).toContainText("Cached priorities");
+    await expect(tile).toContainText(
+      /Updating priorities|Refreshing priorities/,
+    );
+    await expect(tile).toContainText("Fresh priorities");
+  });
+
+  test("Failed refresh keeps the previous priorities tile visible", async ({
+    page,
+  }) => {
+    await installHomeFocusMockApi(page, {
+      seedTodos: buildSeedTodos(),
+      prioritiesBriefResponses: [
+        {
+          html: buildPrioritiesBriefMarkup("Visible priorities"),
+          generatedAt: "2026-03-20T12:00:00.000Z",
+        },
+        {
+          status: 500,
+          error: "Refresh failed",
+        },
+      ],
+    });
+
+    await openHomeApp(page);
+
+    const tile = page.locator('[data-testid="home-priorities-tile"]');
+    await expect(tile).toContainText("Visible priorities");
+
+    await page.locator(".home-priorities-refresh-btn").click();
+
+    await expect(tile).toContainText("Visible priorities");
+    await expect(tile).toContainText("Showing the last update.");
   });
 });


### PR DESCRIPTION
## Summary
This PR implements the next queued Home AI issue by changing the priorities tile lifecycle to stale-while-refresh behavior.

On Home load, the app now shows the last successful priorities brief immediately from local storage instead of blanking the tile behind a loading state. It then refreshes the tile in-session and swaps in fresher server content only when it is available.

## User impact
Previously, Home could feel slow or visually unstable because the priorities tile cleared itself while waiting on `/ai/priorities-brief`, and any refresh failure dropped the user into a loading or error-only state.

With this change, the tile stays visually stable:
- returning users see the most recent priorities brief immediately
- background refreshes no longer clear the visible tile
- failed refreshes preserve the last good brief and show a small non-destructive status instead

## Root cause
The current Home priorities path rendered from a session-only in-memory state and treated each fetch as fresh-or-empty. The server route also only supported fresh cache hits or synchronous regeneration, so the client had no way to distinguish a usable stale snapshot from a genuinely missing result.

## Fix
The client now persists the last good priorities brief in local storage and rehydrates from that cache before network completes. The tile module also tracks refreshing vs. hard-loading states so it can keep visible HTML on screen while newer data is fetched.

On the server, `/ai/priorities-brief` now serves the latest usable cached snapshot with freshness metadata (`cached`, `isStale`, `refreshInFlight`, `expiresAt`) and triggers background regeneration when the cache is stale. The refresh endpoint marks the cached entry stale and starts regeneration without removing the current snapshot.

## Tests
Validated with:
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`

Additional focused coverage was added for:
- cached startup rendering
- background stale refresh swap-in behavior
- failed refresh preserving the last visible tile
- stale/fresh metadata returned by the priorities brief route
