### PR TITLE
[codex] add feedback triage pipeline

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -412,6 +412,7 @@ import {
   loadAdminFeedbackQueue,
   selectAdminFeedback,
   setAdminFeedbackFilter,
+  runAdminFeedbackTriage,
   updateAdminFeedbackStatus,
 } from "./modules/adminFeedback.js";
 import * as DragDrop from "./modules/dragDrop.js";
@@ -1771,6 +1772,7 @@ window.changeUserRole = changeUserRole;
 window.deleteUser = deleteUser;
 window.selectAdminFeedback = selectAdminFeedback;
 window.setAdminFeedbackFilter = setAdminFeedbackFilter;
+window.runAdminFeedbackTriage = runAdminFeedbackTriage;
 window.updateAdminFeedbackStatus = updateAdminFeedbackStatus;
 
 // ---------------------------------------------------------------------------

--- a/client/modules/adminFeedback.js
+++ b/client/modules/adminFeedback.js
@@ -168,6 +168,61 @@ function renderMetadataRow(label, value) {
   `;
 }
 
+function renderListBlock(title, items, emptyLabel = "None") {
+  const listItems = Array.isArray(items) ? items.filter(Boolean) : [];
+  return `
+    <div class="admin-detail-block">
+      <h4>${escape(title)}</h4>
+      ${
+        listItems.length
+          ? `<ul class="admin-detail-list">${listItems
+              .map((item) => `<li>${escape(item)}</li>`)
+              .join("")}</ul>`
+          : `<p class="admin-detail-empty-copy">${escape(emptyLabel)}</p>`
+      }
+    </div>
+  `;
+}
+
+function renderTriagePanel(item) {
+  const confidence =
+    typeof item.triageConfidence === "number"
+      ? `${Math.round(item.triageConfidence * 100)}%`
+      : "Not triaged yet";
+
+  return `
+    <div class="admin-detail-panel">
+      <div class="admin-detail-block">
+        <div class="admin-detail-block__header">
+          <h4>AI Triage</h4>
+          <button type="button" class="action-btn" data-onclick="runAdminFeedbackTriage()">
+            ${item.classification ? "Re-run triage" : "Run triage"}
+          </button>
+        </div>
+        <div class="admin-detail-meta">
+          ${renderMetadataRow("Classification", item.classification || "")}
+          ${renderMetadataRow("Confidence", confidence)}
+          ${renderMetadataRow("Normalized title", item.normalizedTitle || "")}
+          ${renderMetadataRow("Summary", item.triageSummary || "")}
+          ${renderMetadataRow("Impact", item.impactSummary || "")}
+          ${renderMetadataRow("Expected behavior", item.expectedBehavior || "")}
+          ${renderMetadataRow("Actual behavior", item.actualBehavior || "")}
+          ${renderMetadataRow("Proposed outcome", item.proposedOutcome || "")}
+          ${renderMetadataRow("Dedupe key", item.dedupeKey || "")}
+          ${renderMetadataRow("Severity", item.severity || "")}
+        </div>
+      </div>
+      <div class="admin-detail-block">
+        <h4>Normalized body</h4>
+        <pre class="admin-detail-pre">${escape(item.normalizedBody || "No triage output yet.")}</pre>
+      </div>
+      ${renderListBlock("Repro steps", item.reproSteps, "No repro steps extracted")}
+      ${renderListBlock("Labels", item.agentLabels, "No labels assigned")}
+      ${renderListBlock("Missing info flags", item.missingInfo, "No missing info flags")}
+    </div>
+  `;
+}
+
 function renderAdminFeedbackDetail() {
   const { detail } = getAdminFeedbackElements();
   if (!(detail instanceof HTMLElement)) {
@@ -211,26 +266,30 @@ function renderAdminFeedbackDetail() {
         </div>
       </div>
 
-      <div class="admin-detail-block">
-        <h4>Submission</h4>
-        <pre class="admin-detail-pre">${escape(item.body)}</pre>
-      </div>
+      <div class="admin-detail-columns">
+        <div class="admin-detail-panel">
+          <div class="admin-detail-block">
+            <h4>Raw submission</h4>
+            <pre class="admin-detail-pre">${escape(item.body)}</pre>
+          </div>
 
-      <div class="admin-detail-block">
-        <h4>Captured Metadata</h4>
-        <div class="admin-detail-meta">
-          ${renderMetadataRow("User", item.user?.email || item.userId)}
-          ${renderMetadataRow("Reviewer", item.reviewer?.email || "")}
-          ${renderMetadataRow("Reviewed at", item.reviewedAt ? formatDateTime(item.reviewedAt) : "")}
-          ${renderMetadataRow("Page URL", item.pageUrl || "")}
-          ${renderMetadataRow("App version", item.appVersion || "")}
-          ${renderMetadataRow("Browser", item.userAgent || "")}
-          ${renderMetadataRow("Screenshot URL", item.screenshotUrl || "")}
-          ${renderMetadataRow("Attachment", attachmentSummary)}
-          ${renderMetadataRow("Triage summary", item.triageSummary || "")}
-          ${renderMetadataRow("Severity", item.severity || "")}
-          ${renderMetadataRow("Rejection reason", item.rejectionReason || "")}
+          <div class="admin-detail-block">
+            <h4>Captured metadata</h4>
+            <div class="admin-detail-meta">
+              ${renderMetadataRow("User", item.user?.email || item.userId)}
+              ${renderMetadataRow("Reviewer", item.reviewer?.email || "")}
+              ${renderMetadataRow("Reviewed at", item.reviewedAt ? formatDateTime(item.reviewedAt) : "")}
+              ${renderMetadataRow("Page URL", item.pageUrl || "")}
+              ${renderMetadataRow("App version", item.appVersion || "")}
+              ${renderMetadataRow("Browser", item.userAgent || "")}
+              ${renderMetadataRow("Screenshot URL", item.screenshotUrl || "")}
+              ${renderMetadataRow("Attachment", attachmentSummary)}
+              ${renderMetadataRow("Rejection reason", item.rejectionReason || "")}
+            </div>
+          </div>
         </div>
+
+        ${renderTriagePanel(item)}
       </div>
 
       <div class="admin-detail-block">
@@ -412,6 +471,50 @@ export async function updateAdminFeedbackStatus(status) {
 
     hooks.showMessage?.("adminMessage", `Feedback marked ${status}`, "success");
     await loadAdminFeedbackQueue();
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  }
+}
+
+export async function runAdminFeedbackTriage() {
+  if (!state.adminFeedbackSelectedId) {
+    return;
+  }
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}/triage`,
+      {
+        method: "POST",
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to triage feedback",
+        "error",
+      );
+      return;
+    }
+
+    hooks.showMessage?.("adminMessage", "Feedback triage updated", "success");
+    state.adminFeedbackDetail = data;
+    const itemIndex = state.adminFeedbackItems.findIndex(
+      (item) => item.id === data.id,
+    );
+    if (itemIndex >= 0) {
+      state.adminFeedbackItems[itemIndex] = {
+        ...state.adminFeedbackItems[itemIndex],
+        ...data,
+      };
+    }
+    renderAdminFeedbackWorkspace();
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",

--- a/client/styles.css
+++ b/client/styles.css
@@ -3850,9 +3850,28 @@ body.is-todos-view .floating-new-task-cta {
   margin: 0;
 }
 
+.admin-detail-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.admin-detail-panel {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
 .admin-detail-block {
   display: grid;
   gap: 10px;
+}
+
+.admin-detail-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .admin-detail-pre {
@@ -3888,6 +3907,19 @@ body.is-todos-view .floating-new-task-cta {
 .admin-detail-meta__value {
   color: var(--text-primary);
   word-break: break-word;
+}
+
+.admin-detail-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: var(--text-primary);
+}
+
+.admin-detail-empty-copy {
+  margin: 0;
+  color: var(--text-secondary);
 }
 
 .admin-feedback-actions {
@@ -4020,6 +4052,10 @@ body.is-todos-view .floating-new-task-cta {
   }
 
   .admin-feedback-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-detail-columns {
     grid-template-columns: 1fr;
   }
 }

--- a/prisma/migrations/20260320183000_add_feedback_triage_fields/migration.sql
+++ b/prisma/migrations/20260320183000_add_feedback_triage_fields/migration.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "FeedbackClassification" AS ENUM (
+  'bug',
+  'feature',
+  'support',
+  'duplicate_candidate',
+  'noise'
+);
+
+ALTER TABLE "feedback_requests"
+ADD COLUMN "classification" "FeedbackClassification",
+ADD COLUMN "triage_confidence" DOUBLE PRECISION,
+ADD COLUMN "normalized_title" VARCHAR(200),
+ADD COLUMN "normalized_body" TEXT,
+ADD COLUMN "impact_summary" TEXT,
+ADD COLUMN "repro_steps_json" JSONB,
+ADD COLUMN "expected_behavior" TEXT,
+ADD COLUMN "actual_behavior" TEXT,
+ADD COLUMN "proposed_outcome" TEXT,
+ADD COLUMN "agent_labels_json" JSONB,
+ADD COLUMN "missing_info_json" JSONB;
+
+CREATE INDEX "feedback_requests_classification_triage_confidence_idx"
+ON "feedback_requests"("classification", "triage_confidence");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,14 @@ enum FeedbackStatus {
   rejected
 }
 
+enum FeedbackClassification {
+  bug
+  feature
+  support
+  duplicate_candidate
+  noise
+}
+
 enum AiSuggestionStatus {
   pending
   accepted
@@ -475,6 +483,17 @@ model FeedbackRequest {
   userAgent          String?        @map("user_agent") @db.VarChar(2000)
   appVersion         String?        @map("app_version") @db.VarChar(50)
   status             FeedbackStatus @default(new)
+  classification     FeedbackClassification?
+  triageConfidence   Float?         @map("triage_confidence")
+  normalizedTitle    String?        @map("normalized_title") @db.VarChar(200)
+  normalizedBody     String?        @map("normalized_body") @db.Text
+  impactSummary      String?        @map("impact_summary") @db.Text
+  reproStepsJson     Json?          @map("repro_steps_json")
+  expectedBehavior   String?        @map("expected_behavior") @db.Text
+  actualBehavior     String?        @map("actual_behavior") @db.Text
+  proposedOutcome    String?        @map("proposed_outcome") @db.Text
+  agentLabelsJson    Json?          @map("agent_labels_json")
+  missingInfoJson    Json?          @map("missing_info_json")
   triageSummary      String?        @map("triage_summary") @db.Text
   severity           String?        @db.VarChar(20)
   dedupeKey          String?        @map("dedupe_key") @db.VarChar(255)
@@ -491,6 +510,7 @@ model FeedbackRequest {
   @@index([userId, status, createdAt])
   @@index([userId, type, createdAt])
   @@index([status, type, createdAt])
+  @@index([classification, triageConfidence])
   @@index([reviewedByUserId, reviewedAt])
   @@index([dedupeKey])
   @@map("feedback_requests")

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,7 @@ import { createCaptureRouter } from "./routes/captureRouter";
 import { createPreferencesRouter } from "./routes/preferencesRouter";
 import { createAgentEnrollmentRouter } from "./routes/agentEnrollmentRouter";
 import { FeedbackService } from "./services/feedbackService";
+import { FeedbackTriageService } from "./services/feedbackTriageService";
 import { createFeedbackRouter } from "./routes/feedbackRouter";
 import { AgentEnrollmentService } from "./services/agentEnrollmentService";
 import {
@@ -88,6 +89,9 @@ export function createApp(
     : null;
   const feedbackService = persistencePrisma
     ? new FeedbackService(persistencePrisma)
+    : null;
+  const feedbackTriageService = persistencePrisma
+    ? new FeedbackTriageService(persistencePrisma)
     : null;
 
   const resolveTodoUserId = (req: Request, res: Response): string | null => {
@@ -254,6 +258,7 @@ export function createApp(
     createAdminRouter({
       authService,
       feedbackService: feedbackService ?? undefined,
+      feedbackTriageService: feedbackTriageService ?? undefined,
     }),
   );
   app.use("/users", createUsersRouter({ authService }));

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -260,9 +260,79 @@ describe("Feedback API Integration", () => {
     expect(persisted?.reviewedAt).not.toBeNull();
   });
 
+  it("POST /admin/feedback/:id/triage stores structured triage output", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Task drawer crashes on save",
+        body: [
+          "What happened?",
+          "The drawer crashed after pressing save.",
+          "",
+          "What did you expect?",
+          "The task should save.",
+          "",
+          "What were you doing right before it happened?",
+          "Editing notes in the task drawer.",
+        ].join("\n"),
+        status: "new",
+        pageUrl: "https://app.example.com/?view=todos",
+      },
+    });
+
+    const response = await request(app)
+      .post(`/admin/feedback/${feedback.id}/triage`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      id: feedback.id,
+      classification: "bug",
+      normalizedTitle: "Task drawer crashes on save",
+      triageSummary: expect.any(String),
+      actualBehavior: "The drawer crashed after pressing save.",
+      expectedBehavior: "The task should save.",
+      reproSteps: [
+        "Editing notes in the task drawer.",
+        "The drawer crashed after pressing save.",
+      ],
+    });
+    expect(response.body.triageConfidence).toBeGreaterThan(0.8);
+    expect(response.body.agentLabels).toContain("feedback:bug");
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+
+    expect(persisted?.classification).toBe("bug");
+    expect(persisted?.normalizedTitle).toBe("Task drawer crashes on save");
+    expect(persisted?.triageConfidence).toBeGreaterThan(0.8);
+    expect(persisted?.expectedBehavior).toBe("The task should save.");
+  });
+
   it("GET /admin/feedback returns 403 for non-admin users", async () => {
     await request(app)
       .get("/admin/feedback")
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(403)
+      .expect({
+        error: "Forbidden: Admin access required",
+      });
+  });
+
+  it("POST /admin/feedback/:id/triage returns 403 for non-admin users", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Add a planning helper",
+        body: "What are you trying to do?\nPlan my week.",
+      },
+    });
+
+    await request(app)
+      .post(`/admin/feedback/${feedback.id}/triage`)
       .set("Authorization", `Bearer ${authToken}`)
       .expect(403)
       .expect({

--- a/src/feedbackTriageService.test.ts
+++ b/src/feedbackTriageService.test.ts
@@ -1,0 +1,95 @@
+import {
+  FeedbackTriageService,
+  triageFeedbackDeterministic,
+} from "./services/feedbackTriageService";
+
+describe("FeedbackTriageService", () => {
+  it("builds a repro-oriented deterministic bug triage payload", () => {
+    const result = triageFeedbackDeterministic({
+      id: "feedback-1",
+      type: "bug",
+      title: "Task drawer crashes on save",
+      body: [
+        "What happened?",
+        "The task drawer crashed when I hit save.",
+        "",
+        "What did you expect?",
+        "The task should save cleanly.",
+        "",
+        "What were you doing right before it happened?",
+        "Editing notes in the drawer.",
+      ].join("\n"),
+      screenshotUrl: "https://example.com/bug.png",
+      pageUrl: "https://app.example.com/?view=todos",
+      userAgent: "Jest Browser",
+      appVersion: "1.6.0",
+      triageSummary: null,
+      dedupeKey: null,
+    });
+
+    expect(result.classification).toBe("bug");
+    expect(result.triageConfidence).toBeGreaterThan(0.8);
+    expect(result.reproSteps).toEqual([
+      "Editing notes in the drawer.",
+      "The task drawer crashed when I hit save.",
+    ]);
+    expect(result.expectedBehavior).toBe("The task should save cleanly.");
+    expect(result.actualBehavior).toBe(
+      "The task drawer crashed when I hit save.",
+    );
+    expect(result.labels).toContain("feedback:bug");
+    expect(result.missingInfo).toEqual([]);
+    expect(result.dedupeKey).toHaveLength(24);
+  });
+
+  it("falls back to deterministic triage when provider output is invalid", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: "feedback-2",
+          type: "feature",
+          title: "Make weekly planning easier",
+          body: [
+            "What are you trying to do?",
+            "Plan the week quickly.",
+            "",
+            "What is hard today?",
+            "I have to sort tasks by hand.",
+            "",
+            "What would make this better?",
+            "Auto-group related tasks into bundles.",
+          ].join("\n"),
+          screenshotUrl: null,
+          pageUrl: "https://app.example.com/?view=planning",
+          userAgent: "Jest Browser",
+          appVersion: "1.6.0",
+          triageSummary: null,
+          dedupeKey: null,
+        }),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    } as any;
+    const provider = {
+      generateJson: jest.fn().mockResolvedValue({ classification: "oops" }),
+    };
+    const service = new FeedbackTriageService(prisma, { provider });
+
+    const result = await service.triageFeedback("feedback-2");
+
+    expect(provider.generateJson).toHaveBeenCalledTimes(1);
+    expect(result.classification).toBe("feature");
+    expect(result.proposedOutcome).toBe(
+      "Auto-group related tasks into bundles.",
+    );
+    expect(result.missingInfo).toEqual([]);
+    expect(prisma.feedbackRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "feedback-2" },
+        data: expect.objectContaining({
+          classification: "feature",
+          normalizedTitle: "Make weekly planning easier",
+        }),
+      }),
+    );
+  });
+});

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response, NextFunction } from "express";
 import { AuthService } from "../services/authService";
 import { HttpError, hasPrismaCode } from "../errorHandling";
 import { FeedbackService } from "../services/feedbackService";
+import { FeedbackTriageService } from "../services/feedbackTriageService";
 import {
   validateListAdminFeedbackRequestsQuery,
   validateUpdateAdminFeedbackRequest,
@@ -10,11 +11,13 @@ import {
 interface AdminRouterDeps {
   authService?: AuthService;
   feedbackService?: FeedbackService;
+  feedbackTriageService?: FeedbackTriageService;
 }
 
 export function createAdminRouter({
   authService,
   feedbackService,
+  feedbackTriageService,
 }: AdminRouterDeps): Router {
   const router = Router();
 
@@ -186,6 +189,38 @@ export function createAdminRouter({
       } catch (error) {
         if (hasPrismaCode(error, ["P2025"])) {
           return next(new HttpError(404, "Feedback request not found"));
+        }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    "/feedback/:id/triage",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService || !feedbackTriageService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback triage not configured" });
+      }
+
+      try {
+        const feedbackId = String(req.params.id);
+        await feedbackTriageService.triageFeedback(feedbackId);
+        const feedbackRequest = await feedbackService.getForAdmin(feedbackId);
+        if (!feedbackRequest) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+        res.json(feedbackRequest);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "Feedback request not found"
+        ) {
+          return next(new HttpError(404, error.message));
         }
         if (hasPrismaCode(error, ["P2023"])) {
           return next(new HttpError(400, "Invalid feedback request ID format"));

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -3,6 +3,7 @@ import {
   CreateFeedbackRequestDto,
   FeedbackRequestAdminDetailDto,
   FeedbackRequestAdminListItemDto,
+  FeedbackTriageResultDto,
   FeedbackRequestDto,
   FeedbackAttachmentMetadataDto,
   ListAdminFeedbackRequestsQuery,
@@ -138,6 +139,23 @@ export class FeedbackService {
     userAgent: string | null;
     appVersion: string | null;
     status: "new" | "triaged" | "promoted" | "rejected";
+    classification:
+      | "bug"
+      | "feature"
+      | "support"
+      | "duplicate_candidate"
+      | "noise"
+      | null;
+    triageConfidence: number | null;
+    normalizedTitle: string | null;
+    normalizedBody: string | null;
+    impactSummary: string | null;
+    reproStepsJson: unknown;
+    expectedBehavior: string | null;
+    actualBehavior: string | null;
+    proposedOutcome: string | null;
+    agentLabelsJson: unknown;
+    missingInfoJson: unknown;
     triageSummary: string | null;
     severity: string | null;
     dedupeKey: string | null;
@@ -149,6 +167,22 @@ export class FeedbackService {
     createdAt: Date;
     updatedAt: Date;
   }): FeedbackRequestDto {
+    const reproSteps = Array.isArray(record.reproStepsJson)
+      ? record.reproStepsJson.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+    const agentLabels = Array.isArray(record.agentLabelsJson)
+      ? record.agentLabelsJson.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+    const missingInfo = Array.isArray(record.missingInfoJson)
+      ? record.missingInfoJson.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+
     return {
       id: record.id,
       userId: record.userId,
@@ -163,6 +197,17 @@ export class FeedbackService {
       userAgent: record.userAgent,
       appVersion: record.appVersion,
       status: record.status,
+      classification: record.classification,
+      triageConfidence: record.triageConfidence,
+      normalizedTitle: record.normalizedTitle,
+      normalizedBody: record.normalizedBody,
+      impactSummary: record.impactSummary,
+      reproSteps,
+      expectedBehavior: record.expectedBehavior,
+      actualBehavior: record.actualBehavior,
+      proposedOutcome: record.proposedOutcome,
+      agentLabels,
+      missingInfo,
       triageSummary: record.triageSummary,
       severity: record.severity,
       dedupeKey: record.dedupeKey,
@@ -189,6 +234,23 @@ export class FeedbackService {
     userAgent: string | null;
     appVersion: string | null;
     status: "new" | "triaged" | "promoted" | "rejected";
+    classification:
+      | "bug"
+      | "feature"
+      | "support"
+      | "duplicate_candidate"
+      | "noise"
+      | null;
+    triageConfidence: number | null;
+    normalizedTitle: string | null;
+    normalizedBody: string | null;
+    impactSummary: string | null;
+    reproStepsJson: unknown;
+    expectedBehavior: string | null;
+    actualBehavior: string | null;
+    proposedOutcome: string | null;
+    agentLabelsJson: unknown;
+    missingInfoJson: unknown;
     triageSummary: string | null;
     severity: string | null;
     dedupeKey: string | null;

--- a/src/services/feedbackTriageService.ts
+++ b/src/services/feedbackTriageService.ts
@@ -1,0 +1,363 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { createHash } from "crypto";
+import { config } from "../config";
+import {
+  FeedbackRequestType,
+  FeedbackTriageClassification,
+  FeedbackTriageResultDto,
+} from "../types";
+import { validateFeedbackTriageOutput } from "../validation/feedbackTriageContracts";
+
+interface AiProvider {
+  generateJson<T>(systemPrompt: string, userPrompt: string): Promise<T>;
+}
+
+export interface FeedbackTriageServiceDeps {
+  provider?: AiProvider;
+}
+
+type FeedbackRecord = {
+  id: string;
+  type: FeedbackRequestType;
+  title: string;
+  body: string;
+  screenshotUrl: string | null;
+  pageUrl: string | null;
+  userAgent: string | null;
+  appVersion: string | null;
+  triageSummary: string | null;
+  dedupeKey: string | null;
+};
+
+class OpenAiCompatibleProvider implements AiProvider {
+  async generateJson<T>(systemPrompt: string, userPrompt: string): Promise<T> {
+    const response = await fetch(
+      `${config.aiProviderBaseUrl}/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.aiProviderApiKey}`,
+        },
+        body: JSON.stringify({
+          model: config.aiProviderModel,
+          response_format: { type: "json_object" },
+          messages: [
+            { role: "system", content: systemPrompt },
+            { role: "user", content: userPrompt },
+          ],
+          temperature: 0,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `AI provider request failed with status ${response.status}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new Error("AI provider returned empty content");
+    }
+
+    return JSON.parse(content) as T;
+  }
+}
+
+function normalizeWhitespace(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .trim();
+}
+
+function titleCaseLabel(value: string): string {
+  return value
+    .split(/[_\-\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function buildDedupeKey(
+  record: FeedbackRecord,
+  classification: string,
+): string {
+  const normalized = `${classification}|${record.type}|${record.title}|${record.body
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()}`;
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 24);
+}
+
+function extractSection(body: string, prompts: string[]): string | null {
+  const lines = body.split(/\n+/).map((line) => line.trim());
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const lower = line.toLowerCase();
+    const match = prompts.find((prompt) =>
+      lower.startsWith(prompt.toLowerCase()),
+    );
+    if (!match) {
+      continue;
+    }
+    const inlineValue = line
+      .slice(match.length)
+      .replace(/^[:\-\s]+/, "")
+      .trim();
+    if (inlineValue) {
+      return inlineValue;
+    }
+    const nextLine = lines[index + 1]?.trim();
+    if (nextLine) {
+      return nextLine;
+    }
+  }
+  return null;
+}
+
+function buildSummary(record: FeedbackRecord, classification: string): string {
+  const pageContext = record.pageUrl ? ` on ${record.pageUrl}` : "";
+  return `${titleCaseLabel(classification)} feedback from "${record.title}"${pageContext}.`;
+}
+
+export function triageFeedbackDeterministic(
+  record: FeedbackRecord,
+): FeedbackTriageResultDto & { triageSummary: string; dedupeKey: string } {
+  const normalizedTitle = normalizeWhitespace(record.title).slice(0, 200);
+  const normalizedBody = normalizeWhitespace(record.body);
+  const titleLower = normalizedTitle.toLowerCase();
+  const bodyLower = normalizedBody.toLowerCase();
+
+  let classification: FeedbackTriageClassification =
+    record.type === "feature"
+      ? "feature"
+      : record.type === "bug"
+        ? "bug"
+        : "support";
+  let triageConfidence = 0.72;
+
+  if (
+    bodyLower.includes("duplicate") ||
+    bodyLower.includes("same issue") ||
+    titleLower.includes("again")
+  ) {
+    classification = "duplicate_candidate";
+    triageConfidence = 0.79;
+  } else if (
+    bodyLower.includes("help") ||
+    bodyLower.includes("how do i") ||
+    bodyLower.includes("how can i")
+  ) {
+    classification = "support";
+    triageConfidence = 0.76;
+  } else if (
+    normalizedBody.length < 20 ||
+    ["test", "hello", "asdf"].includes(titleLower)
+  ) {
+    classification = "noise";
+    triageConfidence = 0.84;
+  } else if (record.type === "feature") {
+    classification = "feature";
+    triageConfidence = 0.84;
+  } else if (record.type === "bug") {
+    classification = "bug";
+    triageConfidence = 0.86;
+  }
+
+  const reproSteps = [
+    extractSection(record.body, [
+      "what were you doing right before it happened?",
+      "steps to reproduce",
+      "repro steps",
+    ]),
+    extractSection(record.body, ["what happened?", "actual behavior"]),
+  ].filter((value): value is string => Boolean(value));
+
+  const expectedBehavior = extractSection(record.body, [
+    "what did you expect?",
+    "expected behavior",
+  ]);
+  const actualBehavior = extractSection(record.body, [
+    "what happened?",
+    "actual behavior",
+  ]);
+  const problemToday = extractSection(record.body, ["what is hard today?"]);
+  const desiredOutcome = extractSection(record.body, [
+    "what would make this better?",
+    "what are you trying to do?",
+    "proposed outcome",
+  ]);
+
+  const labels = Array.from(
+    new Set(
+      [
+        `feedback:${classification}`,
+        `source:${record.type}`,
+        record.screenshotUrl ? "has:screenshot" : "",
+        record.pageUrl ? "has:page-context" : "",
+      ].filter(Boolean),
+    ),
+  );
+
+  const missingInfo = [
+    classification === "bug" && reproSteps.length === 0
+      ? "missing_repro_steps"
+      : "",
+    classification === "bug" && !expectedBehavior
+      ? "missing_expected_behavior"
+      : "",
+    classification === "feature" && !desiredOutcome
+      ? "missing_desired_outcome"
+      : "",
+    !record.pageUrl ? "missing_page_context" : "",
+  ].filter(Boolean);
+
+  const triageSummary = buildSummary(record, classification);
+  const impactSummary =
+    classification === "feature"
+      ? problemToday || desiredOutcome || null
+      : actualBehavior || normalizedBody.slice(0, 280);
+  const proposedOutcome =
+    classification === "feature"
+      ? desiredOutcome
+      : classification === "bug"
+        ? expectedBehavior
+        : desiredOutcome || expectedBehavior;
+  const dedupeKey = buildDedupeKey(record, classification);
+
+  return {
+    classification,
+    triageConfidence,
+    normalizedTitle,
+    normalizedBody,
+    impactSummary,
+    reproSteps,
+    expectedBehavior,
+    actualBehavior,
+    proposedOutcome,
+    labels,
+    missingInfo,
+    triageSummary,
+    dedupeKey,
+  };
+}
+
+function buildSystemPrompt(): string {
+  return [
+    "You classify product feedback into engineering-ready JSON.",
+    "Return only valid JSON matching the requested schema.",
+    "Never include markdown or commentary.",
+    "Use one classification from bug, feature, support, duplicate_candidate, noise.",
+    "Keep titles concise, factual, and implementation-oriented.",
+    "Use empty arrays when information is missing.",
+  ].join(" ");
+}
+
+function buildUserPrompt(record: FeedbackRecord): string {
+  return JSON.stringify({
+    instruction:
+      "Produce deterministic structured triage output with fields classification, triageConfidence, normalizedTitle, normalizedBody, impactSummary, reproSteps, expectedBehavior, actualBehavior, proposedOutcome, labels, missingInfo.",
+    feedback: {
+      id: record.id,
+      type: record.type,
+      title: record.title,
+      body: record.body,
+      screenshotUrl: record.screenshotUrl,
+      pageUrl: record.pageUrl,
+      userAgent: record.userAgent,
+      appVersion: record.appVersion,
+    },
+  });
+}
+
+export class FeedbackTriageService {
+  private readonly provider?: AiProvider;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    deps: FeedbackTriageServiceDeps = {},
+  ) {
+    this.provider =
+      deps.provider ??
+      (config.aiProviderEnabled ? new OpenAiCompatibleProvider() : undefined);
+  }
+
+  async triageFeedback(feedbackId: string): Promise<FeedbackTriageResultDto> {
+    const record = await this.prisma.feedbackRequest.findUnique({
+      where: { id: feedbackId },
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        body: true,
+        screenshotUrl: true,
+        pageUrl: true,
+        userAgent: true,
+        appVersion: true,
+        triageSummary: true,
+        dedupeKey: true,
+      },
+    });
+
+    if (!record) {
+      throw new Error("Feedback request not found");
+    }
+
+    const fallback = triageFeedbackDeterministic(record);
+    let normalized = fallback;
+
+    if (this.provider) {
+      try {
+        const aiOutput = await this.provider.generateJson<unknown>(
+          buildSystemPrompt(),
+          buildUserPrompt(record),
+        );
+        const validated = validateFeedbackTriageOutput(aiOutput);
+        normalized = {
+          ...validated,
+          triageSummary: buildSummary(record, validated.classification),
+          dedupeKey: buildDedupeKey(record, validated.classification),
+        };
+      } catch {
+        normalized = fallback;
+      }
+    }
+
+    await this.prisma.feedbackRequest.update({
+      where: { id: feedbackId },
+      data: {
+        classification: normalized.classification,
+        triageConfidence: normalized.triageConfidence,
+        normalizedTitle: normalized.normalizedTitle,
+        normalizedBody: normalized.normalizedBody,
+        impactSummary: normalized.impactSummary ?? null,
+        reproStepsJson:
+          (normalized.reproSteps ?? []).length > 0
+            ? ((normalized.reproSteps ?? []) as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+        expectedBehavior: normalized.expectedBehavior ?? null,
+        actualBehavior: normalized.actualBehavior ?? null,
+        proposedOutcome: normalized.proposedOutcome ?? null,
+        agentLabelsJson:
+          normalized.labels.length > 0
+            ? (normalized.labels as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+        missingInfoJson:
+          normalized.missingInfo.length > 0
+            ? (normalized.missingInfo as Prisma.InputJsonValue)
+            : Prisma.JsonNull,
+        triageSummary: normalized.triageSummary,
+        dedupeKey: normalized.dedupeKey,
+      },
+    });
+
+    return normalized;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,12 +344,32 @@ export interface CreateCaptureItemDto {
 export type FeedbackRequestType = "bug" | "feature" | "general";
 export type FeedbackRequestStatus = "new" | "triaged" | "promoted" | "rejected";
 export type FeedbackReviewAction = "triaged" | "promoted" | "rejected";
+export type FeedbackTriageClassification =
+  | "bug"
+  | "feature"
+  | "support"
+  | "duplicate_candidate"
+  | "noise";
 
 export interface FeedbackAttachmentMetadataDto {
   name?: string | null;
   type?: string | null;
   size?: number | null;
   lastModified?: number | null;
+}
+
+export interface FeedbackTriageResultDto {
+  classification: FeedbackTriageClassification;
+  triageConfidence: number;
+  normalizedTitle: string;
+  normalizedBody: string;
+  impactSummary?: string | null;
+  reproSteps?: string[];
+  expectedBehavior?: string | null;
+  actualBehavior?: string | null;
+  proposedOutcome?: string | null;
+  labels: string[];
+  missingInfo: string[];
 }
 
 export interface CreateFeedbackRequestDto {
@@ -375,6 +395,17 @@ export interface FeedbackRequestDto {
   userAgent?: string | null;
   appVersion?: string | null;
   status: FeedbackRequestStatus;
+  classification?: FeedbackTriageClassification | null;
+  triageConfidence?: number | null;
+  normalizedTitle?: string | null;
+  normalizedBody?: string | null;
+  impactSummary?: string | null;
+  reproSteps?: string[];
+  expectedBehavior?: string | null;
+  actualBehavior?: string | null;
+  proposedOutcome?: string | null;
+  agentLabels?: string[];
+  missingInfo?: string[];
   triageSummary?: string | null;
   severity?: string | null;
   dedupeKey?: string | null;

--- a/src/validation/feedbackTriageContracts.ts
+++ b/src/validation/feedbackTriageContracts.ts
@@ -1,0 +1,148 @@
+import {
+  FeedbackTriageClassification,
+  FeedbackTriageResultDto,
+} from "../types";
+import { ValidationError } from "./validation";
+
+const ALLOWED_CLASSIFICATIONS: FeedbackTriageClassification[] = [
+  "bug",
+  "feature",
+  "support",
+  "duplicate_candidate",
+  "noise",
+];
+const MAX_TEXT_LENGTH = 4000;
+const MAX_LABELS = 10;
+const MAX_STEPS = 12;
+const MAX_MISSING_FLAGS = 10;
+
+function assertObject(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertOptionalString(
+  value: unknown,
+  field: string,
+  maxLength = MAX_TEXT_LENGTH,
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new ValidationError(`${field} must be a string`);
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.length > maxLength) {
+    throw new ValidationError(`${field} cannot exceed ${maxLength} characters`);
+  }
+  return normalized;
+}
+
+function assertRequiredString(
+  value: unknown,
+  field: string,
+  maxLength = MAX_TEXT_LENGTH,
+): string {
+  const normalized = assertOptionalString(value, field, maxLength);
+  if (!normalized) {
+    throw new ValidationError(`${field} cannot be empty`);
+  }
+  return normalized;
+}
+
+function assertStringArray(
+  value: unknown,
+  field: string,
+  maxItems: number,
+  maxItemLength: number,
+): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new ValidationError(`${field} must be an array of strings`);
+  }
+  if (value.length > maxItems) {
+    throw new ValidationError(`${field} cannot exceed ${maxItems} items`);
+  }
+
+  const normalized = value.map((item, index) =>
+    assertRequiredString(item, `${field}[${index}]`, maxItemLength),
+  );
+
+  return Array.from(new Set(normalized));
+}
+
+function assertConfidence(value: unknown): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new ValidationError("triageConfidence must be a number");
+  }
+  if (value < 0 || value > 1) {
+    throw new ValidationError("triageConfidence must be between 0 and 1");
+  }
+  return Number(value.toFixed(3));
+}
+
+export function validateFeedbackTriageOutput(
+  value: unknown,
+): FeedbackTriageResultDto {
+  const output = assertObject(value, "triageOutput");
+  const classification = output.classification;
+
+  if (
+    typeof classification !== "string" ||
+    !ALLOWED_CLASSIFICATIONS.includes(
+      classification as FeedbackTriageClassification,
+    )
+  ) {
+    throw new ValidationError(
+      "classification must be bug, feature, support, duplicate_candidate, or noise",
+    );
+  }
+
+  return {
+    classification: classification as FeedbackTriageClassification,
+    triageConfidence: assertConfidence(output.triageConfidence),
+    normalizedTitle: assertRequiredString(
+      output.normalizedTitle,
+      "normalizedTitle",
+      200,
+    ),
+    normalizedBody: assertRequiredString(
+      output.normalizedBody,
+      "normalizedBody",
+    ),
+    impactSummary: assertOptionalString(output.impactSummary, "impactSummary"),
+    reproSteps: assertStringArray(
+      output.reproSteps,
+      "reproSteps",
+      MAX_STEPS,
+      500,
+    ),
+    expectedBehavior: assertOptionalString(
+      output.expectedBehavior,
+      "expectedBehavior",
+    ),
+    actualBehavior: assertOptionalString(
+      output.actualBehavior,
+      "actualBehavior",
+    ),
+    proposedOutcome: assertOptionalString(
+      output.proposedOutcome,
+      "proposedOutcome",
+    ),
+    labels: assertStringArray(output.labels, "labels", MAX_LABELS, 60),
+    missingInfo: assertStringArray(
+      output.missingInfo,
+      "missingInfo",
+      MAX_MISSING_FLAGS,
+      80,
+    ),
+  };
+}

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -19,6 +19,17 @@ function buildFeedback(overrides: Record<string, unknown> = {}) {
     userAgent: "Playwright Browser",
     appVersion: "1.6.0",
     status: "new",
+    classification: null,
+    triageConfidence: null,
+    normalizedTitle: null,
+    normalizedBody: null,
+    impactSummary: null,
+    reproSteps: [],
+    expectedBehavior: null,
+    actualBehavior: null,
+    proposedOutcome: null,
+    agentLabels: [],
+    missingInfo: [],
     triageSummary: "Likely reproducible",
     severity: "medium",
     dedupeKey: null,
@@ -44,6 +55,7 @@ test.describe("Admin feedback queue", () => {
     page,
   }) => {
     let patchPayload: Record<string, unknown> | null = null;
+    let triageCalled = false;
     const bugFeedback = buildFeedback();
     const featureFeedback = buildFeedback({
       id: "feedback-2",
@@ -86,6 +98,33 @@ test.describe("Admin feedback queue", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify([featureFeedback, bugFeedback]),
+      });
+    });
+
+    await page.route("**/admin/feedback/feedback-1/triage", async (route) => {
+      triageCalled = true;
+      Object.assign(bugFeedback, {
+        classification: "bug",
+        triageConfidence: 0.93,
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody:
+          "Bug report describing a task drawer save crash while editing notes.",
+        impactSummary: "Users cannot save task edits from the drawer.",
+        reproSteps: ["Edit notes in the task drawer.", "Press save."],
+        expectedBehavior: "The task should save successfully.",
+        actualBehavior: "The task drawer crashes on save.",
+        proposedOutcome:
+          "Stabilize drawer save handling and preserve note edits.",
+        agentLabels: ["feedback:bug", "source:bug", "has:screenshot"],
+        missingInfo: [],
+        triageSummary:
+          'Bug feedback from "Task drawer crashes" on https://app.example.com/?view=todos.',
+        dedupeKey: "abc123dedupekeyxyz789012",
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(bugFeedback),
       });
     });
 
@@ -163,6 +202,24 @@ test.describe("Admin feedback queue", () => {
     );
     await expect(page.locator("#adminFeedbackDetail")).toContainText(
       "https://app.example.com/?view=todos",
+    );
+
+    await page
+      .locator("#adminFeedbackDetail")
+      .getByRole("button", { name: "Run triage", exact: true })
+      .click();
+    expect(triageCalled).toBe(true);
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Feedback triage updated",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Task drawer crashes on save",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Users cannot save task edits from the drawer.",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "feedback:bug",
     );
 
     await page


### PR DESCRIPTION
## Summary
Adds the missing AI-assisted feedback triage pipeline for feedback submissions.

This introduces schema-validated normalized triage output, optional AI-provider-backed classification with deterministic fallback behavior, admin-triggered triage execution, and an admin review surface that shows normalized engineering-ready output next to the raw submission.

## User impact
Friends-and-family feedback can now be transformed into structured internal records before any future promotion flow writes to GitHub. Admins can inspect confidence, classification, repro details, normalized summaries, and missing-information flags directly in the queue.

## Root cause
The feedback flow and admin review queue had already landed, but there was no merged implementation for the normalization and triage step between raw feedback intake and downstream issue creation workflows.

## Fix
- add feedback triage persistence fields and migration
- add strict triage output DTOs and validation contract
- add a Prisma-backed triage service with optional AI provider and deterministic fallback
- add `POST /admin/feedback/:id/triage`
- return stored triage output through feedback admin/detail DTOs
- render raw and normalized feedback side-by-side in the admin queue
- add unit, integration, and UI coverage for the new flow

## Validation
- `npx prisma generate`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts`
- `CI=1 npm run test:ui:fast`

## Notes
The feedback integration suite still emits the repo's existing email verification credential warnings during auth registration, but the test run passes cleanly.
