### PR TITLE
feat(api): add feedback issue promotion service

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -412,6 +412,8 @@ import {
   confirmAdminFeedbackDuplicate,
   ignoreDuplicateAndPromote,
   loadAdminFeedbackQueue,
+  promoteAdminFeedback,
+  runAdminFeedbackPromotionPreview,
   runAdminFeedbackDuplicateCheck,
   selectAdminFeedback,
   setAdminFeedbackFilter,
@@ -1778,6 +1780,8 @@ window.setAdminFeedbackFilter = setAdminFeedbackFilter;
 window.runAdminFeedbackDuplicateCheck = runAdminFeedbackDuplicateCheck;
 window.confirmAdminFeedbackDuplicate = confirmAdminFeedbackDuplicate;
 window.ignoreDuplicateAndPromote = ignoreDuplicateAndPromote;
+window.runAdminFeedbackPromotionPreview = runAdminFeedbackPromotionPreview;
+window.promoteAdminFeedback = promoteAdminFeedback;
 window.runAdminFeedbackTriage = runAdminFeedbackTriage;
 window.updateAdminFeedbackStatus = updateAdminFeedbackStatus;
 

--- a/client/modules/adminFeedback.js
+++ b/client/modules/adminFeedback.js
@@ -289,6 +289,84 @@ function renderDuplicatePanel(item) {
   `;
 }
 
+function renderPromotionPanel(item) {
+  if (state.adminFeedbackPromotionPreviewLoading) {
+    return `
+      <div class="admin-detail-block">
+        <div class="loading">
+          <div class="spinner"></div>
+          Building issue preview...
+        </div>
+      </div>
+    `;
+  }
+
+  if (state.adminFeedbackPromotionPreviewError) {
+    return `
+      <div class="admin-detail-block">
+        <div class="admin-detail-block__header">
+          <h4>Promotion Preview</h4>
+          <button type="button" class="action-btn" data-onclick="runAdminFeedbackPromotionPreview()">
+            Refresh preview
+          </button>
+        </div>
+        <p class="admin-detail-empty-copy">${escape(state.adminFeedbackPromotionPreviewError)}</p>
+      </div>
+    `;
+  }
+
+  const preview = state.adminFeedbackPromotionPreview;
+  if (!preview) {
+    return "";
+  }
+
+  const promoteButtonLabel = item.duplicateCandidate
+    ? "Ignore duplicate and create issue"
+    : item.githubIssueNumber
+      ? "Issue already created"
+      : "Create GitHub issue";
+
+  return `
+    <div class="admin-detail-block">
+      <div class="admin-detail-block__header">
+        <h4>Promotion Preview</h4>
+        <button type="button" class="action-btn" data-onclick="runAdminFeedbackPromotionPreview()">
+          Refresh preview
+        </button>
+      </div>
+      <div class="admin-detail-meta">
+        ${renderMetadataRow("Issue type", preview.issueType)}
+        ${renderMetadataRow("Issue title", preview.title)}
+        ${renderMetadataRow("Labels", (preview.labels || []).join(", "))}
+        ${renderMetadataRow("Source feedback IDs", (preview.sourceFeedbackIds || []).join(", "))}
+        ${renderMetadataRow("Promotion status", item.githubIssueNumber ? `Created as #${item.githubIssueNumber}` : preview.canPromote ? "Ready" : "Blocked")}
+      </div>
+      ${
+        item.githubIssueUrl
+          ? `<div class="admin-detail-links">
+              <a class="admin-detail-link" href="${escape(item.githubIssueUrl)}" target="_blank" rel="noreferrer">Open created GitHub issue</a>
+            </div>`
+          : ""
+      }
+      ${renderListBlock("Labels to apply", preview.labels, "No labels suggested")}
+      <div class="admin-detail-block">
+        <h4>Issue body</h4>
+        <pre class="admin-detail-pre">${escape(preview.body)}</pre>
+      </div>
+      <div class="admin-feedback-actions">
+        <button
+          type="button"
+          class="action-btn promote"
+          data-onclick="${item.duplicateCandidate ? "ignoreDuplicateAndPromote()" : "promoteAdminFeedback()"}"
+          ${item.githubIssueNumber ? "disabled" : ""}
+        >
+          ${escape(promoteButtonLabel)}
+        </button>
+      </div>
+    </div>
+  `;
+}
+
 function renderAdminFeedbackDetail() {
   const { detail } = getAdminFeedbackElements();
   if (!(detail instanceof HTMLElement)) {
@@ -345,6 +423,7 @@ function renderAdminFeedbackDetail() {
               ${renderMetadataRow("User", item.user?.email || item.userId)}
               ${renderMetadataRow("Reviewer", item.reviewer?.email || "")}
               ${renderMetadataRow("Reviewed at", item.reviewedAt ? formatDateTime(item.reviewedAt) : "")}
+              ${renderMetadataRow("Promoted at", item.promotedAt ? formatDateTime(item.promotedAt) : "")}
               ${renderMetadataRow("Page URL", item.pageUrl || "")}
               ${renderMetadataRow("App version", item.appVersion || "")}
               ${renderMetadataRow("Browser", item.userAgent || "")}
@@ -359,12 +438,12 @@ function renderAdminFeedbackDetail() {
       </div>
 
       ${renderDuplicatePanel(item)}
+      ${renderPromotionPanel(item)}
 
       <div class="admin-detail-block">
         <h4>Review Actions</h4>
         <div class="admin-feedback-actions">
           <button type="button" class="action-btn demote" data-onclick="updateAdminFeedbackStatus('triaged')">Mark reviewed</button>
-          <button type="button" class="action-btn promote" data-onclick="updateAdminFeedbackStatus('promoted')">Ready for promotion</button>
           <button type="button" class="action-btn delete" data-onclick="updateAdminFeedbackStatus('rejected')">Reject</button>
         </div>
         <label class="feedback-form__label" for="adminFeedbackRejectionReason">Rejection reason</label>
@@ -398,12 +477,16 @@ export async function selectAdminFeedback(feedbackId) {
   if (!feedbackId) {
     state.adminFeedbackSelectedId = "";
     state.adminFeedbackDetail = null;
+    state.adminFeedbackPromotionPreview = null;
+    state.adminFeedbackPromotionPreviewError = "";
     renderAdminFeedbackDetail();
     return;
   }
 
   state.adminFeedbackSelectedId = feedbackId;
   state.adminFeedbackDetailLoading = true;
+  state.adminFeedbackPromotionPreview = null;
+  state.adminFeedbackPromotionPreviewError = "";
   renderAdminFeedbackWorkspace();
 
   try {
@@ -435,6 +518,8 @@ export async function selectAdminFeedback(feedbackId) {
     state.adminFeedbackDetailLoading = false;
     renderAdminFeedbackWorkspace();
   }
+
+  await loadAdminFeedbackPromotionPreview();
 }
 
 export async function loadAdminFeedbackQueue() {
@@ -457,6 +542,8 @@ export async function loadAdminFeedbackQueue() {
       state.adminFeedbackItems = [];
       state.adminFeedbackSelectedId = "";
       state.adminFeedbackDetail = null;
+      state.adminFeedbackPromotionPreview = null;
+      state.adminFeedbackPromotionPreviewError = "";
       return;
     }
 
@@ -482,6 +569,8 @@ export async function loadAdminFeedbackQueue() {
     state.adminFeedbackItems = [];
     state.adminFeedbackSelectedId = "";
     state.adminFeedbackDetail = null;
+    state.adminFeedbackPromotionPreview = null;
+    state.adminFeedbackPromotionPreviewError = "";
   } finally {
     state.adminFeedbackListLoading = false;
     renderAdminFeedbackWorkspace();
@@ -594,6 +683,7 @@ export async function runAdminFeedbackTriage() {
       };
     }
     renderAdminFeedbackWorkspace();
+    await loadAdminFeedbackPromotionPreview();
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",
@@ -672,13 +762,7 @@ export async function confirmAdminFeedbackDuplicate(kind) {
 }
 
 export async function ignoreDuplicateAndPromote() {
-  await patchAdminFeedback(
-    {
-      status: "promoted",
-      ignoreDuplicateSuggestion: true,
-    },
-    "Feedback promoted after ignoring duplicate suggestion",
-  );
+  await promoteAdminFeedback(true);
 }
 
 export async function runAdminFeedbackDuplicateCheck() {
@@ -713,6 +797,105 @@ export async function runAdminFeedbackDuplicateCheck() {
     );
     state.adminFeedbackDetail = data;
     renderAdminFeedbackWorkspace();
+    await loadAdminFeedbackPromotionPreview();
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  }
+}
+
+export async function loadAdminFeedbackPromotionPreview() {
+  if (!state.adminFeedbackSelectedId) {
+    state.adminFeedbackPromotionPreview = null;
+    state.adminFeedbackPromotionPreviewError = "";
+    return;
+  }
+
+  state.adminFeedbackPromotionPreviewLoading = true;
+  state.adminFeedbackPromotionPreviewError = "";
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}/promotion-preview`,
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      state.adminFeedbackPromotionPreview = null;
+      state.adminFeedbackPromotionPreviewError =
+        data.error || "Promotion preview unavailable";
+      renderAdminFeedbackWorkspace();
+      return;
+    }
+
+    state.adminFeedbackPromotionPreview = data;
+    renderAdminFeedbackWorkspace();
+  } catch (error) {
+    state.adminFeedbackPromotionPreview = null;
+    state.adminFeedbackPromotionPreviewError =
+      "Network error while building promotion preview";
+    renderAdminFeedbackWorkspace();
+  } finally {
+    state.adminFeedbackPromotionPreviewLoading = false;
+    renderAdminFeedbackWorkspace();
+  }
+}
+
+export async function runAdminFeedbackPromotionPreview() {
+  await loadAdminFeedbackPromotionPreview();
+}
+
+export async function promoteAdminFeedback(ignoreDuplicateSuggestion = false) {
+  if (!state.adminFeedbackSelectedId) {
+    return;
+  }
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}/promote`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ignoreDuplicateSuggestion }),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      if (response?.status === 409 && data.feedbackRequest) {
+        hooks.showMessage?.(
+          "adminMessage",
+          data.error || "Duplicate candidate found. Review suggestions below.",
+          "error",
+        );
+        state.adminFeedbackDetail = data.feedbackRequest;
+        renderAdminFeedbackWorkspace();
+        await loadAdminFeedbackPromotionPreview();
+        return;
+      }
+
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to promote feedback to GitHub",
+        "error",
+      );
+      return;
+    }
+
+    state.adminFeedbackDetail =
+      data.feedbackRequest || state.adminFeedbackDetail;
+    hooks.showMessage?.(
+      "adminMessage",
+      data.promotion?.issueNumber
+        ? `Created GitHub issue #${data.promotion.issueNumber}`
+        : "Feedback promoted",
+      "success",
+    );
+    await loadAdminFeedbackQueue();
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -160,6 +160,9 @@ export const state = {
   },
   adminFeedbackListLoading: false,
   adminFeedbackDetailLoading: false,
+  adminFeedbackPromotionPreview: null,
+  adminFeedbackPromotionPreviewLoading: false,
+  adminFeedbackPromotionPreviewError: "",
 
   // AI
   aiSuggestions: [],

--- a/prisma/migrations/20260321030000_add_feedback_promotion_metadata/migration.sql
+++ b/prisma/migrations/20260321030000_add_feedback_promotion_metadata/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "feedback_requests"
+ADD COLUMN "promoted_at" TIMESTAMP(3);
+
+CREATE INDEX "feedback_requests_promoted_at_idx"
+ON "feedback_requests"("promoted_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -506,6 +506,7 @@ model FeedbackRequest {
   duplicateReason    String?        @map("duplicate_reason") @db.Text
   githubIssueNumber  Int?           @map("github_issue_number")
   githubIssueUrl     String?        @map("github_issue_url") @db.VarChar(2000)
+  promotedAt         DateTime?      @map("promoted_at")
   reviewedAt         DateTime?      @map("reviewed_at")
   rejectionReason    String?        @map("rejection_reason") @db.Text
   createdAt          DateTime       @default(now()) @map("created_at")
@@ -523,6 +524,7 @@ model FeedbackRequest {
   @@index([duplicateCandidate, createdAt])
   @@index([duplicateOfFeedbackId])
   @@index([duplicateOfGithubIssueNumber])
+  @@index([promotedAt])
   @@map("feedback_requests")
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,7 @@ import { createPreferencesRouter } from "./routes/preferencesRouter";
 import { createAgentEnrollmentRouter } from "./routes/agentEnrollmentRouter";
 import { FeedbackService } from "./services/feedbackService";
 import { FeedbackDuplicateService } from "./services/feedbackDuplicateService";
+import { FeedbackPromotionService } from "./services/feedbackPromotionService";
 import { FeedbackTriageService } from "./services/feedbackTriageService";
 import { createFeedbackRouter } from "./routes/feedbackRouter";
 import { AgentEnrollmentService } from "./services/agentEnrollmentService";
@@ -96,6 +97,12 @@ export function createApp(
     : null;
   const feedbackDuplicateService = persistencePrisma
     ? new FeedbackDuplicateService(persistencePrisma)
+    : null;
+  const feedbackPromotionService = persistencePrisma
+    ? new FeedbackPromotionService(persistencePrisma, {
+        feedbackService: feedbackService ?? undefined,
+        feedbackDuplicateService: feedbackDuplicateService ?? undefined,
+      })
     : null;
 
   const resolveTodoUserId = (req: Request, res: Response): string | null => {
@@ -264,6 +271,7 @@ export function createApp(
       feedbackService: feedbackService ?? undefined,
       feedbackTriageService: feedbackTriageService ?? undefined,
       feedbackDuplicateService: feedbackDuplicateService ?? undefined,
+      feedbackPromotionService: feedbackPromotionService ?? undefined,
     }),
   );
   app.use("/users", createUsersRouter({ authService }));

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -13,6 +13,7 @@ describe("Feedback API Integration", () => {
   let userEmail: string;
   let adminEmail: string;
   let testRunId = 0;
+  const originalFetch = global.fetch;
 
   beforeAll(() => {
     process.env.JWT_SECRET = "test-secret-for-feedback-api-tests";
@@ -58,6 +59,10 @@ describe("Feedback API Integration", () => {
       where: { id: adminUserId },
       data: { role: "admin" },
     });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it("POST /feedback creates a bug report with captured context", async () => {
@@ -461,6 +466,176 @@ describe("Feedback API Integration", () => {
     });
   });
 
+  it("GET /admin/feedback/:id/promotion-preview renders a canonical bug issue preview", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Task drawer crashes",
+        body: "raw input that should not be rendered directly",
+        status: "triaged",
+        classification: "bug",
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody:
+          "Saving from the task drawer crashes the current editing session.",
+        impactSummary: "Users cannot save task edits from the drawer.",
+        expectedBehavior: "The task should save normally.",
+        actualBehavior: "The task drawer crashes and loses the draft.",
+        reproStepsJson: ["Open the task drawer", "Edit notes", "Press save"],
+        agentLabelsJson: ["ui"],
+        pageUrl: "https://app.example.com/?view=todos",
+        appVersion: "1.6.0",
+        userAgent: "Integration Test Browser",
+        screenshotUrl: "https://example.com/bug.png",
+      },
+    });
+
+    const response = await request(app)
+      .get(`/admin/feedback/${feedback.id}/promotion-preview`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(response.body).toEqual({
+      issueType: "bug",
+      title: "Task drawer crashes on save",
+      body: expect.stringContaining("## Steps To Reproduce"),
+      labels: ["bug", "triaged-by-agent", "ui"],
+      sourceFeedbackIds: [feedback.id],
+      canPromote: true,
+      duplicateCandidate: false,
+      duplicateReason: null,
+      existingGithubIssueNumber: null,
+      existingGithubIssueUrl: null,
+    });
+    expect(response.body.body).toContain("Source feedback IDs");
+    expect(response.body.body).not.toContain(
+      "raw input that should not be rendered directly",
+    );
+  });
+
+  it("POST /admin/feedback/:id/promote creates a GitHub issue and stores promotion metadata", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Planning bundles",
+        body: "raw feature request",
+        status: "triaged",
+        classification: "feature",
+        normalizedTitle: "Add planning bundles",
+        normalizedBody:
+          "Users need a bundled planning flow to reduce manual setup.",
+        impactSummary: "Weekly planning takes too many manual steps.",
+        proposedOutcome: "Offer suggested planning bundles.",
+        triageSummary: "Feature feedback from planning bundles.",
+        agentLabelsJson: ["ui"],
+      },
+    });
+
+    global.fetch = jest.fn(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/repos/karthikg80/todos-api/issues")) {
+        expect(init?.method).toBe("POST");
+        return {
+          ok: true,
+          json: async () => ({
+            number: 512,
+            html_url: "https://github.com/karthikg80/todos-api/issues/512",
+          }),
+        } as Response;
+      }
+      if (url.endsWith("/repos/karthikg80/todos-api/issues/512/labels")) {
+        expect(init?.method).toBe("POST");
+        return {
+          ok: true,
+          json: async () => [
+            { name: "feature" },
+            { name: "triaged-by-agent" },
+            { name: "ui" },
+          ],
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    const response = await request(app)
+      .post(`/admin/feedback/${feedback.id}/promote`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({})
+      .expect(200);
+
+    expect(response.body.promotion).toMatchObject({
+      issueNumber: 512,
+      issueUrl: "https://github.com/karthikg80/todos-api/issues/512",
+      preview: {
+        issueType: "feature",
+        title: "Add planning bundles",
+        labels: ["feature", "triaged-by-agent", "ui"],
+      },
+    });
+    expect(response.body.feedbackRequest).toMatchObject({
+      id: feedback.id,
+      status: "promoted",
+      githubIssueNumber: 512,
+      githubIssueUrl: "https://github.com/karthikg80/todos-api/issues/512",
+      reviewedByUserId: adminUserId,
+    });
+    expect(response.body.feedbackRequest.promotedAt).toEqual(
+      expect.any(String),
+    );
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+    expect(persisted?.status).toBe("promoted");
+    expect(persisted?.githubIssueNumber).toBe(512);
+    expect(persisted?.githubIssueUrl).toBe(
+      "https://github.com/karthikg80/todos-api/issues/512",
+    );
+    expect(persisted?.promotedAt).not.toBeNull();
+  });
+
+  it("POST /admin/feedback/:id/promote blocks issue creation when duplicate candidates are found", async () => {
+    await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Drawer crash",
+        body: "Existing report",
+        status: "triaged",
+        classification: "bug",
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody: "Existing report",
+        dedupeKey: "shared-promotion-key",
+      },
+    });
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Drawer crash again",
+        body: "Fresh report",
+        status: "triaged",
+        classification: "bug",
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody: "Fresh report",
+        dedupeKey: "shared-promotion-key",
+      },
+    });
+
+    const response = await request(app)
+      .post(`/admin/feedback/${feedback.id}/promote`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({})
+      .expect(409);
+
+    expect(response.body.error).toBe("Duplicate candidate found");
+    expect(response.body.feedbackRequest).toMatchObject({
+      id: feedback.id,
+      duplicateCandidate: true,
+    });
+  });
+
   it("GET /admin/feedback returns 403 for non-admin users", async () => {
     await request(app)
       .get("/admin/feedback")
@@ -503,6 +678,30 @@ describe("Feedback API Integration", () => {
     await request(app)
       .post(`/admin/feedback/${feedback.id}/duplicate-check`)
       .set("Authorization", `Bearer ${authToken}`)
+      .expect(403)
+      .expect({
+        error: "Forbidden: Admin access required",
+      });
+  });
+
+  it("POST /admin/feedback/:id/promote returns 403 for non-admin users", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Add planning helper",
+        body: "What are you trying to do?\nPlan my week.",
+        status: "triaged",
+        classification: "feature",
+        normalizedTitle: "Add planning helper",
+        normalizedBody: "Users need guided planning help.",
+      },
+    });
+
+    await request(app)
+      .post(`/admin/feedback/${feedback.id}/promote`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({})
       .expect(403)
       .expect({
         error: "Forbidden: Admin access required",

--- a/src/feedbackPromotionService.test.ts
+++ b/src/feedbackPromotionService.test.ts
@@ -1,0 +1,133 @@
+import { FeedbackPromotionService } from "./services/feedbackPromotionService";
+
+describe("FeedbackPromotionService", () => {
+  const baseRecord = {
+    id: "feedback-1",
+    type: "bug" as const,
+    status: "triaged" as const,
+    classification: "bug" as const,
+    normalizedTitle: "Task drawer crashes on save",
+    normalizedBody:
+      "Saving from the task drawer crashes the current editing session.",
+    impactSummary: "Users cannot save edits from the task drawer.",
+    reproStepsJson: ["Open the task drawer", "Edit notes", "Press save"],
+    expectedBehavior: "The task should save normally.",
+    actualBehavior: "The task drawer crashes and loses the draft.",
+    proposedOutcome: "Stabilize save handling in the task drawer.",
+    triageSummary:
+      'Bug feedback from "Task drawer crashes" on https://app.example.com/?view=todos.',
+    missingInfoJson: [],
+    agentLabelsJson: ["ui"],
+    pageUrl: "https://app.example.com/?view=todos",
+    appVersion: "1.6.0",
+    userAgent: "Playwright Browser",
+    screenshotUrl: "https://example.com/bug.png",
+    duplicateCandidate: false,
+    duplicateReason: null,
+    duplicateOfFeedbackId: null,
+    duplicateOfGithubIssueNumber: null,
+    githubIssueNumber: null,
+    githubIssueUrl: null,
+  };
+
+  it("builds a deterministic bug preview with stable labels", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue(baseRecord),
+      },
+    } as never;
+
+    const service = new FeedbackPromotionService(prisma, {
+      feedbackService: {
+        recordPromotion: jest.fn(),
+      } as never,
+      feedbackDuplicateService: {
+        assertPromotionIsSafe: jest.fn(),
+      } as never,
+      gitHubIssueAdapter: {
+        searchIssues: jest.fn(),
+        createIssue: jest.fn(),
+        applyLabels: jest.fn(),
+      },
+    });
+
+    const preview = await service.buildPreview("feedback-1");
+
+    expect(preview).toEqual({
+      issueType: "bug",
+      title: "Task drawer crashes on save",
+      body: expect.stringContaining("## Steps To Reproduce"),
+      labels: ["bug", "triaged-by-agent", "ui"],
+      sourceFeedbackIds: ["feedback-1"],
+      canPromote: true,
+      duplicateCandidate: false,
+      duplicateReason: null,
+      existingGithubIssueNumber: null,
+      existingGithubIssueUrl: null,
+    });
+    expect(preview.body).toContain("Source feedback IDs: `feedback-1`");
+    expect(preview.body).not.toContain("What happened?");
+  });
+
+  it("creates a GitHub issue, applies labels, and records promotion metadata", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue({
+          ...baseRecord,
+          type: "feature",
+          classification: "feature",
+          normalizedTitle: "Add planning bundles",
+          normalizedBody:
+            "Users need a bundled planning flow to reduce manual setup.",
+          impactSummary: "Weekly planning takes too many manual steps.",
+          proposedOutcome: "Offer suggested planning bundles.",
+          triageSummary: 'Feature feedback from "Add planning bundles".',
+        }),
+      },
+    } as never;
+    const recordPromotion = jest.fn().mockResolvedValue({});
+    const createIssue = jest.fn().mockResolvedValue({
+      number: 412,
+      url: "https://github.com/karthikg80/todos-api/issues/412",
+    });
+    const applyLabels = jest
+      .fn()
+      .mockResolvedValue(["feature", "triaged-by-agent", "ui"]);
+
+    const service = new FeedbackPromotionService(prisma, {
+      feedbackService: {
+        recordPromotion,
+      } as never,
+      feedbackDuplicateService: {
+        assertPromotionIsSafe: jest.fn().mockResolvedValue(undefined),
+      } as never,
+      gitHubIssueAdapter: {
+        searchIssues: jest.fn(),
+        createIssue,
+        applyLabels,
+      },
+    });
+
+    const result = await service.promoteFeedback("feedback-1", "admin-1");
+
+    expect(createIssue).toHaveBeenCalledWith({
+      title: "Add planning bundles",
+      body: expect.stringContaining("## Proposed Outcome"),
+    });
+    expect(applyLabels).toHaveBeenCalledWith(412, [
+      "feature",
+      "triaged-by-agent",
+      "ui",
+    ]);
+    expect(recordPromotion).toHaveBeenCalledWith(
+      "feedback-1",
+      "admin-1",
+      expect.objectContaining({
+        githubIssueNumber: 412,
+        githubIssueUrl: "https://github.com/karthikg80/todos-api/issues/412",
+      }),
+    );
+    expect(result.issueNumber).toBe(412);
+    expect(result.preview.issueType).toBe("feature");
+  });
+});

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -6,9 +6,11 @@ import {
   DuplicatePromotionConflictError,
   FeedbackDuplicateService,
 } from "../services/feedbackDuplicateService";
+import { FeedbackPromotionService } from "../services/feedbackPromotionService";
 import { FeedbackTriageService } from "../services/feedbackTriageService";
 import {
   validateListAdminFeedbackRequestsQuery,
+  validatePromoteFeedbackRequest,
   validateUpdateAdminFeedbackRequest,
 } from "../validation/validation";
 
@@ -17,6 +19,7 @@ interface AdminRouterDeps {
   feedbackService?: FeedbackService;
   feedbackTriageService?: FeedbackTriageService;
   feedbackDuplicateService?: FeedbackDuplicateService;
+  feedbackPromotionService?: FeedbackPromotionService;
 }
 
 export function createAdminRouter({
@@ -24,6 +27,7 @@ export function createAdminRouter({
   feedbackService,
   feedbackTriageService,
   feedbackDuplicateService,
+  feedbackPromotionService,
 }: AdminRouterDeps): Router {
   const router = Router();
 
@@ -220,6 +224,112 @@ export function createAdminRouter({
         }
         if (hasPrismaCode(error, ["P2025"])) {
           return next(new HttpError(404, "Feedback request not found"));
+        }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    "/feedback/:id/promote",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService || !feedbackPromotionService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback promotion not configured" });
+      }
+
+      try {
+        const reviewerUserId = req.user?.userId;
+        const feedbackId = String(req.params.id);
+        if (!reviewerUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const dto = validatePromoteFeedbackRequest(req.body);
+        const promotion = await feedbackPromotionService.promoteFeedback(
+          feedbackId,
+          reviewerUserId,
+          dto,
+        );
+        const feedbackRequest = await feedbackService.getForAdmin(feedbackId);
+        if (!feedbackRequest) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+
+        res.json({
+          feedbackRequest,
+          promotion,
+        });
+      } catch (error) {
+        if (error instanceof DuplicatePromotionConflictError) {
+          const feedbackRequest = await feedbackService.getForAdmin(
+            String(req.params.id),
+          );
+          return res.status(409).json({
+            error: error.message,
+            duplicateDetection: error.assessment,
+            feedbackRequest,
+          });
+        }
+        if (
+          error instanceof Error &&
+          [
+            "Feedback request not found",
+            "Feedback must be triaged before promotion",
+            "Feedback must be triaged as bug or feature before promotion",
+            "Confirmed duplicates cannot be promoted",
+            "Feedback has already been promoted",
+          ].includes(error.message)
+        ) {
+          return next(
+            new HttpError(
+              error.message === "Feedback request not found" ? 404 : 400,
+              error.message,
+            ),
+          );
+        }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/feedback/:id/promotion-preview",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackPromotionService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback promotion not configured" });
+      }
+
+      try {
+        const feedbackId = String(req.params.id);
+        const preview = await feedbackPromotionService.buildPreview(feedbackId);
+        res.json(preview);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          [
+            "Feedback request not found",
+            "Feedback must be triaged before promotion",
+            "Feedback must be triaged as bug or feature before promotion",
+            "Confirmed duplicates cannot be promoted",
+            "Feedback has already been promoted",
+          ].includes(error.message)
+        ) {
+          return next(
+            new HttpError(
+              error.message === "Feedback request not found" ? 404 : 400,
+              error.message,
+            ),
+          );
         }
         if (hasPrismaCode(error, ["P2023"])) {
           return next(new HttpError(400, "Invalid feedback request ID format"));

--- a/src/services/feedbackIssueRenderer.ts
+++ b/src/services/feedbackIssueRenderer.ts
@@ -1,0 +1,224 @@
+import {
+  FeedbackPromotionIssueType,
+  FeedbackPromotionPreviewDto,
+} from "../types";
+
+type PromotionRenderRecord = {
+  id: string;
+  type: "bug" | "feature" | "general";
+  status: "new" | "triaged" | "promoted" | "rejected";
+  classification:
+    | "bug"
+    | "feature"
+    | "support"
+    | "duplicate_candidate"
+    | "noise"
+    | null;
+  normalizedTitle: string | null;
+  normalizedBody: string | null;
+  impactSummary: string | null;
+  reproStepsJson: unknown;
+  expectedBehavior: string | null;
+  actualBehavior: string | null;
+  proposedOutcome: string | null;
+  triageSummary: string | null;
+  missingInfoJson: unknown;
+  agentLabelsJson: unknown;
+  pageUrl: string | null;
+  appVersion: string | null;
+  userAgent: string | null;
+  screenshotUrl: string | null;
+  duplicateCandidate: boolean;
+  duplicateReason: string | null;
+  duplicateOfFeedbackId: string | null;
+  duplicateOfGithubIssueNumber: number | null;
+  githubIssueNumber: number | null;
+  githubIssueUrl: string | null;
+};
+
+function coerceStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function issueTypeForRecord(
+  record: PromotionRenderRecord,
+): FeedbackPromotionIssueType | null {
+  if (record.classification === "bug" || record.classification === "feature") {
+    return record.classification;
+  }
+  if (record.type === "bug" || record.type === "feature") {
+    return record.type;
+  }
+  return null;
+}
+
+function cleanText(
+  value: string | null | undefined,
+  fallback = "Not provided",
+): string {
+  const normalized = (value || "").trim();
+  return normalized || fallback;
+}
+
+function toBulletList(items: string[], fallback: string): string {
+  if (!items.length) {
+    return `- ${fallback}`;
+  }
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function extractAreaLabels(record: PromotionRenderRecord): string[] {
+  const haystack = [
+    record.normalizedTitle,
+    record.normalizedBody,
+    record.impactSummary,
+    record.pageUrl,
+    record.userAgent,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const areaLabels = new Set<string>();
+  if (
+    /\b(ui|button|drawer|modal|sheet|screen|layout|page|tooltip|header|footer|mobile web)\b/.test(
+      haystack,
+    )
+  ) {
+    areaLabels.add("ui");
+  }
+  if (
+    /\b(auth|login|logout|password|verification|oauth|sign in|sign-in)\b/.test(
+      haystack,
+    )
+  ) {
+    areaLabels.add("auth");
+  }
+  if (/\b(mobile|ios|android|iphone|ipad|touch|responsive)\b/.test(haystack)) {
+    areaLabels.add("mobile");
+  }
+  if (
+    /\b(slow|latency|performance|lag|freeze|frozen|timeout|time out|loading)\b/.test(
+      haystack,
+    )
+  ) {
+    areaLabels.add("performance");
+  }
+
+  for (const label of coerceStringArray(record.agentLabelsJson)) {
+    if (["ui", "auth", "mobile", "performance"].includes(label)) {
+      areaLabels.add(label);
+    }
+  }
+
+  return Array.from(areaLabels).sort();
+}
+
+function buildLabels(
+  record: PromotionRenderRecord,
+  issueType: FeedbackPromotionIssueType,
+): string[] {
+  return [issueType, "triaged-by-agent", ...extractAreaLabels(record)];
+}
+
+function buildContextSection(record: PromotionRenderRecord): string {
+  const missingInfo = coerceStringArray(record.missingInfoJson);
+  return [
+    "## Context",
+    `- Source feedback IDs: \`${record.id}\``,
+    `- Feedback status: ${record.status}`,
+    `- Page URL: ${cleanText(record.pageUrl)}`,
+    `- App version: ${cleanText(record.appVersion)}`,
+    `- Browser user agent: ${cleanText(record.userAgent)}`,
+    `- Screenshot URL: ${cleanText(record.screenshotUrl)}`,
+    `- Missing information flags: ${
+      missingInfo.length ? missingInfo.join(", ") : "none"
+    }`,
+  ].join("\n");
+}
+
+function buildBugBody(record: PromotionRenderRecord): string {
+  const reproSteps = coerceStringArray(record.reproStepsJson);
+  return [
+    "## Summary",
+    cleanText(record.triageSummary || record.normalizedBody),
+    "",
+    "## Impact",
+    cleanText(record.impactSummary),
+    "",
+    "## Steps To Reproduce",
+    toBulletList(
+      reproSteps,
+      "Not enough information provided to reproduce yet.",
+    ),
+    "",
+    "## Expected Behavior",
+    cleanText(record.expectedBehavior),
+    "",
+    "## Actual Behavior",
+    cleanText(record.actualBehavior),
+    "",
+    buildContextSection(record),
+  ].join("\n");
+}
+
+function buildFeatureBody(record: PromotionRenderRecord): string {
+  return [
+    "## Problem",
+    cleanText(
+      record.impactSummary || record.triageSummary || record.normalizedBody,
+    ),
+    "",
+    "## Proposed Outcome",
+    cleanText(record.proposedOutcome),
+    "",
+    "## Current Experience",
+    cleanText(record.normalizedBody),
+    "",
+    "## Success Criteria",
+    toBulletList(
+      [record.proposedOutcome, record.impactSummary].filter(
+        (value): value is string => Boolean(value && value.trim()),
+      ),
+      "Define measurable success criteria during implementation planning.",
+    ),
+    "",
+    buildContextSection(record),
+  ].join("\n");
+}
+
+export function renderFeedbackIssuePreview(
+  record: PromotionRenderRecord,
+): FeedbackPromotionPreviewDto {
+  const issueType = issueTypeForRecord(record);
+  if (!issueType) {
+    throw new Error(
+      "Feedback must be triaged as bug or feature before promotion",
+    );
+  }
+  if (!record.normalizedTitle || !record.normalizedBody) {
+    throw new Error("Feedback must be triaged before promotion");
+  }
+  if (record.duplicateOfFeedbackId || record.duplicateOfGithubIssueNumber) {
+    throw new Error("Confirmed duplicates cannot be promoted");
+  }
+
+  const title = record.normalizedTitle.trim();
+  const body =
+    issueType === "bug" ? buildBugBody(record) : buildFeatureBody(record);
+
+  return {
+    issueType,
+    title,
+    body,
+    labels: buildLabels(record, issueType),
+    sourceFeedbackIds: [record.id],
+    canPromote: !record.duplicateCandidate && !record.githubIssueNumber,
+    duplicateCandidate: record.duplicateCandidate,
+    duplicateReason: record.duplicateReason,
+    existingGithubIssueNumber: record.githubIssueNumber,
+    existingGithubIssueUrl: record.githubIssueUrl,
+  };
+}

--- a/src/services/feedbackPromotionService.ts
+++ b/src/services/feedbackPromotionService.ts
@@ -1,0 +1,151 @@
+import { PrismaClient } from "@prisma/client";
+import {
+  FeedbackPromotionPreviewDto,
+  FeedbackPromotionResultDto,
+} from "../types";
+import {
+  GitHubIssueAdapter,
+  GitHubIssueSearchService,
+} from "./githubIssueSearchService";
+import {
+  DuplicatePromotionConflictError,
+  FeedbackDuplicateService,
+} from "./feedbackDuplicateService";
+import { renderFeedbackIssuePreview } from "./feedbackIssueRenderer";
+import { FeedbackService } from "./feedbackService";
+
+type PromotionRecord = {
+  id: string;
+  type: "bug" | "feature" | "general";
+  status: "new" | "triaged" | "promoted" | "rejected";
+  classification:
+    | "bug"
+    | "feature"
+    | "support"
+    | "duplicate_candidate"
+    | "noise"
+    | null;
+  normalizedTitle: string | null;
+  normalizedBody: string | null;
+  impactSummary: string | null;
+  reproStepsJson: unknown;
+  expectedBehavior: string | null;
+  actualBehavior: string | null;
+  proposedOutcome: string | null;
+  triageSummary: string | null;
+  missingInfoJson: unknown;
+  agentLabelsJson: unknown;
+  pageUrl: string | null;
+  appVersion: string | null;
+  userAgent: string | null;
+  screenshotUrl: string | null;
+  duplicateCandidate: boolean;
+  duplicateReason: string | null;
+  duplicateOfFeedbackId: string | null;
+  duplicateOfGithubIssueNumber: number | null;
+  githubIssueNumber: number | null;
+  githubIssueUrl: string | null;
+};
+
+export interface FeedbackPromotionServiceDeps {
+  feedbackService?: FeedbackService;
+  feedbackDuplicateService?: FeedbackDuplicateService;
+  gitHubIssueAdapter?: GitHubIssueAdapter;
+}
+
+export class FeedbackPromotionService {
+  private readonly feedbackService: FeedbackService;
+  private readonly feedbackDuplicateService: FeedbackDuplicateService;
+  private readonly gitHubIssueAdapter: GitHubIssueAdapter;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    deps: FeedbackPromotionServiceDeps = {},
+  ) {
+    this.feedbackService = deps.feedbackService ?? new FeedbackService(prisma);
+    this.feedbackDuplicateService =
+      deps.feedbackDuplicateService ?? new FeedbackDuplicateService(prisma);
+    this.gitHubIssueAdapter =
+      deps.gitHubIssueAdapter ?? new GitHubIssueSearchService();
+  }
+
+  async buildPreview(feedbackId: string): Promise<FeedbackPromotionPreviewDto> {
+    const record = await this.loadRecord(feedbackId);
+    return renderFeedbackIssuePreview(record);
+  }
+
+  async promoteFeedback(
+    feedbackId: string,
+    reviewerUserId: string,
+    options: { ignoreDuplicateSuggestion?: boolean } = {},
+  ): Promise<FeedbackPromotionResultDto> {
+    if (!options.ignoreDuplicateSuggestion) {
+      await this.feedbackDuplicateService.assertPromotionIsSafe(feedbackId);
+    }
+
+    const preview = await this.buildPreview(feedbackId);
+    if (preview.existingGithubIssueNumber || preview.existingGithubIssueUrl) {
+      throw new Error("Feedback has already been promoted");
+    }
+    const createdIssue = await this.gitHubIssueAdapter.createIssue({
+      title: preview.title,
+      body: preview.body,
+    });
+    await this.gitHubIssueAdapter.applyLabels(
+      createdIssue.number,
+      preview.labels,
+    );
+
+    const promotedAt = new Date();
+    await this.feedbackService.recordPromotion(feedbackId, reviewerUserId, {
+      githubIssueNumber: createdIssue.number,
+      githubIssueUrl: createdIssue.url,
+      promotedAt,
+    });
+
+    return {
+      issueNumber: createdIssue.number,
+      issueUrl: createdIssue.url,
+      promotedAt: promotedAt.toISOString(),
+      preview,
+    };
+  }
+
+  private async loadRecord(feedbackId: string): Promise<PromotionRecord> {
+    const record = await this.prisma.feedbackRequest.findUnique({
+      where: { id: feedbackId },
+      select: {
+        id: true,
+        type: true,
+        status: true,
+        classification: true,
+        normalizedTitle: true,
+        normalizedBody: true,
+        impactSummary: true,
+        reproStepsJson: true,
+        expectedBehavior: true,
+        actualBehavior: true,
+        proposedOutcome: true,
+        triageSummary: true,
+        missingInfoJson: true,
+        agentLabelsJson: true,
+        pageUrl: true,
+        appVersion: true,
+        userAgent: true,
+        screenshotUrl: true,
+        duplicateCandidate: true,
+        duplicateReason: true,
+        duplicateOfFeedbackId: true,
+        duplicateOfGithubIssueNumber: true,
+        githubIssueNumber: true,
+        githubIssueUrl: true,
+      },
+    });
+
+    if (!record) {
+      throw new Error("Feedback request not found");
+    }
+
+    return record;
+  }
+}

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -117,6 +117,7 @@ export class FeedbackService {
         reviewedByUserId: reviewerUserId,
         reviewedAt: new Date(),
         rejectionReason: dto.status === "rejected" ? dto.rejectionReason : null,
+        promotedAt: dto.status === "promoted" ? new Date() : undefined,
         duplicateCandidate: shouldResolveDuplicate ? false : undefined,
         matchedFeedbackIds: shouldResolveDuplicate
           ? Prisma.JsonNull
@@ -132,6 +133,46 @@ export class FeedbackService {
         duplicateReason: shouldResolveDuplicate
           ? (dto.duplicateReason ?? null)
           : undefined,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+        reviewer: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return this.toAdminDto(record);
+  }
+
+  async recordPromotion(
+    id: string,
+    reviewerUserId: string,
+    promotion: {
+      githubIssueNumber: number;
+      githubIssueUrl: string;
+      promotedAt: Date;
+    },
+  ): Promise<FeedbackRequestAdminDetailDto> {
+    const record = await this.prisma.feedbackRequest.update({
+      where: { id },
+      data: {
+        status: "promoted",
+        reviewedByUserId: reviewerUserId,
+        reviewedAt: promotion.promotedAt,
+        promotedAt: promotion.promotedAt,
+        githubIssueNumber: promotion.githubIssueNumber,
+        githubIssueUrl: promotion.githubIssueUrl,
       },
       include: {
         user: {
@@ -195,6 +236,7 @@ export class FeedbackService {
     duplicateReason: string | null;
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
+    promotedAt: Date | null;
     reviewedByUserId: string | null;
     reviewedAt: Date | null;
     rejectionReason: string | null;
@@ -262,6 +304,7 @@ export class FeedbackService {
       duplicateReason: record.duplicateReason,
       githubIssueNumber: record.githubIssueNumber,
       githubIssueUrl: record.githubIssueUrl,
+      promotedAt: record.promotedAt?.toISOString() ?? null,
       reviewedByUserId: record.reviewedByUserId,
       reviewedAt: record.reviewedAt?.toISOString() ?? null,
       rejectionReason: record.rejectionReason,
@@ -312,6 +355,7 @@ export class FeedbackService {
     duplicateReason: string | null;
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
+    promotedAt: Date | null;
     reviewedAt: Date | null;
     rejectionReason: string | null;
     createdAt: Date;

--- a/src/services/githubIssueSearchService.ts
+++ b/src/services/githubIssueSearchService.ts
@@ -7,25 +7,47 @@ export interface GitHubIssueMatch {
   state: string;
 }
 
+export interface CreateGitHubIssueInput {
+  title: string;
+  body: string;
+}
+
+export interface CreateGitHubIssueResult {
+  number: number;
+  url: string;
+}
+
 export interface GitHubIssueSearchAdapter {
   searchIssues(query: string): Promise<GitHubIssueMatch[]>;
 }
 
-export class GitHubIssueSearchService implements GitHubIssueSearchAdapter {
+export interface GitHubIssueAdapter extends GitHubIssueSearchAdapter {
+  createIssue(input: CreateGitHubIssueInput): Promise<CreateGitHubIssueResult>;
+  applyLabels(issueNumber: number, labels: string[]): Promise<string[]>;
+}
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "todos-api-feedback-promotion",
+  };
+  if (config.githubToken) {
+    headers.Authorization = `Bearer ${config.githubToken}`;
+  }
+  return headers;
+}
+
+function buildIssuesUrl(pathname: string): URL {
+  return new URL(pathname, config.githubApiBaseUrl);
+}
+
+export class GitHubIssueSearchService implements GitHubIssueAdapter {
   async searchIssues(query: string): Promise<GitHubIssueMatch[]> {
-    const url = new URL("/search/issues", config.githubApiBaseUrl);
+    const url = buildIssuesUrl("/search/issues");
     url.searchParams.set("q", query);
     url.searchParams.set("per_page", "10");
 
-    const headers: Record<string, string> = {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "todos-api-feedback-dedupe",
-    };
-    if (config.githubToken) {
-      headers.Authorization = `Bearer ${config.githubToken}`;
-    }
-
-    const response = await fetch(url.toString(), { headers });
+    const response = await fetch(url.toString(), { headers: buildHeaders() });
     if (!response.ok) {
       throw new Error(
         `GitHub issue search failed with status ${response.status}`,
@@ -62,5 +84,74 @@ export class GitHubIssueSearchService implements GitHubIssueSearchAdapter {
           },
         ];
       });
+  }
+
+  async createIssue(
+    input: CreateGitHubIssueInput,
+  ): Promise<CreateGitHubIssueResult> {
+    const response = await fetch(
+      buildIssuesUrl(`/repos/${config.githubRepo}/issues`).toString(),
+      {
+        method: "POST",
+        headers: {
+          ...buildHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: input.title,
+          body: input.body,
+        }),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `GitHub issue creation failed with status ${response.status}`,
+      );
+    }
+
+    const data = (await response.json()) as {
+      number?: number;
+      html_url?: string;
+    };
+    if (typeof data.number !== "number" || typeof data.html_url !== "string") {
+      throw new Error("GitHub issue creation returned an invalid response");
+    }
+
+    return {
+      number: data.number,
+      url: data.html_url,
+    };
+  }
+
+  async applyLabels(issueNumber: number, labels: string[]): Promise<string[]> {
+    if (!labels.length) {
+      return [];
+    }
+
+    const response = await fetch(
+      buildIssuesUrl(
+        `/repos/${config.githubRepo}/issues/${issueNumber}/labels`,
+      ).toString(),
+      {
+        method: "POST",
+        headers: {
+          ...buildHeaders(),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ labels }),
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `GitHub label apply failed with status ${response.status}`,
+      );
+    }
+
+    const data = (await response.json()) as Array<{ name?: string }>;
+    return Array.isArray(data)
+      ? data
+          .map((item) => item.name)
+          .filter((value): value is string => typeof value === "string")
+      : [];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,6 +380,32 @@ export interface FeedbackDuplicateMatchDto {
   duplicateReason?: string | null;
 }
 
+export type FeedbackPromotionIssueType = "bug" | "feature";
+
+export interface FeedbackPromotionPreviewDto {
+  issueType: FeedbackPromotionIssueType;
+  title: string;
+  body: string;
+  labels: string[];
+  sourceFeedbackIds: string[];
+  canPromote: boolean;
+  duplicateCandidate: boolean;
+  duplicateReason?: string | null;
+  existingGithubIssueNumber?: number | null;
+  existingGithubIssueUrl?: string | null;
+}
+
+export interface FeedbackPromotionResultDto {
+  issueNumber: number;
+  issueUrl: string;
+  promotedAt: string;
+  preview: FeedbackPromotionPreviewDto;
+}
+
+export interface PromoteFeedbackRequestDto {
+  ignoreDuplicateSuggestion?: boolean;
+}
+
 export interface CreateFeedbackRequestDto {
   type: FeedbackRequestType;
   title: string;
@@ -427,6 +453,7 @@ export interface FeedbackRequestDto {
   duplicateReason?: string | null;
   githubIssueNumber?: number | null;
   githubIssueUrl?: string | null;
+  promotedAt?: string | null;
   reviewedByUserId?: string | null;
   reviewedAt?: string | null;
   rejectionReason?: string | null;

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -17,6 +17,7 @@ import {
   CreateFeedbackRequestDto,
   FeedbackAttachmentMetadataDto,
   FeedbackRequestStatus,
+  PromoteFeedbackRequestDto,
   FeedbackRequestType,
   ListAdminFeedbackRequestsQuery,
   Priority,
@@ -1806,5 +1807,28 @@ export function validateUpdateAdminFeedbackRequest(
     duplicateOfFeedbackId: duplicateOfFeedbackIdRaw ?? null,
     duplicateOfGithubIssueNumber: duplicateOfGithubIssueNumber ?? null,
     duplicateReason: duplicateReason ?? null,
+  };
+}
+
+export function validatePromoteFeedbackRequest(
+  data: unknown,
+): PromoteFeedbackRequestDto {
+  if (data === undefined) {
+    return {};
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  const body = data as Record<string, unknown>;
+  if (body.ignoreDuplicateSuggestion === undefined) {
+    return {};
+  }
+  if (typeof body.ignoreDuplicateSuggestion !== "boolean") {
+    throw new ValidationError("ignoreDuplicateSuggestion must be a boolean");
+  }
+
+  return {
+    ignoreDuplicateSuggestion: body.ignoreDuplicateSuggestion,
   };
 }

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -43,6 +43,7 @@ function buildFeedback(overrides: Record<string, unknown> = {}) {
     duplicateReason: null,
     githubIssueNumber: null,
     githubIssueUrl: null,
+    promotedAt: null,
     reviewedByUserId: null,
     reviewedAt: null,
     rejectionReason: null,
@@ -65,6 +66,7 @@ test.describe("Admin feedback queue", () => {
     let patchPayload: Record<string, unknown> | null = null;
     let triageCalled = false;
     let linkDuplicatePayload: Record<string, unknown> | null = null;
+    let promotePayload: Record<string, unknown> | null = null;
     const bugFeedback = buildFeedback();
     const featureFeedback = buildFeedback({
       id: "feedback-2",
@@ -137,31 +139,93 @@ test.describe("Admin feedback queue", () => {
       });
     });
 
-    await page.route("**/admin/feedback/feedback-1", async (route) => {
-      if (route.request().method() === "PATCH") {
-        const payload = JSON.parse(
-          route.request().postData() || "{}",
-        ) as Record<string, unknown>;
-        if (payload.status === "promoted") {
-          Object.assign(bugFeedback, {
-            duplicateCandidate: true,
-            matchedFeedbackIds: ["feedback-2"],
-            matchedGithubIssueNumber: 405,
-            matchedGithubIssueUrl:
-              "https://github.com/karthikg80/todos-api/issues/405",
-            duplicateReason: "Matching dedupe key with normalized feedback",
-          });
+    await page.route(
+      "**/admin/feedback/feedback-1/promotion-preview",
+      async (route) => {
+        if (!bugFeedback.normalizedTitle) {
           await route.fulfill({
-            status: 409,
+            status: 400,
             contentType: "application/json",
             body: JSON.stringify({
-              error: "Duplicate candidate found",
-              feedbackRequest: bugFeedback,
+              error: "Feedback must be triaged before promotion",
             }),
           });
           return;
         }
 
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            issueType: "bug",
+            title: bugFeedback.normalizedTitle,
+            body: [
+              "## Summary",
+              "Bug feedback from task drawer crash.",
+              "",
+              "## Steps To Reproduce",
+              "- Open the task drawer",
+              "- Edit notes",
+              "- Press save",
+              "",
+              "## Context",
+              "- Source feedback IDs: `feedback-1`",
+            ].join("\n"),
+            labels: ["bug", "triaged-by-agent", "ui"],
+            sourceFeedbackIds: ["feedback-1"],
+            canPromote: !bugFeedback.duplicateCandidate,
+            duplicateCandidate: bugFeedback.duplicateCandidate,
+            duplicateReason: bugFeedback.duplicateReason,
+            existingGithubIssueNumber: bugFeedback.githubIssueNumber,
+            existingGithubIssueUrl: bugFeedback.githubIssueUrl,
+          }),
+        });
+      },
+    );
+
+    await page.route(
+      "**/admin/feedback/feedback-2/promotion-preview",
+      async (route) => {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "Feedback must be triaged before promotion",
+          }),
+        });
+      },
+    );
+
+    await page.route("**/admin/feedback/feedback-1/promote", async (route) => {
+      const payload = JSON.parse(route.request().postData() || "{}") as Record<
+        string,
+        unknown
+      >;
+      promotePayload = payload;
+
+      Object.assign(bugFeedback, {
+        duplicateCandidate: true,
+        matchedFeedbackIds: ["feedback-2"],
+        matchedGithubIssueNumber: 405,
+        matchedGithubIssueUrl:
+          "https://github.com/karthikg80/todos-api/issues/405",
+        duplicateReason: "Matching dedupe key with normalized feedback",
+      });
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "Duplicate candidate found",
+          feedbackRequest: bugFeedback,
+        }),
+      });
+    });
+
+    await page.route("**/admin/feedback/feedback-1", async (route) => {
+      if (route.request().method() === "PATCH") {
+        const payload = JSON.parse(
+          route.request().postData() || "{}",
+        ) as Record<string, unknown>;
         if (payload.duplicateOfFeedbackId) {
           linkDuplicatePayload = payload;
           Object.assign(bugFeedback, {
@@ -265,11 +329,20 @@ test.describe("Admin feedback queue", () => {
     await expect(page.locator("#adminFeedbackDetail")).toContainText(
       "feedback:bug",
     );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Create GitHub issue",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "triaged-by-agent",
+    );
 
     await page
       .locator("#adminFeedbackDetail")
-      .getByRole("button", { name: "Ready for promotion", exact: true })
+      .getByRole("button", { name: "Create GitHub issue", exact: true })
       .click();
+    expect(promotePayload).toEqual({
+      ignoreDuplicateSuggestion: false,
+    });
     await expect(page.locator("#adminMessage")).toContainText(
       "Duplicate candidate found",
     );


### PR DESCRIPTION
## Summary
- add a deterministic feedback-to-GitHub issue renderer and promotion service
- expose admin preview and create-issue actions with duplicate-safe blocking
- store GitHub issue metadata and promotion timestamps back on feedback records

## Testing
- npx prisma generate
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts
- CI=1 npm run test:ui:fast