### PR TITLE
feat(api): harden feedback promotion pipeline

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -414,6 +414,7 @@ import {
   loadAdminFeedbackAutomationPanel,
   loadAdminFeedbackQueue,
   promoteAdminFeedback,
+  retryAdminFeedbackAction,
   runAdminFeedbackPromotionPreview,
   runAdminFeedbackAutomation,
   runAdminFeedbackDuplicateCheck,
@@ -1786,6 +1787,7 @@ window.confirmAdminFeedbackDuplicate = confirmAdminFeedbackDuplicate;
 window.ignoreDuplicateAndPromote = ignoreDuplicateAndPromote;
 window.runAdminFeedbackPromotionPreview = runAdminFeedbackPromotionPreview;
 window.promoteAdminFeedback = promoteAdminFeedback;
+window.retryAdminFeedbackAction = retryAdminFeedbackAction;
 window.runAdminFeedbackTriage = runAdminFeedbackTriage;
 window.updateAdminFeedbackStatus = updateAdminFeedbackStatus;
 window.saveAdminFeedbackAutomationConfig = saveAdminFeedbackAutomationConfig;

--- a/client/modules/adminFeedback.js
+++ b/client/modules/adminFeedback.js
@@ -499,6 +499,81 @@ function renderPromotionPanel(item) {
   `;
 }
 
+function mapFailureActionLabel(actionType) {
+  if (actionType === "feedback.triage") {
+    return "Retry triage";
+  }
+  if (actionType === "feedback.duplicate_search") {
+    return "Retry duplicate check";
+  }
+  if (actionType === "feedback.promotion") {
+    return "Retry promotion";
+  }
+  return "Retry";
+}
+
+function mapFailureRetryAction(actionType) {
+  if (actionType === "feedback.triage") {
+    return "triage";
+  }
+  if (actionType === "feedback.duplicate_search") {
+    return "duplicate_check";
+  }
+  if (actionType === "feedback.promotion") {
+    return "promotion";
+  }
+  return "";
+}
+
+function renderFailuresPanel() {
+  if (state.adminFeedbackFailuresLoading) {
+    return `
+      <div class="admin-detail-block">
+        <div class="loading">
+          <div class="spinner"></div>
+          Loading feedback failures...
+        </div>
+      </div>
+    `;
+  }
+
+  if (!state.adminFeedbackFailures.length) {
+    return "";
+  }
+
+  return `
+    <div class="admin-detail-block">
+      <div class="admin-detail-block__header">
+        <h4>Pipeline Failures</h4>
+      </div>
+      <div class="admin-detail-stack">
+        ${state.adminFeedbackFailures
+          .map((failure) => {
+            const retryAction = mapFailureRetryAction(failure.actionType);
+            return `
+              <div class="admin-detail-meta admin-detail-meta--card">
+                ${renderMetadataRow("Action", failure.actionType)}
+                ${renderMetadataRow("Error", failure.errorMessage || failure.errorCode || "")}
+                ${renderMetadataRow("Created", formatDateTime(failure.createdAt))}
+                ${renderMetadataRow("Retry count", String(failure.retryCount ?? 0))}
+                ${renderMetadataRow("Resolved", failure.resolvedAt ? formatDateTime(failure.resolvedAt) : "Open")}
+                ${renderMetadataRow("Resolution", failure.resolution || "")}
+                ${
+                  retryAction && failure.retryable && !failure.resolvedAt
+                    ? `<div class="admin-feedback-actions">
+                        <button type="button" class="action-btn" data-onclick="retryAdminFeedbackAction('${retryAction}')">${escape(mapFailureActionLabel(failure.actionType))}</button>
+                      </div>`
+                    : ""
+                }
+              </div>
+            `;
+          })
+          .join("")}
+      </div>
+    </div>
+  `;
+}
+
 function renderAdminFeedbackDetail() {
   const { detail } = getAdminFeedbackElements();
   if (!(detail instanceof HTMLElement)) {
@@ -575,6 +650,7 @@ function renderAdminFeedbackDetail() {
 
       ${renderDuplicatePanel(item)}
       ${renderPromotionPanel(item)}
+      ${renderFailuresPanel()}
 
       <div class="admin-detail-block">
         <h4>Review Actions</h4>
@@ -682,6 +758,7 @@ export async function selectAdminFeedback(feedbackId) {
   if (!feedbackId) {
     state.adminFeedbackSelectedId = "";
     state.adminFeedbackDetail = null;
+    state.adminFeedbackFailures = [];
     state.adminFeedbackPromotionPreview = null;
     state.adminFeedbackPromotionPreviewError = "";
     renderAdminFeedbackWorkspace();
@@ -690,6 +767,8 @@ export async function selectAdminFeedback(feedbackId) {
 
   state.adminFeedbackSelectedId = feedbackId;
   state.adminFeedbackDetailLoading = true;
+  state.adminFeedbackFailures = [];
+  state.adminFeedbackFailuresLoading = true;
   state.adminFeedbackPromotionPreview = null;
   state.adminFeedbackPromotionPreviewError = "";
   renderAdminFeedbackWorkspace();
@@ -724,7 +803,10 @@ export async function selectAdminFeedback(feedbackId) {
     renderAdminFeedbackWorkspace();
   }
 
-  await loadAdminFeedbackPromotionPreview();
+  await Promise.all([
+    loadAdminFeedbackPromotionPreview(),
+    loadAdminFeedbackFailures(),
+  ]);
 }
 
 export async function loadAdminFeedbackQueue() {
@@ -747,6 +829,7 @@ export async function loadAdminFeedbackQueue() {
       state.adminFeedbackItems = [];
       state.adminFeedbackSelectedId = "";
       state.adminFeedbackDetail = null;
+      state.adminFeedbackFailures = [];
       state.adminFeedbackPromotionPreview = null;
       state.adminFeedbackPromotionPreviewError = "";
       return;
@@ -772,6 +855,7 @@ export async function loadAdminFeedbackQueue() {
     state.adminFeedbackItems = [];
     state.adminFeedbackSelectedId = "";
     state.adminFeedbackDetail = null;
+    state.adminFeedbackFailures = [];
     state.adminFeedbackPromotionPreview = null;
     state.adminFeedbackPromotionPreviewError = "";
   } finally {
@@ -996,6 +1080,7 @@ export async function runAdminFeedbackTriage() {
     updateFeedbackItemInList(data);
     renderAdminFeedbackWorkspace();
     await Promise.all([
+      loadAdminFeedbackFailures(),
       loadAdminFeedbackPromotionPreview(),
       loadAdminFeedbackAutomationPanel(),
     ]);
@@ -1117,6 +1202,7 @@ export async function runAdminFeedbackDuplicateCheck() {
     updateFeedbackItemInList(data);
     renderAdminFeedbackWorkspace();
     await Promise.all([
+      loadAdminFeedbackFailures(),
       loadAdminFeedbackPromotionPreview(),
       loadAdminFeedbackAutomationPanel(),
     ]);
@@ -1194,7 +1280,10 @@ export async function promoteAdminFeedback(ignoreDuplicateSuggestion = false) {
         );
         state.adminFeedbackDetail = data.feedbackRequest;
         renderAdminFeedbackWorkspace();
-        await loadAdminFeedbackPromotionPreview();
+        await Promise.all([
+          loadAdminFeedbackFailures(),
+          loadAdminFeedbackPromotionPreview(),
+        ]);
         return;
       }
 
@@ -1216,7 +1305,103 @@ export async function promoteAdminFeedback(ignoreDuplicateSuggestion = false) {
       "success",
     );
     await Promise.all([
+      loadAdminFeedbackFailures(),
       loadAdminFeedbackAutomationPanel(),
+      loadAdminFeedbackQueue(),
+    ]);
+  } catch (error) {
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  }
+}
+
+export async function loadAdminFeedbackFailures() {
+  if (!state.adminFeedbackSelectedId) {
+    state.adminFeedbackFailures = [];
+    state.adminFeedbackFailuresLoading = false;
+    renderAdminFeedbackWorkspace();
+    return;
+  }
+
+  state.adminFeedbackFailuresLoading = true;
+  renderAdminFeedbackWorkspace();
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}/failures`,
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      state.adminFeedbackFailures = [];
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to load feedback failures",
+        "error",
+      );
+      return;
+    }
+
+    state.adminFeedbackFailures = Array.isArray(data) ? data : [];
+  } catch (error) {
+    state.adminFeedbackFailures = [];
+    hooks.showMessage?.(
+      "adminMessage",
+      "Network error. Please try again.",
+      "error",
+    );
+  } finally {
+    state.adminFeedbackFailuresLoading = false;
+    renderAdminFeedbackWorkspace();
+  }
+}
+
+export async function retryAdminFeedbackAction(action) {
+  if (!state.adminFeedbackSelectedId) {
+    return;
+  }
+
+  try {
+    const response = await hooks.apiCall(
+      `${hooks.API_URL}/admin/feedback/${encodeURIComponent(state.adminFeedbackSelectedId)}/retry`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      },
+    );
+    const data = response ? await hooks.parseApiBody(response) : {};
+
+    if (!response?.ok) {
+      if (response?.status === 409 && data.feedbackRequest) {
+        state.adminFeedbackDetail = data.feedbackRequest;
+        state.adminFeedbackFailures = Array.isArray(data.failures)
+          ? data.failures
+          : state.adminFeedbackFailures;
+        renderAdminFeedbackWorkspace();
+      }
+      hooks.showMessage?.(
+        "adminMessage",
+        data.error || "Failed to retry feedback action",
+        "error",
+      );
+      return;
+    }
+
+    state.adminFeedbackDetail =
+      data.feedbackRequest || state.adminFeedbackDetail;
+    state.adminFeedbackFailures = Array.isArray(data.failures)
+      ? data.failures
+      : [];
+    updateFeedbackItemInList(state.adminFeedbackDetail);
+    hooks.showMessage?.("adminMessage", "Feedback retry completed", "success");
+    renderAdminFeedbackWorkspace();
+    await Promise.all([
+      loadAdminFeedbackAutomationPanel(),
+      loadAdminFeedbackPromotionPreview(),
       loadAdminFeedbackQueue(),
     ]);
   } catch (error) {

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -160,6 +160,8 @@ export const state = {
   },
   adminFeedbackListLoading: false,
   adminFeedbackDetailLoading: false,
+  adminFeedbackFailures: [],
+  adminFeedbackFailuresLoading: false,
   adminFeedbackPromotionPreview: null,
   adminFeedbackPromotionPreviewLoading: false,
   adminFeedbackPromotionPreviewError: "",

--- a/client/styles.css
+++ b/client/styles.css
@@ -3890,6 +3890,13 @@ body.is-todos-view .floating-new-task-cta {
   gap: 10px;
 }
 
+.admin-detail-meta--card {
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+}
+
 .admin-detail-meta__row {
   display: grid;
   gap: 4px;
@@ -3934,6 +3941,11 @@ body.is-todos-view .floating-new-task-cta {
 .admin-detail-links {
   display: flex;
   flex-wrap: wrap;
+  gap: 12px;
+}
+
+.admin-detail-stack {
+  display: grid;
   gap: 12px;
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,8 @@ import { FeedbackDuplicateService } from "./services/feedbackDuplicateService";
 import { FeedbackPromotionService } from "./services/feedbackPromotionService";
 import { FeedbackTriageService } from "./services/feedbackTriageService";
 import { FeedbackAutomationService } from "./services/feedbackAutomationService";
+import { FailedAutomationActionService } from "./services/failedAutomationActionService";
+import { FeedbackFailureService } from "./services/feedbackFailureService";
 import { createFeedbackRouter } from "./routes/feedbackRouter";
 import { AgentEnrollmentService } from "./services/agentEnrollmentService";
 import {
@@ -93,16 +95,26 @@ export function createApp(
   const feedbackService = persistencePrisma
     ? new FeedbackService(persistencePrisma)
     : null;
+  const feedbackFailureService = persistencePrisma
+    ? new FeedbackFailureService(
+        new FailedAutomationActionService(persistencePrisma),
+      )
+    : null;
   const feedbackTriageService = persistencePrisma
-    ? new FeedbackTriageService(persistencePrisma)
+    ? new FeedbackTriageService(persistencePrisma, {
+        feedbackFailureService: feedbackFailureService ?? undefined,
+      })
     : null;
   const feedbackDuplicateService = persistencePrisma
-    ? new FeedbackDuplicateService(persistencePrisma)
+    ? new FeedbackDuplicateService(persistencePrisma, {
+        feedbackFailureService: feedbackFailureService ?? undefined,
+      })
     : null;
   const feedbackPromotionService = persistencePrisma
     ? new FeedbackPromotionService(persistencePrisma, {
         feedbackService: feedbackService ?? undefined,
         feedbackDuplicateService: feedbackDuplicateService ?? undefined,
+        feedbackFailureService: feedbackFailureService ?? undefined,
       })
     : null;
   const feedbackAutomationService = persistencePrisma
@@ -281,6 +293,7 @@ export function createApp(
       feedbackDuplicateService: feedbackDuplicateService ?? undefined,
       feedbackPromotionService: feedbackPromotionService ?? undefined,
       feedbackAutomationService: feedbackAutomationService ?? undefined,
+      feedbackFailureService: feedbackFailureService ?? undefined,
     }),
   );
   app.use("/users", createUsersRouter({ authService }));

--- a/src/feedback.api.integration.test.ts
+++ b/src/feedback.api.integration.test.ts
@@ -483,9 +483,11 @@ describe("Feedback API Integration", () => {
         actualBehavior: "The task drawer crashes and loses the draft.",
         reproStepsJson: ["Open the task drawer", "Edit notes", "Press save"],
         agentLabelsJson: ["ui"],
-        pageUrl: "https://app.example.com/?view=todos",
+        pageUrl:
+          "https://app.example.com/?view=todos&email=reporter@example.com",
         appVersion: "1.6.0",
-        userAgent: "Integration Test Browser",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
         screenshotUrl: "https://example.com/bug.png",
       },
     });
@@ -511,6 +513,11 @@ describe("Feedback API Integration", () => {
     expect(response.body.body).not.toContain(
       "raw input that should not be rendered directly",
     );
+    expect(response.body.body).toContain(
+      "Screenshot captured privately in app review queue and intentionally omitted from GitHub export.",
+    );
+    expect(response.body.body).not.toContain("reporter@example.com");
+    expect(response.body.body).not.toContain("?view=todos");
   });
 
   it("POST /admin/feedback/:id/promote creates a GitHub issue and stores promotion metadata", async () => {
@@ -634,6 +641,112 @@ describe("Feedback API Integration", () => {
       id: feedback.id,
       duplicateCandidate: true,
     });
+  });
+
+  it("records promotion failures and retries safely without creating duplicate GitHub issues", async () => {
+    const feedback = await prisma.feedbackRequest.create({
+      data: {
+        userId,
+        type: "feature",
+        title: "Planning bundles",
+        body: "raw feature request",
+        status: "triaged",
+        classification: "feature",
+        normalizedTitle: "Add planning bundles",
+        normalizedBody:
+          "Users need a bundled planning flow to reduce manual setup.",
+        impactSummary: "Weekly planning takes too many manual steps.",
+        proposedOutcome: "Offer suggested planning bundles.",
+        triageSummary: "Feature feedback from planning bundles.",
+        agentLabelsJson: ["ui"],
+      },
+    });
+
+    const originalUpdate = prisma.feedbackRequest.update.bind(
+      prisma.feedbackRequest,
+    ) as any;
+    let shouldFailPromotionPersist = true;
+    const updateSpy = jest.spyOn(prisma.feedbackRequest, "update") as any;
+    updateSpy.mockImplementation(async (...args: any[]) => {
+      const [input] = args;
+      if (
+        shouldFailPromotionPersist &&
+        input?.where?.id === feedback.id &&
+        typeof input?.data === "object" &&
+        input.data &&
+        "githubIssueNumber" in input.data
+      ) {
+        shouldFailPromotionPersist = false;
+        throw new Error("Simulated recordPromotion failure");
+      }
+      return originalUpdate(...args);
+    });
+
+    let issueCreateCalls = 0;
+    global.fetch = jest.fn(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/repos/karthikg80/todos-api/issues")) {
+        issueCreateCalls += 1;
+        return {
+          ok: true,
+          json: async () => ({
+            number: 712,
+            html_url: "https://github.com/karthikg80/todos-api/issues/712",
+          }),
+        } as Response;
+      }
+      if (url.endsWith("/repos/karthikg80/todos-api/issues/712/labels")) {
+        return {
+          ok: true,
+          json: async () => [{ name: "feature" }, { name: "triaged-by-agent" }],
+        } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }) as typeof fetch;
+
+    await request(app)
+      .post(`/admin/feedback/${feedback.id}/promote`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({})
+      .expect(500);
+
+    const failuresResponse = await request(app)
+      .get(`/admin/feedback/${feedback.id}/failures`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .expect(200);
+
+    expect(failuresResponse.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actionType: "feedback.promotion",
+          retryable: true,
+          resolvedAt: null,
+        }),
+      ]),
+    );
+
+    const retryResponse = await request(app)
+      .post(`/admin/feedback/${feedback.id}/retry`)
+      .set("Authorization", `Bearer ${adminToken}`)
+      .send({ action: "promotion" })
+      .expect(200);
+
+    expect(issueCreateCalls).toBe(1);
+    expect(retryResponse.body.feedbackRequest).toMatchObject({
+      id: feedback.id,
+      status: "promoted",
+      githubIssueNumber: 712,
+    });
+    expect(retryResponse.body.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actionType: "feedback.promotion",
+          resolution: "retried",
+        }),
+      ]),
+    );
+
+    updateSpy.mockRestore();
   });
 
   it("GET and PATCH /admin/feedback/automation/config manage auto-promotion settings", async () => {

--- a/src/feedbackDuplicateService.test.ts
+++ b/src/feedbackDuplicateService.test.ts
@@ -1,6 +1,6 @@
 import {
-  FeedbackDuplicateService,
   DuplicatePromotionConflictError,
+  FeedbackDuplicateService,
 } from "./services/feedbackDuplicateService";
 
 describe("FeedbackDuplicateService", () => {
@@ -9,6 +9,7 @@ describe("FeedbackDuplicateService", () => {
       feedbackRequest: {
         findUnique: jest.fn().mockResolvedValue({
           id: "feedback-1",
+          userId: "user-1",
           type: "bug",
           status: "triaged",
           title: "Task drawer crashes on save",
@@ -60,6 +61,7 @@ describe("FeedbackDuplicateService", () => {
       feedbackRequest: {
         findUnique: jest.fn().mockResolvedValue({
           id: "feedback-1",
+          userId: "user-1",
           type: "feature",
           status: "triaged",
           title: "Add planning bundles",
@@ -106,6 +108,7 @@ describe("FeedbackDuplicateService", () => {
       feedbackRequest: {
         findUnique: jest.fn().mockResolvedValue({
           id: "feedback-1",
+          userId: "user-1",
           type: "bug",
           status: "triaged",
           title: "Task drawer crashes on save",
@@ -138,5 +141,59 @@ describe("FeedbackDuplicateService", () => {
     await expect(
       service.assertPromotionIsSafe("feedback-1"),
     ).rejects.toBeInstanceOf(DuplicatePromotionConflictError);
+  });
+
+  it("records duplicate-search failures conservatively when GitHub lookup fails", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: "feedback-1",
+          userId: "user-1",
+          type: "feature",
+          status: "triaged",
+          title: "Add planning bundles",
+          body: "Feature details",
+          pageUrl: "https://app.example.com/?view=planning",
+          classification: "feature",
+          normalizedTitle: "Add planning bundles",
+          normalizedBody: "Feature details",
+          dedupeKey: "feature-dedupe-key",
+        }),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({}),
+      },
+    } as any;
+    const feedbackFailureService = {
+      record: jest.fn().mockResolvedValue({}),
+      resolveOpenForFeedback: jest.fn().mockResolvedValue(undefined),
+    };
+    const gitHubSearchAdapter = {
+      searchIssues: jest
+        .fn()
+        .mockRejectedValue(new Error("GitHub unavailable")),
+    };
+    const service = new FeedbackDuplicateService(prisma, {
+      gitHubSearchAdapter,
+      feedbackFailureService: feedbackFailureService as never,
+    });
+
+    const assessment = await service.detectAndPersist("feedback-1");
+
+    expect(assessment).toEqual({
+      duplicateCandidate: false,
+      matchedFeedbackIds: [],
+      matchedGithubIssueNumber: null,
+      matchedGithubIssueUrl: null,
+      duplicateReason: null,
+    });
+    expect(feedbackFailureService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedbackId: "feedback-1",
+        actionType: "feedback.duplicate_search",
+      }),
+    );
+    expect(
+      feedbackFailureService.resolveOpenForFeedback,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/feedbackPromotionService.test.ts
+++ b/src/feedbackPromotionService.test.ts
@@ -3,25 +3,27 @@ import { FeedbackPromotionService } from "./services/feedbackPromotionService";
 describe("FeedbackPromotionService", () => {
   const baseRecord = {
     id: "feedback-1",
+    userId: "user-1",
     type: "bug" as const,
     status: "triaged" as const,
     classification: "bug" as const,
-    normalizedTitle: "Task drawer crashes on save",
+    normalizedTitle: "Task drawer crashes on save for reporter@example.com",
     normalizedBody:
-      "Saving from the task drawer crashes the current editing session.",
+      "Saving from the task drawer crashes the current editing session for reporter@example.com.",
     impactSummary: "Users cannot save edits from the task drawer.",
     reproStepsJson: ["Open the task drawer", "Edit notes", "Press save"],
     expectedBehavior: "The task should save normally.",
     actualBehavior: "The task drawer crashes and loses the draft.",
     proposedOutcome: "Stabilize save handling in the task drawer.",
     triageSummary:
-      'Bug feedback from "Task drawer crashes" on https://app.example.com/?view=todos.',
+      'Bug feedback from "Task drawer crashes" on https://app.example.com/?view=todos&email=reporter@example.com.',
     missingInfoJson: [],
     agentLabelsJson: ["ui"],
-    pageUrl: "https://app.example.com/?view=todos",
+    pageUrl: "https://app.example.com/?view=todos&email=reporter@example.com",
     appVersion: "1.6.0",
-    userAgent: "Playwright Browser",
-    screenshotUrl: "https://example.com/bug.png",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/537.36 Chrome/124.0 Safari/537.36",
+    screenshotUrl: "https://example.com/private/bug.png",
     duplicateCandidate: false,
     duplicateReason: null,
     duplicateOfFeedbackId: null,
@@ -30,7 +32,7 @@ describe("FeedbackPromotionService", () => {
     githubIssueUrl: null,
   };
 
-  it("builds a deterministic bug preview with stable labels", async () => {
+  it("builds a deterministic bug preview with stable labels and redacts sensitive context", async () => {
     const prisma = {
       feedbackRequest: {
         findUnique: jest.fn().mockResolvedValue(baseRecord),
@@ -44,6 +46,15 @@ describe("FeedbackPromotionService", () => {
       feedbackDuplicateService: {
         assertPromotionIsSafe: jest.fn(),
       } as never,
+      feedbackFailureService: {
+        listOpenForFeedback: jest.fn().mockResolvedValue([]),
+        resolveOpenForFeedback: jest.fn().mockResolvedValue(undefined),
+        record: jest.fn(),
+      } as never,
+      agentIdempotencyService: {
+        lookup: jest.fn().mockResolvedValue({ kind: "miss" }),
+        store: jest.fn().mockResolvedValue(undefined),
+      } as never,
       gitHubIssueAdapter: {
         searchIssues: jest.fn(),
         createIssue: jest.fn(),
@@ -55,7 +66,7 @@ describe("FeedbackPromotionService", () => {
 
     expect(preview).toEqual({
       issueType: "bug",
-      title: "Task drawer crashes on save",
+      title: "Task drawer crashes on save for [redacted-email]",
       body: expect.stringContaining("## Steps To Reproduce"),
       labels: ["bug", "triaged-by-agent", "ui"],
       sourceFeedbackIds: ["feedback-1"],
@@ -66,7 +77,11 @@ describe("FeedbackPromotionService", () => {
       existingGithubIssueUrl: null,
     });
     expect(preview.body).toContain("Source feedback IDs: `feedback-1`");
-    expect(preview.body).not.toContain("What happened?");
+    expect(preview.body).toContain(
+      "Screenshot captured privately in app review queue and intentionally omitted from GitHub export.",
+    );
+    expect(preview.body).not.toContain("reporter@example.com");
+    expect(preview.body).not.toContain("?view=todos");
   });
 
   it("creates a GitHub issue, applies labels, and records promotion metadata", async () => {
@@ -93,6 +108,15 @@ describe("FeedbackPromotionService", () => {
     const applyLabels = jest
       .fn()
       .mockResolvedValue(["feature", "triaged-by-agent", "ui"]);
+    const feedbackFailureService = {
+      listOpenForFeedback: jest.fn().mockResolvedValue([]),
+      resolveOpenForFeedback: jest.fn().mockResolvedValue(undefined),
+      record: jest.fn(),
+    };
+    const agentIdempotencyService = {
+      lookup: jest.fn().mockResolvedValue({ kind: "miss" }),
+      store: jest.fn().mockResolvedValue(undefined),
+    };
 
     const service = new FeedbackPromotionService(prisma, {
       feedbackService: {
@@ -101,6 +125,8 @@ describe("FeedbackPromotionService", () => {
       feedbackDuplicateService: {
         assertPromotionIsSafe: jest.fn().mockResolvedValue(undefined),
       } as never,
+      feedbackFailureService: feedbackFailureService as never,
+      agentIdempotencyService: agentIdempotencyService as never,
       gitHubIssueAdapter: {
         searchIssues: jest.fn(),
         createIssue,
@@ -127,7 +153,116 @@ describe("FeedbackPromotionService", () => {
         githubIssueUrl: "https://github.com/karthikg80/todos-api/issues/412",
       }),
     );
+    expect(agentIdempotencyService.store).toHaveBeenCalled();
     expect(result.issueNumber).toBe(412);
     expect(result.preview.issueType).toBe("feature");
+  });
+
+  it("replays an idempotent promotion result without creating another issue", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue(baseRecord),
+      },
+    } as never;
+    const createIssue = jest.fn();
+    const replayBody = {
+      issueNumber: 512,
+      issueUrl: "https://github.com/karthikg80/todos-api/issues/512",
+      promotedAt: "2026-03-21T03:00:00.000Z",
+      preview: {
+        issueType: "bug",
+        title: "Task drawer crashes on save",
+        body: "Issue body",
+        labels: ["bug"],
+        sourceFeedbackIds: ["feedback-1"],
+        canPromote: true,
+        duplicateCandidate: false,
+      },
+    };
+    const service = new FeedbackPromotionService(prisma, {
+      feedbackService: {
+        recordPromotion: jest.fn(),
+      } as never,
+      feedbackDuplicateService: {
+        assertPromotionIsSafe: jest.fn().mockResolvedValue(undefined),
+      } as never,
+      feedbackFailureService: {
+        listOpenForFeedback: jest.fn().mockResolvedValue([]),
+        resolveOpenForFeedback: jest.fn().mockResolvedValue(undefined),
+        record: jest.fn(),
+      } as never,
+      agentIdempotencyService: {
+        lookup: jest
+          .fn()
+          .mockResolvedValue({ kind: "replay", status: 200, body: replayBody }),
+        store: jest.fn(),
+      } as never,
+      gitHubIssueAdapter: {
+        searchIssues: jest.fn(),
+        createIssue,
+        applyLabels: jest.fn(),
+      },
+    });
+
+    const result = await service.promoteFeedback("feedback-1", "admin-1");
+
+    expect(result).toEqual(replayBody);
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+
+  it("recovers a partially completed promotion from recorded failure state", async () => {
+    const prisma = {
+      feedbackRequest: {
+        findUnique: jest.fn().mockResolvedValue(baseRecord),
+      },
+    } as never;
+    const recordPromotion = jest.fn().mockResolvedValue({});
+    const createIssue = jest.fn();
+    const feedbackFailureService = {
+      listOpenForFeedback: jest.fn().mockResolvedValue([
+        {
+          id: "failure-1",
+          payload: {
+            createdIssue: {
+              number: 611,
+              url: "https://github.com/karthikg80/todos-api/issues/611",
+            },
+          },
+        },
+      ]),
+      resolveOpenForFeedback: jest.fn().mockResolvedValue(undefined),
+      record: jest.fn(),
+    };
+    const agentIdempotencyService = {
+      lookup: jest.fn().mockResolvedValue({ kind: "miss" }),
+      store: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new FeedbackPromotionService(prisma, {
+      feedbackService: {
+        recordPromotion,
+      } as never,
+      feedbackDuplicateService: {
+        assertPromotionIsSafe: jest.fn().mockResolvedValue(undefined),
+      } as never,
+      feedbackFailureService: feedbackFailureService as never,
+      agentIdempotencyService: agentIdempotencyService as never,
+      gitHubIssueAdapter: {
+        searchIssues: jest.fn(),
+        createIssue,
+        applyLabels: jest.fn(),
+      },
+    });
+
+    const result = await service.promoteFeedback("feedback-1", "admin-1");
+
+    expect(createIssue).not.toHaveBeenCalled();
+    expect(recordPromotion).toHaveBeenCalledWith(
+      "feedback-1",
+      "admin-1",
+      expect.objectContaining({
+        githubIssueNumber: 611,
+      }),
+    );
+    expect(result.issueNumber).toBe(611);
   });
 });

--- a/src/feedbackTriageService.test.ts
+++ b/src/feedbackTriageService.test.ts
@@ -47,6 +47,7 @@ describe("FeedbackTriageService", () => {
       feedbackRequest: {
         findUnique: jest.fn().mockResolvedValue({
           id: "feedback-2",
+          userId: "user-1",
           type: "feature",
           title: "Make weekly planning easier",
           body: [
@@ -72,7 +73,14 @@ describe("FeedbackTriageService", () => {
     const provider = {
       generateJson: jest.fn().mockResolvedValue({ classification: "oops" }),
     };
-    const service = new FeedbackTriageService(prisma, { provider });
+    const feedbackFailureService = {
+      record: jest.fn().mockResolvedValue({}),
+      resolveOpenForFeedback: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new FeedbackTriageService(prisma, {
+      provider,
+      feedbackFailureService: feedbackFailureService as never,
+    });
 
     const result = await service.triageFeedback("feedback-2");
 
@@ -82,6 +90,12 @@ describe("FeedbackTriageService", () => {
       "Auto-group related tasks into bundles.",
     );
     expect(result.missingInfo).toEqual([]);
+    expect(feedbackFailureService.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedbackId: "feedback-2",
+        actionType: "feedback.triage",
+      }),
+    );
     expect(prisma.feedbackRequest.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: "feedback-2" },
@@ -91,5 +105,8 @@ describe("FeedbackTriageService", () => {
         }),
       }),
     );
+    expect(
+      feedbackFailureService.resolveOpenForFeedback,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/adminRouter.ts
+++ b/src/routes/adminRouter.ts
@@ -9,10 +9,12 @@ import {
 import { FeedbackPromotionService } from "../services/feedbackPromotionService";
 import { FeedbackTriageService } from "../services/feedbackTriageService";
 import { FeedbackAutomationService } from "../services/feedbackAutomationService";
+import { FeedbackFailureService } from "../services/feedbackFailureService";
 import {
   validateFeedbackAutomationDecisionLimit,
   validateListAdminFeedbackRequestsQuery,
   validatePromoteFeedbackRequest,
+  validateRetryAdminFeedbackRequest,
   validateRunFeedbackAutomationRequest,
   validateUpdateFeedbackAutomationConfig,
   validateUpdateAdminFeedbackRequest,
@@ -25,6 +27,7 @@ interface AdminRouterDeps {
   feedbackDuplicateService?: FeedbackDuplicateService;
   feedbackPromotionService?: FeedbackPromotionService;
   feedbackAutomationService?: FeedbackAutomationService;
+  feedbackFailureService?: FeedbackFailureService;
 }
 
 export function createAdminRouter({
@@ -34,6 +37,7 @@ export function createAdminRouter({
   feedbackDuplicateService,
   feedbackPromotionService,
   feedbackAutomationService,
+  feedbackFailureService,
 }: AdminRouterDeps): Router {
   const router = Router();
 
@@ -326,6 +330,118 @@ export function createAdminRouter({
         if (hasPrismaCode(error, ["P2025"])) {
           return next(new HttpError(404, "Feedback request not found"));
         }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.post(
+    "/feedback/:id/retry",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (
+        !feedbackService ||
+        !feedbackFailureService ||
+        !feedbackTriageService ||
+        !feedbackDuplicateService ||
+        !feedbackPromotionService
+      ) {
+        return res
+          .status(501)
+          .json({ error: "Feedback retry handling not configured" });
+      }
+
+      try {
+        const reviewerUserId = req.user?.userId;
+        const feedbackId = String(req.params.id);
+        if (!reviewerUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const dto = validateRetryAdminFeedbackRequest(req.body);
+        if (dto.action === "triage") {
+          await feedbackTriageService.triageFeedback(feedbackId);
+        } else if (dto.action === "duplicate_check") {
+          await feedbackDuplicateService.detectAndPersist(feedbackId);
+        } else {
+          await feedbackPromotionService.promoteFeedback(
+            feedbackId,
+            reviewerUserId,
+            {
+              ignoreDuplicateSuggestion: dto.ignoreDuplicateSuggestion,
+            },
+          );
+        }
+
+        const feedbackRequest = await feedbackService.getForAdmin(feedbackId);
+        if (!feedbackRequest) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+        const failures =
+          await feedbackFailureService.listForFeedback(feedbackId);
+        res.json({ feedbackRequest, failures });
+      } catch (error) {
+        if (error instanceof DuplicatePromotionConflictError) {
+          const feedbackRequest = await feedbackService.getForAdmin(
+            String(req.params.id),
+          );
+          const failures = await feedbackFailureService.listForFeedback(
+            String(req.params.id),
+          );
+          return res.status(409).json({
+            error: error.message,
+            duplicateDetection: error.assessment,
+            feedbackRequest,
+            failures,
+          });
+        }
+        if (
+          error instanceof Error &&
+          [
+            "Feedback request not found",
+            "Feedback must be triaged before promotion",
+            "Feedback must be triaged as bug or feature before promotion",
+            "Confirmed duplicates cannot be promoted",
+            "Feedback has already been promoted",
+          ].includes(error.message)
+        ) {
+          return next(
+            new HttpError(
+              error.message === "Feedback request not found" ? 404 : 400,
+              error.message,
+            ),
+          );
+        }
+        if (hasPrismaCode(error, ["P2023"])) {
+          return next(new HttpError(400, "Invalid feedback request ID format"));
+        }
+        next(error);
+      }
+    },
+  );
+
+  router.get(
+    "/feedback/:id/failures",
+    async (req: Request, res: Response, next: NextFunction) => {
+      if (!feedbackService || !feedbackFailureService) {
+        return res
+          .status(501)
+          .json({ error: "Feedback failure history not configured" });
+      }
+
+      try {
+        const feedbackId = String(req.params.id);
+        const feedbackRequest = await feedbackService.getForAdmin(feedbackId);
+        if (!feedbackRequest) {
+          return next(new HttpError(404, "Feedback request not found"));
+        }
+
+        const failures =
+          await feedbackFailureService.listForFeedback(feedbackId);
+        res.json(failures);
+      } catch (error) {
         if (hasPrismaCode(error, ["P2023"])) {
           return next(new HttpError(400, "Invalid feedback request ID format"));
         }

--- a/src/services/failedAutomationActionService.ts
+++ b/src/services/failedAutomationActionService.ts
@@ -79,6 +79,30 @@ export class FailedAutomationActionService {
     return rows.map((r) => this.toRecord(r));
   }
 
+  async listByEntity(
+    entityType: string,
+    entityId: string,
+    filters: {
+      actionType?: string;
+      includeResolved?: boolean;
+      limit?: number;
+    } = {},
+  ): Promise<FailedActionRecord[]> {
+    if (!this.prisma) return [];
+
+    const rows = await this.prisma.failedAutomationAction.findMany({
+      where: {
+        entityType,
+        entityId,
+        ...(filters.actionType ? { actionType: filters.actionType } : {}),
+        ...(filters.includeResolved ? {} : { resolvedAt: null }),
+      },
+      orderBy: { createdAt: "desc" },
+      take: filters.limit ?? 50,
+    });
+    return rows.map((row) => this.toRecord(row));
+  }
+
   async resolve(
     userId: string,
     id: string,
@@ -88,6 +112,19 @@ export class FailedAutomationActionService {
 
     const result = await this.prisma.failedAutomationAction.updateMany({
       where: { id, userId, resolvedAt: null },
+      data: { resolvedAt: new Date(), resolution },
+    });
+    return result.count > 0;
+  }
+
+  async resolveById(
+    id: string,
+    resolution: "retried" | "dismissed",
+  ): Promise<boolean> {
+    if (!this.prisma) return false;
+
+    const result = await this.prisma.failedAutomationAction.updateMany({
+      where: { id, resolvedAt: null },
       data: { resolvedAt: new Date(), resolution },
     });
     return result.count > 0;

--- a/src/services/feedbackDuplicateService.ts
+++ b/src/services/feedbackDuplicateService.ts
@@ -5,9 +5,12 @@ import {
   GitHubIssueSearchAdapter,
   GitHubIssueSearchService,
 } from "./githubIssueSearchService";
+import { FailedAutomationActionService } from "./failedAutomationActionService";
+import { FeedbackFailureService } from "./feedbackFailureService";
 
 type FeedbackDuplicateRecord = {
   id: string;
+  userId: string;
   type: "bug" | "feature" | "general";
   status: "new" | "triaged" | "promoted" | "rejected";
   title: string;
@@ -35,6 +38,7 @@ export interface FeedbackDuplicateAssessment {
 
 export interface FeedbackDuplicateServiceDeps {
   gitHubSearchAdapter?: GitHubIssueSearchAdapter;
+  feedbackFailureService?: FeedbackFailureService;
 }
 
 function normalizeText(value: string): string {
@@ -155,6 +159,7 @@ export class DuplicatePromotionConflictError extends Error {
 
 export class FeedbackDuplicateService {
   private readonly gitHubSearchAdapter: GitHubIssueSearchAdapter;
+  private readonly feedbackFailureService: FeedbackFailureService;
 
   constructor(
     private readonly prisma: PrismaClient,
@@ -162,6 +167,9 @@ export class FeedbackDuplicateService {
   ) {
     this.gitHubSearchAdapter =
       deps.gitHubSearchAdapter ?? new GitHubIssueSearchService();
+    this.feedbackFailureService =
+      deps.feedbackFailureService ??
+      new FeedbackFailureService(new FailedAutomationActionService(prisma));
   }
 
   async detectAndPersist(
@@ -171,6 +179,7 @@ export class FeedbackDuplicateService {
       where: { id: feedbackId },
       select: {
         id: true,
+        userId: true,
         type: true,
         status: true,
         title: true,
@@ -188,11 +197,12 @@ export class FeedbackDuplicateService {
     }
 
     const internalMatches = await this.findInternalMatches(record);
-    const githubMatch =
+    const githubSearchResult =
       internalMatches.matchedFeedbackIds.length > 0 ||
       record.classification === "noise"
-        ? null
+        ? { match: null, failed: false }
         : await this.findGitHubIssueMatch(record);
+    const githubMatch = githubSearchResult.match;
 
     const assessment: FeedbackDuplicateAssessment =
       internalMatches.matchedFeedbackIds.length > 0 || githubMatch
@@ -213,6 +223,12 @@ export class FeedbackDuplicateService {
       where: { id: feedbackId },
       data: buildAssessmentUpdate(assessment),
     });
+    if (!githubSearchResult.failed) {
+      await this.feedbackFailureService.resolveOpenForFeedback(
+        feedbackId,
+        "feedback.duplicate_search",
+      );
+    }
 
     return assessment;
   }
@@ -294,7 +310,7 @@ export class FeedbackDuplicateService {
 
   private async findGitHubIssueMatch(
     record: FeedbackDuplicateRecord,
-  ): Promise<GitHubIssueMatch | null> {
+  ): Promise<{ match: GitHubIssueMatch | null; failed: boolean }> {
     try {
       const issues = await this.gitHubSearchAdapter.searchIssues(
         buildSearchQuery(record),
@@ -308,9 +324,22 @@ export class FeedbackDuplicateService {
           bestMatch = issue;
         }
       }
-      return bestScore >= 0.94 ? bestMatch : null;
-    } catch {
-      return null;
+      return { match: bestScore >= 0.94 ? bestMatch : null, failed: false };
+    } catch (error) {
+      await this.feedbackFailureService.record({
+        userId: record.userId,
+        feedbackId: record.id,
+        actionType: "feedback.duplicate_search",
+        errorCode: "DUPLICATE_SEARCH_FAILED",
+        errorMessage:
+          error instanceof Error ? error.message : "Duplicate search failed",
+        payload: {
+          feedbackId: record.id,
+          query: buildSearchQuery(record),
+        },
+        retryable: true,
+      });
+      return { match: null, failed: true };
     }
   }
 }

--- a/src/services/feedbackFailureService.ts
+++ b/src/services/feedbackFailureService.ts
@@ -1,0 +1,72 @@
+import {
+  FailedActionRecord,
+  FailedAutomationActionService,
+} from "./failedAutomationActionService";
+
+export type FeedbackFailureAction =
+  | "feedback.triage"
+  | "feedback.duplicate_search"
+  | "feedback.promotion";
+
+function buildFeedbackPeriodKey(feedbackId: string): string {
+  return feedbackId.replace(/-/g, "").slice(0, 20);
+}
+
+export class FeedbackFailureService {
+  constructor(
+    private readonly failedActionService: FailedAutomationActionService,
+  ) {}
+
+  async record(input: {
+    userId: string;
+    feedbackId: string;
+    actionType: FeedbackFailureAction;
+    errorCode?: string;
+    errorMessage?: string;
+    payload?: unknown;
+    retryable?: boolean;
+  }): Promise<FailedActionRecord | null> {
+    return this.failedActionService.record({
+      userId: input.userId,
+      jobName: "feedback_pipeline",
+      periodKey: buildFeedbackPeriodKey(input.feedbackId),
+      actionType: input.actionType,
+      entityType: "feedback",
+      entityId: input.feedbackId,
+      errorCode: input.errorCode,
+      errorMessage: input.errorMessage,
+      payload: input.payload,
+      retryable: input.retryable ?? true,
+    });
+  }
+
+  async listForFeedback(feedbackId: string): Promise<FailedActionRecord[]> {
+    return this.failedActionService.listByEntity("feedback", feedbackId, {
+      includeResolved: true,
+      limit: 20,
+    });
+  }
+
+  async listOpenForFeedback(
+    feedbackId: string,
+    actionType?: FeedbackFailureAction,
+  ): Promise<FailedActionRecord[]> {
+    return this.failedActionService.listByEntity("feedback", feedbackId, {
+      actionType,
+      includeResolved: false,
+      limit: 20,
+    });
+  }
+
+  async resolveOpenForFeedback(
+    feedbackId: string,
+    actionType: FeedbackFailureAction,
+  ): Promise<void> {
+    const openFailures = await this.listOpenForFeedback(feedbackId, actionType);
+    await Promise.all(
+      openFailures.map((failure) =>
+        this.failedActionService.resolveById(failure.id, "retried"),
+      ),
+    );
+  }
+}

--- a/src/services/feedbackIssueRenderer.ts
+++ b/src/services/feedbackIssueRenderer.ts
@@ -2,6 +2,10 @@ import {
   FeedbackPromotionIssueType,
   FeedbackPromotionPreviewDto,
 } from "../types";
+import {
+  redactSensitiveText,
+  sanitizeContextForGitHubExport,
+} from "./feedbackPrivacyService";
 
 type PromotionRenderRecord = {
   id: string;
@@ -58,7 +62,7 @@ function cleanText(
   value: string | null | undefined,
   fallback = "Not provided",
 ): string {
-  const normalized = (value || "").trim();
+  const normalized = redactSensitiveText(value).trim();
   return normalized || fallback;
 }
 
@@ -125,14 +129,20 @@ function buildLabels(
 
 function buildContextSection(record: PromotionRenderRecord): string {
   const missingInfo = coerceStringArray(record.missingInfoJson);
+  const context = sanitizeContextForGitHubExport({
+    pageUrl: record.pageUrl,
+    appVersion: record.appVersion,
+    userAgent: record.userAgent,
+    screenshotUrl: record.screenshotUrl,
+  });
   return [
     "## Context",
     `- Source feedback IDs: \`${record.id}\``,
     `- Feedback status: ${record.status}`,
-    `- Page URL: ${cleanText(record.pageUrl)}`,
-    `- App version: ${cleanText(record.appVersion)}`,
-    `- Browser user agent: ${cleanText(record.userAgent)}`,
-    `- Screenshot URL: ${cleanText(record.screenshotUrl)}`,
+    `- Page URL: ${cleanText(context.pageUrl)}`,
+    `- App version: ${cleanText(context.appVersion)}`,
+    `- Browser: ${cleanText(context.userAgent)}`,
+    `- Screenshot: ${context.screenshotNotice}`,
     `- Missing information flags: ${
       missingInfo.length ? missingInfo.join(", ") : "none"
     }`,
@@ -205,7 +215,7 @@ export function renderFeedbackIssuePreview(
     throw new Error("Confirmed duplicates cannot be promoted");
   }
 
-  const title = record.normalizedTitle.trim();
+  const title = cleanText(record.normalizedTitle, "Feedback issue");
   const body =
     issueType === "bug" ? buildBugBody(record) : buildFeatureBody(record);
 

--- a/src/services/feedbackPrivacyService.ts
+++ b/src/services/feedbackPrivacyService.ts
@@ -1,0 +1,94 @@
+type SanitizedContext = {
+  pageUrl: string | null;
+  appVersion: string | null;
+  userAgent: string | null;
+  screenshotNotice: string;
+};
+
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE_PATTERN = /(?:\+?\d[\d().\-\s]{7,}\d)/g;
+const SECRET_PATTERN = /\b(?:sk|gh[opusr]|github_pat)_[A-Za-z0-9_\-]{8,}\b/g;
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+export function redactSensitiveText(value: string | null | undefined): string {
+  const normalized = String(value ?? "");
+  if (!normalized.trim()) {
+    return "";
+  }
+
+  return collapseWhitespace(
+    normalized
+      .replace(EMAIL_PATTERN, "[redacted-email]")
+      .replace(PHONE_PATTERN, "[redacted-phone]")
+      .replace(SECRET_PATTERN, "[redacted-secret]"),
+  );
+}
+
+export function sanitizeUrlForGitHubExport(
+  value: string | null | undefined,
+): string | null {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    const safePath = parsed.pathname || "/";
+    return `${parsed.origin}${safePath}`;
+  } catch {
+    return redactSensitiveText(normalized) || null;
+  }
+}
+
+export function summarizeUserAgentForGitHubExport(
+  value: string | null | undefined,
+): string | null {
+  const userAgent = String(value ?? "").toLowerCase();
+  if (!userAgent.trim()) {
+    return null;
+  }
+
+  if (userAgent.includes("edg")) {
+    return "Edge";
+  }
+  if (userAgent.includes("chrome") && !userAgent.includes("edg")) {
+    return "Chrome";
+  }
+  if (userAgent.includes("firefox")) {
+    return "Firefox";
+  }
+  if (userAgent.includes("safari") && !userAgent.includes("chrome")) {
+    return "Safari";
+  }
+  if (userAgent.includes("playwright")) {
+    return "Playwright";
+  }
+
+  return "Captured privately in app";
+}
+
+export function buildScreenshotNotice(
+  screenshotUrl: string | null | undefined,
+): string {
+  return screenshotUrl
+    ? "Screenshot captured privately in app review queue and intentionally omitted from GitHub export."
+    : "No screenshot attached.";
+}
+
+export function sanitizeContextForGitHubExport(input: {
+  pageUrl?: string | null;
+  appVersion?: string | null;
+  userAgent?: string | null;
+  screenshotUrl?: string | null;
+}): SanitizedContext {
+  return {
+    pageUrl: sanitizeUrlForGitHubExport(input.pageUrl),
+    appVersion: redactSensitiveText(input.appVersion) || null,
+    userAgent: summarizeUserAgentForGitHubExport(input.userAgent),
+    screenshotNotice: buildScreenshotNotice(input.screenshotUrl),
+  };
+}

--- a/src/services/feedbackPromotionService.ts
+++ b/src/services/feedbackPromotionService.ts
@@ -1,8 +1,10 @@
 import { PrismaClient } from "@prisma/client";
+import { createHash } from "crypto";
 import {
   FeedbackPromotionPreviewDto,
   FeedbackPromotionResultDto,
 } from "../types";
+import { AgentIdempotencyService } from "./agentIdempotencyService";
 import {
   GitHubIssueAdapter,
   GitHubIssueSearchService,
@@ -13,9 +15,12 @@ import {
 } from "./feedbackDuplicateService";
 import { renderFeedbackIssuePreview } from "./feedbackIssueRenderer";
 import { FeedbackService } from "./feedbackService";
+import { FailedAutomationActionService } from "./failedAutomationActionService";
+import { FeedbackFailureService } from "./feedbackFailureService";
 
 type PromotionRecord = {
   id: string;
+  userId: string;
   type: "bug" | "feature" | "general";
   status: "new" | "triaged" | "promoted" | "rejected";
   classification:
@@ -51,12 +56,36 @@ export interface FeedbackPromotionServiceDeps {
   feedbackService?: FeedbackService;
   feedbackDuplicateService?: FeedbackDuplicateService;
   gitHubIssueAdapter?: GitHubIssueAdapter;
+  feedbackFailureService?: FeedbackFailureService;
+  agentIdempotencyService?: AgentIdempotencyService;
+}
+
+const FEEDBACK_PROMOTION_ACTION = "feedback_promote";
+
+function buildPromotionIdempotencyKey(
+  feedbackId: string,
+  preview: FeedbackPromotionPreviewDto,
+): string {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify({
+        feedbackId,
+        title: preview.title,
+        body: preview.body,
+        labels: preview.labels,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 24);
+  return `${feedbackId}:${digest}`;
 }
 
 export class FeedbackPromotionService {
   private readonly feedbackService: FeedbackService;
   private readonly feedbackDuplicateService: FeedbackDuplicateService;
   private readonly gitHubIssueAdapter: GitHubIssueAdapter;
+  private readonly feedbackFailureService: FeedbackFailureService;
+  private readonly agentIdempotencyService: AgentIdempotencyService;
 
   constructor(
     private readonly prisma: PrismaClient,
@@ -67,6 +96,11 @@ export class FeedbackPromotionService {
       deps.feedbackDuplicateService ?? new FeedbackDuplicateService(prisma);
     this.gitHubIssueAdapter =
       deps.gitHubIssueAdapter ?? new GitHubIssueSearchService();
+    this.feedbackFailureService =
+      deps.feedbackFailureService ??
+      new FeedbackFailureService(new FailedAutomationActionService(prisma));
+    this.agentIdempotencyService =
+      deps.agentIdempotencyService ?? new AgentIdempotencyService(prisma);
   }
 
   async buildPreview(feedbackId: string): Promise<FeedbackPromotionPreviewDto> {
@@ -84,31 +118,103 @@ export class FeedbackPromotionService {
     }
 
     const preview = await this.buildPreview(feedbackId);
+    const idempotencyKey = buildPromotionIdempotencyKey(feedbackId, preview);
+    const replay = await this.agentIdempotencyService.lookup(
+      FEEDBACK_PROMOTION_ACTION,
+      reviewerUserId,
+      idempotencyKey,
+      {
+        feedbackId,
+        ignoreDuplicateSuggestion: Boolean(options.ignoreDuplicateSuggestion),
+        preview,
+      },
+    );
+    if (replay.kind === "conflict") {
+      throw new Error(
+        "Retry payload changed for the same promotion idempotency key",
+      );
+    }
+    if (replay.kind === "replay") {
+      return replay.body as FeedbackPromotionResultDto;
+    }
+
     if (preview.existingGithubIssueNumber || preview.existingGithubIssueUrl) {
       throw new Error("Feedback has already been promoted");
     }
-    const createdIssue = await this.gitHubIssueAdapter.createIssue({
-      title: preview.title,
-      body: preview.body,
-    });
-    await this.gitHubIssueAdapter.applyLabels(
-      createdIssue.number,
-      preview.labels,
-    );
 
-    const promotedAt = new Date();
-    await this.feedbackService.recordPromotion(feedbackId, reviewerUserId, {
-      githubIssueNumber: createdIssue.number,
-      githubIssueUrl: createdIssue.url,
-      promotedAt,
-    });
-
-    return {
-      issueNumber: createdIssue.number,
-      issueUrl: createdIssue.url,
-      promotedAt: promotedAt.toISOString(),
+    const recovered = await this.tryRecoverRecordedPromotion(
+      feedbackId,
+      reviewerUserId,
       preview,
-    };
+      idempotencyKey,
+      options,
+    );
+    if (recovered) {
+      return recovered;
+    }
+
+    let createdIssue: { number: number; url: string } | null = null;
+    try {
+      createdIssue = await this.gitHubIssueAdapter.createIssue({
+        title: preview.title,
+        body: preview.body,
+      });
+      await this.gitHubIssueAdapter.applyLabels(
+        createdIssue.number,
+        preview.labels,
+      );
+
+      const promotedAt = new Date();
+      await this.feedbackService.recordPromotion(feedbackId, reviewerUserId, {
+        githubIssueNumber: createdIssue.number,
+        githubIssueUrl: createdIssue.url,
+        promotedAt,
+      });
+
+      const result = {
+        issueNumber: createdIssue.number,
+        issueUrl: createdIssue.url,
+        promotedAt: promotedAt.toISOString(),
+        preview,
+      };
+      await this.feedbackFailureService.resolveOpenForFeedback(
+        feedbackId,
+        "feedback.promotion",
+      );
+      await this.agentIdempotencyService.store(
+        FEEDBACK_PROMOTION_ACTION,
+        reviewerUserId,
+        idempotencyKey,
+        {
+          feedbackId,
+          ignoreDuplicateSuggestion: Boolean(options.ignoreDuplicateSuggestion),
+          preview,
+        },
+        200,
+        result,
+      );
+      return result;
+    } catch (error) {
+      const record = await this.loadRecord(feedbackId);
+      await this.feedbackFailureService.record({
+        userId: record.userId,
+        feedbackId,
+        actionType: "feedback.promotion",
+        errorCode: "PROMOTION_FAILED",
+        errorMessage:
+          error instanceof Error ? error.message : "Feedback promotion failed",
+        payload: {
+          feedbackId,
+          preview,
+          createdIssue,
+          labels: preview.labels,
+          idempotencyKey,
+          ignoreDuplicateSuggestion: Boolean(options.ignoreDuplicateSuggestion),
+        },
+        retryable: true,
+      });
+      throw error;
+    }
   }
 
   private async loadRecord(feedbackId: string): Promise<PromotionRecord> {
@@ -116,6 +222,7 @@ export class FeedbackPromotionService {
       where: { id: feedbackId },
       select: {
         id: true,
+        userId: true,
         type: true,
         status: true,
         classification: true,
@@ -147,5 +254,73 @@ export class FeedbackPromotionService {
     }
 
     return record;
+  }
+
+  private async tryRecoverRecordedPromotion(
+    feedbackId: string,
+    reviewerUserId: string,
+    preview: FeedbackPromotionPreviewDto,
+    idempotencyKey: string,
+    options: { ignoreDuplicateSuggestion?: boolean },
+  ): Promise<FeedbackPromotionResultDto | null> {
+    const failures = await this.feedbackFailureService.listOpenForFeedback(
+      feedbackId,
+      "feedback.promotion",
+    );
+
+    for (const failure of failures) {
+      const payload =
+        failure.payload && typeof failure.payload === "object"
+          ? (failure.payload as {
+              createdIssue?: { number?: number; url?: string };
+              labels?: string[];
+            })
+          : {};
+      const createdIssue = payload.createdIssue;
+      if (
+        !createdIssue ||
+        typeof createdIssue.number !== "number" ||
+        typeof createdIssue.url !== "string"
+      ) {
+        continue;
+      }
+
+      await this.gitHubIssueAdapter.applyLabels(
+        createdIssue.number,
+        Array.isArray(payload.labels) ? payload.labels : preview.labels,
+      );
+      const promotedAt = new Date();
+      await this.feedbackService.recordPromotion(feedbackId, reviewerUserId, {
+        githubIssueNumber: createdIssue.number,
+        githubIssueUrl: createdIssue.url,
+        promotedAt,
+      });
+
+      const result = {
+        issueNumber: createdIssue.number,
+        issueUrl: createdIssue.url,
+        promotedAt: promotedAt.toISOString(),
+        preview,
+      };
+      await this.feedbackFailureService.resolveOpenForFeedback(
+        feedbackId,
+        "feedback.promotion",
+      );
+      await this.agentIdempotencyService.store(
+        FEEDBACK_PROMOTION_ACTION,
+        reviewerUserId,
+        idempotencyKey,
+        {
+          feedbackId,
+          ignoreDuplicateSuggestion: Boolean(options.ignoreDuplicateSuggestion),
+          preview,
+        },
+        200,
+        result,
+      );
+      return result;
+    }
+
+    return null;
   }
 }

--- a/src/services/feedbackTriageService.ts
+++ b/src/services/feedbackTriageService.ts
@@ -7,6 +7,8 @@ import {
   FeedbackTriageResultDto,
 } from "../types";
 import { validateFeedbackTriageOutput } from "../validation/feedbackTriageContracts";
+import { FailedAutomationActionService } from "./failedAutomationActionService";
+import { FeedbackFailureService } from "./feedbackFailureService";
 
 interface AiProvider {
   generateJson<T>(systemPrompt: string, userPrompt: string): Promise<T>;
@@ -14,6 +16,7 @@ interface AiProvider {
 
 export interface FeedbackTriageServiceDeps {
   provider?: AiProvider;
+  feedbackFailureService?: FeedbackFailureService;
 }
 
 type FeedbackRecord = {
@@ -279,6 +282,7 @@ function buildUserPrompt(record: FeedbackRecord): string {
 
 export class FeedbackTriageService {
   private readonly provider?: AiProvider;
+  private readonly feedbackFailureService: FeedbackFailureService;
 
   constructor(
     private readonly prisma: PrismaClient,
@@ -287,6 +291,9 @@ export class FeedbackTriageService {
     this.provider =
       deps.provider ??
       (config.aiProviderEnabled ? new OpenAiCompatibleProvider() : undefined);
+    this.feedbackFailureService =
+      deps.feedbackFailureService ??
+      new FeedbackFailureService(new FailedAutomationActionService(prisma));
   }
 
   async triageFeedback(feedbackId: string): Promise<FeedbackTriageResultDto> {
@@ -294,6 +301,7 @@ export class FeedbackTriageService {
       where: { id: feedbackId },
       select: {
         id: true,
+        userId: true,
         type: true,
         title: true,
         body: true,
@@ -312,6 +320,7 @@ export class FeedbackTriageService {
 
     const fallback = triageFeedbackDeterministic(record);
     let normalized = fallback;
+    let providerFailed = false;
 
     if (this.provider) {
       try {
@@ -325,7 +334,21 @@ export class FeedbackTriageService {
           triageSummary: buildSummary(record, validated.classification),
           dedupeKey: buildDedupeKey(record, validated.classification),
         };
-      } catch {
+      } catch (error) {
+        providerFailed = true;
+        await this.feedbackFailureService.record({
+          userId: record.userId,
+          feedbackId,
+          actionType: "feedback.triage",
+          errorCode: "TRIAGE_PROVIDER_FAILED",
+          errorMessage:
+            error instanceof Error ? error.message : "Triage provider failed",
+          payload: {
+            feedbackId,
+            providerEnabled: true,
+          },
+          retryable: true,
+        });
         normalized = fallback;
       }
     }
@@ -357,6 +380,12 @@ export class FeedbackTriageService {
         dedupeKey: normalized.dedupeKey,
       },
     });
+    if (!providerFailed) {
+      await this.feedbackFailureService.resolveOpenForFeedback(
+        feedbackId,
+        "feedback.triage",
+      );
+    }
 
     return normalized;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -452,6 +452,26 @@ export interface FeedbackAutomationRunResultDto {
   decisions: FeedbackAutomationDecisionDto[];
 }
 
+export type FeedbackRetryAction = "triage" | "duplicate_check" | "promotion";
+
+export interface FeedbackFailureDto {
+  id: string;
+  actionType: string;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  retryable: boolean;
+  retryCount: number;
+  resolvedAt?: string | null;
+  resolution?: string | null;
+  createdAt: string;
+  payload?: unknown;
+}
+
+export interface RetryAdminFeedbackRequestDto {
+  action: FeedbackRetryAction;
+  ignoreDuplicateSuggestion?: boolean;
+}
+
 export interface CreateFeedbackRequestDto {
   type: FeedbackRequestType;
   title: string;

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -1,5 +1,8 @@
 import {
+  validateCreateFeedbackRequest,
   validateCreateTodo,
+  validatePromoteFeedbackRequest,
+  validateRetryAdminFeedbackRequest,
   validateUpdateTodo,
   validateId,
   validateReorderTodos,
@@ -11,6 +14,7 @@ import {
   validateReorderHeadings,
   ValidationError,
 } from "./validation/validation";
+import { validateFeedbackTriageOutput } from "./validation/feedbackTriageContracts";
 
 describe("Validation", () => {
   describe("validateCreateTodo", () => {
@@ -554,6 +558,73 @@ describe("Validation", () => {
 
     it("should throw for non-object input", () => {
       expect(() => validateFindTodosQuery(null)).toThrow(ValidationError);
+    });
+  });
+
+  describe("feedback validation", () => {
+    it("validates structured feedback submission input", () => {
+      const result = validateCreateFeedbackRequest({
+        type: "bug",
+        title: " Task drawer crashes ",
+        body: " What happened?\nCrash ",
+        screenshotUrl: "https://example.com/file.png",
+      });
+
+      expect(result).toMatchObject({
+        type: "bug",
+        title: "Task drawer crashes",
+        body: "What happened?\nCrash",
+        screenshotUrl: "https://example.com/file.png",
+      });
+    });
+
+    it("rejects invalid retry actions", () => {
+      expect(() =>
+        validateRetryAdminFeedbackRequest({ action: "ship-it" }),
+      ).toThrow('action must be "triage", "duplicate_check", or "promotion"');
+    });
+
+    it("validates promote request booleans", () => {
+      expect(
+        validatePromoteFeedbackRequest({ ignoreDuplicateSuggestion: true }),
+      ).toEqual({
+        ignoreDuplicateSuggestion: true,
+      });
+      expect(() =>
+        validatePromoteFeedbackRequest({ ignoreDuplicateSuggestion: "yes" }),
+      ).toThrow("ignoreDuplicateSuggestion must be a boolean");
+    });
+
+    it("validates triage output contract strictly", () => {
+      expect(
+        validateFeedbackTriageOutput({
+          classification: "bug",
+          triageConfidence: 0.9231,
+          normalizedTitle: "Task drawer crashes on save",
+          normalizedBody: "Saving from the drawer crashes the session.",
+          impactSummary: "Users lose edits.",
+          reproSteps: ["Open drawer", "Edit notes", "Press save"],
+          expectedBehavior: "Save succeeds.",
+          actualBehavior: "Drawer crashes.",
+          proposedOutcome: null,
+          labels: ["bug", "ui"],
+          missingInfo: [],
+        }),
+      ).toMatchObject({
+        classification: "bug",
+        triageConfidence: 0.923,
+      });
+
+      expect(() =>
+        validateFeedbackTriageOutput({
+          classification: "bug",
+          triageConfidence: 1.5,
+          normalizedTitle: "x",
+          normalizedBody: "y",
+          labels: [],
+          missingInfo: [],
+        }),
+      ).toThrow("triageConfidence must be between 0 and 1");
     });
   });
 });

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -19,6 +19,7 @@ import {
   FeedbackAutomationConfigDto,
   FeedbackRequestStatus,
   PromoteFeedbackRequestDto,
+  RetryAdminFeedbackRequestDto,
   FeedbackRequestType,
   ListAdminFeedbackRequestsQuery,
   Priority,
@@ -1833,6 +1834,40 @@ export function validatePromoteFeedbackRequest(
 
   return {
     ignoreDuplicateSuggestion: body.ignoreDuplicateSuggestion,
+  };
+}
+
+export function validateRetryAdminFeedbackRequest(
+  data: unknown,
+): RetryAdminFeedbackRequestDto {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new ValidationError("Request body must be an object");
+  }
+
+  const body = data as Record<string, unknown>;
+  if (
+    body.action !== "triage" &&
+    body.action !== "duplicate_check" &&
+    body.action !== "promotion"
+  ) {
+    throw new ValidationError(
+      'action must be "triage", "duplicate_check", or "promotion"',
+    );
+  }
+
+  if (
+    body.ignoreDuplicateSuggestion !== undefined &&
+    typeof body.ignoreDuplicateSuggestion !== "boolean"
+  ) {
+    throw new ValidationError("ignoreDuplicateSuggestion must be a boolean");
+  }
+
+  return {
+    action: body.action,
+    ignoreDuplicateSuggestion:
+      typeof body.ignoreDuplicateSuggestion === "boolean"
+        ? body.ignoreDuplicateSuggestion
+        : undefined,
   };
 }
 

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -293,6 +293,22 @@ test.describe("Admin feedback queue", () => {
       },
     );
 
+    await page.route("**/admin/feedback/feedback-1/failures", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route("**/admin/feedback/feedback-2/failures", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
     await page.route("**/admin/feedback/feedback-1/promote", async (route) => {
       const payload = JSON.parse(route.request().postData() || "{}") as Record<
         string,
@@ -515,5 +531,184 @@ test.describe("Admin feedback queue", () => {
     await expect(page.locator("#adminFeedbackDetail")).toContainText(
       "Automation decision",
     );
+  });
+});
+
+test.describe("Admin feedback failures", () => {
+  test("shows feedback pipeline failures and retries promotion safely", async ({
+    page,
+  }) => {
+    let retryPayload: Record<string, unknown> | null = null;
+    const bugFeedback = buildFeedback({
+      status: "triaged",
+      classification: "bug",
+      triageConfidence: 0.94,
+      normalizedTitle: "Task drawer crashes on save",
+      normalizedBody: "Saving from the task drawer crashes the session.",
+      impactSummary: "Users cannot save task edits from the drawer.",
+      reproSteps: ["Open the task drawer", "Edit notes", "Press save"],
+      expectedBehavior: "Task saves successfully.",
+      actualBehavior: "Drawer crashes on save.",
+      agentLabels: ["feedback:bug", "source:bug"],
+    });
+    const failures = [
+      {
+        id: "failure-1",
+        actionType: "feedback.promotion",
+        errorCode: "PROMOTION_FAILED",
+        errorMessage: "Simulated recordPromotion failure",
+        retryable: true,
+        retryCount: 0,
+        resolvedAt: null,
+        resolution: null,
+        createdAt: "2026-03-20T20:40:00.000Z",
+        payload: {
+          createdIssue: {
+            number: 712,
+            url: "https://github.com/karthikg80/todos-api/issues/712",
+          },
+        },
+      },
+    ];
+
+    await page.route("**/admin/users", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+    await page.route("**/admin/feedback/automation/config", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          feedbackAutomationEnabled: false,
+          feedbackAutoPromoteEnabled: false,
+          feedbackAutoPromoteMinConfidence: 0.9,
+          allowlistedClassifications: ["bug", "feature"],
+        }),
+      });
+    });
+    await page.route(
+      "**/admin/feedback/automation/decisions",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([]),
+        });
+      },
+    );
+    await page.route("**/admin/feedback?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([bugFeedback]),
+      });
+    });
+    await page.route("**/admin/feedback", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([bugFeedback]),
+      });
+    });
+    await page.route("**/admin/feedback/feedback-1", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(bugFeedback),
+      });
+    });
+    await page.route("**/admin/feedback/feedback-1/failures", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(failures),
+      });
+    });
+    await page.route(
+      "**/admin/feedback/feedback-1/promotion-preview",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            issueType: "bug",
+            title: bugFeedback.normalizedTitle,
+            body: "## Summary\nSanitized preview",
+            labels: ["bug", "triaged-by-agent", "ui"],
+            sourceFeedbackIds: ["feedback-1"],
+            canPromote: true,
+            duplicateCandidate: false,
+            duplicateReason: null,
+            existingGithubIssueNumber: null,
+            existingGithubIssueUrl: null,
+          }),
+        });
+      },
+    );
+    await page.route("**/admin/feedback/feedback-1/retry", async (route) => {
+      retryPayload = JSON.parse(route.request().postData() || "{}") as Record<
+        string,
+        unknown
+      >;
+      failures[0] = {
+        ...failures[0],
+        resolvedAt: "2026-03-20T20:45:00.000Z",
+        resolution: "retried",
+      };
+      Object.assign(bugFeedback, {
+        status: "promoted",
+        githubIssueNumber: 712,
+        githubIssueUrl: "https://github.com/karthikg80/todos-api/issues/712",
+        promotedAt: "2026-03-20T20:45:00.000Z",
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          feedbackRequest: bugFeedback,
+          failures,
+        }),
+      });
+    });
+
+    await openTodosViewWithStorageState(page, {
+      name: "Admin Reviewer",
+      email: "admin@example.com",
+    });
+
+    await page.evaluate(() => {
+      const adminTab = document.getElementById("adminNavTab");
+      if (adminTab instanceof HTMLElement) {
+        adminTab.style.display = "block";
+      }
+      document.body.classList.add("is-admin-user");
+      (window as Window & { switchView: (view: string) => void }).switchView(
+        "admin",
+      );
+    });
+
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Pipeline Failures",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Simulated recordPromotion failure",
+    );
+    await page
+      .locator("#adminFeedbackDetail")
+      .getByRole("button", { name: "Retry promotion", exact: true })
+      .click();
+
+    expect(retryPayload).toEqual({ action: "promotion" });
+    await expect(page.locator("#adminMessage")).toContainText(
+      "Feedback retry completed",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText(
+      "Created as #712",
+    );
+    await expect(page.locator("#adminFeedbackDetail")).toContainText("retried");
   });
 });


### PR DESCRIPTION
## Summary
- add privacy filtering before GitHub feedback export
- record triage, duplicate search, and promotion failures with admin-visible retry flows
- add idempotent promotion recovery and broader test coverage for feedback pipeline safeguards

## Testing
- npx prisma generate
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- DB_REQUIRED_TESTS=src/feedback.api.integration.test.ts NODE_ENV=test npx jest --runInBand --runTestsByPath src/feedback.api.integration.test.ts
- CI=1 npm run test:ui:fast