### PR TITLE
feat(api): add feedback duplicate detection

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -409,7 +409,10 @@ import {
   deleteUser,
 } from "./modules/adminUsers.js";
 import {
+  confirmAdminFeedbackDuplicate,
+  ignoreDuplicateAndPromote,
   loadAdminFeedbackQueue,
+  runAdminFeedbackDuplicateCheck,
   selectAdminFeedback,
   setAdminFeedbackFilter,
   runAdminFeedbackTriage,
@@ -1772,6 +1775,9 @@ window.changeUserRole = changeUserRole;
 window.deleteUser = deleteUser;
 window.selectAdminFeedback = selectAdminFeedback;
 window.setAdminFeedbackFilter = setAdminFeedbackFilter;
+window.runAdminFeedbackDuplicateCheck = runAdminFeedbackDuplicateCheck;
+window.confirmAdminFeedbackDuplicate = confirmAdminFeedbackDuplicate;
+window.ignoreDuplicateAndPromote = ignoreDuplicateAndPromote;
 window.runAdminFeedbackTriage = runAdminFeedbackTriage;
 window.updateAdminFeedbackStatus = updateAdminFeedbackStatus;
 

--- a/client/modules/adminFeedback.js
+++ b/client/modules/adminFeedback.js
@@ -223,6 +223,72 @@ function renderTriagePanel(item) {
   `;
 }
 
+function renderDuplicatePanel(item) {
+  const hasConfirmedDuplicate =
+    item.duplicateOfFeedbackId || item.duplicateOfGithubIssueNumber;
+  const hasCandidate =
+    item.duplicateCandidate ||
+    (Array.isArray(item.matchedFeedbackIds) &&
+      item.matchedFeedbackIds.length > 0) ||
+    item.matchedGithubIssueNumber;
+
+  if (!hasConfirmedDuplicate && !hasCandidate) {
+    return "";
+  }
+
+  return `
+    <div class="admin-detail-block">
+      <div class="admin-detail-block__header">
+        <h4>Duplicate Review</h4>
+        <button type="button" class="action-btn" data-onclick="runAdminFeedbackDuplicateCheck()">
+          Check duplicates
+        </button>
+      </div>
+      <div class="admin-detail-meta">
+        ${renderMetadataRow("Suggested duplicate", item.duplicateCandidate ? "Yes" : "No")}
+        ${renderMetadataRow("Suggested feedback IDs", (item.matchedFeedbackIds || []).join(", "))}
+        ${renderMetadataRow("Suggested GitHub issue", item.matchedGithubIssueNumber ? `#${item.matchedGithubIssueNumber}` : "")}
+        ${renderMetadataRow("Confirmed feedback duplicate", item.duplicateOfFeedbackId || "")}
+        ${renderMetadataRow("Confirmed GitHub duplicate", item.duplicateOfGithubIssueNumber ? `#${item.duplicateOfGithubIssueNumber}` : "")}
+        ${renderMetadataRow("Duplicate reason", item.duplicateReason || "")}
+      </div>
+      ${
+        item.matchedGithubIssueUrl || item.duplicateOfGithubIssueUrl
+          ? `<div class="admin-detail-links">
+              ${
+                item.matchedGithubIssueUrl
+                  ? `<a class="admin-detail-link" href="${escape(item.matchedGithubIssueUrl)}" target="_blank" rel="noreferrer">Suggested GitHub issue</a>`
+                  : ""
+              }
+              ${
+                item.duplicateOfGithubIssueUrl
+                  ? `<a class="admin-detail-link" href="${escape(item.duplicateOfGithubIssueUrl)}" target="_blank" rel="noreferrer">Confirmed GitHub issue</a>`
+                  : ""
+              }
+            </div>`
+          : ""
+      }
+      ${
+        item.duplicateCandidate
+          ? `<div class="admin-feedback-actions">
+              ${
+                item.matchedFeedbackIds?.[0]
+                  ? `<button type="button" class="action-btn demote" data-onclick="confirmAdminFeedbackDuplicate('feedback')">Link matched feedback</button>`
+                  : ""
+              }
+              ${
+                item.matchedGithubIssueNumber
+                  ? `<button type="button" class="action-btn demote" data-onclick="confirmAdminFeedbackDuplicate('github')">Link GitHub issue</button>`
+                  : ""
+              }
+              <button type="button" class="action-btn promote" data-onclick="ignoreDuplicateAndPromote()">Ignore and promote</button>
+            </div>`
+          : ""
+      }
+    </div>
+  `;
+}
+
 function renderAdminFeedbackDetail() {
   const { detail } = getAdminFeedbackElements();
   if (!(detail instanceof HTMLElement)) {
@@ -291,6 +357,8 @@ function renderAdminFeedbackDetail() {
 
         ${renderTriagePanel(item)}
       </div>
+
+      ${renderDuplicatePanel(item)}
 
       <div class="admin-detail-block">
         <h4>Review Actions</h4>
@@ -461,6 +529,17 @@ export async function updateAdminFeedbackStatus(status) {
     const data = response ? await hooks.parseApiBody(response) : {};
 
     if (!response?.ok) {
+      if (response?.status === 409 && data.feedbackRequest) {
+        hooks.showMessage?.(
+          "adminMessage",
+          data.error || "Duplicate candidate found. Review suggestions below.",
+          "error",
+        );
+        state.adminFeedbackDetail = data.feedbackRequest;
+        renderAdminFeedbackWorkspace();
+        return;
+      }
+
       hooks.showMessage?.(
         "adminMessage",
         data.error || "Failed to update feedback status",
@@ -514,6 +593,125 @@ export async function runAdminFeedbackTriage() {
         ...data,
       };
     }
+    renderAdminFeedbackWorkspace();
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  }
+}
+
+async function patchAdminFeedback(payload, successMessage) {
+  if (!state.adminFeedbackSelectedId) {
+    return;
+  }
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to update duplicate resolution",
+        "error",
+      );
+      return;
+    }
+
+    hooks.showMessage?.("adminMessage", successMessage, "success");
+    await loadAdminFeedbackQueue();
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  }
+}
+
+export async function confirmAdminFeedbackDuplicate(kind) {
+  const item = state.adminFeedbackDetail;
+  if (!item) {
+    return;
+  }
+
+  if (kind === "feedback" && item.matchedFeedbackIds?.[0]) {
+    await patchAdminFeedback(
+      {
+        status: "triaged",
+        duplicateOfFeedbackId: item.matchedFeedbackIds[0],
+        duplicateReason:
+          item.duplicateReason || "Confirmed duplicate of existing feedback",
+      },
+      "Feedback linked as duplicate",
+    );
+  }
+
+  if (kind === "github" && item.matchedGithubIssueNumber) {
+    await patchAdminFeedback(
+      {
+        status: "triaged",
+        duplicateOfGithubIssueNumber: item.matchedGithubIssueNumber,
+        duplicateReason:
+          item.duplicateReason ||
+          "Confirmed duplicate of existing GitHub issue",
+      },
+      "Feedback linked to existing GitHub issue",
+    );
+  }
+}
+
+export async function ignoreDuplicateAndPromote() {
+  await patchAdminFeedback(
+    {
+      status: "promoted",
+      ignoreDuplicateSuggestion: true,
+    },
+    "Feedback promoted after ignoring duplicate suggestion",
+  );
+}
+
+export async function runAdminFeedbackDuplicateCheck() {
+  if (!state.adminFeedbackSelectedId) {
+    return;
+  }
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}/duplicate-check`,
+      {
+        method: "POST",
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to check duplicates",
+        "error",
+      );
+      return;
+    }
+
+    hooks.showMessage?.(
+      "adminMessage",
+      data.duplicateCandidate
+        ? "Duplicate candidates found"
+        : "No duplicate candidates found",
+      "success",
+    );
+    state.adminFeedbackDetail = data;
     renderAdminFeedbackWorkspace();
   } catch (error) {
     hooks.showMessage?.(

--- a/client/styles.css
+++ b/client/styles.css
@@ -3922,6 +3922,21 @@ body.is-todos-view .floating-new-task-cta {
   color: var(--text-secondary);
 }
 
+.admin-detail-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.admin-detail-link:hover {
+  text-decoration: underline;
+}
+
+.admin-detail-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .admin-feedback-actions {
   display: flex;
   flex-wrap: wrap;

--- a/prisma/migrations/20260321021500_add_feedback_duplicate_detection/migration.sql
+++ b/prisma/migrations/20260321021500_add_feedback_duplicate_detection/migration.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "feedback_requests"
+ADD COLUMN "duplicate_candidate" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "matched_feedback_ids" JSONB,
+ADD COLUMN "matched_github_issue_number" INTEGER,
+ADD COLUMN "matched_github_issue_url" VARCHAR(2000),
+ADD COLUMN "duplicate_of_feedback_id" TEXT,
+ADD COLUMN "duplicate_of_github_issue_number" INTEGER,
+ADD COLUMN "duplicate_reason" TEXT;
+
+CREATE INDEX "feedback_requests_duplicate_candidate_created_at_idx"
+ON "feedback_requests"("duplicate_candidate", "created_at");
+
+CREATE INDEX "feedback_requests_duplicate_of_feedback_id_idx"
+ON "feedback_requests"("duplicate_of_feedback_id");
+
+CREATE INDEX "feedback_requests_duplicate_of_github_issue_number_idx"
+ON "feedback_requests"("duplicate_of_github_issue_number");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -497,6 +497,13 @@ model FeedbackRequest {
   triageSummary      String?        @map("triage_summary") @db.Text
   severity           String?        @db.VarChar(20)
   dedupeKey          String?        @map("dedupe_key") @db.VarChar(255)
+  duplicateCandidate Boolean        @default(false) @map("duplicate_candidate")
+  matchedFeedbackIds Json?          @map("matched_feedback_ids")
+  matchedGithubIssueNumber Int?     @map("matched_github_issue_number")
+  matchedGithubIssueUrl String?     @map("matched_github_issue_url") @db.VarChar(2000)
+  duplicateOfFeedbackId String?     @map("duplicate_of_feedback_id")
+  duplicateOfGithubIssueNumber Int? @map("duplicate_of_github_issue_number")
+  duplicateReason    String?        @map("duplicate_reason") @db.Text
   githubIssueNumber  Int?           @map("github_issue_number")
   githubIssueUrl     String?        @map("github_issue_url") @db.VarChar(2000)
   reviewedAt         DateTime?      @map("reviewed_at")
@@ -513,6 +520,9 @@ model FeedbackRequest {
   @@index([classification, triageConfidence])
   @@index([reviewedByUserId, reviewedAt])
   @@index([dedupeKey])
+  @@index([duplicateCandidate, createdAt])
+  @@index([duplicateOfFeedbackId])
+  @@index([duplicateOfGithubIssueNumber])
   @@map("feedback_requests")
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,6 +38,7 @@ import { createCaptureRouter } from "./routes/captureRouter";
 import { createPreferencesRouter } from "./routes/preferencesRouter";
 import { createAgentEnrollmentRouter } from "./routes/agentEnrollmentRouter";
 import { FeedbackService } from "./services/feedbackService";
+import { FeedbackDuplicateService } from "./services/feedbackDuplicateService";
 import { FeedbackTriageService } from "./services/feedbackTriageService";
 import { createFeedbackRouter } from "./routes/feedbackRouter";
 import { AgentEnrollmentService } from "./services/agentEnrollmentService";
@@ -92,6 +93,9 @@ export function createApp(
     : null;
   const feedbackTriageService = persistencePrisma
     ? new FeedbackTriageService(persistencePrisma)
+    : null;
+  const feedbackDuplicateService = persistencePrisma
+    ? new FeedbackDuplicateService(persistencePrisma)
     : null;
 
   const resolveTodoUserId = (req: Request, res: Response): string | null => {
@@ -259,6 +263,7 @@ export function createApp(
       authService,
       feedbackService: feedbackService ?? undefined,
       feedbackTriageService: feedbackTriageService ?? undefined,
+      feedbackDuplicateService: feedbackDuplicateService ?? undefined,
     }),
   );
   app.use("/users", createUsersRouter({ authService }));

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,16 @@ const aiProviderBaseUrl = (
 ).trim();
 const aiProviderApiKey = (process.env.AI_PROVIDER_API_KEY || "").trim();
 const aiProviderModel = (process.env.AI_PROVIDER_MODEL || "gpt-4o-mini").trim();
+const githubRepo = (process.env.GITHUB_REPO || "karthikg80/todos-api").trim();
+const githubApiBaseUrl = (
+  process.env.GITHUB_API_BASE_URL || "https://api.github.com"
+).trim();
+const githubToken = (
+  process.env.GITHUB_TOKEN ||
+  process.env.GITHUB_API_TOKEN ||
+  process.env.GH_TOKEN ||
+  ""
+).trim();
 const aiDailySuggestionLimitRaw = (
   process.env.AI_DAILY_SUGGESTION_LIMIT || "50"
 ).trim();
@@ -200,6 +210,9 @@ export const config = {
   aiProviderBaseUrl,
   aiProviderApiKey,
   aiProviderModel,
+  githubRepo,
+  githubApiBaseUrl,
+  githubToken,
   aiDailySuggestionLimit:
     Number.isInteger(aiDailySuggestionLimit) && aiDailySuggestionLimit > 0
       ? aiDailySuggestionLimit

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -10,6 +10,9 @@ describe("Feedback API Integration", () => {
   let userId: string;
   let adminToken: string;
   let adminUserId: string;
+  let userEmail: string;
+  let adminEmail: string;
+  let testRunId = 0;
 
   beforeAll(() => {
     process.env.JWT_SECRET = "test-secret-for-feedback-api-tests";
@@ -19,27 +22,34 @@ describe("Feedback API Integration", () => {
   });
 
   beforeEach(async () => {
+    testRunId += 1;
     await prisma.feedbackRequest.deleteMany();
     await prisma.captureItem.deleteMany();
     await prisma.refreshToken.deleteMany();
     await prisma.user.deleteMany();
 
-    const registerResponse = await request(app).post("/auth/register").send({
-      email: "feedback-test@example.com",
-      password: "password123",
-      name: "Feedback Tester",
-    });
+    userEmail = `feedback-test-${testRunId}@example.com`;
+    const registerResponse = await request(app)
+      .post("/auth/register")
+      .send({
+        email: userEmail,
+        password: "password123",
+        name: "Feedback Tester",
+      })
+      .expect(201);
 
     authToken = registerResponse.body.token;
     userId = registerResponse.body.user.id;
 
+    adminEmail = `feedback-admin-${testRunId}@example.com`;
     const adminRegisterResponse = await request(app)
       .post("/auth/register")
       .send({
-        email: "feedback-admin@example.com",
+        email: adminEmail,
         password: "password123",
         name: "Feedback Admin",
-      });
+      })
+      .expect(201);
 
     adminToken = adminRegisterResponse.body.token;
     adminUserId = adminRegisterResponse.body.user.id;
@@ -178,7 +188,7 @@ describe("Feedback API Integration", () => {
       type: "feature",
       user: {
         id: userId,
-        email: "feedback-test@example.com",
+        email: userEmail,
       },
     });
     expect(response.body[0].id).not.toBe(older.id);
@@ -213,7 +223,7 @@ describe("Feedback API Integration", () => {
       triageSummary: "Likely duplicate of filter bug",
       user: {
         id: userId,
-        email: "feedback-test@example.com",
+        email: userEmail,
       },
     });
   });
@@ -245,7 +255,7 @@ describe("Feedback API Integration", () => {
       rejectionReason: "Not actionable enough yet",
       reviewer: {
         id: adminUserId,
-        email: "feedback-admin@example.com",
+        email: adminEmail,
       },
     });
     expect(response.body.reviewedAt).toEqual(expect.any(String));
@@ -311,6 +321,146 @@ describe("Feedback API Integration", () => {
     expect(persisted?.expectedBehavior).toBe("The task should save.");
   });
 
+  it("POST /admin/feedback/:id/duplicate-check stores internal duplicate suggestions", async () => {
+    const existing = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Task drawer crashes on save",
+        body: "Existing crash report",
+        status: "triaged",
+        classification: "bug",
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody: "Existing crash report",
+        dedupeKey: "shared-feedback-key",
+      },
+    });
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Task drawer crashes on save",
+        body: "Fresh crash report",
+        status: "new",
+        classification: "bug",
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody: "Fresh crash report",
+        dedupeKey: "shared-feedback-key",
+      },
+    });
+
+    const response = await request(app)
+      .post(`/admin/feedback/${feedback.id}/duplicate-check`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      id: feedback.id,
+      duplicateCandidate: true,
+      matchedFeedbackIds: [existing.id],
+      duplicateReason: "Matching dedupe key with normalized feedback",
+    });
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+
+    expect(persisted?.duplicateCandidate).toBe(true);
+    expect(persisted?.duplicateReason).toBe(
+      "Matching dedupe key with normalized feedback",
+    );
+  });
+
+  it("PATCH /admin/feedback/:id blocks promotion when duplicate candidates are found", async () => {
+    await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Add planning bundles",
+        body: "Existing feature report",
+        status: "triaged",
+        classification: "feature",
+        normalizedTitle: "Add planning bundles",
+        normalizedBody: "Existing feature report",
+        dedupeKey: "shared-feature-key",
+      },
+    });
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Add planning bundles",
+        body: "Fresh feature report",
+        status: "triaged",
+        classification: "feature",
+        normalizedTitle: "Add planning bundles",
+        normalizedBody: "Fresh feature report",
+        dedupeKey: "shared-feature-key",
+      },
+    });
+
+    const response = await request(app)
+      .patch(`/admin/feedback/${feedback.id}`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        status: "promoted",
+      })
+      .expect(409);
+
+    expect(response.body.error).toBe("Duplicate candidate found");
+    expect(response.body.feedbackRequest).toMatchObject({
+      id: feedback.id,
+      duplicateCandidate: true,
+    });
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+
+    expect(persisted?.status).toBe("triaged");
+    expect(persisted?.duplicateCandidate).toBe(true);
+  });
+
+  it("PATCH /admin/feedback/:id links a confirmed duplicate instead of promoting", async () => {
+    const existing = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Drawer crash",
+        body: "Existing report",
+        status: "triaged",
+      },
+    });
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Drawer crash again",
+        body: "Fresh report",
+        status: "new",
+        duplicateCandidate: true,
+      },
+    });
+
+    const response = await request(app)
+      .patch(`/admin/feedback/${feedback.id}`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        status: "triaged",
+        duplicateOfFeedbackId: existing.id,
+        duplicateReason: "Confirmed duplicate of existing feedback",
+      })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      id: feedback.id,
+      status: "triaged",
+      duplicateOfFeedbackId: existing.id,
+      duplicateReason: "Confirmed duplicate of existing feedback",
+      duplicateCandidate: false,
+    });
+  });
+
   it("GET /admin/feedback returns 403 for non-admin users", async () => {
     await request(app)
       .get("/admin/feedback")
@@ -333,6 +483,25 @@ describe("Feedback API Integration", () => {
 
     await request(app)
       .post(`/admin/feedback/${feedback.id}/triage`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .expect(403)
+      .expect({
+        error: "Forbidden: Admin access required",
+      });
+  });
+
+  it("POST /admin/feedback/:id/duplicate-check returns 403 for non-admin users", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Add a planning helper",
+        body: "What are you trying to do?\nPlan my week.",
+      },
+    });
+
+    await request(app)
+      .post(`/admin/feedback/${feedback.id}/duplicate-check`)
       .set("Authorization", `Bearer ${authToken}`)
       .expect(403)
       .expect({

--- a/src/feedbackDuplicateService.test.ts
+++ b/src/feedbackDuplicateService.test.ts
@@ -1,0 +1,142 @@
+import {
+  FeedbackDuplicateService,
+  DuplicatePromotionConflictError,
+} from "./services/feedbackDuplicateService";
+
+describe("FeedbackDuplicateService", () => {
+  it("detects internal feedback duplicates conservatively and skips GitHub search", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: "feedback-1",
+          type: "bug",
+          status: "triaged",
+          title: "Task drawer crashes on save",
+          body: "Crash details",
+          pageUrl: "https://app.example.com/?view=todos",
+          classification: "bug",
+          normalizedTitle: "Task drawer crashes on save",
+          normalizedBody: "Crash details",
+          dedupeKey: "same-dedupe-key",
+        }),
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "feedback-2",
+            type: "bug",
+            status: "triaged",
+            title: "Task drawer crashes on save",
+            body: "Same crash details",
+            pageUrl: "https://app.example.com/?view=todos",
+            classification: "bug",
+            normalizedTitle: "Task drawer crashes on save",
+            normalizedBody: "Same crash details",
+            dedupeKey: "same-dedupe-key",
+          },
+        ]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    } as any;
+    const gitHubSearchAdapter = {
+      searchIssues: jest.fn(),
+    };
+    const service = new FeedbackDuplicateService(prisma, {
+      gitHubSearchAdapter,
+    });
+
+    const assessment = await service.detectAndPersist("feedback-1");
+
+    expect(assessment).toEqual({
+      duplicateCandidate: true,
+      matchedFeedbackIds: ["feedback-2"],
+      matchedGithubIssueNumber: null,
+      matchedGithubIssueUrl: null,
+      duplicateReason: "Matching dedupe key with normalized feedback",
+    });
+    expect(gitHubSearchAdapter.searchIssues).not.toHaveBeenCalled();
+  });
+
+  it("uses GitHub issue search when no internal duplicate is found", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: "feedback-1",
+          type: "feature",
+          status: "triaged",
+          title: "Add planning bundles",
+          body: "Feature details",
+          pageUrl: "https://app.example.com/?view=planning",
+          classification: "feature",
+          normalizedTitle: "Add planning bundles",
+          normalizedBody: "Feature details",
+          dedupeKey: "feature-dedupe-key",
+        }),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    } as any;
+    const gitHubSearchAdapter = {
+      searchIssues: jest.fn().mockResolvedValue([
+        {
+          number: 405,
+          url: "https://github.com/karthikg80/todos-api/issues/405",
+          title: "Add planning bundles",
+          state: "open",
+        },
+      ]),
+    };
+    const service = new FeedbackDuplicateService(prisma, {
+      gitHubSearchAdapter,
+    });
+
+    const assessment = await service.detectAndPersist("feedback-1");
+
+    expect(gitHubSearchAdapter.searchIssues).toHaveBeenCalledTimes(1);
+    expect(assessment).toEqual({
+      duplicateCandidate: true,
+      matchedFeedbackIds: [],
+      matchedGithubIssueNumber: 405,
+      matchedGithubIssueUrl:
+        "https://github.com/karthikg80/todos-api/issues/405",
+      duplicateReason: "Likely matches GitHub issue #405",
+    });
+  });
+
+  it("throws a promotion conflict when duplicates are found", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: "feedback-1",
+          type: "bug",
+          status: "triaged",
+          title: "Task drawer crashes on save",
+          body: "Crash details",
+          pageUrl: "https://app.example.com/?view=todos",
+          classification: "bug",
+          normalizedTitle: "Task drawer crashes on save",
+          normalizedBody: "Crash details",
+          dedupeKey: "same-dedupe-key",
+        }),
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "feedback-2",
+            type: "bug",
+            status: "triaged",
+            title: "Task drawer crashes on save",
+            body: "Same crash details",
+            pageUrl: "https://app.example.com/?view=todos",
+            classification: "bug",
+            normalizedTitle: "Task drawer crashes on save",
+            normalizedBody: "Same crash details",
+            dedupeKey: "same-dedupe-key",
+          },
+        ]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    } as any;
+    const service = new FeedbackDuplicateService(prisma);
+
+    await expect(
+      service.assertPromotionIsSafe("feedback-1"),
+    ).rejects.toBeInstanceOf(DuplicatePromotionConflictError);
+  });
+});

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -2,6 +2,10 @@ import { Router, Request, Response, NextFunction } from "express";
 import { AuthService } from "../services/authService";
 import { HttpError, hasPrismaCode } from "../errorHandling";
 import { FeedbackService } from "../services/feedbackService";
+import {
+  DuplicatePromotionConflictError,
+  FeedbackDuplicateService,
+} from "../services/feedbackDuplicateService";
 import { FeedbackTriageService } from "../services/feedbackTriageService";
 import {
   validateListAdminFeedbackRequestsQuery,
@@ -12,12 +16,14 @@ interface AdminRouterDeps {
   authService?: AuthService;
   feedbackService?: FeedbackService;
   feedbackTriageService?: FeedbackTriageService;
+  feedbackDuplicateService?: FeedbackDuplicateService;
 }
 
 export function createAdminRouter({
   authService,
   feedbackService,
   feedbackTriageService,
+  feedbackDuplicateService,
 }: AdminRouterDeps): Router {
   const router = Router();
 
@@ -180,6 +186,21 @@ export function createAdminRouter({
         }
 
         const dto = validateUpdateAdminFeedbackRequest(req.body);
+        if (
+          dto.status === "promoted" &&
+          !dto.ignoreDuplicateSuggestion &&
+          !dto.duplicateOfFeedbackId &&
+          !dto.duplicateOfGithubIssueNumber
+        ) {
+          if (!feedbackDuplicateService) {
+            return res
+              .status(501)
+              .json({ error: "Feedback duplicate detection not configured" });
+          }
+
+          await feedbackDuplicateService.assertPromotionIsSafe(feedbackId);
+        }
+
         const feedbackRequest = await feedbackService.updateReviewStatus(
           feedbackId,
           reviewerUserId,
@@ -187,8 +208,50 @@ export function createAdminRouter({
         );
         res.json(feedbackRequest);
       } catch (error) {
+        if (error instanceof DuplicatePromotionConflictError) {
+          const feedbackRequest = await feedbackService.getForAdmin(
+            String(req.params.id),
+          );
+          return res.status(409).json({
+            error: error.message,
+            duplicateDetection: error.assessment,
+            feedbackRequest,
+          });
+        }
         if (hasPrismaCode(error, ["P2025"])) {
           return next(new HttpError(404, "Feedback request not found"));
+        }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    "/feedback/:id/duplicate-check",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService || !feedbackDuplicateService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback duplicate detection not configured" });
+      }
+
+      try {
+        const feedbackId = String(req.params.id);
+        await feedbackDuplicateService.detectAndPersist(feedbackId);
+        const feedbackRequest = await feedbackService.getForAdmin(feedbackId);
+        if (!feedbackRequest) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+        res.json(feedbackRequest);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "Feedback request not found"
+        ) {
+          return next(new HttpError(404, error.message));
         }
         if (hasPrismaCode(error, ["P2023"])) {
           return next(new HttpError(400, "Invalid feedback request ID format"));

--- a/src/services/feedbackDuplicateService.ts
+++ b/src/services/feedbackDuplicateService.ts
@@ -1,0 +1,316 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { config } from "../config";
+import {
+  GitHubIssueMatch,
+  GitHubIssueSearchAdapter,
+  GitHubIssueSearchService,
+} from "./githubIssueSearchService";
+
+type FeedbackDuplicateRecord = {
+  id: string;
+  type: "bug" | "feature" | "general";
+  status: "new" | "triaged" | "promoted" | "rejected";
+  title: string;
+  body: string;
+  pageUrl: string | null;
+  classification:
+    | "bug"
+    | "feature"
+    | "support"
+    | "duplicate_candidate"
+    | "noise"
+    | null;
+  normalizedTitle: string | null;
+  normalizedBody: string | null;
+  dedupeKey: string | null;
+};
+
+export interface FeedbackDuplicateAssessment {
+  duplicateCandidate: boolean;
+  matchedFeedbackIds: string[];
+  matchedGithubIssueNumber: number | null;
+  matchedGithubIssueUrl: string | null;
+  duplicateReason: string | null;
+}
+
+export interface FeedbackDuplicateServiceDeps {
+  gitHubSearchAdapter?: GitHubIssueSearchAdapter;
+}
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\b(a|an|the|to|for|in|on|at|by|with|from|of|and)\b/g, " ")
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function levenshtein(a: string, b: string): number {
+  const matrix = Array.from({ length: a.length + 1 }, (_, row) =>
+    Array.from({ length: b.length + 1 }, (_, column) =>
+      row === 0 ? column : column === 0 ? row : 0,
+    ),
+  );
+  for (let row = 1; row <= a.length; row += 1) {
+    for (let column = 1; column <= b.length; column += 1) {
+      matrix[row][column] =
+        a[row - 1] === b[column - 1]
+          ? matrix[row - 1][column - 1]
+          : 1 +
+            Math.min(
+              matrix[row - 1][column],
+              matrix[row][column - 1],
+              matrix[row - 1][column - 1],
+            );
+    }
+  }
+  return matrix[a.length][b.length];
+}
+
+function similarityScore(a: string, b: string): number {
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+  const maxLength = Math.max(a.length, b.length);
+  if (maxLength === 0) return 0;
+  return 1 - levenshtein(a, b) / maxLength;
+}
+
+function sharedTokenCount(a: string, b: string): number {
+  const left = new Set(a.split(" ").filter((token) => token.length >= 4));
+  const right = new Set(b.split(" ").filter((token) => token.length >= 4));
+  let shared = 0;
+  left.forEach((token) => {
+    if (right.has(token)) {
+      shared += 1;
+    }
+  });
+  return shared;
+}
+
+function buildSearchQuery(record: FeedbackDuplicateRecord): string {
+  const normalizedTitle = normalizeText(record.normalizedTitle || record.title);
+  const terms = normalizedTitle
+    .split(" ")
+    .filter((token) => token.length >= 4)
+    .slice(0, 6)
+    .join(" ");
+  return `repo:${config.githubRepo} is:issue "${terms || record.title}"`;
+}
+
+function buildAssessmentUpdate(
+  assessment: FeedbackDuplicateAssessment,
+): Prisma.FeedbackRequestUpdateInput {
+  return {
+    duplicateCandidate: assessment.duplicateCandidate,
+    matchedFeedbackIds:
+      assessment.matchedFeedbackIds.length > 0
+        ? (assessment.matchedFeedbackIds as Prisma.InputJsonValue)
+        : Prisma.JsonNull,
+    matchedGithubIssueNumber: assessment.matchedGithubIssueNumber,
+    matchedGithubIssueUrl: assessment.matchedGithubIssueUrl,
+    duplicateReason: assessment.duplicateReason,
+  };
+}
+
+function buildEmptyAssessment(): FeedbackDuplicateAssessment {
+  return {
+    duplicateCandidate: false,
+    matchedFeedbackIds: [],
+    matchedGithubIssueNumber: null,
+    matchedGithubIssueUrl: null,
+    duplicateReason: null,
+  };
+}
+
+function scoreGitHubIssue(
+  record: FeedbackDuplicateRecord,
+  issue: GitHubIssueMatch,
+): number {
+  const normalizedRecord = normalizeText(
+    record.normalizedTitle || record.title,
+  );
+  const normalizedIssue = normalizeText(issue.title);
+  const similarity = similarityScore(normalizedRecord, normalizedIssue);
+  const tokenOverlap = sharedTokenCount(normalizedRecord, normalizedIssue);
+
+  if (normalizedRecord === normalizedIssue) {
+    return 1;
+  }
+  if (similarity >= 0.94 && tokenOverlap >= 3) {
+    return similarity;
+  }
+  return 0;
+}
+
+export class DuplicatePromotionConflictError extends Error {
+  constructor(
+    public readonly assessment: FeedbackDuplicateAssessment,
+    message = "Duplicate candidate found",
+  ) {
+    super(message);
+    this.name = "DuplicatePromotionConflictError";
+  }
+}
+
+export class FeedbackDuplicateService {
+  private readonly gitHubSearchAdapter: GitHubIssueSearchAdapter;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    deps: FeedbackDuplicateServiceDeps = {},
+  ) {
+    this.gitHubSearchAdapter =
+      deps.gitHubSearchAdapter ?? new GitHubIssueSearchService();
+  }
+
+  async detectAndPersist(
+    feedbackId: string,
+  ): Promise<FeedbackDuplicateAssessment> {
+    const record = await this.prisma.feedbackRequest.findUnique({
+      where: { id: feedbackId },
+      select: {
+        id: true,
+        type: true,
+        status: true,
+        title: true,
+        body: true,
+        pageUrl: true,
+        classification: true,
+        normalizedTitle: true,
+        normalizedBody: true,
+        dedupeKey: true,
+      },
+    });
+
+    if (!record) {
+      throw new Error("Feedback request not found");
+    }
+
+    const internalMatches = await this.findInternalMatches(record);
+    const githubMatch =
+      internalMatches.matchedFeedbackIds.length > 0 ||
+      record.classification === "noise"
+        ? null
+        : await this.findGitHubIssueMatch(record);
+
+    const assessment: FeedbackDuplicateAssessment =
+      internalMatches.matchedFeedbackIds.length > 0 || githubMatch
+        ? {
+            duplicateCandidate: true,
+            matchedFeedbackIds: internalMatches.matchedFeedbackIds,
+            matchedGithubIssueNumber: githubMatch?.number ?? null,
+            matchedGithubIssueUrl: githubMatch?.url ?? null,
+            duplicateReason:
+              internalMatches.duplicateReason ||
+              (githubMatch
+                ? `Likely matches GitHub issue #${githubMatch.number}`
+                : null),
+          }
+        : buildEmptyAssessment();
+
+    await this.prisma.feedbackRequest.update({
+      where: { id: feedbackId },
+      data: buildAssessmentUpdate(assessment),
+    });
+
+    return assessment;
+  }
+
+  async assertPromotionIsSafe(feedbackId: string): Promise<void> {
+    const assessment = await this.detectAndPersist(feedbackId);
+    if (assessment.duplicateCandidate) {
+      throw new DuplicatePromotionConflictError(assessment);
+    }
+  }
+
+  private async findInternalMatches(
+    record: FeedbackDuplicateRecord,
+  ): Promise<FeedbackDuplicateAssessment> {
+    const candidates = await this.prisma.feedbackRequest.findMany({
+      where: {
+        id: { not: record.id },
+        status: { not: "rejected" },
+        ...(record.classification
+          ? { classification: record.classification }
+          : { type: record.type }),
+      },
+      select: {
+        id: true,
+        type: true,
+        status: true,
+        title: true,
+        body: true,
+        pageUrl: true,
+        classification: true,
+        normalizedTitle: true,
+        normalizedBody: true,
+        dedupeKey: true,
+      },
+      orderBy: [{ createdAt: "desc" }],
+      take: 25,
+    });
+
+    const normalizedRecord = normalizeText(
+      record.normalizedTitle || record.title,
+    );
+    const matchedFeedbackIds: string[] = [];
+    let duplicateReason: string | null = null;
+
+    for (const candidate of candidates) {
+      const normalizedCandidate = normalizeText(
+        candidate.normalizedTitle || candidate.title,
+      );
+      const sameKey =
+        Boolean(record.dedupeKey) &&
+        Boolean(candidate.dedupeKey) &&
+        record.dedupeKey === candidate.dedupeKey;
+      const sameNormalizedTitle =
+        normalizedRecord.length > 0 && normalizedRecord === normalizedCandidate;
+      const similarTitle =
+        similarityScore(normalizedRecord, normalizedCandidate) >= 0.95 &&
+        sharedTokenCount(normalizedRecord, normalizedCandidate) >= 3;
+
+      if (sameKey || sameNormalizedTitle || similarTitle) {
+        matchedFeedbackIds.push(candidate.id);
+        if (!duplicateReason) {
+          duplicateReason = sameKey
+            ? "Matching dedupe key with normalized feedback"
+            : sameNormalizedTitle
+              ? "Matching normalized title with existing feedback"
+              : "Very similar normalized title with existing feedback";
+        }
+      }
+    }
+
+    return {
+      duplicateCandidate: matchedFeedbackIds.length > 0,
+      matchedFeedbackIds: matchedFeedbackIds.slice(0, 5),
+      matchedGithubIssueNumber: null,
+      matchedGithubIssueUrl: null,
+      duplicateReason,
+    };
+  }
+
+  private async findGitHubIssueMatch(
+    record: FeedbackDuplicateRecord,
+  ): Promise<GitHubIssueMatch | null> {
+    try {
+      const issues = await this.gitHubSearchAdapter.searchIssues(
+        buildSearchQuery(record),
+      );
+      let bestMatch: GitHubIssueMatch | null = null;
+      let bestScore = 0;
+      for (const issue of issues) {
+        const score = scoreGitHubIssue(record, issue);
+        if (score > bestScore) {
+          bestScore = score;
+          bestMatch = issue;
+        }
+      }
+      return bestScore >= 0.94 ? bestMatch : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -1,9 +1,9 @@
 import { Prisma, PrismaClient } from "@prisma/client";
+import { config } from "../config";
 import {
   CreateFeedbackRequestDto,
   FeedbackRequestAdminDetailDto,
   FeedbackRequestAdminListItemDto,
-  FeedbackTriageResultDto,
   FeedbackRequestDto,
   FeedbackAttachmentMetadataDto,
   ListAdminFeedbackRequestsQuery,
@@ -12,6 +12,13 @@ import {
 
 export class FeedbackService {
   constructor(private readonly prisma: PrismaClient) {}
+
+  private buildGitHubIssueUrl(issueNumber: number | null): string | null {
+    if (!issueNumber) {
+      return null;
+    }
+    return `https://github.com/${config.githubRepo}/issues/${issueNumber}`;
+  }
 
   async create(
     userId: string,
@@ -98,6 +105,11 @@ export class FeedbackService {
     reviewerUserId: string,
     dto: UpdateAdminFeedbackRequestDto,
   ): Promise<FeedbackRequestAdminDetailDto> {
+    const shouldResolveDuplicate = Boolean(
+      dto.ignoreDuplicateSuggestion ||
+      dto.duplicateOfFeedbackId ||
+      dto.duplicateOfGithubIssueNumber,
+    );
     const record = await this.prisma.feedbackRequest.update({
       where: { id },
       data: {
@@ -105,6 +117,21 @@ export class FeedbackService {
         reviewedByUserId: reviewerUserId,
         reviewedAt: new Date(),
         rejectionReason: dto.status === "rejected" ? dto.rejectionReason : null,
+        duplicateCandidate: shouldResolveDuplicate ? false : undefined,
+        matchedFeedbackIds: shouldResolveDuplicate
+          ? Prisma.JsonNull
+          : undefined,
+        matchedGithubIssueNumber: shouldResolveDuplicate ? null : undefined,
+        matchedGithubIssueUrl: shouldResolveDuplicate ? null : undefined,
+        duplicateOfFeedbackId: shouldResolveDuplicate
+          ? (dto.duplicateOfFeedbackId ?? null)
+          : undefined,
+        duplicateOfGithubIssueNumber: shouldResolveDuplicate
+          ? (dto.duplicateOfGithubIssueNumber ?? null)
+          : undefined,
+        duplicateReason: shouldResolveDuplicate
+          ? (dto.duplicateReason ?? null)
+          : undefined,
       },
       include: {
         user: {
@@ -159,6 +186,13 @@ export class FeedbackService {
     triageSummary: string | null;
     severity: string | null;
     dedupeKey: string | null;
+    duplicateCandidate: boolean;
+    matchedFeedbackIds: unknown;
+    matchedGithubIssueNumber: number | null;
+    matchedGithubIssueUrl: string | null;
+    duplicateOfFeedbackId: string | null;
+    duplicateOfGithubIssueNumber: number | null;
+    duplicateReason: string | null;
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
     reviewedByUserId: string | null;
@@ -174,6 +208,11 @@ export class FeedbackService {
       : [];
     const agentLabels = Array.isArray(record.agentLabelsJson)
       ? record.agentLabelsJson.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+    const matchedFeedbackIds = Array.isArray(record.matchedFeedbackIds)
+      ? record.matchedFeedbackIds.filter(
           (value): value is string => typeof value === "string",
         )
       : [];
@@ -211,6 +250,16 @@ export class FeedbackService {
       triageSummary: record.triageSummary,
       severity: record.severity,
       dedupeKey: record.dedupeKey,
+      duplicateCandidate: record.duplicateCandidate,
+      matchedFeedbackIds,
+      matchedGithubIssueNumber: record.matchedGithubIssueNumber,
+      matchedGithubIssueUrl: record.matchedGithubIssueUrl,
+      duplicateOfFeedbackId: record.duplicateOfFeedbackId,
+      duplicateOfGithubIssueNumber: record.duplicateOfGithubIssueNumber,
+      duplicateOfGithubIssueUrl: this.buildGitHubIssueUrl(
+        record.duplicateOfGithubIssueNumber,
+      ),
+      duplicateReason: record.duplicateReason,
       githubIssueNumber: record.githubIssueNumber,
       githubIssueUrl: record.githubIssueUrl,
       reviewedByUserId: record.reviewedByUserId,
@@ -254,6 +303,13 @@ export class FeedbackService {
     triageSummary: string | null;
     severity: string | null;
     dedupeKey: string | null;
+    duplicateCandidate: boolean;
+    matchedFeedbackIds: unknown;
+    matchedGithubIssueNumber: number | null;
+    matchedGithubIssueUrl: string | null;
+    duplicateOfFeedbackId: string | null;
+    duplicateOfGithubIssueNumber: number | null;
+    duplicateReason: string | null;
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
     reviewedAt: Date | null;

--- a/src/services/githubIssueSearchService.ts
+++ b/src/services/githubIssueSearchService.ts
@@ -1,0 +1,66 @@
+import { config } from "../config";
+
+export interface GitHubIssueMatch {
+  number: number;
+  url: string;
+  title: string;
+  state: string;
+}
+
+export interface GitHubIssueSearchAdapter {
+  searchIssues(query: string): Promise<GitHubIssueMatch[]>;
+}
+
+export class GitHubIssueSearchService implements GitHubIssueSearchAdapter {
+  async searchIssues(query: string): Promise<GitHubIssueMatch[]> {
+    const url = new URL("/search/issues", config.githubApiBaseUrl);
+    url.searchParams.set("q", query);
+    url.searchParams.set("per_page", "10");
+
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "todos-api-feedback-dedupe",
+    };
+    if (config.githubToken) {
+      headers.Authorization = `Bearer ${config.githubToken}`;
+    }
+
+    const response = await fetch(url.toString(), { headers });
+    if (!response.ok) {
+      throw new Error(
+        `GitHub issue search failed with status ${response.status}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      items?: Array<{
+        number?: number;
+        html_url?: string;
+        title?: string;
+        state?: string;
+        pull_request?: unknown;
+      }>;
+    };
+
+    return (data.items || [])
+      .filter((item) => !item.pull_request)
+      .flatMap((item) => {
+        if (
+          typeof item.number !== "number" ||
+          typeof item.html_url !== "string" ||
+          typeof item.title !== "string"
+        ) {
+          return [];
+        }
+
+        return [
+          {
+            number: item.number,
+            url: item.html_url,
+            title: item.title,
+            state: typeof item.state === "string" ? item.state : "open",
+          },
+        ];
+      });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -372,6 +372,14 @@ export interface FeedbackTriageResultDto {
   missingInfo: string[];
 }
 
+export interface FeedbackDuplicateMatchDto {
+  duplicateCandidate: boolean;
+  matchedFeedbackIds: string[];
+  matchedGithubIssueNumber?: number | null;
+  matchedGithubIssueUrl?: string | null;
+  duplicateReason?: string | null;
+}
+
 export interface CreateFeedbackRequestDto {
   type: FeedbackRequestType;
   title: string;
@@ -409,6 +417,14 @@ export interface FeedbackRequestDto {
   triageSummary?: string | null;
   severity?: string | null;
   dedupeKey?: string | null;
+  duplicateCandidate?: boolean;
+  matchedFeedbackIds?: string[];
+  matchedGithubIssueNumber?: number | null;
+  matchedGithubIssueUrl?: string | null;
+  duplicateOfFeedbackId?: string | null;
+  duplicateOfGithubIssueNumber?: number | null;
+  duplicateOfGithubIssueUrl?: string | null;
+  duplicateReason?: string | null;
   githubIssueNumber?: number | null;
   githubIssueUrl?: string | null;
   reviewedByUserId?: string | null;
@@ -439,4 +455,8 @@ export interface ListAdminFeedbackRequestsQuery {
 export interface UpdateAdminFeedbackRequestDto {
   status: FeedbackReviewAction;
   rejectionReason?: string | null;
+  ignoreDuplicateSuggestion?: boolean;
+  duplicateOfFeedbackId?: string | null;
+  duplicateOfGithubIssueNumber?: number | null;
+  duplicateReason?: string | null;
 }

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -1724,10 +1724,75 @@ export function validateUpdateAdminFeedbackRequest(
     "rejectionReason",
     4000,
   );
+  const duplicateReason = normalizeNullableString(
+    body.duplicateReason,
+    "duplicateReason",
+    4000,
+  );
+  const ignoreDuplicateSuggestion =
+    body.ignoreDuplicateSuggestion === undefined
+      ? undefined
+      : typeof body.ignoreDuplicateSuggestion === "boolean"
+        ? body.ignoreDuplicateSuggestion
+        : (() => {
+            throw new ValidationError(
+              "ignoreDuplicateSuggestion must be a boolean",
+            );
+          })();
+  const duplicateOfFeedbackIdRaw = normalizeNullableString(
+    body.duplicateOfFeedbackId,
+    "duplicateOfFeedbackId",
+    120,
+  );
+  const duplicateOfGithubIssueNumber =
+    body.duplicateOfGithubIssueNumber === undefined
+      ? undefined
+      : body.duplicateOfGithubIssueNumber === null
+        ? null
+        : typeof body.duplicateOfGithubIssueNumber === "number" &&
+            Number.isInteger(body.duplicateOfGithubIssueNumber) &&
+            body.duplicateOfGithubIssueNumber > 0
+          ? body.duplicateOfGithubIssueNumber
+          : (() => {
+              throw new ValidationError(
+                "duplicateOfGithubIssueNumber must be a positive integer",
+              );
+            })();
+
+  if (duplicateOfFeedbackIdRaw) {
+    validateId(duplicateOfFeedbackIdRaw);
+  }
 
   if (status === "rejected" && !rejectionReason) {
     throw new ValidationError(
       "rejectionReason is required when status is rejected",
+    );
+  }
+
+  if (duplicateOfFeedbackIdRaw && duplicateOfGithubIssueNumber) {
+    throw new ValidationError(
+      "Provide either duplicateOfFeedbackId or duplicateOfGithubIssueNumber, not both",
+    );
+  }
+
+  const hasDuplicateResolution = Boolean(
+    duplicateOfFeedbackIdRaw || duplicateOfGithubIssueNumber,
+  );
+  if (hasDuplicateResolution && status !== "triaged") {
+    throw new ValidationError(
+      "status must be triaged when linking a confirmed duplicate",
+    );
+  }
+
+  if (hasDuplicateResolution && !duplicateReason) {
+    throw new ValidationError(
+      "duplicateReason is required when linking a confirmed duplicate",
+    );
+  }
+
+  if (ignoreDuplicateSuggestion && status !== "promoted") {
+    throw new ValidationError(
+      "ignoreDuplicateSuggestion can only be used when status is promoted",
     );
   }
 
@@ -1737,5 +1802,9 @@ export function validateUpdateAdminFeedbackRequest(
       status === "rejected"
         ? (rejectionReason ?? null)
         : (rejectionReason ?? null),
+    ignoreDuplicateSuggestion,
+    duplicateOfFeedbackId: duplicateOfFeedbackIdRaw ?? null,
+    duplicateOfGithubIssueNumber: duplicateOfGithubIssueNumber ?? null,
+    duplicateReason: duplicateReason ?? null,
   };
 }

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -33,6 +33,14 @@ function buildFeedback(overrides: Record<string, unknown> = {}) {
     triageSummary: "Likely reproducible",
     severity: "medium",
     dedupeKey: null,
+    duplicateCandidate: false,
+    matchedFeedbackIds: [],
+    matchedGithubIssueNumber: null,
+    matchedGithubIssueUrl: null,
+    duplicateOfFeedbackId: null,
+    duplicateOfGithubIssueNumber: null,
+    duplicateOfGithubIssueUrl: null,
+    duplicateReason: null,
     githubIssueNumber: null,
     githubIssueUrl: null,
     reviewedByUserId: null,
@@ -56,6 +64,7 @@ test.describe("Admin feedback queue", () => {
   }) => {
     let patchPayload: Record<string, unknown> | null = null;
     let triageCalled = false;
+    let linkDuplicatePayload: Record<string, unknown> | null = null;
     const bugFeedback = buildFeedback();
     const featureFeedback = buildFeedback({
       id: "feedback-2",
@@ -130,13 +139,48 @@ test.describe("Admin feedback queue", () => {
 
     await page.route("**/admin/feedback/feedback-1", async (route) => {
       if (route.request().method() === "PATCH") {
-        patchPayload = JSON.parse(route.request().postData() || "{}") as Record<
-          string,
-          unknown
-        >;
+        const payload = JSON.parse(
+          route.request().postData() || "{}",
+        ) as Record<string, unknown>;
+        if (payload.status === "promoted") {
+          Object.assign(bugFeedback, {
+            duplicateCandidate: true,
+            matchedFeedbackIds: ["feedback-2"],
+            matchedGithubIssueNumber: 405,
+            matchedGithubIssueUrl:
+              "https://github.com/karthikg80/todos-api/issues/405",
+            duplicateReason: "Matching dedupe key with normalized feedback",
+          });
+          await route.fulfill({
+            status: 409,
+            contentType: "application/json",
+            body: JSON.stringify({
+              error: "Duplicate candidate found",
+              feedbackRequest: bugFeedback,
+            }),
+          });
+          return;
+        }
+
+        if (payload.duplicateOfFeedbackId) {
+          linkDuplicatePayload = payload;
+          Object.assign(bugFeedback, {
+            status: payload.status,
+            duplicateCandidate: false,
+            duplicateOfFeedbackId: payload.duplicateOfFeedbackId,
+            duplicateReason: payload.duplicateReason,
+            matchedFeedbackIds: [],
+            matchedGithubIssueNumber: null,
+            matchedGithubIssueUrl: null,
+          });
+        } else {
+          patchPayload = payload;
+          Object.assign(bugFeedback, {
+            status: patchPayload.status,
+            rejectionReason: patchPayload.rejectionReason,
+          });
+        }
         Object.assign(bugFeedback, {
-          status: patchPayload.status,
-          rejectionReason: patchPayload.rejectionReason,
           reviewedByUserId: "admin-1",
           reviewedAt: "2026-03-20T20:00:00.000Z",
           reviewer: {
@@ -220,6 +264,35 @@ test.describe("Admin feedback queue", () => {
     );
     await expect(page.locator("#adminFeedbackDetail")).toContainText(
       "feedback:bug",
+    );
+
+    await page
+      .locator("#adminFeedbackDetail")
+      .getByRole("button", { name: "Ready for promotion", exact: true })
+      .click();
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Duplicate candidate found",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "feedback-2",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText("#405");
+
+    await page
+      .locator("#adminFeedbackDetail")
+      .getByRole("button", { name: "Link matched feedback", exact: true })
+      .click();
+
+    expect(linkDuplicatePayload).toEqual({
+      status: "triaged",
+      duplicateOfFeedbackId: "feedback-2",
+      duplicateReason: "Matching dedupe key with normalized feedback",
+    });
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Feedback linked as duplicate",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Confirmed feedback duplicate",
     );
 
     await page


### PR DESCRIPTION
## Summary
- add conservative duplicate detection for normalized feedback before promotion
- search existing GitHub issues only when no strong internal duplicate exists
- let admins review, confirm, or ignore duplicate suggestions in the feedback queue

## Testing
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts
- CI=1 npm run test:ui:fast