### PR TITLE
fix(api): MCP OAuth redirect blocked by CSP in embedded webviews

### DIFF
--- a/src/mcp/mcpOAuthPages.ts
+++ b/src/mcp/mcpOAuthPages.ts
@@ -171,7 +171,10 @@ export function renderOAuthLoginPage(input: {
   );
 }
 
-export function renderOAuthRedirectPage(input: { redirectUri: string }) {
+export function renderOAuthRedirectPage(input: {
+  redirectUri: string;
+  nonce: string;
+}) {
   const safe = escapeHtml(input.redirectUri);
   return renderPageShell(
     "Redirecting…",
@@ -179,7 +182,7 @@ export function renderOAuthRedirectPage(input: { redirectUri: string }) {
      <p>Redirecting you back to the assistant…</p>
      <p><a class="primary" href="${safe}" style="display:inline-block;padding:12px 18px;border-radius:999px;background:#111827;color:white;text-decoration:none;font-weight:600;">Return to assistant</a></p>
      <meta http-equiv="refresh" content="0; url=${safe}">
-     <script>
+     <script nonce="${escapeHtml(input.nonce)}">
        try { window.location.replace(${JSON.stringify(input.redirectUri)}); } catch(_){}
      </script>`,
   );

--- a/src/routes/mcpPublicRouter.ts
+++ b/src/routes/mcpPublicRouter.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { randomBytes, randomUUID } from "crypto";
 import { Request, Response, Router } from "express";
 import { AuthService } from "../services/authService";
 import { McpOAuthService } from "../services/mcpOAuthService";
@@ -742,10 +742,19 @@ export function createMcpPublicRouter({
       // rich HTML body so embedded webviews / in-app browsers (e.g. ChatGPT)
       // can redirect via meta-refresh or JS when the Location header is not
       // automatically followed.
+      // A per-response CSP nonce allows the inline redirect script through
+      // the global Helmet CSP (which blocks inline scripts by default).
+      const nonce = randomBytes(16).toString("base64");
       res
         .status(303)
         .setHeader("Location", finalRedirectUri)
-        .send(renderOAuthRedirectPage({ redirectUri: finalRedirectUri }));
+        .setHeader(
+          "Content-Security-Policy",
+          `default-src 'self'; script-src 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`,
+        )
+        .send(
+          renderOAuthRedirectPage({ redirectUri: finalRedirectUri, nonce }),
+        );
     } catch (error) {
       const message = error instanceof Error ? error.message : "";
       const mapped = mapAuthorizeError(message);


### PR DESCRIPTION
## Summary

- MCP OAuth redirect after approval was not automatic in ChatGPT and Claude — users had to manually copy the redirect URL from dev tools
- **Root cause:** Helmet's global CSP (`scriptSrc: ['self']`) blocked the inline `<script>` fallback in the OAuth redirect page. Embedded webviews in ChatGPT/Claude don't follow HTTP 303 redirects automatically, so the JS fallback was the critical path.
- **Fix:** Generate a per-response cryptographic nonce and set a scoped `Content-Security-Policy` header on the redirect response, allowing the inline `window.location.replace()` to execute

## Test plan

- [ ] Unit tests pass (296/296, no DB required)
- [ ] Typecheck passes
- [ ] Manually test MCP OAuth flow via ChatGPT or Claude — redirect should now be automatic after clicking "Allow Access"

🤖 Generated with [Claude Code](https://claude.com/claude-code)