### PR TITLE
[codex] add admin feedback review queue

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -405,10 +405,15 @@ import {
 } from "./modules/drawerUi.js";
 import {
   loadAdminUsers,
-  renderAdminUsers,
   changeUserRole,
   deleteUser,
 } from "./modules/adminUsers.js";
+import {
+  loadAdminFeedbackQueue,
+  selectAdminFeedback,
+  setAdminFeedbackFilter,
+  updateAdminFeedbackStatus,
+} from "./modules/adminFeedback.js";
 import * as DragDrop from "./modules/dragDrop.js";
 import { toggleShortcuts, closeShortcutsOverlay } from "./modules/shortcuts.js";
 import {
@@ -653,7 +658,10 @@ const { ensureTodosShellActive, selectWorkspaceView, switchView } =
     loadAiUsage,
     loadAiInsights,
     loadAiFeedbackSummary,
-    loadAdminUsers,
+    loadAdminUsers: () => {
+      void loadAdminFeedbackQueue();
+      void loadAdminUsers();
+    },
     prepareFeedbackView,
   });
 
@@ -1761,6 +1769,9 @@ window.onboardingSetDueDate = onboardingSetDueDate;
 // Admin
 window.changeUserRole = changeUserRole;
 window.deleteUser = deleteUser;
+window.selectAdminFeedback = selectAdminFeedback;
+window.setAdminFeedbackFilter = setAdminFeedbackFilter;
+window.updateAdminFeedbackStatus = updateAdminFeedbackStatus;
 
 // ---------------------------------------------------------------------------
 // App bootstrap

--- a/client/index.html
+++ b/client/index.html
@@ -2485,11 +2485,10 @@
                   aria-live="polite"
                   aria-atomic="true"
                 ></div>
-                <h2>User Management</h2>
                 <div id="adminContent">
                   <div class="loading">
                     <div class="spinner"></div>
-                    Loading users...
+                    Loading admin tools...
                   </div>
                 </div>
               </div>

--- a/client/modules/adminFeedback.js
+++ b/client/modules/adminFeedback.js
@@ -1,0 +1,424 @@
+import { state, hooks } from "./store.js";
+
+const STATUS_FILTERS = ["new", "triaged", "promoted", "rejected"];
+const TYPE_FILTERS = ["bug", "feature"];
+
+function escape(value) {
+  return hooks.escapeHtml
+    ? hooks.escapeHtml(String(value ?? ""))
+    : String(value ?? "");
+}
+
+function formatDateTime(value) {
+  if (!value) return "Unknown";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString();
+}
+
+function getAdminFeedbackElements() {
+  return {
+    container: document.getElementById("adminContent"),
+    list: document.getElementById("adminFeedbackList"),
+    detail: document.getElementById("adminFeedbackDetail"),
+  };
+}
+
+function ensureAdminWorkspaceShell() {
+  const { container } = getAdminFeedbackElements();
+  if (!(container instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (container.dataset.adminShellReady === "true") {
+    return true;
+  }
+
+  container.innerHTML = `
+    <div class="admin-layout">
+      <section class="admin-section admin-feedback-section">
+        <div class="admin-section__header">
+          <div>
+            <h2 class="admin-section__title">Feedback Queue</h2>
+            <p class="admin-section__subtitle">Review incoming bugs and feature requests before promotion.</p>
+          </div>
+        </div>
+        <div class="admin-filter-groups">
+          <div class="admin-filter-group">
+            <span class="admin-filter-label">Status</span>
+            <div class="admin-filter-row">
+              <button type="button" class="admin-filter-chip" data-onclick="setAdminFeedbackFilter('status', '')">All</button>
+              ${STATUS_FILTERS.map(
+                (status) =>
+                  `<button type="button" class="admin-filter-chip" data-onclick="setAdminFeedbackFilter('status', '${status}')">${escape(status)}</button>`,
+              ).join("")}
+            </div>
+          </div>
+          <div class="admin-filter-group">
+            <span class="admin-filter-label">Type</span>
+            <div class="admin-filter-row">
+              <button type="button" class="admin-filter-chip" data-onclick="setAdminFeedbackFilter('type', '')">All</button>
+              ${TYPE_FILTERS.map(
+                (type) =>
+                  `<button type="button" class="admin-filter-chip" data-onclick="setAdminFeedbackFilter('type', '${type}')">${escape(type)}</button>`,
+              ).join("")}
+            </div>
+          </div>
+        </div>
+        <div class="admin-feedback-grid">
+          <div id="adminFeedbackList" class="admin-feedback-list"></div>
+          <div id="adminFeedbackDetail" class="admin-feedback-detail"></div>
+        </div>
+      </section>
+      <section class="admin-section">
+        <div id="adminUsersContent">
+          <div class="loading">
+            <div class="spinner"></div>
+            Loading users...
+          </div>
+        </div>
+      </section>
+    </div>
+  `;
+  container.dataset.adminShellReady = "true";
+  return true;
+}
+
+function renderFilterChips() {
+  const container = document.getElementById("adminContent");
+  if (!(container instanceof HTMLElement)) {
+    return;
+  }
+
+  container.querySelectorAll(".admin-filter-chip").forEach((element) => {
+    if (!(element instanceof HTMLButtonElement)) {
+      return;
+    }
+    const handler = element.dataset.onclick || "";
+    const statusMatch = handler.match(
+      /setAdminFeedbackFilter\('status', '([^']*)'\)/,
+    );
+    const typeMatch = handler.match(
+      /setAdminFeedbackFilter\('type', '([^']*)'\)/,
+    );
+    const active =
+      (statusMatch && statusMatch[1] === state.adminFeedbackFilters.status) ||
+      (typeMatch && typeMatch[1] === state.adminFeedbackFilters.type);
+    element.classList.toggle("is-active", Boolean(active));
+  });
+}
+
+function renderAdminFeedbackList() {
+  const { list } = getAdminFeedbackElements();
+  if (!(list instanceof HTMLElement)) {
+    return;
+  }
+
+  renderFilterChips();
+
+  if (state.adminFeedbackListLoading) {
+    list.innerHTML = `
+      <div class="loading">
+        <div class="spinner"></div>
+        Loading feedback...
+      </div>
+    `;
+    return;
+  }
+
+  if (!state.adminFeedbackItems.length) {
+    list.innerHTML = `
+      <div class="admin-feedback-empty">
+        No feedback matches the current filters.
+      </div>
+    `;
+    return;
+  }
+
+  list.innerHTML = state.adminFeedbackItems
+    .map((item) => {
+      const isSelected = item.id === state.adminFeedbackSelectedId;
+      return `
+        <button
+          type="button"
+          class="admin-feedback-row${isSelected ? " is-selected" : ""}"
+          data-onclick="selectAdminFeedback('${item.id}')"
+        >
+          <div class="admin-feedback-row__top">
+            <span class="admin-feedback-pill admin-feedback-pill--${escape(item.type)}">${escape(item.type)}</span>
+            <span class="admin-feedback-pill admin-feedback-pill--status">${escape(item.status)}</span>
+          </div>
+          <strong class="admin-feedback-row__title">${escape(item.title)}</strong>
+          <div class="admin-feedback-row__meta">
+            <span>${escape(item.user?.email || item.userId)}</span>
+            <span>${escape(formatDateTime(item.createdAt))}</span>
+          </div>
+        </button>
+      `;
+    })
+    .join("");
+}
+
+function renderMetadataRow(label, value) {
+  return `
+    <div class="admin-detail-meta__row">
+      <span class="admin-detail-meta__label">${escape(label)}</span>
+      <span class="admin-detail-meta__value">${escape(value || "—")}</span>
+    </div>
+  `;
+}
+
+function renderAdminFeedbackDetail() {
+  const { detail } = getAdminFeedbackElements();
+  if (!(detail instanceof HTMLElement)) {
+    return;
+  }
+
+  if (state.adminFeedbackDetailLoading) {
+    detail.innerHTML = `
+      <div class="loading">
+        <div class="spinner"></div>
+        Loading details...
+      </div>
+    `;
+    return;
+  }
+
+  const item = state.adminFeedbackDetail;
+  if (!item) {
+    detail.innerHTML = `
+      <div class="admin-feedback-empty">
+        Select a feedback item to inspect the full submission and metadata.
+      </div>
+    `;
+    return;
+  }
+
+  const attachmentSummary = item.attachmentMetadata
+    ? `${item.attachmentMetadata.name || "Attachment"} • ${item.attachmentMetadata.type || "unknown"} • ${item.attachmentMetadata.size ?? 0} bytes`
+    : "No attachment metadata";
+
+  detail.innerHTML = `
+    <div class="admin-detail-card">
+      <div class="admin-detail-card__header">
+        <div>
+          <div class="admin-feedback-row__top">
+            <span class="admin-feedback-pill admin-feedback-pill--${escape(item.type)}">${escape(item.type)}</span>
+            <span class="admin-feedback-pill admin-feedback-pill--status">${escape(item.status)}</span>
+          </div>
+          <h3>${escape(item.title)}</h3>
+          <p class="admin-section__subtitle">Submitted by ${escape(item.user?.email || item.userId)} on ${escape(formatDateTime(item.createdAt))}</p>
+        </div>
+      </div>
+
+      <div class="admin-detail-block">
+        <h4>Submission</h4>
+        <pre class="admin-detail-pre">${escape(item.body)}</pre>
+      </div>
+
+      <div class="admin-detail-block">
+        <h4>Captured Metadata</h4>
+        <div class="admin-detail-meta">
+          ${renderMetadataRow("User", item.user?.email || item.userId)}
+          ${renderMetadataRow("Reviewer", item.reviewer?.email || "")}
+          ${renderMetadataRow("Reviewed at", item.reviewedAt ? formatDateTime(item.reviewedAt) : "")}
+          ${renderMetadataRow("Page URL", item.pageUrl || "")}
+          ${renderMetadataRow("App version", item.appVersion || "")}
+          ${renderMetadataRow("Browser", item.userAgent || "")}
+          ${renderMetadataRow("Screenshot URL", item.screenshotUrl || "")}
+          ${renderMetadataRow("Attachment", attachmentSummary)}
+          ${renderMetadataRow("Triage summary", item.triageSummary || "")}
+          ${renderMetadataRow("Severity", item.severity || "")}
+          ${renderMetadataRow("Rejection reason", item.rejectionReason || "")}
+        </div>
+      </div>
+
+      <div class="admin-detail-block">
+        <h4>Review Actions</h4>
+        <div class="admin-feedback-actions">
+          <button type="button" class="action-btn demote" data-onclick="updateAdminFeedbackStatus('triaged')">Mark reviewed</button>
+          <button type="button" class="action-btn promote" data-onclick="updateAdminFeedbackStatus('promoted')">Ready for promotion</button>
+          <button type="button" class="action-btn delete" data-onclick="updateAdminFeedbackStatus('rejected')">Reject</button>
+        </div>
+        <label class="feedback-form__label" for="adminFeedbackRejectionReason">Rejection reason</label>
+        <textarea id="adminFeedbackRejectionReason" class="feedback-form__textarea admin-feedback-rejection" placeholder="Add context if you reject this item.">${escape(item.rejectionReason || "")}</textarea>
+      </div>
+    </div>
+  `;
+}
+
+function renderAdminFeedbackWorkspace() {
+  if (!ensureAdminWorkspaceShell()) {
+    return;
+  }
+  renderAdminFeedbackList();
+  renderAdminFeedbackDetail();
+}
+
+function buildQueryString() {
+  const search = new URLSearchParams();
+  if (state.adminFeedbackFilters.status) {
+    search.set("status", state.adminFeedbackFilters.status);
+  }
+  if (state.adminFeedbackFilters.type) {
+    search.set("type", state.adminFeedbackFilters.type);
+  }
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+export async function selectAdminFeedback(feedbackId) {
+  if (!feedbackId) {
+    state.adminFeedbackSelectedId = "";
+    state.adminFeedbackDetail = null;
+    renderAdminFeedbackDetail();
+    return;
+  }
+
+  state.adminFeedbackSelectedId = feedbackId;
+  state.adminFeedbackDetailLoading = true;
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(feedbackId)}`,
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to load feedback details",
+        "error",
+      );
+      state.adminFeedbackDetail = null;
+      return;
+    }
+
+    hooks.hideMessage?.("adminMessage");
+    state.adminFeedbackDetail = data;
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+    state.adminFeedbackDetail = null;
+  } finally {
+    state.adminFeedbackDetailLoading = false;
+    renderAdminFeedbackWorkspace();
+  }
+}
+
+export async function loadAdminFeedbackQueue() {
+  ensureAdminWorkspaceShell();
+  state.adminFeedbackListLoading = true;
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback${buildQueryString()}`,
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to load feedback queue",
+        "error",
+      );
+      state.adminFeedbackItems = [];
+      state.adminFeedbackSelectedId = "";
+      state.adminFeedbackDetail = null;
+      return;
+    }
+
+    hooks.hideMessage?.("adminMessage");
+    state.adminFeedbackItems = Array.isArray(data) ? data : [];
+
+    const selectedStillExists = state.adminFeedbackItems.some(
+      (item) => item.id === state.adminFeedbackSelectedId,
+    );
+    const nextSelectedId =
+      (selectedStillExists && state.adminFeedbackSelectedId) ||
+      state.adminFeedbackItems[0]?.id ||
+      "";
+
+    state.adminFeedbackSelectedId = nextSelectedId;
+    state.adminFeedbackDetail = null;
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+    state.adminFeedbackItems = [];
+    state.adminFeedbackSelectedId = "";
+    state.adminFeedbackDetail = null;
+  } finally {
+    state.adminFeedbackListLoading = false;
+    renderAdminFeedbackWorkspace();
+  }
+
+  if (state.adminFeedbackSelectedId) {
+    await selectAdminFeedback(state.adminFeedbackSelectedId);
+  }
+}
+
+export function setAdminFeedbackFilter(kind, value) {
+  if (kind !== "status" && kind !== "type") {
+    return;
+  }
+
+  state.adminFeedbackFilters[kind] = value || "";
+  void loadAdminFeedbackQueue();
+}
+
+export async function updateAdminFeedbackStatus(status) {
+  if (!state.adminFeedbackSelectedId) {
+    return;
+  }
+
+  const rejectionField = document.getElementById(
+    "adminFeedbackRejectionReason",
+  );
+  const rejectionReason =
+    rejectionField instanceof HTMLTextAreaElement
+      ? rejectionField.value.trim()
+      : "";
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status,
+          rejectionReason: rejectionReason || null,
+        }),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to update feedback status",
+        "error",
+      );
+      return;
+    }
+
+    hooks.showMessage?.("adminMessage", `Feedback marked ${status}`, "success");
+    await loadAdminFeedbackQueue();
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  }
+}
+
+export { renderAdminFeedbackWorkspace };

--- a/client/modules/adminUsers.js
+++ b/client/modules/adminUsers.js
@@ -34,9 +34,21 @@ async function loadAdminUsers() {
 
 // Render admin users
 function renderAdminUsers() {
-  const container = document.getElementById("adminContent");
+  const container =
+    document.getElementById("adminUsersContent") ||
+    document.getElementById("adminContent");
+
+  if (!(container instanceof HTMLElement)) {
+    return;
+  }
 
   container.innerHTML = `
+                <div class="admin-section__header">
+                    <div>
+                        <h3 class="admin-section__title">User Management</h3>
+                        <p class="admin-section__subtitle">Manage admin access and account cleanup.</p>
+                    </div>
+                </div>
                 <table class="users-table">
                     <thead>
                         <tr>

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -151,6 +151,15 @@ export const state = {
   // Users / admin
   users: [],
   adminBootstrapAvailable: false,
+  adminFeedbackItems: [],
+  adminFeedbackSelectedId: "",
+  adminFeedbackDetail: null,
+  adminFeedbackFilters: {
+    status: "",
+    type: "",
+  },
+  adminFeedbackListLoading: false,
+  adminFeedbackDetailLoading: false,
 
   // AI
   aiSuggestions: [],

--- a/client/styles.css
+++ b/client/styles.css
@@ -3696,6 +3696,217 @@ body.is-todos-view .floating-new-task-cta {
   color: var(--text-primary);
 }
 
+.admin-layout {
+  display: grid;
+  gap: 24px;
+}
+
+.admin-section {
+  background: var(--surface-elevated, var(--card-bg));
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  padding: 20px;
+}
+
+.admin-section__header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.admin-section__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.admin-section__subtitle {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+}
+
+.admin-filter-groups {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.admin-filter-group {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-filter-label {
+  font-size: 0.85rem;
+  font-weight: var(--fw-semibold);
+  color: var(--text-secondary);
+}
+
+.admin-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-filter-chip {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.admin-filter-chip.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.admin-feedback-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 18px;
+}
+
+.admin-feedback-list,
+.admin-feedback-detail {
+  min-height: 220px;
+}
+
+.admin-feedback-row {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  border-radius: var(--r-md);
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+  display: grid;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.admin-feedback-row.is-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.admin-feedback-row__top,
+.admin-feedback-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  align-items: center;
+}
+
+.admin-feedback-row__meta {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.admin-feedback-row__title {
+  color: var(--text-primary);
+}
+
+.admin-feedback-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  font-weight: var(--fw-semibold);
+  background: var(--card-bg);
+  color: var(--text-secondary);
+}
+
+.admin-feedback-pill--bug {
+  background: rgb(203 72 57 / 12%);
+  color: #9c2f20;
+}
+
+.admin-feedback-pill--feature {
+  background: rgb(44 136 104 / 12%);
+  color: #15654b;
+}
+
+.admin-feedback-pill--general,
+.admin-feedback-pill--status {
+  background: rgb(79 110 247 / 13%);
+  color: var(--accent);
+}
+
+.admin-detail-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  padding: 18px;
+  display: grid;
+  gap: 18px;
+}
+
+.admin-detail-card__header h3,
+.admin-detail-block h4 {
+  margin: 0;
+}
+
+.admin-detail-block {
+  display: grid;
+  gap: 10px;
+}
+
+.admin-detail-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 14px;
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  font: inherit;
+}
+
+.admin-detail-meta {
+  display: grid;
+  gap: 10px;
+}
+
+.admin-detail-meta__row {
+  display: grid;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.admin-detail-meta__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.admin-detail-meta__value {
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.admin-feedback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.admin-feedback-empty {
+  border: 1px dashed var(--border-color);
+  border-radius: var(--r-md);
+  padding: 24px;
+  color: var(--text-secondary);
+}
+
+.admin-feedback-rejection {
+  min-height: 100px;
+}
+
 .users-table {
   width: 100%;
   border-collapse: collapse;
@@ -3806,6 +4017,10 @@ body.is-todos-view .floating-new-task-cta {
   .action-btn {
     padding: 4px 8px;
     font-size: 0.75em;
+  }
+
+  .admin-feedback-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todos-api",
-  "version": "1.0.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "todos-api",
-      "version": "1.0.0",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -3551,9 +3551,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "ts-node": "^10.9.2"
   },
   "overrides": {
+    "effect": "^3.21.0",
     "swagger-jsdoc": {
       "glob": "^11.0.0"
     }

--- a/prisma/migrations/20260320133000_add_feedback_review_queue/migration.sql
+++ b/prisma/migrations/20260320133000_add_feedback_review_queue/migration.sql
@@ -1,0 +1,34 @@
+-- Alter feedback status enum to support admin review workflow
+ALTER TYPE "FeedbackStatus" RENAME TO "FeedbackStatus_old";
+
+CREATE TYPE "FeedbackStatus" AS ENUM ('new', 'triaged', 'promoted', 'rejected');
+
+ALTER TABLE "feedback_requests"
+  ALTER COLUMN "status" DROP DEFAULT,
+  ALTER COLUMN "status" TYPE "FeedbackStatus"
+  USING (
+    CASE
+      WHEN "status"::text = 'closed' THEN 'triaged'
+      ELSE "status"::text
+    END
+  )::"FeedbackStatus";
+
+DROP TYPE "FeedbackStatus_old";
+
+ALTER TABLE "feedback_requests"
+  ALTER COLUMN "status" SET DEFAULT 'new',
+  ADD COLUMN "reviewed_by_user_id" TEXT,
+  ADD COLUMN "reviewed_at" TIMESTAMP(3),
+  ADD COLUMN "rejection_reason" TEXT;
+
+CREATE INDEX "feedback_requests_status_type_created_at_idx"
+ON "feedback_requests"("status", "type", "created_at");
+
+CREATE INDEX "feedback_requests_reviewed_by_user_id_reviewed_at_idx"
+ON "feedback_requests"("reviewed_by_user_id", "reviewed_at");
+
+ALTER TABLE "feedback_requests"
+  ADD CONSTRAINT "feedback_requests_reviewed_by_user_id_fkey"
+  FOREIGN KEY ("reviewed_by_user_id") REFERENCES "users"("id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,7 +100,8 @@ enum FeedbackType {
 enum FeedbackStatus {
   new
   triaged
-  closed
+  promoted
+  rejected
 }
 
 enum AiSuggestionStatus {
@@ -110,44 +111,45 @@ enum AiSuggestionStatus {
 }
 
 model User {
-  id                String         @id @default(uuid())
-  email             String         @unique @db.VarChar(255)
-  password          String         @db.VarChar(255)
-  name              String?        @db.VarChar(100)
-  isVerified        Boolean        @default(false) @map("is_verified")
-  verificationToken String?        @unique @db.VarChar(255) @map("verification_token")
-  resetToken        String?        @unique @db.VarChar(255) @map("reset_token")
-  resetTokenExpiry  DateTime?      @map("reset_token_expiry")
-  role              UserRole       @default(user)
-  plan              UserPlan       @default(free)
+  id                    String    @id @default(uuid())
+  email                 String    @unique @db.VarChar(255)
+  password              String    @db.VarChar(255)
+  name                  String?   @db.VarChar(100)
+  isVerified            Boolean   @default(false) @map("is_verified")
+  verificationToken     String?   @unique @map("verification_token") @db.VarChar(255)
+  resetToken            String?   @unique @map("reset_token") @db.VarChar(255)
+  resetTokenExpiry      DateTime? @map("reset_token_expiry")
+  role                  UserRole  @default(user)
+  plan                  UserPlan  @default(free)
   onboardingStep        Int       @default(0) @map("onboarding_step")
   onboardingCompletedAt DateTime? @map("onboarding_completed_at")
-  mcpRevokedAfter   DateTime?      @map("mcp_revoked_after")
-  createdAt         DateTime       @default(now()) @map("created_at")
-  updatedAt         DateTime       @updatedAt @map("updated_at")
+  mcpRevokedAfter       DateTime? @map("mcp_revoked_after")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
 
-  todos             Todo[]
-  projects          Project[]
-  refreshTokens     RefreshToken[]
-  mcpAuthorizationCodes McpAuthorizationCode[]
-  mcpAssistantSessions McpAssistantSession[]
-  mcpRefreshTokens  McpRefreshToken[]
-  agentIdempotencyRecords AgentIdempotencyRecord[]
-  agentActionAudits AgentActionAudit[]
-  agentEnrollment   AgentEnrollment?
-  agentJobRuns      AgentJobRun[]
-  agentConfig       AgentConfig?
-  agentMetricEvents AgentMetricEvent[]
-  recommendationFeedback TaskRecommendationFeedback[]
-  dayContexts            UserDayContext[]
-  learningRecommendations LearningRecommendation[]
-  failedAutomationActions FailedAutomationAction[]
-  aiSuggestions     AiSuggestion[]
-  captureItems      CaptureItem[]
-  feedbackRequests  FeedbackRequest[]
-  areas             Area[]
-  goals             Goal[]
-  planningPreferences UserPlanningPreferences?
+  todos                    Todo[]
+  projects                 Project[]
+  refreshTokens            RefreshToken[]
+  mcpAuthorizationCodes    McpAuthorizationCode[]
+  mcpAssistantSessions     McpAssistantSession[]
+  mcpRefreshTokens         McpRefreshToken[]
+  agentIdempotencyRecords  AgentIdempotencyRecord[]
+  agentActionAudits        AgentActionAudit[]
+  agentEnrollment          AgentEnrollment?
+  agentJobRuns             AgentJobRun[]
+  agentConfig              AgentConfig?
+  agentMetricEvents        AgentMetricEvent[]
+  recommendationFeedback   TaskRecommendationFeedback[]
+  dayContexts              UserDayContext[]
+  learningRecommendations  LearningRecommendation[]
+  failedAutomationActions  FailedAutomationAction[]
+  aiSuggestions            AiSuggestion[]
+  captureItems             CaptureItem[]
+  feedbackRequests         FeedbackRequest[]
+  reviewedFeedbackRequests FeedbackRequest[]            @relation("FeedbackReviewer")
+  areas                    Area[]
+  goals                    Goal[]
+  planningPreferences      UserPlanningPreferences?
 
   @@map("users")
 }
@@ -161,83 +163,83 @@ model RefreshToken {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("refresh_tokens")
   @@index([userId])
+  @@map("refresh_tokens")
 }
 
 model McpAssistantSession {
-  id                    String    @id @default(uuid()) @db.Uuid
-  userId                String    @map("user_id")
-  clientId              String?   @db.VarChar(5000) @map("client_id")
-  assistantName         String?   @db.VarChar(100) @map("assistant_name")
-  scopes                String[]  @default([])
-  source                String    @db.VarChar(20)
-  revokedAt             DateTime? @map("revoked_at")
+  id                      String    @id @default(uuid()) @db.Uuid
+  userId                  String    @map("user_id")
+  clientId                String?   @map("client_id") @db.VarChar(5000)
+  assistantName           String?   @map("assistant_name") @db.VarChar(100)
+  scopes                  String[]  @default([])
+  source                  String    @db.VarChar(20)
+  revokedAt               DateTime? @map("revoked_at")
   lastAccessTokenIssuedAt DateTime? @map("last_access_token_issued_at")
-  lastUsedAt            DateTime? @map("last_used_at")
-  createdAt             DateTime  @default(now()) @map("created_at")
-  updatedAt             DateTime  @updatedAt @map("updated_at")
+  lastUsedAt              DateTime? @map("last_used_at")
+  createdAt               DateTime  @default(now()) @map("created_at")
+  updatedAt               DateTime  @updatedAt @map("updated_at")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user          User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   refreshTokens McpRefreshToken[]
 
-  @@map("mcp_assistant_sessions")
   @@index([userId, revokedAt])
   @@index([clientId])
+  @@map("mcp_assistant_sessions")
 }
 
 model McpAuthorizationCode {
-  code               String   @id @db.Uuid
-  userId             String   @map("user_id")
-  email              String   @db.VarChar(255)
-  clientId           String   @db.VarChar(5000) @map("client_id")
-  redirectUri        String   @db.VarChar(1000) @map("redirect_uri")
-  scopes             String[] @default([])
-  assistantName      String?  @db.VarChar(100) @map("assistant_name")
-  state              String?  @db.VarChar(200)
-  codeChallenge      String   @db.VarChar(128) @map("code_challenge")
-  codeChallengeMethod String  @db.VarChar(10) @map("code_challenge_method")
-  expiresAt          DateTime @map("expires_at")
-  usedAt             DateTime? @map("used_at")
-  createdAt          DateTime @default(now()) @map("created_at")
+  code                String    @id @db.Uuid
+  userId              String    @map("user_id")
+  email               String    @db.VarChar(255)
+  clientId            String    @map("client_id") @db.VarChar(5000)
+  redirectUri         String    @map("redirect_uri") @db.VarChar(1000)
+  scopes              String[]  @default([])
+  assistantName       String?   @map("assistant_name") @db.VarChar(100)
+  state               String?   @db.VarChar(200)
+  codeChallenge       String    @map("code_challenge") @db.VarChar(128)
+  codeChallengeMethod String    @map("code_challenge_method") @db.VarChar(10)
+  expiresAt           DateTime  @map("expires_at")
+  usedAt              DateTime? @map("used_at")
+  createdAt           DateTime  @default(now()) @map("created_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("mcp_authorization_codes")
   @@index([userId])
   @@index([expiresAt])
+  @@map("mcp_authorization_codes")
 }
 
 model McpRefreshToken {
-  id            String   @id @default(uuid()) @db.Uuid
-  tokenHash     String   @unique @db.VarChar(128) @map("token_hash")
-  userId        String   @map("user_id")
-  sessionId     String?  @map("session_id") @db.Uuid
-  email         String   @db.VarChar(255)
-  scopes        String[] @default([])
-  assistantName String?  @db.VarChar(100) @map("assistant_name")
-  clientId      String?  @db.VarChar(5000) @map("client_id")
-  expiresAt     DateTime @map("expires_at")
+  id            String    @id @default(uuid()) @db.Uuid
+  tokenHash     String    @unique @map("token_hash") @db.VarChar(128)
+  userId        String    @map("user_id")
+  sessionId     String?   @map("session_id") @db.Uuid
+  email         String    @db.VarChar(255)
+  scopes        String[]  @default([])
+  assistantName String?   @map("assistant_name") @db.VarChar(100)
+  clientId      String?   @map("client_id") @db.VarChar(5000)
+  expiresAt     DateTime  @map("expires_at")
   revokedAt     DateTime? @map("revoked_at")
   rotatedAt     DateTime? @map("rotated_at")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user    User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
   session McpAssistantSession? @relation(fields: [sessionId], references: [id], onDelete: Cascade)
 
-  @@map("mcp_refresh_tokens")
   @@index([userId])
   @@index([sessionId])
   @@index([expiresAt])
+  @@map("mcp_refresh_tokens")
 }
 
 model AgentIdempotencyRecord {
   id             String   @id @default(uuid()) @db.Uuid
   action         String   @db.VarChar(100)
   userId         String   @map("user_id")
-  idempotencyKey String   @db.VarChar(255) @map("idempotency_key")
-  inputHash      String   @db.VarChar(64) @map("input_hash")
+  idempotencyKey String   @map("idempotency_key") @db.VarChar(255)
+  inputHash      String   @map("input_hash") @db.VarChar(64)
   status         Int
   response       Json
   expiresAt      DateTime @map("expires_at")
@@ -246,10 +248,10 @@ model AgentIdempotencyRecord {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("agent_idempotency_records")
   @@unique([action, userId, idempotencyKey])
   @@index([expiresAt])
   @@index([userId])
+  @@map("agent_idempotency_records")
 }
 
 model AgentActionAudit {
@@ -260,24 +262,24 @@ model AgentActionAudit {
   outcome        String   @db.VarChar(20)
   status         Int
   userId         String   @map("user_id")
-  requestId      String   @db.VarChar(255) @map("request_id")
+  requestId      String   @map("request_id") @db.VarChar(255)
   actor          String   @db.VarChar(255)
-  idempotencyKey String?  @db.VarChar(255) @map("idempotency_key")
+  idempotencyKey String?  @map("idempotency_key") @db.VarChar(255)
   replayed       Boolean  @default(false)
-  errorCode      String?  @db.VarChar(100) @map("error_code")
-  jobName        String?  @db.VarChar(100) @map("job_name")
-  jobPeriodKey   String?  @db.VarChar(20) @map("job_period_key")
-  triggeredBy    String?  @db.VarChar(20) @map("triggered_by")
+  errorCode      String?  @map("error_code") @db.VarChar(100)
+  jobName        String?  @map("job_name") @db.VarChar(100)
+  jobPeriodKey   String?  @map("job_period_key") @db.VarChar(20)
+  triggeredBy    String?  @map("triggered_by") @db.VarChar(20)
   metadata       Json?
   createdAt      DateTime @default(now()) @map("created_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("agent_action_audits")
   @@index([userId, createdAt])
   @@index([requestId])
   @@index([action, createdAt])
   @@index([jobName, jobPeriodKey])
+  @@map("agent_action_audits")
 }
 
 model Project {
@@ -297,23 +299,23 @@ model Project {
   createdAt      DateTime              @default(now()) @map("created_at")
   updatedAt      DateTime              @updatedAt @map("updated_at")
 
-  areaId        String?               @db.Uuid @map("area_id")
-  goalId        String?               @db.Uuid @map("goal_id")
+  areaId String? @map("area_id") @db.Uuid
+  goalId String? @map("goal_id") @db.Uuid
 
-  user     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   todos    Todo[]
   headings Heading[]
-  areaRef  Area?   @relation(fields: [areaId], references: [id], onDelete: SetNull)
-  goalRef  Goal?   @relation(fields: [goalId], references: [id], onDelete: SetNull)
+  areaRef  Area?     @relation(fields: [areaId], references: [id], onDelete: SetNull)
+  goalRef  Goal?     @relation(fields: [goalId], references: [id], onDelete: SetNull)
 
-  @@map("projects")
   @@unique([userId, name])
   @@index([userId])
+  @@map("projects")
 }
 
 model Heading {
   id        String   @id @default(uuid()) @db.Uuid
-  projectId String   @db.Uuid @map("project_id")
+  projectId String   @map("project_id") @db.Uuid
   name      String   @db.VarChar(100)
   sortOrder Int      @default(0) @map("sort_order")
   createdAt DateTime @default(now()) @map("created_at")
@@ -322,61 +324,60 @@ model Heading {
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   todos   Todo[]
 
-  @@map("headings")
   @@index([projectId])
   @@index([projectId, sortOrder])
+  @@map("headings")
 }
 
 model Todo {
-  id                    String             @id @default(uuid()) @db.Uuid
-  title                 String             @db.VarChar(200)
-  description           String?            @db.VarChar(1000)
-  status                TodoStatus         @default(next)
-  completed             Boolean            @default(false)
-  category              String?            @db.VarChar(50)
-  projectId             String?            @db.Uuid @map("project_id")
-  headingId             String?            @db.Uuid @map("heading_id")
-  context               String?            @db.VarChar(100)
-  energy                TodoEnergy?
-  dueDate               DateTime?          @map("due_date")
-  startDate             DateTime?          @map("start_date")
-  scheduledDate         DateTime?          @map("scheduled_date")
-  reviewDate            DateTime?          @map("review_date")
-  completedAt           DateTime?          @map("completed_at")
-  estimateMinutes       Int?               @map("estimate_minutes")
-  waitingOn             String?            @map("waiting_on") @db.VarChar(255)
-  dependsOnTaskIds      String[]           @default([]) @map("depends_on_task_ids")
-  tags                  String[]           @default([])
-  order                 Int                @default(0)
-  priority              TodoPriority       @default(medium)
-  archived              Boolean            @default(false)
-  recurrenceType        TodoRecurrenceType @default(none) @map("recurrence_type")
-  recurrenceInterval    Int?               @map("recurrence_interval")
-  recurrenceRrule       String?            @map("recurrence_rrule") @db.Text
-  recurrenceNextOccurrence DateTime?       @map("recurrence_next_occurrence")
-  source                TodoSource?
-  doDate                DateTime?          @map("do_date")
-  blockedReason         String?            @map("blocked_reason") @db.VarChar(500)
-  effortScore           Int?               @map("effort_score")
-  confidenceScore       Int?               @map("confidence_score")
-  sourceText            String?            @map("source_text") @db.Text
-  createdByPrompt       String?            @map("created_by_prompt") @db.Text
-  notes                 String?            @db.Text
-  areaId                String?            @db.Uuid @map("area_id")
-  goalId                String?            @db.Uuid @map("goal_id")
-  userId                String             @map("user_id")
-  createdAt             DateTime           @default(now()) @map("created_at")
-  updatedAt             DateTime           @updatedAt @map("updated_at")
+  id                       String             @id @default(uuid()) @db.Uuid
+  title                    String             @db.VarChar(200)
+  description              String?            @db.VarChar(1000)
+  status                   TodoStatus         @default(next)
+  completed                Boolean            @default(false)
+  category                 String?            @db.VarChar(50)
+  projectId                String?            @map("project_id") @db.Uuid
+  headingId                String?            @map("heading_id") @db.Uuid
+  context                  String?            @db.VarChar(100)
+  energy                   TodoEnergy?
+  dueDate                  DateTime?          @map("due_date")
+  startDate                DateTime?          @map("start_date")
+  scheduledDate            DateTime?          @map("scheduled_date")
+  reviewDate               DateTime?          @map("review_date")
+  completedAt              DateTime?          @map("completed_at")
+  estimateMinutes          Int?               @map("estimate_minutes")
+  waitingOn                String?            @map("waiting_on") @db.VarChar(255)
+  dependsOnTaskIds         String[]           @default([]) @map("depends_on_task_ids")
+  tags                     String[]           @default([])
+  order                    Int                @default(0)
+  priority                 TodoPriority       @default(medium)
+  archived                 Boolean            @default(false)
+  recurrenceType           TodoRecurrenceType @default(none) @map("recurrence_type")
+  recurrenceInterval       Int?               @map("recurrence_interval")
+  recurrenceRrule          String?            @map("recurrence_rrule") @db.Text
+  recurrenceNextOccurrence DateTime?          @map("recurrence_next_occurrence")
+  source                   TodoSource?
+  doDate                   DateTime?          @map("do_date")
+  blockedReason            String?            @map("blocked_reason") @db.VarChar(500)
+  effortScore              Int?               @map("effort_score")
+  confidenceScore          Int?               @map("confidence_score")
+  sourceText               String?            @map("source_text") @db.Text
+  createdByPrompt          String?            @map("created_by_prompt") @db.Text
+  notes                    String?            @db.Text
+  areaId                   String?            @map("area_id") @db.Uuid
+  goalId                   String?            @map("goal_id") @db.Uuid
+  userId                   String             @map("user_id")
+  createdAt                DateTime           @default(now()) @map("created_at")
+  updatedAt                DateTime           @updatedAt @map("updated_at")
 
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  project  Project?  @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  heading  Heading?  @relation(fields: [headingId], references: [id], onDelete: SetNull)
-  area     Area?     @relation(fields: [areaId], references: [id], onDelete: SetNull)
-  goal     Goal?     @relation(fields: [goalId], references: [id], onDelete: SetNull)
-  subtasks Subtask[]
+  user                     User                      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  project                  Project?                  @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  heading                  Heading?                  @relation(fields: [headingId], references: [id], onDelete: SetNull)
+  area                     Area?                     @relation(fields: [areaId], references: [id], onDelete: SetNull)
+  goal                     Goal?                     @relation(fields: [goalId], references: [id], onDelete: SetNull)
+  subtasks                 Subtask[]
   aiSuggestionAppliedTodos AiSuggestionAppliedTodo[]
 
-  @@map("todos")
   @@index([userId, category])
   @@index([userId, projectId])
   @@index([userId, headingId])
@@ -388,58 +389,59 @@ model Todo {
   @@index([userId, scheduledDate])
   @@index([userId, order])
   @@index([userId, priority])
+  @@map("todos")
 }
 
 model Subtask {
-  id          String   @id @default(uuid()) @db.Uuid
-  title       String   @db.VarChar(200)
-  completed   Boolean  @default(false)
-  order       Int      @default(0)
+  id          String    @id @default(uuid()) @db.Uuid
+  title       String    @db.VarChar(200)
+  completed   Boolean   @default(false)
+  order       Int       @default(0)
   completedAt DateTime? @map("completed_at")
-  todoId      String   @db.Uuid @map("todo_id")
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
+  todoId      String    @map("todo_id") @db.Uuid
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
 
   todo Todo @relation(fields: [todoId], references: [id], onDelete: Cascade)
 
-  @@map("subtasks")
-  @@index([todoId, order])
   @@unique([todoId, order])
+  @@index([todoId, order])
+  @@map("subtasks")
 }
 
 model AiSuggestion {
-  id        String            @id @default(uuid())
-  userId    String            @map("user_id")
-  type      AiSuggestionType
-  input     Json
-  output    Json
-  feedback  Json?
-  appliedAt DateTime?          @map("applied_at")
-  appliedTodoIds Json?         @map("applied_todo_ids")
-  status    AiSuggestionStatus @default(pending)
-  createdAt DateTime          @default(now()) @map("created_at")
-  updatedAt DateTime          @updatedAt @map("updated_at")
+  id             String             @id @default(uuid())
+  userId         String             @map("user_id")
+  type           AiSuggestionType
+  input          Json
+  output         Json
+  feedback       Json?
+  appliedAt      DateTime?          @map("applied_at")
+  appliedTodoIds Json?              @map("applied_todo_ids")
+  status         AiSuggestionStatus @default(pending)
+  createdAt      DateTime           @default(now()) @map("created_at")
+  updatedAt      DateTime           @updatedAt @map("updated_at")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User                      @relation(fields: [userId], references: [id], onDelete: Cascade)
   appliedTodos AiSuggestionAppliedTodo[]
 
-  @@map("ai_suggestions")
   @@index([userId, createdAt])
   @@index([userId, status])
+  @@map("ai_suggestions")
 }
 
 model AiSuggestionAppliedTodo {
   id           String   @id @default(uuid())
   suggestionId String   @map("suggestion_id")
-  todoId       String   @db.Uuid @map("todo_id")
+  todoId       String   @map("todo_id") @db.Uuid
   createdAt    DateTime @default(now()) @map("created_at")
 
   suggestion AiSuggestion @relation(fields: [suggestionId], references: [id], onDelete: Cascade)
   todo       Todo         @relation(fields: [todoId], references: [id], onDelete: Cascade)
 
-  @@map("ai_suggestion_applied_todos")
   @@unique([suggestionId, todoId])
   @@index([todoId])
+  @@map("ai_suggestion_applied_todos")
 }
 
 model CaptureItem {
@@ -455,55 +457,61 @@ model CaptureItem {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("capture_items")
   @@index([userId, lifecycle])
   @@index([userId, capturedAt])
+  @@map("capture_items")
 }
 
 model FeedbackRequest {
-  id                String         @id @default(uuid()) @db.Uuid
-  userId            String         @map("user_id")
-  type              FeedbackType
-  title             String         @db.VarChar(200)
-  body              String         @db.Text
-  screenshotUrl     String?        @db.VarChar(2000) @map("screenshot_url")
-  attachmentMetadata Json?         @map("attachment_metadata")
-  pageUrl           String?        @db.VarChar(2000) @map("page_url")
-  userAgent         String?        @db.VarChar(2000) @map("user_agent")
-  appVersion        String?        @db.VarChar(50) @map("app_version")
-  status            FeedbackStatus @default(new)
-  triageSummary     String?        @db.Text @map("triage_summary")
-  severity          String?        @db.VarChar(20)
-  dedupeKey         String?        @db.VarChar(255) @map("dedupe_key")
-  githubIssueNumber Int?           @map("github_issue_number")
-  githubIssueUrl    String?        @db.VarChar(2000) @map("github_issue_url")
-  createdAt         DateTime       @default(now()) @map("created_at")
-  updatedAt         DateTime       @updatedAt @map("updated_at")
+  id                 String         @id @default(uuid()) @db.Uuid
+  userId             String         @map("user_id")
+  reviewedByUserId   String?        @map("reviewed_by_user_id")
+  type               FeedbackType
+  title              String         @db.VarChar(200)
+  body               String         @db.Text
+  screenshotUrl      String?        @map("screenshot_url") @db.VarChar(2000)
+  attachmentMetadata Json?          @map("attachment_metadata")
+  pageUrl            String?        @map("page_url") @db.VarChar(2000)
+  userAgent          String?        @map("user_agent") @db.VarChar(2000)
+  appVersion         String?        @map("app_version") @db.VarChar(50)
+  status             FeedbackStatus @default(new)
+  triageSummary      String?        @map("triage_summary") @db.Text
+  severity           String?        @db.VarChar(20)
+  dedupeKey          String?        @map("dedupe_key") @db.VarChar(255)
+  githubIssueNumber  Int?           @map("github_issue_number")
+  githubIssueUrl     String?        @map("github_issue_url") @db.VarChar(2000)
+  reviewedAt         DateTime?      @map("reviewed_at")
+  rejectionReason    String?        @map("rejection_reason") @db.Text
+  createdAt          DateTime       @default(now()) @map("created_at")
+  updatedAt          DateTime       @updatedAt @map("updated_at")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user     User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  reviewer User? @relation("FeedbackReviewer", fields: [reviewedByUserId], references: [id], onDelete: SetNull)
 
-  @@map("feedback_requests")
   @@index([userId, status, createdAt])
   @@index([userId, type, createdAt])
+  @@index([status, type, createdAt])
+  @@index([reviewedByUserId, reviewedAt])
   @@index([dedupeKey])
+  @@map("feedback_requests")
 }
 
 model Area {
-  id          String    @id @default(uuid()) @db.Uuid
-  userId      String    @map("user_id")
-  name        String    @db.VarChar(100)
-  description String?   @db.Text
-  archived    Boolean   @default(false)
-  createdAt   DateTime  @default(now()) @map("created_at")
-  updatedAt   DateTime  @updatedAt @map("updated_at")
+  id          String   @id @default(uuid()) @db.Uuid
+  userId      String   @map("user_id")
+  name        String   @db.VarChar(100)
+  description String?  @db.Text
+  archived    Boolean  @default(false)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   projects Project[]
   todos    Todo[]
 
-  @@map("areas")
   @@unique([userId, name])
   @@index([userId])
+  @@map("areas")
 }
 
 model Goal {
@@ -520,64 +528,64 @@ model Goal {
   projects Project[]
   todos    Todo[]
 
-  @@map("goals")
   @@index([userId])
+  @@map("goals")
 }
 
 model AgentEnrollment {
-  id             String    @id @default(uuid()) @db.Uuid
-  userId         String    @unique @map("user_id")
-  refreshToken   String    @db.VarChar(128) @map("refresh_token")
-  dailyEnabled   Boolean   @default(true) @map("daily_enabled")
-  weeklyEnabled  Boolean   @default(true) @map("weekly_enabled")
-  timezone       String    @default("America/New_York") @db.VarChar(50)
-  active         Boolean   @default(true)
-  enrolledAt     DateTime  @default(now()) @map("enrolled_at")
-  lastRunAt      DateTime? @map("last_run_at")
-  lastRunStatus  String?   @db.VarChar(20) @map("last_run_status")
-  lastRunError   String?   @db.VarChar(500) @map("last_run_error")
-  createdAt      DateTime  @default(now()) @map("created_at")
-  updatedAt      DateTime  @updatedAt @map("updated_at")
+  id            String    @id @default(uuid()) @db.Uuid
+  userId        String    @unique @map("user_id")
+  refreshToken  String    @map("refresh_token") @db.VarChar(128)
+  dailyEnabled  Boolean   @default(true) @map("daily_enabled")
+  weeklyEnabled Boolean   @default(true) @map("weekly_enabled")
+  timezone      String    @default("America/New_York") @db.VarChar(50)
+  active        Boolean   @default(true)
+  enrolledAt    DateTime  @default(now()) @map("enrolled_at")
+  lastRunAt     DateTime? @map("last_run_at")
+  lastRunStatus String?   @map("last_run_status") @db.VarChar(20)
+  lastRunError  String?   @map("last_run_error") @db.VarChar(500)
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("agent_enrollments")
   @@index([active])
+  @@map("agent_enrollments")
 }
 
 model AgentJobRun {
   id           String    @id @default(uuid()) @db.Uuid
   userId       String    @map("user_id")
-  jobName      String    @db.VarChar(100) @map("job_name")
-  periodKey    String    @db.VarChar(20) @map("period_key")
+  jobName      String    @map("job_name") @db.VarChar(100)
+  periodKey    String    @map("period_key") @db.VarChar(20)
   status       String    @db.VarChar(20)
   retryCount   Int       @default(0) @map("retry_count")
   claimedAt    DateTime  @default(now()) @map("claimed_at")
   completedAt  DateTime? @map("completed_at")
   failedAt     DateTime? @map("failed_at")
-  errorMessage String?   @db.VarChar(500) @map("error_message")
+  errorMessage String?   @map("error_message") @db.VarChar(500)
   metadata     Json?
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime  @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("agent_job_runs")
   @@unique([userId, jobName, periodKey])
   @@index([userId])
   @@index([status])
+  @@map("agent_job_runs")
 }
 
 model FailedAutomationAction {
   id           String    @id @default(uuid()) @db.Uuid
   userId       String    @map("user_id")
-  jobName      String    @db.VarChar(100) @map("job_name")
-  periodKey    String    @db.VarChar(20) @map("period_key")
-  actionType   String    @db.VarChar(100) @map("action_type")
-  entityType   String?   @db.VarChar(50) @map("entity_type")
-  entityId     String?   @db.VarChar(100) @map("entity_id")
-  errorCode    String?   @db.VarChar(100) @map("error_code")
-  errorMessage String?   @db.VarChar(1000) @map("error_message")
+  jobName      String    @map("job_name") @db.VarChar(100)
+  periodKey    String    @map("period_key") @db.VarChar(20)
+  actionType   String    @map("action_type") @db.VarChar(100)
+  entityType   String?   @map("entity_type") @db.VarChar(50)
+  entityId     String?   @map("entity_id") @db.VarChar(100)
+  errorCode    String?   @map("error_code") @db.VarChar(100)
+  errorMessage String?   @map("error_message") @db.VarChar(1000)
   payload      Json?
   retryable    Boolean   @default(false)
   retryCount   Int       @default(0) @map("retry_count")
@@ -588,10 +596,10 @@ model FailedAutomationAction {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("failed_automation_actions")
   @@index([userId, createdAt])
   @@index([userId, jobName, periodKey])
   @@index([resolvedAt])
+  @@map("failed_automation_actions")
 }
 
 model AgentConfig {
@@ -624,21 +632,21 @@ model AgentConfig {
 model AgentMetricEvent {
   id         String   @id @default(uuid()) @db.Uuid
   userId     String   @map("user_id")
-  jobName    String   @db.VarChar(100) @map("job_name")
-  periodKey  String   @db.VarChar(20) @map("period_key")
-  metricType String   @db.VarChar(100) @map("metric_type")
-  entityType String?  @db.VarChar(50) @map("entity_type")
-  entityId   String?  @db.VarChar(100) @map("entity_id")
+  jobName    String   @map("job_name") @db.VarChar(100)
+  periodKey  String   @map("period_key") @db.VarChar(20)
+  metricType String   @map("metric_type") @db.VarChar(100)
+  entityType String?  @map("entity_type") @db.VarChar(50)
+  entityId   String?  @map("entity_id") @db.VarChar(100)
   value      Float    @default(1)
   metadata   Json?
   recordedAt DateTime @default(now()) @map("recorded_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("agent_metric_events")
   @@index([userId, recordedAt])
   @@index([userId, jobName, periodKey])
   @@index([userId, metricType])
+  @@map("agent_metric_events")
 }
 
 model UserPlanningPreferences {
@@ -646,7 +654,7 @@ model UserPlanningPreferences {
   userId                String   @unique @map("user_id")
   maxDailyTasks         Int?     @map("max_daily_tasks")
   preferredChunkMinutes Int?     @map("preferred_chunk_minutes")
-  deepWorkPreference    String?  @db.VarChar(20) @map("deep_work_preference")
+  deepWorkPreference    String?  @map("deep_work_preference") @db.VarChar(20)
   weekendsActive        Boolean  @default(true) @map("weekends_active")
   preferredContexts     String[] @default([]) @map("preferred_contexts")
   waitingFollowUpDays   Int      @default(7) @map("waiting_follow_up_days")
@@ -662,8 +670,8 @@ model UserPlanningPreferences {
 model TaskRecommendationFeedback {
   id               String   @id @default(uuid()) @db.Uuid
   userId           String   @map("user_id")
-  planDate         String   @db.VarChar(10) @map("plan_date")
-  taskId           String   @db.VarChar(100) @map("task_id")
+  planDate         String   @map("plan_date") @db.VarChar(10)
+  taskId           String   @map("task_id") @db.VarChar(100)
   signal           String   @db.VarChar(20)
   energy           String?  @db.VarChar(20)
   availableMinutes Int?     @map("available_minutes")
@@ -672,16 +680,16 @@ model TaskRecommendationFeedback {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("task_recommendation_feedback")
   @@index([userId, planDate])
   @@index([userId, taskId])
+  @@map("task_recommendation_feedback")
 }
 
 model UserDayContext {
   id          String   @id @default(uuid()) @db.Uuid
   userId      String   @map("user_id")
-  contextDate String   @db.VarChar(10) @map("context_date")
-  mode        String   @db.VarChar(20) @default("normal")
+  contextDate String   @map("context_date") @db.VarChar(10)
+  mode        String   @default("normal") @db.VarChar(20)
   energy      String?  @db.VarChar(20)
   notes       String?  @db.VarChar(500)
   createdAt   DateTime @default(now()) @map("created_at")
@@ -689,9 +697,9 @@ model UserDayContext {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("user_day_contexts")
   @@unique([userId, contextDate])
   @@index([userId, contextDate])
+  @@map("user_day_contexts")
 }
 
 model LearningRecommendation {
@@ -712,7 +720,7 @@ model LearningRecommendation {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("learning_recommendations")
   @@index([userId, status])
   @@index([userId, createdAt])
+  @@map("learning_recommendations")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -249,7 +249,13 @@ export function createApp(
     );
   }
 
-  app.use("/admin", createAdminRouter({ authService }));
+  app.use(
+    "/admin",
+    createAdminRouter({
+      authService,
+      feedbackService: feedbackService ?? undefined,
+    }),
+  );
   app.use("/users", createUsersRouter({ authService }));
   app.use(
     "/todos",

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -8,6 +8,8 @@ describe("Feedback API Integration", () => {
   let app: ReturnType<typeof createApp>;
   let authToken: string;
   let userId: string;
+  let adminToken: string;
+  let adminUserId: string;
 
   beforeAll(() => {
     process.env.JWT_SECRET = "test-secret-for-feedback-api-tests";
@@ -30,6 +32,22 @@ describe("Feedback API Integration", () => {
 
     authToken = registerResponse.body.token;
     userId = registerResponse.body.user.id;
+
+    const adminRegisterResponse = await request(app)
+      .post("/auth/register")
+      .send({
+        email: "feedback-admin@example.com",
+        password: "password123",
+        name: "Feedback Admin",
+      });
+
+    adminToken = adminRegisterResponse.body.token;
+    adminUserId = adminRegisterResponse.body.user.id;
+
+    await prisma.user.update({
+      where: { id: adminUserId },
+      data: { role: "admin" },
+    });
   });
 
   it("POST /feedback creates a bug report with captured context", async () => {
@@ -123,5 +141,132 @@ describe("Feedback API Integration", () => {
         body: "Should not work",
       })
       .expect(401);
+  });
+
+  it("GET /admin/feedback lists feedback for admins with filters", async () => {
+    const older = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Drawer crashes",
+        body: "Crash details",
+        status: "new",
+      },
+    });
+
+    const newer = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Calendar planning",
+        body: "Feature details",
+        status: "triaged",
+      },
+    });
+
+    const response = await request(app)
+      .get("/admin/feedback")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .query({ type: "feature", status: "triaged" })
+      .expect(200);
+
+    expect(response.body).toHaveLength(1);
+    expect(response.body[0]).toMatchObject({
+      id: newer.id,
+      title: "Calendar planning",
+      status: "triaged",
+      type: "feature",
+      user: {
+        id: userId,
+        email: "feedback-test@example.com",
+      },
+    });
+    expect(response.body[0].id).not.toBe(older.id);
+  });
+
+  it("GET /admin/feedback/:id returns detail for admins", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Filtering breaks",
+        body: "Full raw submission",
+        screenshotUrl: "https://example.com/bug.png",
+        pageUrl: "https://app.example.com/?view=todos",
+        appVersion: "1.6.0",
+        userAgent: "Integration Test Browser",
+        triageSummary: "Likely duplicate of filter bug",
+      },
+    });
+
+    const response = await request(app)
+      .get(`/admin/feedback/${feedback.id}`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      id: feedback.id,
+      title: "Filtering breaks",
+      screenshotUrl: "https://example.com/bug.png",
+      pageUrl: "https://app.example.com/?view=todos",
+      appVersion: "1.6.0",
+      triageSummary: "Likely duplicate of filter bug",
+      user: {
+        id: userId,
+        email: "feedback-test@example.com",
+      },
+    });
+  });
+
+  it("PATCH /admin/feedback/:id updates review state and metadata", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Promote this",
+        body: "Promotion candidate",
+        status: "new",
+      },
+    });
+
+    const response = await request(app)
+      .patch(`/admin/feedback/${feedback.id}`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        status: "rejected",
+        rejectionReason: "Not actionable enough yet",
+      })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      id: feedback.id,
+      status: "rejected",
+      reviewedByUserId: adminUserId,
+      rejectionReason: "Not actionable enough yet",
+      reviewer: {
+        id: adminUserId,
+        email: "feedback-admin@example.com",
+      },
+    });
+    expect(response.body.reviewedAt).toEqual(expect.any(String));
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+
+    expect(persisted?.status).toBe("rejected");
+    expect(persisted?.reviewedByUserId).toBe(adminUserId);
+    expect(persisted?.rejectionReason).toBe("Not actionable enough yet");
+    expect(persisted?.reviewedAt).not.toBeNull();
+  });
+
+  it("GET /admin/feedback returns 403 for non-admin users", async () => {
+    await request(app)
+      .get("/admin/feedback")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(403)
+      .expect({
+        error: "Forbidden: Admin access required",
+      });
   });
 });

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -1,12 +1,21 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { AuthService } from "../services/authService";
 import { HttpError, hasPrismaCode } from "../errorHandling";
+import { FeedbackService } from "../services/feedbackService";
+import {
+  validateListAdminFeedbackRequestsQuery,
+  validateUpdateAdminFeedbackRequest,
+} from "../validation/validation";
 
 interface AdminRouterDeps {
   authService?: AuthService;
+  feedbackService?: FeedbackService;
 }
 
-export function createAdminRouter({ authService }: AdminRouterDeps): Router {
+export function createAdminRouter({
+  authService,
+  feedbackService,
+}: AdminRouterDeps): Router {
   const router = Router();
 
   router.get(
@@ -102,6 +111,86 @@ export function createAdminRouter({ authService }: AdminRouterDeps): Router {
           return next(new HttpError(400, "Invalid user ID format"));
         }
         return next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/feedback",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback persistence not configured" });
+      }
+
+      try {
+        const query = validateListAdminFeedbackRequestsQuery(req.query);
+        const feedbackRequests = await feedbackService.listForAdmin(query);
+        res.json(feedbackRequests);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/feedback/:id",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback persistence not configured" });
+      }
+
+      try {
+        const feedbackId = String(req.params.id);
+        const feedbackRequest = await feedbackService.getForAdmin(feedbackId);
+        if (!feedbackRequest) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+
+        res.json(feedbackRequest);
+      } catch (error) {
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.patch(
+    "/feedback/:id",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback persistence not configured" });
+      }
+
+      try {
+        const reviewerUserId = req.user?.userId;
+        const feedbackId = String(req.params.id);
+        if (!reviewerUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const dto = validateUpdateAdminFeedbackRequest(req.body);
+        const feedbackRequest = await feedbackService.updateReviewStatus(
+          feedbackId,
+          reviewerUserId,
+          dto,
+        );
+        res.json(feedbackRequest);
+      } catch (error) {
+        if (hasPrismaCode(error, ["P2025"])) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
       }
     },
   );

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -1,8 +1,12 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import {
   CreateFeedbackRequestDto,
+  FeedbackRequestAdminDetailDto,
+  FeedbackRequestAdminListItemDto,
   FeedbackRequestDto,
   FeedbackAttachmentMetadataDto,
+  ListAdminFeedbackRequestsQuery,
+  UpdateAdminFeedbackRequestDto,
 } from "../types";
 
 export class FeedbackService {
@@ -34,6 +38,94 @@ export class FeedbackService {
     return this.toDto(record);
   }
 
+  async listForAdmin(
+    filters: ListAdminFeedbackRequestsQuery,
+  ): Promise<FeedbackRequestAdminListItemDto[]> {
+    const records = await this.prisma.feedbackRequest.findMany({
+      where: {
+        ...(filters.status ? { status: filters.status } : {}),
+        ...(filters.type ? { type: filters.type } : {}),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+        reviewer: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [{ createdAt: "desc" }, { updatedAt: "desc" }],
+    });
+
+    return records.map((record) => this.toAdminDto(record));
+  }
+
+  async getForAdmin(id: string): Promise<FeedbackRequestAdminDetailDto | null> {
+    const record = await this.prisma.feedbackRequest.findUnique({
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+        reviewer: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return record ? this.toAdminDto(record) : null;
+  }
+
+  async updateReviewStatus(
+    id: string,
+    reviewerUserId: string,
+    dto: UpdateAdminFeedbackRequestDto,
+  ): Promise<FeedbackRequestAdminDetailDto> {
+    const record = await this.prisma.feedbackRequest.update({
+      where: { id },
+      data: {
+        status: dto.status,
+        reviewedByUserId: reviewerUserId,
+        reviewedAt: new Date(),
+        rejectionReason: dto.status === "rejected" ? dto.rejectionReason : null,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+        reviewer: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return this.toAdminDto(record);
+  }
+
   private toDto(record: {
     id: string;
     userId: string;
@@ -45,12 +137,15 @@ export class FeedbackService {
     pageUrl: string | null;
     userAgent: string | null;
     appVersion: string | null;
-    status: "new" | "triaged" | "closed";
+    status: "new" | "triaged" | "promoted" | "rejected";
     triageSummary: string | null;
     severity: string | null;
     dedupeKey: string | null;
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
+    reviewedByUserId: string | null;
+    reviewedAt: Date | null;
+    rejectionReason: string | null;
     createdAt: Date;
     updatedAt: Date;
   }): FeedbackRequestDto {
@@ -73,8 +168,51 @@ export class FeedbackService {
       dedupeKey: record.dedupeKey,
       githubIssueNumber: record.githubIssueNumber,
       githubIssueUrl: record.githubIssueUrl,
+      reviewedByUserId: record.reviewedByUserId,
+      reviewedAt: record.reviewedAt?.toISOString() ?? null,
+      rejectionReason: record.rejectionReason,
       createdAt: record.createdAt.toISOString(),
       updatedAt: record.updatedAt.toISOString(),
+    };
+  }
+
+  private toAdminDto(record: {
+    id: string;
+    userId: string;
+    reviewedByUserId: string | null;
+    type: "bug" | "feature" | "general";
+    title: string;
+    body: string;
+    screenshotUrl: string | null;
+    attachmentMetadata: unknown;
+    pageUrl: string | null;
+    userAgent: string | null;
+    appVersion: string | null;
+    status: "new" | "triaged" | "promoted" | "rejected";
+    triageSummary: string | null;
+    severity: string | null;
+    dedupeKey: string | null;
+    githubIssueNumber: number | null;
+    githubIssueUrl: string | null;
+    reviewedAt: Date | null;
+    rejectionReason: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    user: {
+      id: string;
+      email: string;
+      name: string | null;
+    };
+    reviewer: {
+      id: string;
+      email: string;
+      name: string | null;
+    } | null;
+  }): FeedbackRequestAdminDetailDto {
+    return {
+      ...this.toDto(record),
+      user: record.user,
+      reviewer: record.reviewer,
     };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -342,7 +342,8 @@ export interface CreateCaptureItemDto {
 }
 
 export type FeedbackRequestType = "bug" | "feature" | "general";
-export type FeedbackRequestStatus = "new" | "triaged" | "closed";
+export type FeedbackRequestStatus = "new" | "triaged" | "promoted" | "rejected";
+export type FeedbackReviewAction = "triaged" | "promoted" | "rejected";
 
 export interface FeedbackAttachmentMetadataDto {
   name?: string | null;
@@ -379,6 +380,32 @@ export interface FeedbackRequestDto {
   dedupeKey?: string | null;
   githubIssueNumber?: number | null;
   githubIssueUrl?: string | null;
+  reviewedByUserId?: string | null;
+  reviewedAt?: string | null;
+  rejectionReason?: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface FeedbackRequestAdminUserDto {
+  id: string;
+  email: string;
+  name?: string | null;
+}
+
+export interface FeedbackRequestAdminListItemDto extends FeedbackRequestDto {
+  user: FeedbackRequestAdminUserDto;
+  reviewer?: FeedbackRequestAdminUserDto | null;
+}
+
+export interface FeedbackRequestAdminDetailDto extends FeedbackRequestAdminListItemDto {}
+
+export interface ListAdminFeedbackRequestsQuery {
+  status?: FeedbackRequestStatus;
+  type?: FeedbackRequestType;
+}
+
+export interface UpdateAdminFeedbackRequestDto {
+  status: FeedbackReviewAction;
+  rejectionReason?: string | null;
 }

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -16,11 +16,15 @@ import {
   FindTodosQuery,
   CreateFeedbackRequestDto,
   FeedbackAttachmentMetadataDto,
+  FeedbackRequestStatus,
+  FeedbackRequestType,
+  ListAdminFeedbackRequestsQuery,
   Priority,
   TaskSource,
   TaskStatus,
   TodoSortBy,
   SortOrder,
+  UpdateAdminFeedbackRequestDto,
 } from "../types";
 import {
   MAX_PAGE_SIZE,
@@ -1667,5 +1671,71 @@ export function validateCreateFeedbackRequest(
       normalizeOptionalAbsoluteUrl(body.pageUrl, "pageUrl", 2000) ?? undefined,
     userAgent: normalizeOptionalString(body.userAgent, "userAgent", 2000),
     appVersion: normalizeOptionalString(body.appVersion, "appVersion", 50),
+  };
+}
+
+export function validateListAdminFeedbackRequestsQuery(
+  query: unknown,
+): ListAdminFeedbackRequestsQuery {
+  if (!query || typeof query !== "object" || Array.isArray(query)) {
+    return {};
+  }
+
+  const params = query as Record<string, unknown>;
+  const status = normalizeOptionalString(params.status, "status", 20);
+  const type = normalizeOptionalString(params.type, "type", 20);
+
+  if (status && !["new", "triaged", "promoted", "rejected"].includes(status)) {
+    throw new ValidationError(
+      'status must be "new", "triaged", "promoted", or "rejected"',
+    );
+  }
+
+  if (type && !["bug", "feature", "general"].includes(type)) {
+    throw new ValidationError('type must be "bug", "feature", or "general"');
+  }
+
+  return {
+    status: status as FeedbackRequestStatus | undefined,
+    type: type as FeedbackRequestType | undefined,
+  };
+}
+
+export function validateUpdateAdminFeedbackRequest(
+  data: unknown,
+): UpdateAdminFeedbackRequestDto {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  const body = data as Record<string, unknown>;
+  const status = body.status;
+  if (typeof status !== "string") {
+    throw new ValidationError("status is required");
+  }
+  if (!["triaged", "promoted", "rejected"].includes(status)) {
+    throw new ValidationError(
+      'status must be "triaged", "promoted", or "rejected"',
+    );
+  }
+
+  const rejectionReason = normalizeNullableString(
+    body.rejectionReason,
+    "rejectionReason",
+    4000,
+  );
+
+  if (status === "rejected" && !rejectionReason) {
+    throw new ValidationError(
+      "rejectionReason is required when status is rejected",
+    );
+  }
+
+  return {
+    status: status as UpdateAdminFeedbackRequestDto["status"],
+    rejectionReason:
+      status === "rejected"
+        ? (rejectionReason ?? null)
+        : (rejectionReason ?? null),
   };
 }

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test } from "@playwright/test";
+import { openTodosViewWithStorageState } from "./helpers/todos-view";
+
+function buildFeedback(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "feedback-1",
+    userId: "user-1",
+    type: "bug",
+    title: "Task drawer crashes",
+    body: "What happened?\nTask drawer crashed.\n\nWhat did you expect?\nA save.\n\nWhat were you doing right before it happened?\nEditing notes.",
+    screenshotUrl: "https://example.com/bug.png",
+    attachmentMetadata: {
+      name: "bug.png",
+      type: "image/png",
+      size: 2048,
+      lastModified: 1710000000000,
+    },
+    pageUrl: "https://app.example.com/?view=todos",
+    userAgent: "Playwright Browser",
+    appVersion: "1.6.0",
+    status: "new",
+    triageSummary: "Likely reproducible",
+    severity: "medium",
+    dedupeKey: null,
+    githubIssueNumber: null,
+    githubIssueUrl: null,
+    reviewedByUserId: null,
+    reviewedAt: null,
+    rejectionReason: null,
+    createdAt: "2026-03-20T18:00:00.000Z",
+    updatedAt: "2026-03-20T18:00:00.000Z",
+    user: {
+      id: "user-1",
+      email: "reporter@example.com",
+      name: "Reporter",
+    },
+    reviewer: null,
+    ...overrides,
+  };
+}
+
+test.describe("Admin feedback queue", () => {
+  test("filters feedback, shows detail, and updates review state", async ({
+    page,
+  }) => {
+    let patchPayload: Record<string, unknown> | null = null;
+    const bugFeedback = buildFeedback();
+    const featureFeedback = buildFeedback({
+      id: "feedback-2",
+      type: "feature",
+      title: "Add planning bundles",
+      body: "What are you trying to do?\nPlan next week.\n\nWhat is hard today?\nToo many manual steps.\n\nWhat would make this better?\nSuggested bundles.",
+      status: "triaged",
+      createdAt: "2026-03-20T19:00:00.000Z",
+      updatedAt: "2026-03-20T19:00:00.000Z",
+    });
+
+    await page.route("**/admin/users", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route("**/admin/feedback?*", async (route) => {
+      const url = new URL(route.request().url());
+      const type = url.searchParams.get("type");
+      const status = url.searchParams.get("status");
+      let items = [featureFeedback, bugFeedback];
+      if (type) {
+        items = items.filter((item) => item.type === type);
+      }
+      if (status) {
+        items = items.filter((item) => item.status === status);
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(items),
+      });
+    });
+
+    await page.route("**/admin/feedback", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([featureFeedback, bugFeedback]),
+      });
+    });
+
+    await page.route("**/admin/feedback/feedback-1", async (route) => {
+      if (route.request().method() === "PATCH") {
+        patchPayload = JSON.parse(route.request().postData() || "{}") as Record<
+          string,
+          unknown
+        >;
+        Object.assign(bugFeedback, {
+          status: patchPayload.status,
+          rejectionReason: patchPayload.rejectionReason,
+          reviewedByUserId: "admin-1",
+          reviewedAt: "2026-03-20T20:00:00.000Z",
+          reviewer: {
+            id: "admin-1",
+            email: "admin@example.com",
+            name: "Admin",
+          },
+        });
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(bugFeedback),
+      });
+    });
+
+    await page.route("**/admin/feedback/feedback-2", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(featureFeedback),
+      });
+    });
+
+    await openTodosViewWithStorageState(page, {
+      name: "Admin Reviewer",
+      email: "admin@example.com",
+    });
+
+    await page.evaluate(() => {
+      const adminTab = document.getElementById("adminNavTab");
+      if (adminTab instanceof HTMLElement) {
+        adminTab.style.display = "block";
+      }
+      document.body.classList.add("is-admin-user");
+      (window as Window & { switchView: (view: string) => void }).switchView(
+        "admin",
+      );
+    });
+
+    await expect(page.locator("#adminView")).toHaveClass(/active/);
+    await expect(page.locator("#adminFeedbackList")).toContainText(
+      "Add planning bundles",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Plan next week.",
+    );
+
+    await page
+      .locator(".admin-filter-group")
+      .filter({ hasText: "Type" })
+      .getByRole("button", { name: "bug", exact: true })
+      .click();
+    await expect(page.locator("#adminFeedbackList")).toContainText(
+      "Task drawer crashes",
+    );
+    await expect(page.locator("#adminFeedbackList")).not.toContainText(
+      "Add planning bundles",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Task drawer crashed.",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "https://app.example.com/?view=todos",
+    );
+
+    await page
+      .locator("#adminFeedbackRejectionReason")
+      .fill("Missing enough detail to act on this safely");
+    await page
+      .locator("#adminFeedbackDetail")
+      .getByRole("button", { name: "Reject", exact: true })
+      .click();
+
+    expect(patchPayload).toEqual({
+      status: "rejected",
+      rejectionReason: "Missing enough detail to act on this safely",
+    });
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Feedback marked rejected",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Missing enough detail to act on this safely",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This change adds an admin-only feedback review queue for the in-app feedback flow. Admins can now browse incoming submissions, filter by status and type, inspect the raw report plus captured metadata, and update review state to triaged, promoted, or rejected.

## Problem
Issue 1 added a low-friction in-app feedback submission flow for friends-and-family users, but there was no human review surface between collection and any future automation. That meant feedback could be stored, but not safely inspected, de-duplicated, or promoted by an admin before downstream AI triage or GitHub issue creation is enabled.

## Root Cause
The app only supported feedback creation. The data model lacked reviewer metadata, the API exposed no admin feedback endpoints, and the client admin area only handled user management. Without an explicit review state model and UI, feedback could not move through a controlled queue.

## Fix
The feedback model now supports admin review workflow with `promoted` and `rejected` statuses plus reviewer metadata (`reviewedByUserId`, `reviewedAt`, `rejectionReason`). A new migration upgrades the existing enum and safely maps any legacy `closed` feedback records to `triaged`.

On the backend, the existing admin router now exposes admin-only feedback queue endpoints for listing, reading, and updating feedback. These endpoints reuse the repo's current auth and admin middleware patterns and validate filter/update inputs before persisting changes through the Prisma-backed feedback service.

On the client, the existing Admin view now includes a minimal feedback queue optimized for triage speed. It shows status and type filters, a newest-first queue, a detail panel with raw submission content and captured metadata, and actions to mark feedback reviewed, reject it, or mark it ready for promotion. The existing user-management section remains in the same admin screen.

## User Impact
Admins now have a functional review surface for in-app feedback, while non-admin users remain blocked from the queue. This creates a safer rollout path for future AI triage and issue promotion because feedback can be reviewed and normalized first.

## Validation
I ran the repo's required checks plus targeted integration coverage:

- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts`
- `CI=1 npm run test:ui:fast`
