### PR TITLE
[codex] add in-app feedback flow

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -186,6 +186,14 @@ import {
 } from "./modules/responsiveLayout.js";
 import { createWorkspaceController } from "./modules/workspaceController.js";
 import {
+  prepareFeedbackView,
+  syncFeedbackFormCopy,
+  handleFeedbackTypeChange,
+  handleFeedbackAttachmentChange,
+  handleFeedbackSubmit,
+  resetFeedbackFormView,
+} from "./modules/feedbackUi.js";
+import {
   setAuthState,
   handleAuthFailure,
   handleAuthTokens,
@@ -646,6 +654,7 @@ const { ensureTodosShellActive, selectWorkspaceView, switchView } =
     loadAiInsights,
     loadAiFeedbackSummary,
     loadAdminUsers,
+    prepareFeedbackView,
   });
 
 function moveProjectHeading(headingId, direction) {
@@ -1611,6 +1620,8 @@ function bindDeclarativeHandlers() {
   hooks.showInputDialog = showInputDialog;
   hooks.syncProjectHeaderActions = syncProjectHeaderActions;
   hooks.syncQuickEntryProjectActions = syncQuickEntryProjectActions;
+  hooks.prepareFeedbackView = prepareFeedbackView;
+  hooks.syncFeedbackFormCopy = syncFeedbackFormCopy;
   hooks.updateHeaderFromVisibleTodos = updateHeaderFromVisibleTodos;
   hooks.updateQuickEntryPropertiesSummary = updateQuickEntryPropertiesSummary;
   hooks.updateTaskComposerDueClearButton = updateTaskComposerDueClearButton;
@@ -1665,6 +1676,10 @@ window.setSelectedProjectKey = setSelectedProjectKey;
 window.switchView = switchView;
 window.toggleProfilePanel = toggleProfilePanel;
 window.logout = logout;
+window.handleFeedbackTypeChange = handleFeedbackTypeChange;
+window.handleFeedbackAttachmentChange = handleFeedbackAttachmentChange;
+window.handleFeedbackSubmit = handleFeedbackSubmit;
+window.resetFeedbackFormView = resetFeedbackFormView;
 // Shortcuts / UI toggles
 window.toggleShortcuts = toggleShortcuts;
 window.closeShortcutsOverlay = closeShortcutsOverlay;

--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="app-version" content="1.6.0" />
     <title>Todo App - Complete</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
@@ -59,6 +60,12 @@
                 data-onclick="switchView('settings', this)"
               >
                 Profile
+              </button>
+              <button
+                class="nav-tab"
+                data-onclick="switchView('feedback', this)"
+              >
+                Feedback
               </button>
               <button
                 class="nav-tab"
@@ -647,6 +654,35 @@
                       class="projects-rail__section projects-rail__section--utilities"
                     >
                       <div class="projects-rail__utility-list">
+                        <button
+                          type="button"
+                          class="projects-rail-item projects-rail-utility-item sidebar-nav-item"
+                          data-sidebar-view="feedback"
+                          data-onclick="switchView('feedback', this)"
+                          title="Feedback"
+                          aria-label="Feedback"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path
+                              d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+                            />
+                          </svg>
+                          <span class="projects-rail-item__label"
+                            >Feedback</span
+                          >
+                        </button>
                         <button
                           type="button"
                           class="projects-rail-item projects-rail-utility-item sidebar-nav-item"
@@ -2262,6 +2298,168 @@
                 </button>
               </div>
 
+              <!-- Feedback View -->
+              <div id="feedbackView" class="view">
+                <section class="feedback-view">
+                  <div class="feedback-view__header">
+                    <p class="feedback-view__eyebrow">
+                      Friends-and-family beta
+                    </p>
+                    <h2>Feedback</h2>
+                    <p class="feedback-view__lede">
+                      Share bugs, rough edges, or ideas without needing GitHub.
+                    </p>
+                  </div>
+
+                  <div
+                    class="message"
+                    id="feedbackMessage"
+                    role="status"
+                    aria-live="polite"
+                    aria-atomic="true"
+                  ></div>
+
+                  <div
+                    id="feedbackConfirmation"
+                    class="feedback-confirmation"
+                    hidden
+                  >
+                    <h3 id="feedbackConfirmationTitle">Feedback sent</h3>
+                    <p id="feedbackConfirmationBody"></p>
+                    <p
+                      id="feedbackConfirmationMeta"
+                      class="feedback-confirmation__meta"
+                    ></p>
+                    <button
+                      type="button"
+                      class="btn btn-secondary"
+                      data-onclick="resetFeedbackFormView()"
+                    >
+                      Send another
+                    </button>
+                  </div>
+
+                  <form
+                    id="feedbackForm"
+                    data-onsubmit="handleFeedbackSubmit(event)"
+                  >
+                    <div class="feedback-grid">
+                      <div class="feedback-card">
+                        <div class="form-group">
+                          <label for="feedbackType">Submission type</label>
+                          <select
+                            id="feedbackType"
+                            data-onchange="handleFeedbackTypeChange(event)"
+                          >
+                            <option value="bug">Bug report</option>
+                            <option value="feature">Feature request</option>
+                          </select>
+                        </div>
+                        <div class="form-group">
+                          <label for="feedbackTitle">Title</label>
+                          <input
+                            id="feedbackTitle"
+                            type="text"
+                            maxlength="200"
+                            required
+                            placeholder="Short summary"
+                          />
+                        </div>
+                        <div class="form-group">
+                          <label
+                            id="feedbackQuestionOneLabel"
+                            for="feedbackQuestionOne"
+                            >What happened?</label
+                          >
+                          <textarea
+                            id="feedbackQuestionOne"
+                            rows="4"
+                            required
+                          ></textarea>
+                        </div>
+                        <div class="form-group">
+                          <label
+                            id="feedbackQuestionTwoLabel"
+                            for="feedbackQuestionTwo"
+                            >What did you expect?</label
+                          >
+                          <textarea
+                            id="feedbackQuestionTwo"
+                            rows="4"
+                            required
+                          ></textarea>
+                        </div>
+                        <div class="form-group">
+                          <label
+                            id="feedbackQuestionThreeLabel"
+                            for="feedbackQuestionThree"
+                            >What were you doing right before it
+                            happened?</label
+                          >
+                          <textarea
+                            id="feedbackQuestionThree"
+                            rows="4"
+                            required
+                          ></textarea>
+                        </div>
+                      </div>
+
+                      <aside class="feedback-card feedback-card--context">
+                        <h3>Optional screenshot</h3>
+                        <div class="form-group">
+                          <label for="feedbackScreenshotUrl"
+                            >Screenshot URL</label
+                          >
+                          <input
+                            id="feedbackScreenshotUrl"
+                            type="url"
+                            inputmode="url"
+                            placeholder="https://example.com/screenshot.png"
+                          />
+                        </div>
+                        <div class="form-group">
+                          <label for="feedbackAttachment"
+                            >Screenshot file metadata</label
+                          >
+                          <input
+                            id="feedbackAttachment"
+                            type="file"
+                            accept="image/*"
+                            data-onchange="handleFeedbackAttachmentChange(event)"
+                          />
+                          <p
+                            id="feedbackAttachmentSummary"
+                            class="feedback-helper"
+                          >
+                            No screenshot file selected.
+                          </p>
+                        </div>
+
+                        <h3>Captured context</h3>
+                        <dl class="feedback-context-list">
+                          <div class="feedback-context-row">
+                            <dt>Current page</dt>
+                            <dd id="feedbackContextPage"></dd>
+                          </div>
+                          <div class="feedback-context-row">
+                            <dt>App version</dt>
+                            <dd id="feedbackContextVersion"></dd>
+                          </div>
+                          <div class="feedback-context-row">
+                            <dt>User</dt>
+                            <dd id="feedbackContextUser"></dd>
+                          </div>
+                        </dl>
+
+                        <button type="submit" class="btn feedback-submit-btn">
+                          Send feedback
+                        </button>
+                      </aside>
+                    </div>
+                  </form>
+                </section>
+              </div>
+
               <!-- Profile View -->
               <div id="profileView" class="view">
                 <div class="profile-section">
@@ -2333,6 +2531,31 @@
               d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
             />
             <circle cx="12" cy="12" r="3" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="dock-icon-btn"
+          data-onclick="switchView('feedback', this)"
+          aria-label="Feedback"
+          title="Feedback"
+        >
+          <svg
+            class="dock-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path
+              d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+            />
           </svg>
         </button>
         <button

--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -737,6 +737,9 @@ export function showAppView() {
   hooks.setSettingsPaneVisible?.(false);
   document.getElementById("authView").classList.remove("active");
   document.getElementById("todosView").classList.add("active");
+  document.getElementById("feedbackView")?.classList.remove("active");
+  document.getElementById("profileView")?.classList.remove("active");
+  document.getElementById("adminView")?.classList.remove("active");
   document.getElementById("navTabs").style.display = "flex";
   document.getElementById("userBar").style.display = "flex";
   document.querySelectorAll(".nav-tab")[0].classList.add("active");
@@ -798,6 +801,7 @@ export function showAuthView() {
   hooks.setSettingsPaneVisible?.(false);
   document.getElementById("authView").classList.add("active");
   document.getElementById("todosView").classList.remove("active");
+  document.getElementById("feedbackView")?.classList.remove("active");
   document.getElementById("profileView").classList.remove("active");
   document.getElementById("adminView").classList.remove("active");
   document.getElementById("navTabs").style.display = "none";

--- a/client/modules/feedbackUi.js
+++ b/client/modules/feedbackUi.js
@@ -1,0 +1,313 @@
+import { state, hooks } from "./store.js";
+
+const BUG_QUESTIONS = {
+  firstLabel: "What happened?",
+  firstPlaceholder: "Describe the bug or broken behavior you ran into.",
+  secondLabel: "What did you expect?",
+  secondPlaceholder: "Tell us what you thought should happen instead.",
+  thirdLabel: "What were you doing right before it happened?",
+  thirdPlaceholder: "Share the steps, clicks, or context leading up to it.",
+  successTitle: "Bug report sent",
+  successBody:
+    "Thanks for the report. We saved the context with it so we can triage it later.",
+};
+
+const FEATURE_QUESTIONS = {
+  firstLabel: "What are you trying to do?",
+  firstPlaceholder: "Describe the goal or workflow you want help with.",
+  secondLabel: "What is hard today?",
+  secondPlaceholder: "Explain where the current app gets in your way.",
+  thirdLabel: "What would make this better?",
+  thirdPlaceholder:
+    "Share the change, shortcut, or capability you wish existed.",
+  successTitle: "Feature request sent",
+  successBody:
+    "Thanks for the idea. We saved it with your app context so it is ready for review.",
+};
+
+function getQuestionCopy(type) {
+  return type === "feature" ? FEATURE_QUESTIONS : BUG_QUESTIONS;
+}
+
+function getFeedbackElements() {
+  return {
+    form: document.getElementById("feedbackForm"),
+    type: document.getElementById("feedbackType"),
+    title: document.getElementById("feedbackTitle"),
+    screenshotUrl: document.getElementById("feedbackScreenshotUrl"),
+    attachment: document.getElementById("feedbackAttachment"),
+    attachmentSummary: document.getElementById("feedbackAttachmentSummary"),
+    firstLabel: document.getElementById("feedbackQuestionOneLabel"),
+    firstField: document.getElementById("feedbackQuestionOne"),
+    secondLabel: document.getElementById("feedbackQuestionTwoLabel"),
+    secondField: document.getElementById("feedbackQuestionTwo"),
+    thirdLabel: document.getElementById("feedbackQuestionThreeLabel"),
+    thirdField: document.getElementById("feedbackQuestionThree"),
+    message: document.getElementById("feedbackMessage"),
+    confirmation: document.getElementById("feedbackConfirmation"),
+    confirmationTitle: document.getElementById("feedbackConfirmationTitle"),
+    confirmationBody: document.getElementById("feedbackConfirmationBody"),
+    confirmationMeta: document.getElementById("feedbackConfirmationMeta"),
+    currentPage: document.getElementById("feedbackContextPage"),
+    appVersion: document.getElementById("feedbackContextVersion"),
+    userValue: document.getElementById("feedbackContextUser"),
+  };
+}
+
+function getSelectedType() {
+  const { type } = getFeedbackElements();
+  if (!(type instanceof HTMLSelectElement)) {
+    return "bug";
+  }
+  return type.value === "feature" ? "feature" : "bug";
+}
+
+function readAppVersion() {
+  const fromMeta = document
+    .querySelector('meta[name="app-version"]')
+    ?.getAttribute("content");
+  return fromMeta?.trim() || "unknown";
+}
+
+function getAttachmentMetadata() {
+  const { attachment } = getFeedbackElements();
+  if (!(attachment instanceof HTMLInputElement) || !attachment.files?.length) {
+    return null;
+  }
+
+  const file = attachment.files[0];
+  return {
+    name: file.name || null,
+    type: file.type || null,
+    size: Number.isFinite(file.size) ? file.size : null,
+    lastModified: Number.isFinite(file.lastModified) ? file.lastModified : null,
+  };
+}
+
+function buildFeedbackBody(type) {
+  const { firstField, secondField, thirdField } = getFeedbackElements();
+  const first =
+    firstField instanceof HTMLTextAreaElement ? firstField.value : "";
+  const second =
+    secondField instanceof HTMLTextAreaElement ? secondField.value : "";
+  const third =
+    thirdField instanceof HTMLTextAreaElement ? thirdField.value : "";
+
+  const sections =
+    type === "feature"
+      ? [
+          ["What are you trying to do?", first],
+          ["What is hard today?", second],
+          ["What would make this better?", third],
+        ]
+      : [
+          ["What happened?", first],
+          ["What did you expect?", second],
+          ["What were you doing right before it happened?", third],
+        ];
+
+  return sections
+    .map(([label, value]) => `${label}\n${String(value || "").trim()}`)
+    .join("\n\n")
+    .trim();
+}
+
+function syncContextPreview() {
+  const { currentPage, appVersion, userValue } = getFeedbackElements();
+  if (currentPage instanceof HTMLElement) {
+    currentPage.textContent = window.location.href;
+  }
+  if (appVersion instanceof HTMLElement) {
+    appVersion.textContent = readAppVersion();
+  }
+  if (userValue instanceof HTMLElement) {
+    userValue.textContent = state.currentUser?.id || "Signed out";
+  }
+}
+
+export function syncFeedbackFormCopy() {
+  const {
+    type,
+    firstLabel,
+    firstField,
+    secondLabel,
+    secondField,
+    thirdLabel,
+    thirdField,
+  } = getFeedbackElements();
+
+  const feedbackType =
+    type instanceof HTMLSelectElement && type.value === "feature"
+      ? "feature"
+      : "bug";
+  const copy = getQuestionCopy(feedbackType);
+
+  if (firstLabel instanceof HTMLElement) {
+    firstLabel.textContent = copy.firstLabel;
+  }
+  if (firstField instanceof HTMLTextAreaElement) {
+    firstField.placeholder = copy.firstPlaceholder;
+  }
+  if (secondLabel instanceof HTMLElement) {
+    secondLabel.textContent = copy.secondLabel;
+  }
+  if (secondField instanceof HTMLTextAreaElement) {
+    secondField.placeholder = copy.secondPlaceholder;
+  }
+  if (thirdLabel instanceof HTMLElement) {
+    thirdLabel.textContent = copy.thirdLabel;
+  }
+  if (thirdField instanceof HTMLTextAreaElement) {
+    thirdField.placeholder = copy.thirdPlaceholder;
+  }
+
+  syncContextPreview();
+}
+
+export function handleFeedbackTypeChange() {
+  syncFeedbackFormCopy();
+}
+
+export function handleFeedbackAttachmentChange() {
+  const { attachmentSummary } = getFeedbackElements();
+  if (!(attachmentSummary instanceof HTMLElement)) {
+    return;
+  }
+
+  const metadata = getAttachmentMetadata();
+  if (!metadata) {
+    attachmentSummary.textContent = "No screenshot file selected.";
+    return;
+  }
+
+  attachmentSummary.textContent = `${metadata.name || "Attachment"} (${metadata.type || "unknown type"}, ${metadata.size ?? 0} bytes)`;
+}
+
+function showConfirmation(type, requestId) {
+  const {
+    form,
+    confirmation,
+    confirmationTitle,
+    confirmationBody,
+    confirmationMeta,
+  } = getFeedbackElements();
+  const copy = getQuestionCopy(type);
+
+  if (form instanceof HTMLFormElement) {
+    form.hidden = true;
+  }
+  if (confirmation instanceof HTMLElement) {
+    confirmation.hidden = false;
+  }
+  if (confirmationTitle instanceof HTMLElement) {
+    confirmationTitle.textContent = copy.successTitle;
+  }
+  if (confirmationBody instanceof HTMLElement) {
+    confirmationBody.textContent = copy.successBody;
+  }
+  if (confirmationMeta instanceof HTMLElement) {
+    confirmationMeta.textContent = requestId
+      ? `Reference ID: ${requestId}`
+      : "Your feedback has been saved.";
+  }
+}
+
+export function resetFeedbackFormView() {
+  const { form, confirmation, attachmentSummary, message, type } =
+    getFeedbackElements();
+
+  if (form instanceof HTMLFormElement) {
+    form.reset();
+    form.hidden = false;
+  }
+  if (type instanceof HTMLSelectElement) {
+    type.value = "bug";
+  }
+  if (confirmation instanceof HTMLElement) {
+    confirmation.hidden = true;
+  }
+  if (attachmentSummary instanceof HTMLElement) {
+    attachmentSummary.textContent = "No screenshot file selected.";
+  }
+  hooks.hideMessage?.("feedbackMessage");
+  if (message instanceof HTMLElement) {
+    message.textContent = "";
+  }
+
+  syncFeedbackFormCopy();
+  syncContextPreview();
+}
+
+export function prepareFeedbackView() {
+  syncFeedbackFormCopy();
+  syncContextPreview();
+}
+
+export async function handleFeedbackSubmit(event) {
+  event?.preventDefault?.();
+
+  const { title, screenshotUrl } = getFeedbackElements();
+  const type = getSelectedType();
+  const titleValue =
+    title instanceof HTMLInputElement ? title.value.trim() : "";
+  const body = buildFeedbackBody(type);
+
+  if (!titleValue) {
+    hooks.showMessage?.(
+      "feedbackMessage",
+      "Please add a short title.",
+      "error",
+    );
+    return;
+  }
+
+  if (!body) {
+    hooks.showMessage?.(
+      "feedbackMessage",
+      "Please answer the feedback questions before sending.",
+      "error",
+    );
+    return;
+  }
+
+  const payload = {
+    type,
+    title: titleValue,
+    body,
+    screenshotUrl:
+      screenshotUrl instanceof HTMLInputElement && screenshotUrl.value.trim()
+        ? screenshotUrl.value.trim()
+        : null,
+    attachmentMetadata: getAttachmentMetadata(),
+    pageUrl: window.location.href,
+    userAgent: window.navigator.userAgent || null,
+    appVersion: readAppVersion(),
+  };
+
+  try {
+    const response = await hooks.apiCall(`${hooks.API_URL}/feedback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "feedbackMessage",
+        data.error || "We could not send your feedback.",
+        "error",
+      );
+      return;
+    }
+
+    hooks.hideMessage?.("feedbackMessage");
+    showConfirmation(type, data.id);
+  } catch (error) {
+    hooks.showMessage?.(
+      "feedbackMessage",
+      "We could not send your feedback.",
+      "error",
+    );
+  }
+}

--- a/client/modules/workspaceController.js
+++ b/client/modules/workspaceController.js
@@ -31,6 +31,7 @@ export function createWorkspaceController({
   loadAiInsights,
   loadAiFeedbackSummary,
   loadAdminUsers,
+  prepareFeedbackView,
 }) {
   function switchView(view, triggerEl = null) {
     const requestedView = view === "profile" ? "settings" : view;
@@ -110,6 +111,18 @@ export function createWorkspaceController({
       closeProjectsRailSheet({ restoreFocus: false });
       closeTodoDrawer({ restoreFocus: false });
       loadAdminUsers();
+      return;
+    }
+
+    if (requestedView === "feedback") {
+      closeCommandPalette({ restoreFocus: false });
+      closeProjectCrudModal({ restoreFocus: false });
+      closeProjectEditDrawer({ restoreFocus: false });
+      closeProjectDeleteDialog();
+      closeMoreFilters();
+      closeProjectsRailSheet({ restoreFocus: false });
+      closeTodoDrawer({ restoreFocus: false });
+      prepareFeedbackView?.();
     }
   }
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -540,6 +540,7 @@ body.is-todos-view #todosView.view.active {
 }
 
 .form-group input,
+.form-group select,
 .form-group textarea {
   width: 100%;
   padding: var(--s-3);
@@ -553,6 +554,7 @@ body.is-todos-view #todosView.view.active {
 }
 
 .form-group input:focus,
+.form-group select:focus,
 .form-group textarea:focus {
   outline: none;
   border-color: var(--accent);
@@ -3572,9 +3574,108 @@ body.is-todos-view .floating-new-task-cta {
   margin-bottom: 30px;
 }
 
+.feedback-view {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: var(--s-3) 0 var(--s-6);
+}
+
+.feedback-view__header {
+  margin-bottom: var(--s-5);
+}
+
+.feedback-view__eyebrow {
+  margin: 0 0 var(--s-2);
+  color: var(--accent);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.feedback-view__lede {
+  max-width: 56ch;
+  color: var(--text-secondary);
+}
+
+.feedback-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
+  gap: var(--s-4);
+  align-items: start;
+}
+
+.feedback-card {
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-sm);
+}
+
+.feedback-card--context {
+  position: sticky;
+  top: var(--s-4);
+}
+
+.feedback-helper {
+  margin: var(--s-2) 0 0;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.feedback-context-list {
+  margin: 0 0 var(--s-5);
+}
+
+.feedback-context-row {
+  display: grid;
+  grid-template-columns: minmax(0, 110px) minmax(0, 1fr);
+  gap: var(--s-2);
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.feedback-context-row dt {
+  color: var(--text-secondary);
+  font-weight: var(--fw-medium);
+}
+
+.feedback-context-row dd {
+  margin: 0;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.feedback-submit-btn {
+  margin-top: var(--s-4);
+}
+
+.feedback-confirmation {
+  margin-bottom: var(--s-4);
+  padding: var(--s-4);
+  border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border-color));
+  border-radius: var(--r-lg);
+  background: color-mix(in oklab, var(--accent) 8%, var(--card-bg));
+}
+
+.feedback-confirmation__meta {
+  color: var(--text-secondary);
+}
+
 .profile-section h3 {
   margin-bottom: 15px;
   color: var(--text-primary);
+}
+
+@media (max-width: 960px) {
+  .feedback-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feedback-card--context {
+    position: static;
+  }
 }
 
 .info-row {

--- a/prisma/migrations/20260320110000_add_feedback_requests/migration.sql
+++ b/prisma/migrations/20260320110000_add_feedback_requests/migration.sql
@@ -1,0 +1,41 @@
+-- CreateEnum
+CREATE TYPE "FeedbackType" AS ENUM ('bug', 'feature', 'general');
+
+-- CreateEnum
+CREATE TYPE "FeedbackStatus" AS ENUM ('new', 'triaged', 'closed');
+
+-- CreateTable
+CREATE TABLE "feedback_requests" (
+    "id" UUID NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "type" "FeedbackType" NOT NULL,
+    "title" VARCHAR(200) NOT NULL,
+    "body" TEXT NOT NULL,
+    "screenshot_url" VARCHAR(2000),
+    "attachment_metadata" JSONB,
+    "page_url" VARCHAR(2000),
+    "user_agent" VARCHAR(2000),
+    "app_version" VARCHAR(50),
+    "status" "FeedbackStatus" NOT NULL DEFAULT 'new',
+    "triage_summary" TEXT,
+    "severity" VARCHAR(20),
+    "dedupe_key" VARCHAR(255),
+    "github_issue_number" INTEGER,
+    "github_issue_url" VARCHAR(2000),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "feedback_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "feedback_requests_user_id_status_created_at_idx" ON "feedback_requests"("user_id", "status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "feedback_requests_user_id_type_created_at_idx" ON "feedback_requests"("user_id", "type", "created_at");
+
+-- CreateIndex
+CREATE INDEX "feedback_requests_dedupe_key_idx" ON "feedback_requests"("dedupe_key");
+
+-- AddForeignKey
+ALTER TABLE "feedback_requests" ADD CONSTRAINT "feedback_requests_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,18 @@ enum CaptureLifecycle {
   discarded
 }
 
+enum FeedbackType {
+  bug
+  feature
+  general
+}
+
+enum FeedbackStatus {
+  new
+  triaged
+  closed
+}
+
 enum AiSuggestionStatus {
   pending
   accepted
@@ -132,6 +144,7 @@ model User {
   failedAutomationActions FailedAutomationAction[]
   aiSuggestions     AiSuggestion[]
   captureItems      CaptureItem[]
+  feedbackRequests  FeedbackRequest[]
   areas             Area[]
   goals             Goal[]
   planningPreferences UserPlanningPreferences?
@@ -445,6 +458,34 @@ model CaptureItem {
   @@map("capture_items")
   @@index([userId, lifecycle])
   @@index([userId, capturedAt])
+}
+
+model FeedbackRequest {
+  id                String         @id @default(uuid()) @db.Uuid
+  userId            String         @map("user_id")
+  type              FeedbackType
+  title             String         @db.VarChar(200)
+  body              String         @db.Text
+  screenshotUrl     String?        @db.VarChar(2000) @map("screenshot_url")
+  attachmentMetadata Json?         @map("attachment_metadata")
+  pageUrl           String?        @db.VarChar(2000) @map("page_url")
+  userAgent         String?        @db.VarChar(2000) @map("user_agent")
+  appVersion        String?        @db.VarChar(50) @map("app_version")
+  status            FeedbackStatus @default(new)
+  triageSummary     String?        @db.Text @map("triage_summary")
+  severity          String?        @db.VarChar(20)
+  dedupeKey         String?        @db.VarChar(255) @map("dedupe_key")
+  githubIssueNumber Int?           @map("github_issue_number")
+  githubIssueUrl    String?        @db.VarChar(2000) @map("github_issue_url")
+  createdAt         DateTime       @default(now()) @map("created_at")
+  updatedAt         DateTime       @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("feedback_requests")
+  @@index([userId, status, createdAt])
+  @@index([userId, type, createdAt])
+  @@index([dedupeKey])
 }
 
 model Area {

--- a/src/app.ts
+++ b/src/app.ts
@@ -37,6 +37,8 @@ import { CaptureService } from "./services/captureService";
 import { createCaptureRouter } from "./routes/captureRouter";
 import { createPreferencesRouter } from "./routes/preferencesRouter";
 import { createAgentEnrollmentRouter } from "./routes/agentEnrollmentRouter";
+import { FeedbackService } from "./services/feedbackService";
+import { createFeedbackRouter } from "./routes/feedbackRouter";
 import { AgentEnrollmentService } from "./services/agentEnrollmentService";
 import {
   authLimiter,
@@ -83,6 +85,9 @@ export function createApp(
   const mcpClientService = new McpClientService();
   const captureService = persistencePrisma
     ? new CaptureService(persistencePrisma)
+    : null;
+  const feedbackService = persistencePrisma
+    ? new FeedbackService(persistencePrisma)
     : null;
 
   const resolveTodoUserId = (req: Request, res: Response): string | null => {
@@ -205,6 +210,7 @@ export function createApp(
   app.use("/agent", apiLimiter);
   app.use("/mcp", apiLimiter);
   app.use("/capture", apiLimiter);
+  app.use("/feedback", apiLimiter);
   app.use("/preferences", apiLimiter);
   app.use("/oauth", mcpPublicLimiter);
   app.use("/.well-known", mcpPublicLimiter);
@@ -234,6 +240,7 @@ export function createApp(
     app.use("/ai", authMiddleware(authService));
     app.use("/projects", authMiddleware(authService));
     app.use("/capture", authMiddleware(authService));
+    app.use("/feedback", authMiddleware(authService));
     app.use("/preferences", authMiddleware(authService));
     app.use(
       "/admin",
@@ -300,6 +307,10 @@ export function createApp(
 
   if (captureService) {
     app.use("/capture", createCaptureRouter(captureService));
+  }
+
+  if (feedbackService) {
+    app.use("/feedback", createFeedbackRouter({ feedbackService }));
   }
 
   if (persistencePrisma) {

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -1,0 +1,127 @@
+import request from "supertest";
+import { createApp } from "./app";
+import { PrismaTodoService } from "./services/prismaTodoService";
+import { AuthService } from "./services/authService";
+import { prisma } from "./prismaClient";
+
+describe("Feedback API Integration", () => {
+  let app: ReturnType<typeof createApp>;
+  let authToken: string;
+  let userId: string;
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = "test-secret-for-feedback-api-tests";
+    const todoService = new PrismaTodoService(prisma);
+    const authService = new AuthService(prisma);
+    app = createApp(todoService, authService);
+  });
+
+  beforeEach(async () => {
+    await prisma.feedbackRequest.deleteMany();
+    await prisma.captureItem.deleteMany();
+    await prisma.refreshToken.deleteMany();
+    await prisma.user.deleteMany();
+
+    const registerResponse = await request(app).post("/auth/register").send({
+      email: "feedback-test@example.com",
+      password: "password123",
+      name: "Feedback Tester",
+    });
+
+    authToken = registerResponse.body.token;
+    userId = registerResponse.body.user.id;
+  });
+
+  it("POST /feedback creates a bug report with captured context", async () => {
+    const response = await request(app)
+      .post("/feedback")
+      .set("Authorization", `Bearer ${authToken}`)
+      .set("User-Agent", "Feedback Integration Test UA")
+      .send({
+        type: "bug",
+        title: "Task drawer crashes on save",
+        body: "What happened: Save throws an error.\nExpected: Task updates.\nRight before: Edited notes.",
+        screenshotUrl: "https://example.com/screenshots/task-drawer.png",
+        attachmentMetadata: {
+          name: "task-drawer.png",
+          type: "image/png",
+          size: 48291,
+          lastModified: 1710000000000,
+        },
+        pageUrl: "https://app.example.com/?view=todos",
+        userAgent: "Feedback Integration Test UA",
+        appVersion: "1.6.0",
+      })
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      userId,
+      type: "bug",
+      title: "Task drawer crashes on save",
+      screenshotUrl: "https://example.com/screenshots/task-drawer.png",
+      pageUrl: "https://app.example.com/?view=todos",
+      userAgent: "Feedback Integration Test UA",
+      appVersion: "1.6.0",
+      status: "new",
+    });
+    expect(response.body.attachmentMetadata).toEqual({
+      name: "task-drawer.png",
+      type: "image/png",
+      size: 48291,
+      lastModified: 1710000000000,
+    });
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: response.body.id },
+    });
+
+    expect(persisted).not.toBeNull();
+    expect(persisted?.userId).toBe(userId);
+    expect(persisted?.type).toBe("bug");
+    expect(persisted?.status).toBe("new");
+    expect(persisted?.pageUrl).toBe("https://app.example.com/?view=todos");
+  });
+
+  it("POST /feedback creates a feature request without screenshot fields", async () => {
+    const response = await request(app)
+      .post("/feedback")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        type: "feature",
+        title: "Make weekly planning easier",
+        body: "Trying to do: review next week.\nHard today: too much manual sorting.\nWould help: suggested grouping.",
+      })
+      .expect(201);
+
+    expect(response.body.type).toBe("feature");
+    expect(response.body.screenshotUrl).toBeNull();
+    expect(response.body.attachmentMetadata).toBeNull();
+  });
+
+  it("POST /feedback returns clear validation errors", async () => {
+    const response = await request(app)
+      .post("/feedback")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        type: "idea",
+        title: "   ",
+        body: "",
+      })
+      .expect(400);
+
+    expect(response.body).toEqual({
+      error: 'type must be "bug", "feature", or "general"',
+    });
+  });
+
+  it("POST /feedback returns 401 without auth", async () => {
+    await request(app)
+      .post("/feedback")
+      .send({
+        type: "bug",
+        title: "Missing auth",
+        body: "Should not work",
+      })
+      .expect(401);
+  });
+});

--- a/src/routes/feedbackRouter.ts
+++ b/src/routes/feedbackRouter.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { FeedbackService } from "../services/feedbackService";
+import { validateCreateFeedbackRequest } from "../validation/validation";
+
+interface FeedbackRouterDeps {
+  feedbackService: FeedbackService;
+}
+
+export function createFeedbackRouter({
+  feedbackService,
+}: FeedbackRouterDeps): Router {
+  const router = Router();
+
+  router.post("/", async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+
+      const dto = validateCreateFeedbackRequest(req.body);
+      const feedbackRequest = await feedbackService.create(userId, dto);
+      res.status(201).json(feedbackRequest);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -1,0 +1,80 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import {
+  CreateFeedbackRequestDto,
+  FeedbackRequestDto,
+  FeedbackAttachmentMetadataDto,
+} from "../types";
+
+export class FeedbackService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(
+    userId: string,
+    dto: CreateFeedbackRequestDto,
+  ): Promise<FeedbackRequestDto> {
+    const record = await this.prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: dto.type,
+        title: dto.title,
+        body: dto.body,
+        screenshotUrl: dto.screenshotUrl ?? null,
+        attachmentMetadata:
+          dto.attachmentMetadata === undefined
+            ? undefined
+            : dto.attachmentMetadata === null
+              ? Prisma.JsonNull
+              : (dto.attachmentMetadata as Prisma.InputJsonValue),
+        pageUrl: dto.pageUrl ?? null,
+        userAgent: dto.userAgent ?? null,
+        appVersion: dto.appVersion ?? null,
+      },
+    });
+
+    return this.toDto(record);
+  }
+
+  private toDto(record: {
+    id: string;
+    userId: string;
+    type: "bug" | "feature" | "general";
+    title: string;
+    body: string;
+    screenshotUrl: string | null;
+    attachmentMetadata: unknown;
+    pageUrl: string | null;
+    userAgent: string | null;
+    appVersion: string | null;
+    status: "new" | "triaged" | "closed";
+    triageSummary: string | null;
+    severity: string | null;
+    dedupeKey: string | null;
+    githubIssueNumber: number | null;
+    githubIssueUrl: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): FeedbackRequestDto {
+    return {
+      id: record.id,
+      userId: record.userId,
+      type: record.type,
+      title: record.title,
+      body: record.body,
+      screenshotUrl: record.screenshotUrl,
+      attachmentMetadata:
+        (record.attachmentMetadata as FeedbackAttachmentMetadataDto | null) ??
+        null,
+      pageUrl: record.pageUrl,
+      userAgent: record.userAgent,
+      appVersion: record.appVersion,
+      status: record.status,
+      triageSummary: record.triageSummary,
+      severity: record.severity,
+      dedupeKey: record.dedupeKey,
+      githubIssueNumber: record.githubIssueNumber,
+      githubIssueUrl: record.githubIssueUrl,
+      createdAt: record.createdAt.toISOString(),
+      updatedAt: record.updatedAt.toISOString(),
+    };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -340,3 +340,45 @@ export interface CreateCaptureItemDto {
   source?: string;
   capturedAt?: string;
 }
+
+export type FeedbackRequestType = "bug" | "feature" | "general";
+export type FeedbackRequestStatus = "new" | "triaged" | "closed";
+
+export interface FeedbackAttachmentMetadataDto {
+  name?: string | null;
+  type?: string | null;
+  size?: number | null;
+  lastModified?: number | null;
+}
+
+export interface CreateFeedbackRequestDto {
+  type: FeedbackRequestType;
+  title: string;
+  body: string;
+  screenshotUrl?: string | null;
+  attachmentMetadata?: FeedbackAttachmentMetadataDto | null;
+  pageUrl?: string | null;
+  userAgent?: string | null;
+  appVersion?: string | null;
+}
+
+export interface FeedbackRequestDto {
+  id: string;
+  userId: string;
+  type: FeedbackRequestType;
+  title: string;
+  body: string;
+  screenshotUrl?: string | null;
+  attachmentMetadata?: FeedbackAttachmentMetadataDto | null;
+  pageUrl?: string | null;
+  userAgent?: string | null;
+  appVersion?: string | null;
+  status: FeedbackRequestStatus;
+  triageSummary?: string | null;
+  severity?: string | null;
+  dedupeKey?: string | null;
+  githubIssueNumber?: number | null;
+  githubIssueUrl?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -14,6 +14,8 @@ import {
   ReorderTodoItemDto,
   ReorderHeadingItemDto,
   FindTodosQuery,
+  CreateFeedbackRequestDto,
+  FeedbackAttachmentMetadataDto,
   Priority,
   TaskSource,
   TaskStatus,
@@ -1532,4 +1534,138 @@ export function validateUpdateSubtask(data: unknown): UpdateSubtaskDto {
   }
 
   return update;
+}
+
+function normalizeOptionalAbsoluteUrl(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string | null | undefined {
+  const normalized = normalizeNullableString(value, field, maxLength);
+  if (normalized == null) {
+    return normalized;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new ValidationError(`${field} must be a valid absolute URL`);
+  }
+  if (!parsed.protocol || !parsed.host) {
+    throw new ValidationError(`${field} must be a valid absolute URL`);
+  }
+  return normalized;
+}
+
+function normalizeFeedbackAttachmentMetadata(
+  value: unknown,
+): FeedbackAttachmentMetadataDto | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError("attachmentMetadata must be an object");
+  }
+
+  const body = value as Record<string, unknown>;
+  const metadata: FeedbackAttachmentMetadataDto = {};
+
+  const name = normalizeNullableString(
+    body.name,
+    "attachmentMetadata.name",
+    255,
+  );
+  if (name !== undefined) {
+    metadata.name = name;
+  }
+
+  const type = normalizeNullableString(
+    body.type,
+    "attachmentMetadata.type",
+    100,
+  );
+  if (type !== undefined) {
+    metadata.type = type;
+  }
+
+  const size = body.size;
+  if (size !== undefined) {
+    if (size === null) {
+      metadata.size = null;
+    } else if (
+      typeof size === "number" &&
+      Number.isInteger(size) &&
+      size >= 0
+    ) {
+      metadata.size = size;
+    } else {
+      throw new ValidationError(
+        "attachmentMetadata.size must be a non-negative integer",
+      );
+    }
+  }
+
+  const lastModified = body.lastModified;
+  if (lastModified !== undefined) {
+    if (lastModified === null) {
+      metadata.lastModified = null;
+    } else if (
+      typeof lastModified === "number" &&
+      Number.isInteger(lastModified) &&
+      lastModified >= 0
+    ) {
+      metadata.lastModified = lastModified;
+    } else {
+      throw new ValidationError(
+        "attachmentMetadata.lastModified must be a non-negative integer",
+      );
+    }
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+export function validateCreateFeedbackRequest(
+  data: unknown,
+): CreateFeedbackRequestDto {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  const body = data as Record<string, unknown>;
+  const type = body.type;
+  if (typeof type !== "string") {
+    throw new ValidationError("type is required");
+  }
+  if (!["bug", "feature", "general"].includes(type)) {
+    throw new ValidationError('type must be "bug", "feature", or "general"');
+  }
+
+  const title = normalizeOptionalString(body.title, "title", 200);
+  if (!title) {
+    throw new ValidationError("title is required");
+  }
+
+  const feedbackBody = normalizeOptionalString(body.body, "body", 8000);
+  if (!feedbackBody) {
+    throw new ValidationError("body is required");
+  }
+
+  return {
+    type: type as CreateFeedbackRequestDto["type"],
+    title,
+    body: feedbackBody,
+    screenshotUrl:
+      normalizeOptionalAbsoluteUrl(body.screenshotUrl, "screenshotUrl", 2000) ??
+      undefined,
+    attachmentMetadata:
+      normalizeFeedbackAttachmentMetadata(body.attachmentMetadata) ?? undefined,
+    pageUrl:
+      normalizeOptionalAbsoluteUrl(body.pageUrl, "pageUrl", 2000) ?? undefined,
+    userAgent: normalizeOptionalString(body.userAgent, "userAgent", 2000),
+    appVersion: normalizeOptionalString(body.appVersion, "appVersion", 50),
+  };
 }

--- a/tests/ui/feedback-flow.spec.ts
+++ b/tests/ui/feedback-flow.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import { openTodosViewWithStorageState } from "./helpers/todos-view";
+
+test.describe("Feedback flow", () => {
+  test("submits structured feedback and shows confirmation", async ({
+    page,
+  }) => {
+    let submittedPayload: Record<string, unknown> | null = null;
+
+    await page.route("**/feedback", async (route) => {
+      submittedPayload = JSON.parse(
+        route.request().postData() || "{}",
+      ) as Record<string, unknown>;
+
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "feedback-1",
+          userId: "user-1",
+          type: submittedPayload?.type || "feature",
+          title: submittedPayload?.title || "Requested improvement",
+          body: submittedPayload?.body || "",
+          screenshotUrl: submittedPayload?.screenshotUrl || null,
+          attachmentMetadata: submittedPayload?.attachmentMetadata || null,
+          pageUrl: submittedPayload?.pageUrl || null,
+          userAgent: submittedPayload?.userAgent || null,
+          appVersion: submittedPayload?.appVersion || null,
+          status: "new",
+          triageSummary: null,
+          severity: null,
+          dedupeKey: null,
+          githubIssueNumber: null,
+          githubIssueUrl: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
+      });
+    });
+
+    await openTodosViewWithStorageState(page, {
+      name: "Feedback Tester",
+      email: "user@example.com",
+    });
+
+    await page.evaluate(() =>
+      (window as Window & { switchView: (view: string) => void }).switchView(
+        "feedback",
+      ),
+    );
+    await expect(page.locator("#feedbackView")).toHaveClass(/active/);
+
+    await page.locator("#feedbackType").selectOption("feature");
+    await page.locator("#feedbackTitle").fill("Make planning easier");
+    await page
+      .locator("#feedbackQuestionOne")
+      .fill("I am trying to sketch next week's plan.");
+    await page
+      .locator("#feedbackQuestionTwo")
+      .fill("It takes too many manual clicks to group related work.");
+    await page
+      .locator("#feedbackQuestionThree")
+      .fill("Suggested bundles for today and upcoming work would help.");
+    await page
+      .locator("#feedbackScreenshotUrl")
+      .fill("https://example.com/feedback/planning.png");
+    await page.locator("#feedbackAttachment").setInputFiles({
+      name: "planning.png",
+      mimeType: "image/png",
+      buffer: Buffer.from("fake-image"),
+    });
+
+    await page.getByRole("button", { name: "Send feedback" }).click();
+
+    await expect(page.locator("#feedbackConfirmation")).toBeVisible();
+    await expect(page.locator("#feedbackConfirmationTitle")).toHaveText(
+      "Feature request sent",
+    );
+    expect(submittedPayload).not.toBeNull();
+    expect(submittedPayload).toMatchObject({
+      type: "feature",
+      title: "Make planning easier",
+      screenshotUrl: "https://example.com/feedback/planning.png",
+      appVersion: "1.6.0",
+    });
+    expect(typeof submittedPayload?.body).toBe("string");
+    expect(String(submittedPayload?.body)).toContain(
+      "What are you trying to do?",
+    );
+    expect(String(submittedPayload?.pageUrl)).toContain("/");
+    expect(typeof submittedPayload?.userAgent).toBe("string");
+    expect(submittedPayload?.attachmentMetadata).toMatchObject({
+      name: "planning.png",
+      type: "image/png",
+      size: 10,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds an in-app feedback flow so friends-and-family users can send bug reports and feature requests without needing GitHub access. Before this change, non-technical users had no low-friction way to report issues or ideas from inside the product, which meant useful feedback was either lost or had to be relayed manually by someone technical.

## What was happening

The app did not expose any dedicated feedback entry point, and the backend had no persistence model or API route for structured feedback submissions. That meant there was nowhere to collect the context we would want later for triage, such as the authenticated user, the current page, the running app version, or the browser user agent. Even when someone could describe a problem informally, that report was hard to operationalize downstream.

## Root cause

The product was missing both halves of the workflow:

- a user-facing surface to collect the right questions for bug reports and feature requests
- a database-backed server path to validate and store those submissions with contextual metadata

## Fix

This change adds a new Prisma-backed `FeedbackRequest` model and migration, a validated `POST /feedback` route, and a small feedback service that persists structured submissions for the authenticated user. On the client side, it adds a `Feedback` entry point in the app, a dedicated feedback view, question flows tailored to bug reports versus feature requests, and success confirmation after submission.

The frontend also captures useful context automatically where available:

- current page URL
- app version
- browser user agent
- authenticated user id on the server side
- optional screenshot URL
- optional screenshot attachment metadata for a selected image file

## User impact

Friends-and-family users can now report bugs and request features directly from inside the app with a workflow that feels native to the product. Their submissions are stored in a structured format that is ready for later triage and eventual issue creation without adding GitHub as a dependency for them.

## Validation

I validated the change with:

- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts`
- `CI=1 npm run test:ui:fast`
