### PR TITLE
[codex] enable feedback auto-promotion

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -411,10 +411,13 @@ import {
 import {
   confirmAdminFeedbackDuplicate,
   ignoreDuplicateAndPromote,
+  loadAdminFeedbackAutomationPanel,
   loadAdminFeedbackQueue,
   promoteAdminFeedback,
   runAdminFeedbackPromotionPreview,
+  runAdminFeedbackAutomation,
   runAdminFeedbackDuplicateCheck,
+  saveAdminFeedbackAutomationConfig,
   selectAdminFeedback,
   setAdminFeedbackFilter,
   runAdminFeedbackTriage,
@@ -665,6 +668,7 @@ const { ensureTodosShellActive, selectWorkspaceView, switchView } =
     loadAiInsights,
     loadAiFeedbackSummary,
     loadAdminUsers: () => {
+      void loadAdminFeedbackAutomationPanel();
       void loadAdminFeedbackQueue();
       void loadAdminUsers();
     },
@@ -1784,6 +1788,8 @@ window.runAdminFeedbackPromotionPreview = runAdminFeedbackPromotionPreview;
 window.promoteAdminFeedback = promoteAdminFeedback;
 window.runAdminFeedbackTriage = runAdminFeedbackTriage;
 window.updateAdminFeedbackStatus = updateAdminFeedbackStatus;
+window.saveAdminFeedbackAutomationConfig = saveAdminFeedbackAutomationConfig;
+window.runAdminFeedbackAutomation = runAdminFeedbackAutomation;
 
 // ---------------------------------------------------------------------------
 // App bootstrap

--- a/client/modules/adminFeedback.js
+++ b/client/modules/adminFeedback.js
@@ -16,9 +16,14 @@ function formatDateTime(value) {
   return date.toLocaleString();
 }
 
+function formatConfidence(value) {
+  return typeof value === "number" ? `${Math.round(value * 100)}%` : "Unknown";
+}
+
 function getAdminFeedbackElements() {
   return {
     container: document.getElementById("adminContent"),
+    automation: document.getElementById("adminFeedbackAutomationPanel"),
     list: document.getElementById("adminFeedbackList"),
     detail: document.getElementById("adminFeedbackDetail"),
   };
@@ -36,6 +41,15 @@ function ensureAdminWorkspaceShell() {
 
   container.innerHTML = `
     <div class="admin-layout">
+      <section class="admin-section admin-feedback-automation-section">
+        <div class="admin-section__header">
+          <div>
+            <h2 class="admin-section__title">Feedback Automation</h2>
+            <p class="admin-section__subtitle">Keep auto-promotion off by default, then graduate only high-confidence, non-duplicate feedback into GitHub.</p>
+          </div>
+        </div>
+        <div id="adminFeedbackAutomationPanel"></div>
+      </section>
       <section class="admin-section admin-feedback-section">
         <div class="admin-section__header">
           <div>
@@ -108,6 +122,154 @@ function renderFilterChips() {
   });
 }
 
+function renderMetadataRow(label, value) {
+  return `
+    <div class="admin-detail-meta__row">
+      <span class="admin-detail-meta__label">${escape(label)}</span>
+      <span class="admin-detail-meta__value">${escape(value || "—")}</span>
+    </div>
+  `;
+}
+
+function renderListBlock(title, items, emptyLabel = "None") {
+  const listItems = Array.isArray(items) ? items.filter(Boolean) : [];
+  return `
+    <div class="admin-detail-block">
+      <h4>${escape(title)}</h4>
+      ${
+        listItems.length
+          ? `<ul class="admin-detail-list">${listItems
+              .map((item) => `<li>${escape(item)}</li>`)
+              .join("")}</ul>`
+          : `<p class="admin-detail-empty-copy">${escape(emptyLabel)}</p>`
+      }
+    </div>
+  `;
+}
+
+function renderAutomationPanel() {
+  const { automation } = getAdminFeedbackElements();
+  if (!(automation instanceof HTMLElement)) {
+    return;
+  }
+
+  if (
+    state.adminFeedbackAutomationConfigLoading ||
+    state.adminFeedbackAutomationDecisionsLoading
+  ) {
+    automation.innerHTML = `
+      <div class="loading">
+        <div class="spinner"></div>
+        Loading automation controls...
+      </div>
+    `;
+    return;
+  }
+
+  const config = state.adminFeedbackAutomationConfig;
+  if (!config) {
+    automation.innerHTML = `
+      <p class="admin-detail-empty-copy">Automation settings are unavailable right now.</p>
+    `;
+    return;
+  }
+
+  const decisions = state.adminFeedbackAutomationDecisions || [];
+  automation.innerHTML = `
+    <div class="admin-automation-grid">
+      <div class="admin-detail-block">
+        <h4>Controls</h4>
+        <div class="admin-automation-form">
+          <label class="admin-automation-toggle">
+            <input
+              id="adminFeedbackAutomationEnabled"
+              type="checkbox"
+              ${config.feedbackAutomationEnabled ? "checked" : ""}
+            />
+            <span>Enable feedback automation</span>
+          </label>
+          <label class="admin-automation-toggle">
+            <input
+              id="adminFeedbackAutoPromoteEnabled"
+              type="checkbox"
+              ${config.feedbackAutoPromoteEnabled ? "checked" : ""}
+            />
+            <span>Enable auto-promotion after checks pass</span>
+          </label>
+          <label class="feedback-form__label" for="adminFeedbackAutoPromoteMinConfidence">Minimum confidence threshold</label>
+          <input
+            id="adminFeedbackAutoPromoteMinConfidence"
+            class="feedback-form__input"
+            type="number"
+            min="0"
+            max="1"
+            step="0.01"
+            value="${escape(config.feedbackAutoPromoteMinConfidence)}"
+          />
+          <p class="admin-detail-empty-copy">
+            Allowlisted classifications: ${escape(
+              (config.allowlistedClassifications || []).join(", "),
+            )}
+          </p>
+          <div class="admin-feedback-actions">
+            <button
+              type="button"
+              class="action-btn"
+              data-onclick="saveAdminFeedbackAutomationConfig()"
+              ${state.adminFeedbackAutomationSaving ? "disabled" : ""}
+            >
+              ${state.adminFeedbackAutomationSaving ? "Saving..." : "Save settings"}
+            </button>
+            <button
+              type="button"
+              class="action-btn promote"
+              data-onclick="runAdminFeedbackAutomation()"
+              ${state.adminFeedbackAutomationRunLoading ? "disabled" : ""}
+            >
+              ${state.adminFeedbackAutomationRunLoading ? "Running..." : "Run now"}
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="admin-detail-block">
+        <h4>Recent Decisions</h4>
+        ${
+          decisions.length
+            ? `<div class="admin-automation-decision-list">${decisions
+                .map(
+                  (decision) => `
+                    <button
+                      type="button"
+                      class="admin-automation-decision"
+                      data-onclick="selectAdminFeedback('${decision.id}')"
+                    >
+                      <div class="admin-feedback-row__top">
+                        <span class="admin-feedback-pill admin-feedback-pill--${escape(decision.type)}">${escape(decision.type)}</span>
+                        <span class="admin-feedback-pill admin-feedback-pill--status">${escape(decision.promotionDecision)}</span>
+                      </div>
+                      <strong class="admin-feedback-row__title">${escape(decision.title)}</strong>
+                      <div class="admin-feedback-row__meta">
+                        <span>${escape(decision.promotionReason || "No reason captured")}</span>
+                      </div>
+                      <div class="admin-feedback-row__meta">
+                        <span>${escape(formatDateTime(decision.promotionDecidedAt))}</span>
+                        <span>${escape(
+                          decision.githubIssueNumber
+                            ? `#${decision.githubIssueNumber}`
+                            : formatConfidence(decision.triageConfidence),
+                        )}</span>
+                      </div>
+                    </button>
+                  `,
+                )
+                .join("")}</div>`
+            : `<p class="admin-detail-empty-copy">No automation decisions yet.</p>`
+        }
+      </div>
+    </div>
+  `;
+}
+
 function renderAdminFeedbackList() {
   const { list } = getAdminFeedbackElements();
   if (!(list instanceof HTMLElement)) {
@@ -159,37 +321,7 @@ function renderAdminFeedbackList() {
     .join("");
 }
 
-function renderMetadataRow(label, value) {
-  return `
-    <div class="admin-detail-meta__row">
-      <span class="admin-detail-meta__label">${escape(label)}</span>
-      <span class="admin-detail-meta__value">${escape(value || "—")}</span>
-    </div>
-  `;
-}
-
-function renderListBlock(title, items, emptyLabel = "None") {
-  const listItems = Array.isArray(items) ? items.filter(Boolean) : [];
-  return `
-    <div class="admin-detail-block">
-      <h4>${escape(title)}</h4>
-      ${
-        listItems.length
-          ? `<ul class="admin-detail-list">${listItems
-              .map((item) => `<li>${escape(item)}</li>`)
-              .join("")}</ul>`
-          : `<p class="admin-detail-empty-copy">${escape(emptyLabel)}</p>`
-      }
-    </div>
-  `;
-}
-
 function renderTriagePanel(item) {
-  const confidence =
-    typeof item.triageConfidence === "number"
-      ? `${Math.round(item.triageConfidence * 100)}%`
-      : "Not triaged yet";
-
   return `
     <div class="admin-detail-panel">
       <div class="admin-detail-block">
@@ -201,7 +333,7 @@ function renderTriagePanel(item) {
         </div>
         <div class="admin-detail-meta">
           ${renderMetadataRow("Classification", item.classification || "")}
-          ${renderMetadataRow("Confidence", confidence)}
+          ${renderMetadataRow("Confidence", formatConfidence(item.triageConfidence))}
           ${renderMetadataRow("Normalized title", item.normalizedTitle || "")}
           ${renderMetadataRow("Summary", item.triageSummary || "")}
           ${renderMetadataRow("Impact", item.impactSummary || "")}
@@ -424,6 +556,10 @@ function renderAdminFeedbackDetail() {
               ${renderMetadataRow("Reviewer", item.reviewer?.email || "")}
               ${renderMetadataRow("Reviewed at", item.reviewedAt ? formatDateTime(item.reviewedAt) : "")}
               ${renderMetadataRow("Promoted at", item.promotedAt ? formatDateTime(item.promotedAt) : "")}
+              ${renderMetadataRow("Automation decision", item.promotionDecision || "")}
+              ${renderMetadataRow("Decision reason", item.promotionReason || "")}
+              ${renderMetadataRow("Decision run", item.promotionRunId || "")}
+              ${renderMetadataRow("Decision time", item.promotionDecidedAt ? formatDateTime(item.promotionDecidedAt) : "")}
               ${renderMetadataRow("Page URL", item.pageUrl || "")}
               ${renderMetadataRow("App version", item.appVersion || "")}
               ${renderMetadataRow("Browser", item.userAgent || "")}
@@ -457,8 +593,21 @@ function renderAdminFeedbackWorkspace() {
   if (!ensureAdminWorkspaceShell()) {
     return;
   }
+  renderAutomationPanel();
   renderAdminFeedbackList();
   renderAdminFeedbackDetail();
+}
+
+function updateFeedbackItemInList(nextItem) {
+  const itemIndex = state.adminFeedbackItems.findIndex(
+    (item) => item.id === nextItem.id,
+  );
+  if (itemIndex >= 0) {
+    state.adminFeedbackItems[itemIndex] = {
+      ...state.adminFeedbackItems[itemIndex],
+      ...nextItem,
+    };
+  }
 }
 
 function buildQueryString() {
@@ -473,13 +622,69 @@ function buildQueryString() {
   return query ? `?${query}` : "";
 }
 
+export async function loadAdminFeedbackAutomationPanel() {
+  ensureAdminWorkspaceShell();
+  state.adminFeedbackAutomationConfigLoading = true;
+  state.adminFeedbackAutomationDecisionsLoading = true;
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const [configResponse, decisionsResponse] = await Promise.all([
+      hooks.apiCall(`${hooks.API_URL}/admin/feedback/automation/config`),
+      hooks.apiCall(`${hooks.API_URL}/admin/feedback/automation/decisions`),
+    ]);
+    const configData = configResponse
+      ? await hooks.parseApiBody(configResponse)
+      : {};
+    const decisionsData = decisionsResponse
+      ? await hooks.parseApiBody(decisionsResponse)
+      : {};
+
+    if (!configResponse?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        configData.error || "Failed to load feedback automation settings",
+        "error",
+      );
+      state.adminFeedbackAutomationConfig = null;
+    } else {
+      state.adminFeedbackAutomationConfig = configData;
+    }
+
+    if (!decisionsResponse?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        decisionsData.error || "Failed to load automation decisions",
+        "error",
+      );
+      state.adminFeedbackAutomationDecisions = [];
+    } else {
+      state.adminFeedbackAutomationDecisions = Array.isArray(decisionsData)
+        ? decisionsData
+        : [];
+    }
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+    state.adminFeedbackAutomationConfig = null;
+    state.adminFeedbackAutomationDecisions = [];
+  } finally {
+    state.adminFeedbackAutomationConfigLoading = false;
+    state.adminFeedbackAutomationDecisionsLoading = false;
+    renderAdminFeedbackWorkspace();
+  }
+}
+
 export async function selectAdminFeedback(feedbackId) {
   if (!feedbackId) {
     state.adminFeedbackSelectedId = "";
     state.adminFeedbackDetail = null;
     state.adminFeedbackPromotionPreview = null;
     state.adminFeedbackPromotionPreviewError = "";
-    renderAdminFeedbackDetail();
+    renderAdminFeedbackWorkspace();
     return;
   }
 
@@ -553,12 +758,10 @@ export async function loadAdminFeedbackQueue() {
     const selectedStillExists = state.adminFeedbackItems.some(
       (item) => item.id === state.adminFeedbackSelectedId,
     );
-    const nextSelectedId =
+    state.adminFeedbackSelectedId =
       (selectedStillExists && state.adminFeedbackSelectedId) ||
       state.adminFeedbackItems[0]?.id ||
       "";
-
-    state.adminFeedbackSelectedId = nextSelectedId;
     state.adminFeedbackDetail = null;
   } catch (error) {
     hooks.showMessage?.(
@@ -588,6 +791,120 @@ export function setAdminFeedbackFilter(kind, value) {
 
   state.adminFeedbackFilters[kind] = value || "";
   void loadAdminFeedbackQueue();
+}
+
+export async function saveAdminFeedbackAutomationConfig() {
+  const enabledField = document.getElementById(
+    "adminFeedbackAutomationEnabled",
+  );
+  const autoPromoteField = document.getElementById(
+    "adminFeedbackAutoPromoteEnabled",
+  );
+  const thresholdField = document.getElementById(
+    "adminFeedbackAutoPromoteMinConfidence",
+  );
+
+  if (
+    !(enabledField instanceof HTMLInputElement) ||
+    !(autoPromoteField instanceof HTMLInputElement) ||
+    !(thresholdField instanceof HTMLInputElement)
+  ) {
+    return;
+  }
+
+  state.adminFeedbackAutomationSaving = true;
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/automation/config`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feedbackAutomationEnabled: enabledField.checked,
+          feedbackAutoPromoteEnabled: autoPromoteField.checked,
+          feedbackAutoPromoteMinConfidence: Number.parseFloat(
+            thresholdField.value,
+          ),
+        }),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to save feedback automation settings",
+        "error",
+      );
+      return;
+    }
+
+    state.adminFeedbackAutomationConfig = data;
+    hooks.showMessage?.(
+      "adminMessage",
+      "Feedback automation settings updated",
+      "success",
+    );
+    renderAdminFeedbackWorkspace();
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  } finally {
+    state.adminFeedbackAutomationSaving = false;
+    renderAdminFeedbackWorkspace();
+  }
+}
+
+export async function runAdminFeedbackAutomation() {
+  state.adminFeedbackAutomationRunLoading = true;
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/automation/run`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ limit: 20 }),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to run feedback automation",
+        "error",
+      );
+      return;
+    }
+
+    hooks.showMessage?.(
+      "adminMessage",
+      data.skipped
+        ? data.reason || "Feedback automation skipped"
+        : `Automation processed ${data.processedCount} items`,
+      "success",
+    );
+    await Promise.all([
+      loadAdminFeedbackAutomationPanel(),
+      loadAdminFeedbackQueue(),
+    ]);
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  } finally {
+    state.adminFeedbackAutomationRunLoading = false;
+    renderAdminFeedbackWorkspace();
+  }
 }
 
 export async function updateAdminFeedbackStatus(status) {
@@ -638,7 +955,10 @@ export async function updateAdminFeedbackStatus(status) {
     }
 
     hooks.showMessage?.("adminMessage", `Feedback marked ${status}`, "success");
-    await loadAdminFeedbackQueue();
+    await Promise.all([
+      loadAdminFeedbackAutomationPanel(),
+      loadAdminFeedbackQueue(),
+    ]);
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",
@@ -673,17 +993,12 @@ export async function runAdminFeedbackTriage() {
 
     hooks.showMessage?.("adminMessage", "Feedback triage updated", "success");
     state.adminFeedbackDetail = data;
-    const itemIndex = state.adminFeedbackItems.findIndex(
-      (item) => item.id === data.id,
-    );
-    if (itemIndex >= 0) {
-      state.adminFeedbackItems[itemIndex] = {
-        ...state.adminFeedbackItems[itemIndex],
-        ...data,
-      };
-    }
+    updateFeedbackItemInList(data);
     renderAdminFeedbackWorkspace();
-    await loadAdminFeedbackPromotionPreview();
+    await Promise.all([
+      loadAdminFeedbackPromotionPreview(),
+      loadAdminFeedbackAutomationPanel(),
+    ]);
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",
@@ -719,7 +1034,10 @@ async function patchAdminFeedback(payload, successMessage) {
     }
 
     hooks.showMessage?.("adminMessage", successMessage, "success");
-    await loadAdminFeedbackQueue();
+    await Promise.all([
+      loadAdminFeedbackAutomationPanel(),
+      loadAdminFeedbackQueue(),
+    ]);
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",
@@ -796,8 +1114,12 @@ export async function runAdminFeedbackDuplicateCheck() {
       "success",
     );
     state.adminFeedbackDetail = data;
+    updateFeedbackItemInList(data);
     renderAdminFeedbackWorkspace();
-    await loadAdminFeedbackPromotionPreview();
+    await Promise.all([
+      loadAdminFeedbackPromotionPreview(),
+      loadAdminFeedbackAutomationPanel(),
+    ]);
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",
@@ -833,12 +1155,10 @@ export async function loadAdminFeedbackPromotionPreview() {
     }
 
     state.adminFeedbackPromotionPreview = data;
-    renderAdminFeedbackWorkspace();
   } catch (error) {
     state.adminFeedbackPromotionPreview = null;
     state.adminFeedbackPromotionPreviewError =
       "Network error while building promotion preview";
-    renderAdminFeedbackWorkspace();
   } finally {
     state.adminFeedbackPromotionPreviewLoading = false;
     renderAdminFeedbackWorkspace();
@@ -895,7 +1215,10 @@ export async function promoteAdminFeedback(ignoreDuplicateSuggestion = false) {
         : "Feedback promoted",
       "success",
     );
-    await loadAdminFeedbackQueue();
+    await Promise.all([
+      loadAdminFeedbackAutomationPanel(),
+      loadAdminFeedbackQueue(),
+    ]);
   } catch (error) {
     hooks.showMessage?.(
       "adminMessage",

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -163,6 +163,12 @@ export const state = {
   adminFeedbackPromotionPreview: null,
   adminFeedbackPromotionPreviewLoading: false,
   adminFeedbackPromotionPreviewError: "",
+  adminFeedbackAutomationConfig: null,
+  adminFeedbackAutomationConfigLoading: false,
+  adminFeedbackAutomationSaving: false,
+  adminFeedbackAutomationRunLoading: false,
+  adminFeedbackAutomationDecisions: [],
+  adminFeedbackAutomationDecisionsLoading: false,
 
   // AI
   aiSuggestions: [],

--- a/client/styles.css
+++ b/client/styles.css
@@ -3954,6 +3954,50 @@ body.is-todos-view .floating-new-task-cta {
   min-height: 100px;
 }
 
+.admin-automation-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 18px;
+}
+
+.admin-automation-form {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-automation-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-primary);
+}
+
+.admin-automation-toggle input {
+  inline-size: 16px;
+  block-size: 16px;
+}
+
+.admin-automation-decision-list {
+  display: grid;
+  gap: 10px;
+}
+
+.admin-automation-decision {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  border-radius: var(--r-md);
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+  display: grid;
+  gap: 10px;
+}
+
+.admin-automation-decision:hover {
+  border-color: var(--accent);
+}
+
 .users-table {
   width: 100%;
   border-collapse: collapse;
@@ -4067,6 +4111,10 @@ body.is-todos-view .floating-new-task-cta {
   }
 
   .admin-feedback-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-automation-grid {
     grid-template-columns: 1fr;
   }
 

--- a/prisma/migrations/20260321043000_add_feedback_auto_promotion/migration.sql
+++ b/prisma/migrations/20260321043000_add_feedback_auto_promotion/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "feedback_requests"
+ADD COLUMN "promotion_decision" VARCHAR(20),
+ADD COLUMN "promotion_reason" TEXT,
+ADD COLUMN "promotion_run_id" VARCHAR(120),
+ADD COLUMN "promotion_decided_at" TIMESTAMP(3);
+
+CREATE INDEX "feedback_requests_promotion_decision_promotion_decided_at_idx"
+ON "feedback_requests"("promotion_decision", "promotion_decided_at");
+
+CREATE INDEX "feedback_requests_promotion_run_id_idx"
+ON "feedback_requests"("promotion_run_id");
+
+ALTER TABLE "agent_configs"
+ADD COLUMN "feedback_automation_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "feedback_auto_promote_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "feedback_auto_promote_min_confidence" DOUBLE PRECISION NOT NULL DEFAULT 0.9;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -507,6 +507,10 @@ model FeedbackRequest {
   githubIssueNumber  Int?           @map("github_issue_number")
   githubIssueUrl     String?        @map("github_issue_url") @db.VarChar(2000)
   promotedAt         DateTime?      @map("promoted_at")
+  promotionDecision  String?        @map("promotion_decision") @db.VarChar(20)
+  promotionReason    String?        @map("promotion_reason") @db.Text
+  promotionRunId     String?        @map("promotion_run_id") @db.VarChar(120)
+  promotionDecidedAt DateTime?      @map("promotion_decided_at")
   reviewedAt         DateTime?      @map("reviewed_at")
   rejectionReason    String?        @map("rejection_reason") @db.Text
   createdAt          DateTime       @default(now()) @map("created_at")
@@ -525,6 +529,8 @@ model FeedbackRequest {
   @@index([duplicateOfFeedbackId])
   @@index([duplicateOfGithubIssueNumber])
   @@index([promotedAt])
+  @@index([promotionDecision, promotionDecidedAt])
+  @@index([promotionRunId])
   @@map("feedback_requests")
 }
 
@@ -642,6 +648,9 @@ model AgentConfig {
   inboxEnabled             Boolean  @default(true) @map("inbox_enabled")
   watchdogEnabled          Boolean  @default(true) @map("watchdog_enabled")
   decomposerEnabled        Boolean  @default(true) @map("decomposer_enabled")
+  feedbackAutomationEnabled Boolean @default(false) @map("feedback_automation_enabled")
+  feedbackAutoPromoteEnabled Boolean @default(false) @map("feedback_auto_promote_enabled")
+  feedbackAutoPromoteMinConfidence Float @default(0.9) @map("feedback_auto_promote_min_confidence")
   autoApply                Boolean  @default(false) @map("auto_apply")
   maxWriteActionsPerRun    Int      @default(20) @map("max_write_actions_per_run")
   inboxConfidenceThreshold Float    @default(0.9) @map("inbox_confidence_threshold")

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ import { FeedbackService } from "./services/feedbackService";
 import { FeedbackDuplicateService } from "./services/feedbackDuplicateService";
 import { FeedbackPromotionService } from "./services/feedbackPromotionService";
 import { FeedbackTriageService } from "./services/feedbackTriageService";
+import { FeedbackAutomationService } from "./services/feedbackAutomationService";
 import { createFeedbackRouter } from "./routes/feedbackRouter";
 import { AgentEnrollmentService } from "./services/agentEnrollmentService";
 import {
@@ -102,6 +103,13 @@ export function createApp(
     ? new FeedbackPromotionService(persistencePrisma, {
         feedbackService: feedbackService ?? undefined,
         feedbackDuplicateService: feedbackDuplicateService ?? undefined,
+      })
+    : null;
+  const feedbackAutomationService = persistencePrisma
+    ? new FeedbackAutomationService(persistencePrisma, {
+        feedbackService: feedbackService ?? undefined,
+        feedbackDuplicateService: feedbackDuplicateService ?? undefined,
+        feedbackPromotionService: feedbackPromotionService ?? undefined,
       })
     : null;
 
@@ -272,6 +280,7 @@ export function createApp(
       feedbackTriageService: feedbackTriageService ?? undefined,
       feedbackDuplicateService: feedbackDuplicateService ?? undefined,
       feedbackPromotionService: feedbackPromotionService ?? undefined,
+      feedbackAutomationService: feedbackAutomationService ?? undefined,
     }),
   );
   app.use("/users", createUsersRouter({ authService }));

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -636,6 +636,217 @@ describe("Feedback API Integration", () => {
     });
   });
 
+  it("GET and PATCH /admin/feedback/automation/config manage auto-promotion settings", async () => {
+    const initial = await request(app)
+      .get("/admin/feedback/automation/config")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(initial.body).toEqual({
+      feedbackAutomationEnabled: false,
+      feedbackAutoPromoteEnabled: false,
+      feedbackAutoPromoteMinConfidence: 0.9,
+      allowlistedClassifications: ["bug", "feature"],
+    });
+
+    const updated = await request(app)
+      .patch("/admin/feedback/automation/config")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({
+        feedbackAutomationEnabled: true,
+        feedbackAutoPromoteEnabled: true,
+        feedbackAutoPromoteMinConfidence: 0.94,
+      })
+      .expect(200);
+
+    expect(updated.body).toEqual({
+      feedbackAutomationEnabled: true,
+      feedbackAutoPromoteEnabled: true,
+      feedbackAutoPromoteMinConfidence: 0.94,
+      allowlistedClassifications: ["bug", "feature"],
+    });
+  });
+
+  it("POST /admin/feedback/automation/run auto-promotes high-confidence non-duplicate feedback and exposes the decision feed", async () => {
+    await prisma.agentConfig.upsert({
+      where: { userId: adminUserId },
+      create: {
+        userId: adminUserId,
+        feedbackAutomationEnabled: true,
+        feedbackAutoPromoteEnabled: true,
+        feedbackAutoPromoteMinConfidence: 0.9,
+      },
+      update: {
+        feedbackAutomationEnabled: true,
+        feedbackAutoPromoteEnabled: true,
+        feedbackAutoPromoteMinConfidence: 0.9,
+      },
+    });
+
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "bug",
+        title: "Task drawer crashes",
+        body: "raw bug report",
+        status: "triaged",
+        classification: "bug",
+        triageConfidence: 0.96,
+        normalizedTitle: "Task drawer crashes on save",
+        normalizedBody:
+          "Saving from the task drawer crashes the current editing session.",
+        impactSummary: "Users cannot save edits from the task drawer.",
+        expectedBehavior: "The task should save normally.",
+        actualBehavior: "The task drawer crashes and loses the draft.",
+        reproStepsJson: ["Open the task drawer", "Edit notes", "Press save"],
+        agentLabelsJson: ["ui"],
+      },
+    });
+
+    global.fetch = jest.fn(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/search/issues")) {
+        return {
+          ok: true,
+          json: async () => ({
+            items: [],
+          }),
+        } as Response;
+      }
+      if (url.endsWith("/repos/karthikg80/todos-api/issues")) {
+        expect(init?.method).toBe("POST");
+        return {
+          ok: true,
+          json: async () => ({
+            number: 700,
+            html_url: "https://github.com/karthikg80/todos-api/issues/700",
+          }),
+        } as Response;
+      }
+      if (url.endsWith("/repos/karthikg80/todos-api/issues/700/labels")) {
+        return {
+          ok: true,
+          json: async () => [
+            { name: "bug" },
+            { name: "triaged-by-agent" },
+            { name: "ui" },
+          ],
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    const response = await request(app)
+      .post("/admin/feedback/automation/run")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ limit: 10 })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      jobName: "feedback_auto_promotion",
+      claimed: true,
+      skipped: false,
+      processedCount: 1,
+      promotedCount: 1,
+      reviewCount: 0,
+      decisions: [
+        {
+          id: feedback.id,
+          promotionDecision: "promoted",
+          githubIssueNumber: 700,
+        },
+      ],
+    });
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+
+    expect(persisted).toMatchObject({
+      status: "promoted",
+      githubIssueNumber: 700,
+      promotionDecision: "promoted",
+      promotionRunId: response.body.runId,
+    });
+    expect(persisted?.promotionReason).toContain("Auto-promoted");
+    expect(persisted?.promotionDecidedAt).not.toBeNull();
+
+    const decisionsResponse = await request(app)
+      .get("/admin/feedback/automation/decisions")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(decisionsResponse.body[0]).toMatchObject({
+      id: feedback.id,
+      promotionDecision: "promoted",
+      githubIssueNumber: 700,
+    });
+  });
+
+  it("POST /admin/feedback/automation/run keeps low-confidence feedback in review", async () => {
+    await prisma.agentConfig.upsert({
+      where: { userId: adminUserId },
+      create: {
+        userId: adminUserId,
+        feedbackAutomationEnabled: true,
+        feedbackAutoPromoteEnabled: true,
+        feedbackAutoPromoteMinConfidence: 0.95,
+      },
+      update: {
+        feedbackAutomationEnabled: true,
+        feedbackAutoPromoteEnabled: true,
+        feedbackAutoPromoteMinConfidence: 0.95,
+      },
+    });
+
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Add planning bundles",
+        body: "raw feature request",
+        status: "triaged",
+        classification: "feature",
+        triageConfidence: 0.78,
+        normalizedTitle: "Add planning bundles",
+        normalizedBody:
+          "Users need a bundled planning flow to reduce manual setup.",
+        impactSummary: "Weekly planning takes too many manual steps.",
+        proposedOutcome: "Offer suggested planning bundles.",
+      },
+    });
+
+    const response = await request(app)
+      .post("/admin/feedback/automation/run")
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ limit: 10 })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      processedCount: 1,
+      promotedCount: 0,
+      reviewCount: 1,
+      decisions: [
+        {
+          id: feedback.id,
+          promotionDecision: "review",
+        },
+      ],
+    });
+
+    const persisted = await prisma.feedbackRequest.findUnique({
+      where: { id: feedback.id },
+    });
+    expect(persisted).toMatchObject({
+      status: "triaged",
+      promotionDecision: "review",
+      githubIssueNumber: null,
+    });
+    expect(persisted?.promotionReason).toContain(
+      "below the auto-promotion threshold",
+    );
+  });
+
   it("GET /admin/feedback returns 403 for non-admin users", async () => {
     await request(app)
       .get("/admin/feedback")
@@ -700,6 +911,17 @@ describe("Feedback API Integration", () => {
 
     await request(app)
       .post(`/admin/feedback/${feedback.id}/promote`)
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({})
+      .expect(403)
+      .expect({
+        error: "Forbidden: Admin access required",
+      });
+  });
+
+  it("POST /admin/feedback/automation/run returns 403 for non-admin users", async () => {
+    await request(app)
+      .post("/admin/feedback/automation/run")
       .set("Authorization", `Bearer ${authToken}`)
       .send({})
       .expect(403)

--- a/src/feedbackAutomationService.test.ts
+++ b/src/feedbackAutomationService.test.ts
@@ -1,0 +1,242 @@
+import { FeedbackAutomationService } from "./services/feedbackAutomationService";
+
+describe("FeedbackAutomationService", () => {
+  const baseConfig = {
+    id: "config-1",
+    userId: "admin-1",
+    dailyEnabled: true,
+    weeklyEnabled: true,
+    inboxEnabled: true,
+    watchdogEnabled: true,
+    decomposerEnabled: true,
+    feedbackAutomationEnabled: true,
+    feedbackAutoPromoteEnabled: true,
+    feedbackAutoPromoteMinConfidence: 0.9,
+    autoApply: false,
+    maxWriteActionsPerRun: 20,
+    inboxConfidenceThreshold: 0.9,
+    staleThresholdDays: 14,
+    waitingFollowUpDays: 7,
+    plannerWeightPriority: 1,
+    plannerWeightDueDate: 1,
+    plannerWeightEnergyMatch: 1,
+    plannerWeightEstimateFit: 1,
+    plannerWeightFreshness: 1,
+    createdAt: new Date("2026-03-21T03:00:00.000Z"),
+    updatedAt: new Date("2026-03-21T03:00:00.000Z"),
+  };
+
+  const eligibleCandidate = {
+    id: "feedback-1",
+    title: "Task drawer crashes on save",
+    type: "bug" as const,
+    status: "triaged" as const,
+    classification: "bug" as const,
+    triageConfidence: 0.96,
+    normalizedTitle: "Task drawer crashes on save",
+    normalizedBody:
+      "Saving from the task drawer crashes the current editing session.",
+    impactSummary: "Users cannot save edits from the task drawer.",
+    reproStepsJson: ["Open the task drawer", "Edit notes", "Press save"],
+    expectedBehavior: "The task should save normally.",
+    actualBehavior: "The task drawer crashes and loses the draft.",
+    proposedOutcome: "Stabilize drawer save handling.",
+    duplicateCandidate: false,
+    duplicateOfFeedbackId: null,
+    duplicateOfGithubIssueNumber: null,
+    githubIssueNumber: null,
+    githubIssueUrl: null,
+    promotionDecision: null,
+    promotionReason: null,
+    promotionRunId: null,
+    promotionDecidedAt: null,
+  };
+
+  it("auto-promotes eligible triaged feedback", async () => {
+    const claimRun = jest.fn().mockResolvedValue({
+      claimed: true,
+      run: { id: "run-1" },
+    });
+    const completeRun = jest.fn().mockResolvedValue(true);
+    const promoteFeedback = jest.fn().mockResolvedValue({
+      issueNumber: 512,
+      issueUrl: "https://github.com/karthikg80/todos-api/issues/512",
+    });
+    const recordPromotionDecision = jest.fn().mockResolvedValue({
+      ...eligibleCandidate,
+      status: "promoted",
+      promotionDecision: "promoted",
+      promotionReason:
+        "Auto-promoted after passing confidence and duplicate checks",
+      promotionRunId: "run-1",
+      promotionDecidedAt: new Date("2026-03-21T03:05:00.000Z"),
+      githubIssueNumber: 512,
+      githubIssueUrl: "https://github.com/karthikg80/todos-api/issues/512",
+      user: { id: "user-1", email: "user@example.com", name: "User" },
+      reviewer: { id: "admin-1", email: "admin@example.com", name: "Admin" },
+      userId: "user-1",
+      body: "raw",
+      screenshotUrl: null,
+      attachmentMetadata: null,
+      pageUrl: null,
+      userAgent: null,
+      appVersion: null,
+      agentLabels: [],
+      missingInfo: [],
+      triageSummary: null,
+      severity: null,
+      dedupeKey: null,
+      matchedFeedbackIds: [],
+      matchedGithubIssueNumber: null,
+      matchedGithubIssueUrl: null,
+      duplicateOfGithubIssueUrl: null,
+      promotedAt: "2026-03-21T03:05:00.000Z",
+      reviewedByUserId: "admin-1",
+      reviewedAt: "2026-03-21T03:05:00.000Z",
+      rejectionReason: null,
+      createdAt: "2026-03-21T03:00:00.000Z",
+      updatedAt: "2026-03-21T03:05:00.000Z",
+    });
+
+    const service = new FeedbackAutomationService(
+      {
+        feedbackRequest: {
+          findMany: jest.fn().mockResolvedValue([eligibleCandidate]),
+        },
+      } as never,
+      {
+        agentConfigService: {
+          getConfig: jest.fn().mockResolvedValue(baseConfig),
+        } as never,
+        agentJobRunService: {
+          claimRun,
+          completeRun,
+          failRun: jest.fn(),
+        } as never,
+        agentAuditService: {
+          record: jest.fn().mockResolvedValue(undefined),
+        } as never,
+        feedbackDuplicateService: {
+          detectAndPersist: jest.fn().mockResolvedValue({
+            duplicateCandidate: false,
+            matchedFeedbackIds: [],
+            matchedGithubIssueNumber: null,
+            matchedGithubIssueUrl: null,
+            duplicateReason: null,
+          }),
+        } as never,
+        feedbackPromotionService: {
+          promoteFeedback,
+        } as never,
+        feedbackService: {
+          recordPromotionDecision,
+        } as never,
+      },
+    );
+
+    const result = await service.runAutoPromotion("admin-1", { limit: 10 });
+
+    expect(result.claimed).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(result.promotedCount).toBe(1);
+    expect(result.reviewCount).toBe(0);
+    expect(promoteFeedback).toHaveBeenCalledWith("feedback-1", "admin-1");
+    expect(recordPromotionDecision).toHaveBeenCalledWith(
+      "feedback-1",
+      expect.objectContaining({
+        promotionDecision: "promoted",
+        promotionRunId: "run-1",
+      }),
+    );
+    expect(completeRun).toHaveBeenCalled();
+  });
+
+  it("routes low-confidence feedback to human review", async () => {
+    const reviewCandidate = {
+      ...eligibleCandidate,
+      id: "feedback-2",
+      triageConfidence: 0.74,
+    };
+    const promoteFeedback = jest.fn();
+    const recordPromotionDecision = jest.fn().mockResolvedValue({
+      ...reviewCandidate,
+      promotionDecision: "review",
+      promotionReason:
+        "Triage confidence 0.74 is below the auto-promotion threshold",
+      promotionRunId: "run-2",
+      promotionDecidedAt: new Date("2026-03-21T03:10:00.000Z"),
+      user: { id: "user-1", email: "user@example.com", name: "User" },
+      reviewer: null,
+      userId: "user-1",
+      body: "raw",
+      screenshotUrl: null,
+      attachmentMetadata: null,
+      pageUrl: null,
+      userAgent: null,
+      appVersion: null,
+      agentLabels: [],
+      missingInfo: [],
+      triageSummary: null,
+      severity: null,
+      dedupeKey: null,
+      matchedFeedbackIds: [],
+      matchedGithubIssueNumber: null,
+      matchedGithubIssueUrl: null,
+      duplicateOfGithubIssueUrl: null,
+      promotedAt: null,
+      reviewedByUserId: null,
+      reviewedAt: null,
+      rejectionReason: null,
+      createdAt: "2026-03-21T03:00:00.000Z",
+      updatedAt: "2026-03-21T03:10:00.000Z",
+    });
+
+    const service = new FeedbackAutomationService(
+      {
+        feedbackRequest: {
+          findMany: jest.fn().mockResolvedValue([reviewCandidate]),
+        },
+      } as never,
+      {
+        agentConfigService: {
+          getConfig: jest.fn().mockResolvedValue({
+            ...baseConfig,
+            feedbackAutoPromoteMinConfidence: 0.9,
+          }),
+        } as never,
+        agentJobRunService: {
+          claimRun: jest.fn().mockResolvedValue({
+            claimed: true,
+            run: { id: "run-2" },
+          }),
+          completeRun: jest.fn().mockResolvedValue(true),
+          failRun: jest.fn(),
+        } as never,
+        agentAuditService: {
+          record: jest.fn().mockResolvedValue(undefined),
+        } as never,
+        feedbackDuplicateService: {
+          detectAndPersist: jest.fn(),
+        } as never,
+        feedbackPromotionService: {
+          promoteFeedback,
+        } as never,
+        feedbackService: {
+          recordPromotionDecision,
+        } as never,
+      },
+    );
+
+    const result = await service.runAutoPromotion("admin-1", { limit: 10 });
+
+    expect(result.promotedCount).toBe(0);
+    expect(result.reviewCount).toBe(1);
+    expect(promoteFeedback).not.toHaveBeenCalled();
+    expect(recordPromotionDecision).toHaveBeenCalledWith(
+      "feedback-2",
+      expect.objectContaining({
+        promotionDecision: "review",
+      }),
+    );
+  });
+});

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -8,9 +8,13 @@ import {
 } from "../services/feedbackDuplicateService";
 import { FeedbackPromotionService } from "../services/feedbackPromotionService";
 import { FeedbackTriageService } from "../services/feedbackTriageService";
+import { FeedbackAutomationService } from "../services/feedbackAutomationService";
 import {
+  validateFeedbackAutomationDecisionLimit,
   validateListAdminFeedbackRequestsQuery,
   validatePromoteFeedbackRequest,
+  validateRunFeedbackAutomationRequest,
+  validateUpdateFeedbackAutomationConfig,
   validateUpdateAdminFeedbackRequest,
 } from "../validation/validation";
 
@@ -20,6 +24,7 @@ interface AdminRouterDeps {
   feedbackTriageService?: FeedbackTriageService;
   feedbackDuplicateService?: FeedbackDuplicateService;
   feedbackPromotionService?: FeedbackPromotionService;
+  feedbackAutomationService?: FeedbackAutomationService;
 }
 
 export function createAdminRouter({
@@ -28,6 +33,7 @@ export function createAdminRouter({
   feedbackTriageService,
   feedbackDuplicateService,
   feedbackPromotionService,
+  feedbackAutomationService,
 }: AdminRouterDeps): Router {
   const router = Router();
 
@@ -124,6 +130,101 @@ export function createAdminRouter({
           return next(new HttpError(400, "Invalid user ID format"));
         }
         return next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/feedback/automation/config",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackAutomationService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback automation not configured" });
+      }
+
+      try {
+        const userId = req.user?.userId;
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+        const automationConfig =
+          await feedbackAutomationService.getConfig(userId);
+        res.json(automationConfig);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.patch(
+    "/feedback/automation/config",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackAutomationService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback automation not configured" });
+      }
+
+      try {
+        const userId = req.user?.userId;
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+        const update = validateUpdateFeedbackAutomationConfig(req.body);
+        const automationConfig = await feedbackAutomationService.updateConfig(
+          userId,
+          update,
+        );
+        res.json(automationConfig);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/feedback/automation/decisions",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackAutomationService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback automation not configured" });
+      }
+
+      try {
+        const limit = validateFeedbackAutomationDecisionLimit(req.query.limit);
+        const decisions =
+          await feedbackAutomationService.listRecentDecisions(limit);
+        res.json(decisions);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    "/feedback/automation/run",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackAutomationService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback automation not configured" });
+      }
+
+      try {
+        const userId = req.user?.userId;
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+        const input = validateRunFeedbackAutomationRequest(req.body);
+        const result = await feedbackAutomationService.runAutoPromotion(
+          userId,
+          input,
+        );
+        res.json(result);
+      } catch (error) {
+        next(error);
       }
     },
   );

--- a/src/services/agentConfigService.ts
+++ b/src/services/agentConfigService.ts
@@ -8,6 +8,9 @@ export interface AgentConfigRecord {
   inboxEnabled: boolean;
   watchdogEnabled: boolean;
   decomposerEnabled: boolean;
+  feedbackAutomationEnabled: boolean;
+  feedbackAutoPromoteEnabled: boolean;
+  feedbackAutoPromoteMinConfidence: number;
   autoApply: boolean;
   maxWriteActionsPerRun: number;
   inboxConfidenceThreshold: number;
@@ -72,6 +75,9 @@ export class AgentConfigService {
       inboxEnabled: true,
       watchdogEnabled: true,
       decomposerEnabled: true,
+      feedbackAutomationEnabled: false,
+      feedbackAutoPromoteEnabled: false,
+      feedbackAutoPromoteMinConfidence: 0.9,
       autoApply: false,
       maxWriteActionsPerRun: 20,
       inboxConfidenceThreshold: 0.9,
@@ -96,6 +102,9 @@ export class AgentConfigService {
       inboxEnabled: r.inboxEnabled,
       watchdogEnabled: r.watchdogEnabled,
       decomposerEnabled: r.decomposerEnabled,
+      feedbackAutomationEnabled: r.feedbackAutomationEnabled,
+      feedbackAutoPromoteEnabled: r.feedbackAutoPromoteEnabled,
+      feedbackAutoPromoteMinConfidence: r.feedbackAutoPromoteMinConfidence,
       autoApply: r.autoApply,
       maxWriteActionsPerRun: r.maxWriteActionsPerRun,
       inboxConfidenceThreshold: r.inboxConfidenceThreshold,

--- a/src/services/feedbackAutomationService.ts
+++ b/src/services/feedbackAutomationService.ts
@@ -1,0 +1,523 @@
+import { PrismaClient } from "@prisma/client";
+import {
+  FeedbackAutomationConfigDto,
+  FeedbackAutomationDecision,
+  FeedbackAutomationDecisionDto,
+  FeedbackAutomationRunResultDto,
+  FeedbackTriageClassification,
+  RunFeedbackAutomationRequestDto,
+  UpdateFeedbackAutomationConfigDto,
+} from "../types";
+import { AgentConfigRecord, AgentConfigService } from "./agentConfigService";
+import { AgentAuditService } from "./agentAuditService";
+import { AgentJobRunService } from "./agentJobRunService";
+import { FeedbackDuplicateService } from "./feedbackDuplicateService";
+import { FeedbackPromotionService } from "./feedbackPromotionService";
+import { FeedbackService } from "./feedbackService";
+
+const AUTO_PROMOTION_JOB_NAME = "feedback_auto_promotion";
+const ALLOWLISTED_CLASSIFICATIONS: Array<"bug" | "feature"> = [
+  "bug",
+  "feature",
+];
+
+type AutomationCandidateRecord = {
+  id: string;
+  title: string;
+  type: "bug" | "feature" | "general";
+  status: "new" | "triaged" | "promoted" | "rejected";
+  classification: FeedbackTriageClassification | null;
+  triageConfidence?: number | null;
+  normalizedTitle: string | null;
+  normalizedBody: string | null;
+  impactSummary: string | null;
+  reproStepsJson: unknown;
+  expectedBehavior: string | null;
+  actualBehavior: string | null;
+  proposedOutcome: string | null;
+  duplicateCandidate: boolean;
+  duplicateOfFeedbackId: string | null;
+  duplicateOfGithubIssueNumber: number | null;
+  githubIssueNumber: number | null;
+  githubIssueUrl: string | null;
+  promotionDecision: string | null;
+  promotionReason: string | null;
+  promotionRunId: string | null;
+  promotionDecidedAt: Date | null;
+};
+
+export interface FeedbackAutomationServiceDeps {
+  agentConfigService?: AgentConfigService;
+  agentAuditService?: AgentAuditService;
+  agentJobRunService?: AgentJobRunService;
+  feedbackDuplicateService?: FeedbackDuplicateService;
+  feedbackPromotionService?: FeedbackPromotionService;
+  feedbackService?: FeedbackService;
+}
+
+function toConfigDto(config: AgentConfigRecord): FeedbackAutomationConfigDto {
+  return {
+    feedbackAutomationEnabled: config.feedbackAutomationEnabled,
+    feedbackAutoPromoteEnabled: config.feedbackAutoPromoteEnabled,
+    feedbackAutoPromoteMinConfidence: config.feedbackAutoPromoteMinConfidence,
+    allowlistedClassifications: [...ALLOWLISTED_CLASSIFICATIONS],
+  };
+}
+
+function toDecisionDto(record: {
+  id: string;
+  title: string;
+  type: "bug" | "feature" | "general";
+  status: "new" | "triaged" | "promoted" | "rejected";
+  classification?: FeedbackTriageClassification | null;
+  triageConfidence?: number | null;
+  promotionDecision?: string | null;
+  promotionReason?: string | null;
+  promotionRunId?: string | null;
+  promotionDecidedAt?: Date | string | null;
+  githubIssueNumber?: number | null;
+  githubIssueUrl?: string | null;
+}): FeedbackAutomationDecisionDto | null {
+  if (
+    !record.promotionDecidedAt ||
+    (record.promotionDecision !== "review" &&
+      record.promotionDecision !== "promoted")
+  ) {
+    return null;
+  }
+
+  const decidedAt =
+    record.promotionDecidedAt instanceof Date
+      ? record.promotionDecidedAt
+      : new Date(record.promotionDecidedAt);
+  if (Number.isNaN(decidedAt.getTime())) {
+    return null;
+  }
+
+  return {
+    id: record.id,
+    title: record.title,
+    type: record.type,
+    status: record.status,
+    classification: record.classification ?? null,
+    triageConfidence: record.triageConfidence,
+    promotionDecision: record.promotionDecision,
+    promotionReason: record.promotionReason,
+    promotionRunId: record.promotionRunId,
+    promotionDecidedAt: decidedAt.toISOString(),
+    githubIssueNumber: record.githubIssueNumber,
+    githubIssueUrl: record.githubIssueUrl,
+  };
+}
+
+function buildRunPeriodKey(now: Date): string {
+  return now.toISOString().slice(0, 16);
+}
+
+export class FeedbackAutomationService {
+  private readonly agentConfigService: AgentConfigService;
+  private readonly agentAuditService: AgentAuditService;
+  private readonly agentJobRunService: AgentJobRunService;
+  private readonly feedbackDuplicateService: FeedbackDuplicateService;
+  private readonly feedbackPromotionService: FeedbackPromotionService;
+  private readonly feedbackService: FeedbackService;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    deps: FeedbackAutomationServiceDeps = {},
+  ) {
+    this.agentConfigService =
+      deps.agentConfigService ?? new AgentConfigService(prisma);
+    this.agentAuditService =
+      deps.agentAuditService ?? new AgentAuditService(prisma);
+    this.agentJobRunService =
+      deps.agentJobRunService ?? new AgentJobRunService(prisma);
+    this.feedbackDuplicateService =
+      deps.feedbackDuplicateService ?? new FeedbackDuplicateService(prisma);
+    this.feedbackService = deps.feedbackService ?? new FeedbackService(prisma);
+    this.feedbackPromotionService =
+      deps.feedbackPromotionService ??
+      new FeedbackPromotionService(prisma, {
+        feedbackService: this.feedbackService,
+        feedbackDuplicateService: this.feedbackDuplicateService,
+      });
+  }
+
+  async getConfig(userId: string): Promise<FeedbackAutomationConfigDto> {
+    const config = await this.agentConfigService.getConfig(userId);
+    return toConfigDto(config);
+  }
+
+  async updateConfig(
+    userId: string,
+    update: UpdateFeedbackAutomationConfigDto,
+  ): Promise<FeedbackAutomationConfigDto> {
+    const config = await this.agentConfigService.updateConfig(userId, update);
+    return toConfigDto(config);
+  }
+
+  async listRecentDecisions(
+    limit = 10,
+  ): Promise<FeedbackAutomationDecisionDto[]> {
+    const records = await this.prisma.feedbackRequest.findMany({
+      where: {
+        promotionDecision: {
+          not: null,
+        },
+        promotionDecidedAt: {
+          not: null,
+        },
+      },
+      orderBy: [
+        {
+          promotionDecidedAt: "desc",
+        },
+      ],
+      take: limit,
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        status: true,
+        classification: true,
+        triageConfidence: true,
+        promotionDecision: true,
+        promotionReason: true,
+        promotionRunId: true,
+        promotionDecidedAt: true,
+        githubIssueNumber: true,
+        githubIssueUrl: true,
+      },
+    });
+
+    return records.flatMap((record) => {
+      const decision = toDecisionDto(record);
+      return decision ? [decision] : [];
+    });
+  }
+
+  async runAutoPromotion(
+    userId: string,
+    input: RunFeedbackAutomationRequestDto = {},
+  ): Promise<FeedbackAutomationRunResultDto> {
+    const config = await this.agentConfigService.getConfig(userId);
+    const periodKey = buildRunPeriodKey(new Date());
+
+    if (!config.feedbackAutomationEnabled) {
+      return {
+        jobName: AUTO_PROMOTION_JOB_NAME,
+        periodKey,
+        runId: null,
+        claimed: false,
+        skipped: true,
+        reason: "Feedback automation is disabled",
+        processedCount: 0,
+        promotedCount: 0,
+        reviewCount: 0,
+        decisions: [],
+      };
+    }
+
+    const { claimed, run } = await this.agentJobRunService.claimRun(
+      userId,
+      AUTO_PROMOTION_JOB_NAME,
+      periodKey,
+    );
+    if (!claimed) {
+      return {
+        jobName: AUTO_PROMOTION_JOB_NAME,
+        periodKey,
+        runId: null,
+        claimed: false,
+        skipped: true,
+        reason: "An automation run is already in progress for this period",
+        processedCount: 0,
+        promotedCount: 0,
+        reviewCount: 0,
+        decisions: [],
+      };
+    }
+
+    try {
+      const candidates = await this.loadCandidates(input.limit ?? 20);
+      const decisions: FeedbackAutomationDecisionDto[] = [];
+
+      for (const candidate of candidates) {
+        const decision = await this.processCandidate(
+          candidate,
+          userId,
+          config,
+          run?.id ?? null,
+        );
+        decisions.push(decision);
+      }
+
+      const result: FeedbackAutomationRunResultDto = {
+        jobName: AUTO_PROMOTION_JOB_NAME,
+        periodKey,
+        runId: run?.id ?? null,
+        claimed: true,
+        skipped: false,
+        reason: null,
+        processedCount: decisions.length,
+        promotedCount: decisions.filter(
+          (decision) => decision.promotionDecision === "promoted",
+        ).length,
+        reviewCount: decisions.filter(
+          (decision) => decision.promotionDecision === "review",
+        ).length,
+        decisions,
+      };
+
+      await this.agentJobRunService.completeRun(
+        userId,
+        AUTO_PROMOTION_JOB_NAME,
+        periodKey,
+        result,
+      );
+      await this.agentAuditService.record({
+        surface: "agent",
+        action: AUTO_PROMOTION_JOB_NAME,
+        readOnly: false,
+        outcome: "success",
+        status: 200,
+        userId,
+        requestId: `feedback-auto-${periodKey}`,
+        actor: "feedback-automation",
+        jobName: AUTO_PROMOTION_JOB_NAME,
+        jobPeriodKey: periodKey,
+        triggeredBy: "automation",
+      });
+
+      return result;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Feedback automation failed";
+      await this.agentJobRunService.failRun(
+        userId,
+        AUTO_PROMOTION_JOB_NAME,
+        periodKey,
+        message,
+      );
+      await this.agentAuditService.record({
+        surface: "agent",
+        action: AUTO_PROMOTION_JOB_NAME,
+        readOnly: false,
+        outcome: "error",
+        status: 500,
+        userId,
+        requestId: `feedback-auto-${periodKey}`,
+        actor: "feedback-automation",
+        errorCode: "FEEDBACK_AUTOMATION_FAILED",
+        jobName: AUTO_PROMOTION_JOB_NAME,
+        jobPeriodKey: periodKey,
+        triggeredBy: "automation",
+      });
+      throw error;
+    }
+  }
+
+  private async loadCandidates(
+    limit: number,
+  ): Promise<AutomationCandidateRecord[]> {
+    return this.prisma.feedbackRequest.findMany({
+      where: {
+        status: "triaged",
+        githubIssueNumber: null,
+      },
+      orderBy: [{ createdAt: "asc" }],
+      take: limit,
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        status: true,
+        classification: true,
+        triageConfidence: true,
+        normalizedTitle: true,
+        normalizedBody: true,
+        impactSummary: true,
+        reproStepsJson: true,
+        expectedBehavior: true,
+        actualBehavior: true,
+        proposedOutcome: true,
+        duplicateCandidate: true,
+        duplicateOfFeedbackId: true,
+        duplicateOfGithubIssueNumber: true,
+        githubIssueNumber: true,
+        githubIssueUrl: true,
+        promotionDecision: true,
+        promotionReason: true,
+        promotionRunId: true,
+        promotionDecidedAt: true,
+      },
+    });
+  }
+
+  private async processCandidate(
+    record: AutomationCandidateRecord,
+    reviewerUserId: string,
+    config: AgentConfigRecord,
+    runId: string | null,
+  ): Promise<FeedbackAutomationDecisionDto> {
+    const blockedReason = this.getReviewReason(record, config);
+    if (blockedReason) {
+      return this.persistDecision(record.id, {
+        decision: "review",
+        reason: blockedReason,
+        runId,
+      });
+    }
+
+    const duplicateAssessment =
+      await this.feedbackDuplicateService.detectAndPersist(record.id);
+    if (duplicateAssessment.duplicateCandidate) {
+      return this.persistDecision(record.id, {
+        decision: "review",
+        reason:
+          duplicateAssessment.duplicateReason ||
+          "Duplicate candidate found during auto-promotion",
+        runId,
+      });
+    }
+
+    if (!config.feedbackAutoPromoteEnabled) {
+      return this.persistDecision(record.id, {
+        decision: "review",
+        reason: "Auto-promote is disabled; kept in the review queue",
+        runId,
+      });
+    }
+
+    try {
+      await this.feedbackPromotionService.promoteFeedback(
+        record.id,
+        reviewerUserId,
+      );
+      return this.persistDecision(record.id, {
+        decision: "promoted",
+        reason: "Auto-promoted after passing confidence and duplicate checks",
+        runId,
+      });
+    } catch (error) {
+      const reason =
+        error instanceof Error
+          ? `Auto-promotion failed: ${error.message}`
+          : "Auto-promotion failed";
+      return this.persistDecision(record.id, {
+        decision: "review",
+        reason,
+        runId,
+      });
+    }
+  }
+
+  private getReviewReason(
+    record: AutomationCandidateRecord,
+    config: AgentConfigRecord,
+  ): string | null {
+    if (!record.classification) {
+      return "Awaiting triage classification";
+    }
+    if (
+      record.classification !== "bug" &&
+      record.classification !== "feature"
+    ) {
+      return `Classification ${record.classification} is not allowlisted for auto-promotion`;
+    }
+    if (
+      typeof record.triageConfidence !== "number" ||
+      record.triageConfidence < config.feedbackAutoPromoteMinConfidence
+    ) {
+      return `Triage confidence ${this.formatConfidence(record.triageConfidence)} is below the auto-promotion threshold`;
+    }
+    if (record.duplicateOfFeedbackId || record.duplicateOfGithubIssueNumber) {
+      return "Confirmed duplicate records must stay in human review";
+    }
+    if (record.duplicateCandidate) {
+      return "Duplicate review is required before promotion";
+    }
+    if (record.githubIssueNumber) {
+      return "Feedback has already been promoted";
+    }
+
+    const missingFields = this.getMissingRequiredFields(record);
+    if (missingFields.length > 0) {
+      return `Missing required normalized fields: ${missingFields.join(", ")}`;
+    }
+
+    return null;
+  }
+
+  private getMissingRequiredFields(
+    record: AutomationCandidateRecord,
+  ): string[] {
+    const missing: string[] = [];
+    if (!record.normalizedTitle) {
+      missing.push("normalizedTitle");
+    }
+    if (!record.normalizedBody) {
+      missing.push("normalizedBody");
+    }
+    if (!record.impactSummary) {
+      missing.push("impactSummary");
+    }
+
+    const reproSteps = Array.isArray(record.reproStepsJson)
+      ? record.reproStepsJson.filter(
+          (value): value is string =>
+            typeof value === "string" && value.trim().length > 0,
+        )
+      : [];
+
+    if (record.classification === "bug") {
+      if (reproSteps.length === 0) {
+        missing.push("reproSteps");
+      }
+      if (!record.expectedBehavior) {
+        missing.push("expectedBehavior");
+      }
+      if (!record.actualBehavior) {
+        missing.push("actualBehavior");
+      }
+    }
+
+    if (record.classification === "feature" && !record.proposedOutcome) {
+      missing.push("proposedOutcome");
+    }
+
+    return missing;
+  }
+
+  private formatConfidence(value: number | null | undefined): string {
+    if (typeof value !== "number") {
+      return "unknown";
+    }
+    return value.toFixed(2);
+  }
+
+  private async persistDecision(
+    feedbackId: string,
+    input: {
+      decision: FeedbackAutomationDecision;
+      reason: string;
+      runId: string | null;
+    },
+  ): Promise<FeedbackAutomationDecisionDto> {
+    const decidedAt = new Date();
+    const updated = await this.feedbackService.recordPromotionDecision(
+      feedbackId,
+      {
+        promotionDecision: input.decision,
+        promotionReason: input.reason,
+        promotionRunId: input.runId,
+        promotionDecidedAt: decidedAt,
+      },
+    );
+    const decision = toDecisionDto(updated);
+    if (!decision) {
+      throw new Error("Failed to persist feedback automation decision");
+    }
+    return decision;
+  }
+}

--- a/src/services/feedbackService.ts
+++ b/src/services/feedbackService.ts
@@ -2,6 +2,7 @@ import { Prisma, PrismaClient } from "@prisma/client";
 import { config } from "../config";
 import {
   CreateFeedbackRequestDto,
+  FeedbackAutomationDecision,
   FeedbackRequestAdminDetailDto,
   FeedbackRequestAdminListItemDto,
   FeedbackRequestDto,
@@ -162,6 +163,10 @@ export class FeedbackService {
       githubIssueNumber: number;
       githubIssueUrl: string;
       promotedAt: Date;
+      promotionDecision?: FeedbackAutomationDecision;
+      promotionReason?: string | null;
+      promotionRunId?: string | null;
+      promotionDecidedAt?: Date;
     },
   ): Promise<FeedbackRequestAdminDetailDto> {
     const record = await this.prisma.feedbackRequest.update({
@@ -173,6 +178,49 @@ export class FeedbackService {
         promotedAt: promotion.promotedAt,
         githubIssueNumber: promotion.githubIssueNumber,
         githubIssueUrl: promotion.githubIssueUrl,
+        promotionDecision: promotion.promotionDecision ?? "promoted",
+        promotionReason: promotion.promotionReason ?? "Promoted to GitHub",
+        promotionRunId: promotion.promotionRunId ?? null,
+        promotionDecidedAt:
+          promotion.promotionDecidedAt ?? promotion.promotedAt,
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+        reviewer: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return this.toAdminDto(record);
+  }
+
+  async recordPromotionDecision(
+    id: string,
+    decision: {
+      promotionDecision: FeedbackAutomationDecision;
+      promotionReason: string;
+      promotionRunId?: string | null;
+      promotionDecidedAt: Date;
+    },
+  ): Promise<FeedbackRequestAdminDetailDto> {
+    const record = await this.prisma.feedbackRequest.update({
+      where: { id },
+      data: {
+        promotionDecision: decision.promotionDecision,
+        promotionReason: decision.promotionReason,
+        promotionRunId: decision.promotionRunId ?? null,
+        promotionDecidedAt: decision.promotionDecidedAt,
       },
       include: {
         user: {
@@ -237,6 +285,10 @@ export class FeedbackService {
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
     promotedAt: Date | null;
+    promotionDecision: string | null;
+    promotionReason: string | null;
+    promotionRunId: string | null;
+    promotionDecidedAt: Date | null;
     reviewedByUserId: string | null;
     reviewedAt: Date | null;
     rejectionReason: string | null;
@@ -305,6 +357,11 @@ export class FeedbackService {
       githubIssueNumber: record.githubIssueNumber,
       githubIssueUrl: record.githubIssueUrl,
       promotedAt: record.promotedAt?.toISOString() ?? null,
+      promotionDecision:
+        (record.promotionDecision as FeedbackAutomationDecision | null) ?? null,
+      promotionReason: record.promotionReason,
+      promotionRunId: record.promotionRunId,
+      promotionDecidedAt: record.promotionDecidedAt?.toISOString() ?? null,
       reviewedByUserId: record.reviewedByUserId,
       reviewedAt: record.reviewedAt?.toISOString() ?? null,
       rejectionReason: record.rejectionReason,
@@ -356,6 +413,10 @@ export class FeedbackService {
     githubIssueNumber: number | null;
     githubIssueUrl: string | null;
     promotedAt: Date | null;
+    promotionDecision: string | null;
+    promotionReason: string | null;
+    promotionRunId: string | null;
+    promotionDecidedAt: Date | null;
     reviewedAt: Date | null;
     rejectionReason: string | null;
     createdAt: Date;

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,6 +344,7 @@ export interface CreateCaptureItemDto {
 export type FeedbackRequestType = "bug" | "feature" | "general";
 export type FeedbackRequestStatus = "new" | "triaged" | "promoted" | "rejected";
 export type FeedbackReviewAction = "triaged" | "promoted" | "rejected";
+export type FeedbackAutomationDecision = "review" | "promoted";
 export type FeedbackTriageClassification =
   | "bug"
   | "feature"
@@ -406,6 +407,51 @@ export interface PromoteFeedbackRequestDto {
   ignoreDuplicateSuggestion?: boolean;
 }
 
+export interface FeedbackAutomationConfigDto {
+  feedbackAutomationEnabled: boolean;
+  feedbackAutoPromoteEnabled: boolean;
+  feedbackAutoPromoteMinConfidence: number;
+  allowlistedClassifications: Array<"bug" | "feature">;
+}
+
+export interface UpdateFeedbackAutomationConfigDto {
+  feedbackAutomationEnabled?: boolean;
+  feedbackAutoPromoteEnabled?: boolean;
+  feedbackAutoPromoteMinConfidence?: number;
+}
+
+export interface FeedbackAutomationDecisionDto {
+  id: string;
+  title: string;
+  type: FeedbackRequestType;
+  status: FeedbackRequestStatus;
+  classification?: FeedbackTriageClassification | null;
+  triageConfidence?: number | null;
+  promotionDecision: FeedbackAutomationDecision;
+  promotionReason?: string | null;
+  promotionRunId?: string | null;
+  promotionDecidedAt: string;
+  githubIssueNumber?: number | null;
+  githubIssueUrl?: string | null;
+}
+
+export interface RunFeedbackAutomationRequestDto {
+  limit?: number;
+}
+
+export interface FeedbackAutomationRunResultDto {
+  jobName: string;
+  periodKey: string;
+  runId?: string | null;
+  claimed: boolean;
+  skipped: boolean;
+  reason?: string | null;
+  processedCount: number;
+  promotedCount: number;
+  reviewCount: number;
+  decisions: FeedbackAutomationDecisionDto[];
+}
+
 export interface CreateFeedbackRequestDto {
   type: FeedbackRequestType;
   title: string;
@@ -454,6 +500,10 @@ export interface FeedbackRequestDto {
   githubIssueNumber?: number | null;
   githubIssueUrl?: string | null;
   promotedAt?: string | null;
+  promotionDecision?: FeedbackAutomationDecision | null;
+  promotionReason?: string | null;
+  promotionRunId?: string | null;
+  promotionDecidedAt?: string | null;
   reviewedByUserId?: string | null;
   reviewedAt?: string | null;
   rejectionReason?: string | null;

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -16,15 +16,18 @@ import {
   FindTodosQuery,
   CreateFeedbackRequestDto,
   FeedbackAttachmentMetadataDto,
+  FeedbackAutomationConfigDto,
   FeedbackRequestStatus,
   PromoteFeedbackRequestDto,
   FeedbackRequestType,
   ListAdminFeedbackRequestsQuery,
   Priority,
+  RunFeedbackAutomationRequestDto,
   TaskSource,
   TaskStatus,
   TodoSortBy,
   SortOrder,
+  UpdateFeedbackAutomationConfigDto,
   UpdateAdminFeedbackRequestDto,
 } from "../types";
 import {
@@ -1830,5 +1833,112 @@ export function validatePromoteFeedbackRequest(
 
   return {
     ignoreDuplicateSuggestion: body.ignoreDuplicateSuggestion,
+  };
+}
+
+export function validateUpdateFeedbackAutomationConfig(
+  data: unknown,
+): UpdateFeedbackAutomationConfigDto {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  const body = data as Record<string, unknown>;
+  const result: UpdateFeedbackAutomationConfigDto = {};
+
+  if (body.feedbackAutomationEnabled !== undefined) {
+    if (typeof body.feedbackAutomationEnabled !== "boolean") {
+      throw new ValidationError("feedbackAutomationEnabled must be a boolean");
+    }
+    result.feedbackAutomationEnabled = body.feedbackAutomationEnabled;
+  }
+
+  if (body.feedbackAutoPromoteEnabled !== undefined) {
+    if (typeof body.feedbackAutoPromoteEnabled !== "boolean") {
+      throw new ValidationError("feedbackAutoPromoteEnabled must be a boolean");
+    }
+    result.feedbackAutoPromoteEnabled = body.feedbackAutoPromoteEnabled;
+  }
+
+  if (body.feedbackAutoPromoteMinConfidence !== undefined) {
+    if (
+      typeof body.feedbackAutoPromoteMinConfidence !== "number" ||
+      Number.isNaN(body.feedbackAutoPromoteMinConfidence) ||
+      body.feedbackAutoPromoteMinConfidence < 0 ||
+      body.feedbackAutoPromoteMinConfidence > 1
+    ) {
+      throw new ValidationError(
+        "feedbackAutoPromoteMinConfidence must be a number between 0 and 1",
+      );
+    }
+    result.feedbackAutoPromoteMinConfidence =
+      body.feedbackAutoPromoteMinConfidence;
+  }
+
+  if (Object.keys(result).length === 0) {
+    throw new ValidationError(
+      "At least one automation config field is required",
+    );
+  }
+
+  return result;
+}
+
+export function validateRunFeedbackAutomationRequest(
+  data: unknown,
+): RunFeedbackAutomationRequestDto {
+  if (data === undefined || data === null || data === "") {
+    return {};
+  }
+  if (typeof data !== "object" || Array.isArray(data)) {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  const body = data as Record<string, unknown>;
+  if (body.limit === undefined) {
+    return {};
+  }
+
+  if (
+    typeof body.limit !== "number" ||
+    !Number.isInteger(body.limit) ||
+    body.limit < 1 ||
+    body.limit > 100
+  ) {
+    throw new ValidationError("limit must be an integer between 1 and 100");
+  }
+
+  return {
+    limit: body.limit,
+  };
+}
+
+export function validateFeedbackAutomationDecisionLimit(
+  value: unknown,
+): number {
+  if (value === undefined) {
+    return 10;
+  }
+
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw new ValidationError("limit must be an integer between 1 and 50");
+  }
+
+  const limit = Number.parseInt(value, 10);
+  if (limit < 1 || limit > 50) {
+    throw new ValidationError("limit must be an integer between 1 and 50");
+  }
+
+  return limit;
+}
+
+export function toFeedbackAutomationConfigDto(
+  config: FeedbackAutomationConfigDto,
+): FeedbackAutomationConfigDto {
+  return {
+    feedbackAutomationEnabled: config.feedbackAutomationEnabled,
+    feedbackAutoPromoteEnabled: config.feedbackAutoPromoteEnabled,
+    feedbackAutoPromoteMinConfidence: config.feedbackAutoPromoteMinConfidence,
+    allowlistedClassifications: config.allowlistedClassifications,
   };
 }

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -44,6 +44,10 @@ function buildFeedback(overrides: Record<string, unknown> = {}) {
     githubIssueNumber: null,
     githubIssueUrl: null,
     promotedAt: null,
+    promotionDecision: null,
+    promotionReason: null,
+    promotionRunId: null,
+    promotionDecidedAt: null,
     reviewedByUserId: null,
     reviewedAt: null,
     rejectionReason: null,
@@ -67,6 +71,8 @@ test.describe("Admin feedback queue", () => {
     let triageCalled = false;
     let linkDuplicatePayload: Record<string, unknown> | null = null;
     let promotePayload: Record<string, unknown> | null = null;
+    let savedAutomationPayload: Record<string, unknown> | null = null;
+    let automationRunPayload: Record<string, unknown> | null = null;
     const bugFeedback = buildFeedback();
     const featureFeedback = buildFeedback({
       id: "feedback-2",
@@ -77,12 +83,103 @@ test.describe("Admin feedback queue", () => {
       createdAt: "2026-03-20T19:00:00.000Z",
       updatedAt: "2026-03-20T19:00:00.000Z",
     });
+    const automationConfig = {
+      feedbackAutomationEnabled: false,
+      feedbackAutoPromoteEnabled: false,
+      feedbackAutoPromoteMinConfidence: 0.9,
+      allowlistedClassifications: ["bug", "feature"],
+    };
+    const automationDecisions = [
+      {
+        id: "feedback-2",
+        title: "Add planning bundles",
+        type: "feature",
+        status: "triaged",
+        classification: "feature",
+        triageConfidence: 0.88,
+        promotionDecision: "review",
+        promotionReason:
+          "Triage confidence 0.88 is below the auto-promotion threshold",
+        promotionRunId: "run-1",
+        promotionDecidedAt: "2026-03-20T20:30:00.000Z",
+        githubIssueNumber: null,
+        githubIssueUrl: null,
+      },
+    ];
 
     await page.route("**/admin/users", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify([]),
+      });
+    });
+
+    await page.route("**/admin/feedback/automation/config", async (route) => {
+      if (route.request().method() === "PATCH") {
+        savedAutomationPayload = JSON.parse(
+          route.request().postData() || "{}",
+        ) as Record<string, unknown>;
+        Object.assign(automationConfig, savedAutomationPayload);
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(automationConfig),
+      });
+    });
+
+    await page.route(
+      "**/admin/feedback/automation/decisions",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(automationDecisions),
+        });
+      },
+    );
+
+    await page.route("**/admin/feedback/automation/run", async (route) => {
+      automationRunPayload = JSON.parse(
+        route.request().postData() || "{}",
+      ) as Record<string, unknown>;
+      automationDecisions.unshift({
+        id: "feedback-1",
+        title: "Task drawer crashes",
+        type: "bug",
+        status: "triaged",
+        classification: "bug",
+        triageConfidence: 0.93,
+        promotionDecision: "review",
+        promotionReason: "Auto-promote is disabled; kept in the review queue",
+        promotionRunId: "run-2",
+        promotionDecidedAt: "2026-03-20T21:00:00.000Z",
+        githubIssueNumber: null,
+        githubIssueUrl: null,
+      });
+      Object.assign(bugFeedback, {
+        promotionDecision: "review",
+        promotionReason: "Auto-promote is disabled; kept in the review queue",
+        promotionRunId: "run-2",
+        promotionDecidedAt: "2026-03-20T21:00:00.000Z",
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          jobName: "feedback_auto_promotion",
+          periodKey: "2026-03-20T21:00",
+          runId: "run-2",
+          claimed: true,
+          skipped: false,
+          reason: null,
+          processedCount: 1,
+          promotedCount: 0,
+          reviewCount: 1,
+          decisions: [automationDecisions[0]],
+        }),
       });
     });
 
@@ -287,6 +384,35 @@ test.describe("Admin feedback queue", () => {
     });
 
     await expect(page.locator("#adminView")).toHaveClass(/active/);
+    await expect(page.locator("#adminContent")).toContainText(
+      "Feedback Automation",
+    );
+    await expect(page.locator("#adminContent")).toContainText(
+      "below the auto-promotion threshold",
+    );
+    await page.locator("#adminFeedbackAutomationEnabled").check();
+    await page.locator("#adminFeedbackAutoPromoteEnabled").check();
+    await page.locator("#adminFeedbackAutoPromoteMinConfidence").fill("0.94");
+    await page
+      .getByRole("button", { name: "Save settings", exact: true })
+      .click();
+    expect(savedAutomationPayload).toEqual({
+      feedbackAutomationEnabled: true,
+      feedbackAutoPromoteEnabled: true,
+      feedbackAutoPromoteMinConfidence: 0.94,
+    });
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Feedback automation settings updated",
+    );
+
+    await page.getByRole("button", { name: "Run now", exact: true }).click();
+    expect(automationRunPayload).toEqual({ limit: 20 });
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Automation processed 1 items",
+    );
+    await expect(page.locator("#adminContent")).toContainText(
+      "Auto-promote is disabled; kept in the review queue",
+    );
     await expect(page.locator("#adminFeedbackList")).toContainText(
       "Add planning bundles",
     );
@@ -385,6 +511,9 @@ test.describe("Admin feedback queue", () => {
     );
     await expect(page.locator("#adminFeedbackDetail")).toContainText(
       "Missing enough detail to act on this safely",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Automation decision",
     );
   });
 });


### PR DESCRIPTION
## Summary
This PR enables an optional feedback auto-promotion pipeline that can promote high-confidence, non-duplicate, triaged feedback into GitHub issues without a manual review click.

The user impact is intentionally conservative. Admins can keep the system in review-first mode by default, then enable automation and tighten the confidence threshold only when the feedback pipeline is stable enough to trust. Every promotion decision is now visible in the admin queue and persisted on the feedback record so the team can see why an item was promoted automatically or routed back to review.

## Root Cause
The feedback pipeline already supported submission, admin review, AI triage, duplicate detection, and manual promotion, but there was no orchestration layer connecting those steps into a safe automation path. That meant high-quality feedback could not flow automatically, and there was no structured audit trail explaining why a record was or was not promoted.

## Fix
The fix introduces a dedicated feedback automation service that reuses the existing triage, duplicate detection, promotion, job-run, and audit-log patterns already present in the repo.

It adds:
- new automation config flags on `AgentConfig` for enabling feedback automation, enabling auto-promotion, and setting the minimum confidence threshold
- decision fields on `FeedbackRequest` so each item records the last promotion decision, reason, run id, and decision timestamp
- a guarded automation run that only auto-promotes allowlisted `bug` and `feature` feedback when confidence is above threshold, normalized fields are present, and no duplicate is found
- admin endpoints and UI controls for editing the settings, triggering a run, and viewing recent decisions
- unit, integration, and UI coverage for the full path

The renderer and GitHub promotion flow stay separate from this new decision engine, so the automation path still goes through the same promotion logic as manual admin actions.

## Validation
I verified the change with:
- `npx prisma generate`
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts`
- `CI=1 npm run test:ui:fast`

The focused integration test still prints the repo's existing verification-email credential warnings during auth registration, but the suite passes cleanly.
