### PR TITLE
docs: add architecture docs, ADRs, and conventions

### DIFF
--- a/docs/adr/001-frontend-composition-roots.md
+++ b/docs/adr/001-frontend-composition-roots.md
@@ -1,0 +1,35 @@
+# ADR-001: Frontend composition roots
+
+## Status
+
+Accepted
+
+## Context
+
+`client/app.js` (1,791 lines) acts as the universal orchestrator: it imports ~420 named exports from 22 modules, assigns ~120 functions to `window`, wires 137 `hooks.*` entries, and binds all delegated DOM events. Any change to any module risks breaking the star topology.
+
+The codebase already has disciplined patterns — event delegation via `data-onclick` attributes, a hooks registry for circular dependency breaking, and `stateActions.js` for named state transitions — but all wiring runs through `app.js`.
+
+## Decision
+
+Refactor `app.js` into a thin composition root that calls feature initializers.
+
+1. Create `client/bootstrap/` with `initApp.js`, `initShell.js`, `initGlobalListeners.js`
+2. Create `client/features/{name}/init{Name}Feature.js` for each major feature area
+3. Each feature initializer owns its listeners, subscriptions, and hooks wiring
+4. `app.js` becomes: import bootstrap → call initializers → done
+
+## Constraints
+
+- Preserve existing event delegation pattern (`data-onclick` + `window.*` bridge)
+- Preserve `hooks` registry for circular dependency breaking
+- Preserve `filterTodos()` as the canonical filter pipeline entry point
+- Preserve `setSelectedProjectKey()` as the project selection entry point
+- No behavioral change — purely structural
+
+## Consequences
+
+- `app.js` shrinks to ~100–200 lines of import + init calls
+- Feature boundaries become explicit (who owns what listeners)
+- New features add an initializer instead of editing `app.js`
+- `window.*` bridge persists until a build step is adopted

--- a/docs/adr/002-event-bus-contract.md
+++ b/docs/adr/002-event-bus-contract.md
@@ -1,0 +1,31 @@
+# ADR-002: Event bus contract for cross-feature communication
+
+## Status
+
+Accepted
+
+## Context
+
+The frontend uses two communication mechanisms:
+1. **Direct function calls** via imports or `hooks.*` — tight coupling, obscure dependency graph
+2. **EventBus** — only two events in use (`todos:changed`, `todos:render`)
+
+Cross-feature interactions currently go through `app.js` orchestration or the `hooks` service locator. When feature A needs to notify feature B, it either imports B's function directly or goes through a hooks indirection wired in `app.js`.
+
+## Decision
+
+Adopt the EventBus as the primary cross-feature communication mechanism.
+
+1. **Within a feature:** direct function calls are allowed
+2. **Cross-feature:** communication goes through EventBus
+3. **Event naming:** `{domain}.{entity}.{past-tense-verb}` (e.g., `todo.created`, `project.selected`)
+4. **State changes:** happen through named actions (`applyDomainAction`, `applyUiAction`), not direct mutation
+5. **Views:** read from selectors, not arbitrary shared objects
+6. **Event type constants:** defined in `client/platform/events/eventTypes.js`
+
+## Consequences
+
+- Fewer cross-module imports → lower coupling
+- Feature interactions become traceable via event subscriptions
+- Debugging requires checking EventBus subscriptions (mitigated by named constants)
+- The existing `hooks` pattern can be gradually replaced where hooks are used for cross-feature calls (hooks for infra like `apiCall` or `escapeHtml` stay)

--- a/docs/adr/003-agent-worker-queue.md
+++ b/docs/adr/003-agent-worker-queue.md
@@ -1,0 +1,40 @@
+# ADR-003: Background worker model for agent execution
+
+## Status
+
+Proposed (pending evaluation in #396)
+
+## Context
+
+Agent execution currently has two modes:
+
+1. **Scheduled (async):** The Python `agent-runner/` worker runs 7 job types on Railway cron. It reads enrollments from Postgres, exchanges refresh tokens for short-lived JWTs, calls the Node API, and persists results.
+
+2. **On-demand (sync):** User-triggered agent actions (e.g., "plan my day", "break down this project") execute synchronously in Express request handlers via `agentExecutor.ts`. These can block the event loop during LLM calls.
+
+The on-demand sync path is the problem: long-running AI calls contend with CRUD traffic on the same Express process.
+
+## Options
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A: Keep Python worker + add BullMQ for on-demand** | Preserves working scheduled infra; Node handles user-triggered runs | Two runtimes, two deployment targets |
+| **B: Port Python worker to Node.js + BullMQ** | Single runtime, single codebase | Migration effort, must replicate 7 job types |
+| **C: Extend Python worker for on-demand** | Minimal new infra | Requires always-on process (not cron), adds latency |
+
+## Decision
+
+**Deferred.** The choice depends on operational constraints (Railway plan, Redis availability, team comfort with Python vs. Node workers). An explicit evaluation (#396) must produce ADR-005 before implementation proceeds.
+
+## Constraints
+
+- Whatever is chosen, the Express process must not block on agent execution
+- The `AgentJobRun` lifecycle model (queued → running → succeeded/failed) already exists in Prisma
+- The Python agent-runner must continue working during any transition
+- Run status must be queryable (`GET /agent/runs/:id`)
+
+## Consequences
+
+- Phase D of the architecture plan is blocked until this decision is made
+- The `AgentRunService` abstraction (#395) can proceed independently
+- Client polling UI (#399) can be built against the status API regardless of backend choice

--- a/docs/adr/004-domain-oriented-backend-structure.md
+++ b/docs/adr/004-domain-oriented-backend-structure.md
@@ -1,0 +1,53 @@
+# ADR-004: Domain-oriented backend structure
+
+## Status
+
+Accepted
+
+## Context
+
+The backend has 49 service files in a flat `src/services/` directory and a 3,362-line `agentExecutor.ts` that dispatches 98 actions. While the service layer uses interfaces (`ITodoService`, `IProjectService`, etc.), the physical structure doesn't reflect domain boundaries.
+
+Current layout:
+```
+src/services/     ← 49 files, flat (todo + AI + agent + MCP + analytics + feedback mixed)
+src/agent/        ← 2 files (agentExecutor.ts is 3,362 lines)
+src/mcp/          ← 5 files
+src/routes/       ← 14 routers
+```
+
+## Decision
+
+Organize backend code into domain-oriented directories under `src/domains/`:
+
+```
+src/domains/
+├── core/         ← todos, projects, users (CRUD, the "product")
+├── assistant/    ← AI suggestions, critique, planning (LLM-powered features)
+├── agent/        ← automation runs, actions, audits (autonomous execution)
+└── mcp/          ← MCP protocol, OAuth, tool catalog (assistant integration)
+```
+
+Shared infrastructure goes under `src/infra/`:
+```
+src/infra/
+├── db/           ← Prisma client
+├── logging/      ← Structured logger
+├── metrics/      ← Metrics collection
+└── config/       ← Environment configuration
+```
+
+## Rules
+
+1. Route handlers delegate to domain services — no business logic in routes
+2. Domains do not import from each other directly; cross-domain calls go through interfaces or the agent executor
+3. The agent executor is decomposed into domain-scoped action handlers
+4. `src/routes/` and `src/middleware/` remain as-is (routes are a thin HTTP layer)
+
+## Consequences
+
+- Physical structure reflects product domains
+- New features have an obvious landing zone
+- `agentExecutor.ts` shrinks from 3,362 lines to a thin dispatcher (~500 lines)
+- File moves are mechanical and low-risk (one domain at a time)
+- Test files move alongside their source files

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -1,0 +1,126 @@
+# Current Architecture
+
+## Overview
+
+Monolithic Express/PostgreSQL backend (TypeScript, Prisma ORM) with a vanilla JS single-page frontend (no build step). An external Python worker (`agent-runner/`) handles scheduled automation jobs via Railway cron.
+
+## Frontend (`client/`)
+
+### Module layout
+
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| `app.js` (1,791 lines) | 1 | Composition root: imports ~420 named exports from 22 modules, assigns ~120 functions to `window`, wires `hooks`, binds delegated DOM events |
+| `modules/` (18,000+ lines) | 32 | Domain logic: todos, projects, drawer, AI workspace, quick entry, command palette, auth, drag-drop, etc. |
+| `utils/` | 10 | Shared helpers: API client, auth session, DOM selectors, theme, project paths, lint heuristics |
+| `vendor/chrono-node/` | ~80 | Vendored natural date parsing library |
+
+### Key patterns
+
+- **Event delegation:** `app.js` binds `click`, `submit`, `input`, etc. on `document` and resolves handlers via `data-onclick`, `data-onsubmit`, `data-oninput` attributes. Functions must be on `window` to be callable from HTML.
+- **Hooks registry:** `store.js` exports a `hooks` object. `app.js` assigns ~137 functions to `hooks.*` at startup, breaking circular imports. Modules call `hooks.X()` instead of importing directly.
+- **EventBus:** Minimal pub-sub (17 lines). Only two events in use: `todos:changed` (triggers filter + render) and `todos:render` (render only).
+- **State actions:** `stateActions.js` (688 lines) implements `applyUiAction()`, `applyAsyncAction()`, `applyDomainAction()` with named action types (e.g., `TODO_CREATED`, `DRAWER_OPEN`).
+- **DOM patching:** `todosViewPatches.js` (378 lines) provides keyed micro-patches (e.g., `patchTodoRowCompletion`, `patchTodoRowSelection`) to avoid full rerenders for single-todo updates.
+
+### Shared mutable state (`store.js`)
+
+A single `state` object (342 lines, ~100 properties) is imported and mutated directly by all 32 modules. Properties span auth, todos, projects, drawer, rail, AI workspace, command palette, quick entry, home dashboard, and bulk selection.
+
+### Top 10 risky frontend couplings
+
+1. `app.js` imports ~420 named exports — any rename breaks HTML `data-onclick` bindings
+2. `drawerUi.js` (2,146 lines) mixes rendering, draft management, AI assist, and kebab menu
+3. `filterLogic.js` `renderTodos()` does full innerHTML replacement for the visible list
+4. `projectsState.js` (1,391 lines) handles CRUD, headings, catalog, dialogs, and rail updates
+5. `aiWorkspace.js` (1,517 lines) owns critique, plan, and brain-dump flows in one module
+6. `hooks` object (137 assignments) acts as a service locator, obscuring the dependency graph
+7. `state` object is mutated directly — no encapsulation or change notification
+8. `window.*` bridge (~120 assignments) couples HTML templates to JS function names
+9. `onCreateAssist.js` (1,281 lines) manages complex on-create AI suggestion lifecycle
+10. Multiple modules call `EventBus.dispatch("todos:changed")` — render triggers are scattered
+
+## Backend (`src/`)
+
+### Module layout
+
+| Layer | Files | Purpose |
+|-------|-------|---------|
+| `routes/` | 14 routers | HTTP endpoints (138 routes total) |
+| `services/` | 49 files (13,882 lines) | Business logic, persistence, AI orchestration |
+| `agent/` | 2 files | Agent executor (3,362 lines) + context |
+| `mcp/` | 5 files | MCP protocol (auth, errors, OAuth pages, scopes, tool catalog) |
+| `middleware/` | 4 files | Auth, admin, agent auth, rate limiting |
+| `interfaces/` | 4 files | Service interfaces (ITodoService, IProjectService, etc.) |
+
+### Route domains
+
+| Mount | Router | Auth | Rate limit |
+|-------|--------|------|-----------|
+| `/auth` | authRouter | Public | authLimiter (5/15min) |
+| `/oauth`, `/.well-known` | mcpPublicRouter | Public | mcpPublicLimiter (60/min) |
+| `/todos` | todosRouter | JWT | apiLimiter (100/15min) |
+| `/projects` | projectsRouter | JWT | apiLimiter |
+| `/ai` | aiRouter + prioritiesBriefRouter | JWT | apiLimiter |
+| `/agent` | agentRouter | Agent auth | apiLimiter |
+| `/mcp` | mcpRouter | MCP OAuth | apiLimiter |
+| `/capture` | captureRouter | JWT | apiLimiter |
+| `/feedback` | feedbackRouter | JWT | apiLimiter |
+| `/preferences` | preferencesRouter | JWT | apiLimiter |
+| `/admin` | adminRouter | JWT + admin | apiLimiter |
+| `/api/agent-enrollment` | enrollmentRouter | JWT | apiLimiter |
+
+### Agent executor (`agentExecutor.ts` — 3,362 lines)
+
+Dispatches 98 actions (40 read, 53 write, 5 system) in a single file. All MCP tools and agent API routes delegate to this executor. Features: zod validation per action, idempotency (SHA-256 input hashing, 7-day TTL), structured error envelopes, audit logging.
+
+### Data model (Prisma — 26 models)
+
+**Core:** User, Todo, Project, Heading, Subtask, Area, Goal
+**AI:** AiSuggestion, AiSuggestionAppliedTodo, CaptureItem
+**Agent:** AgentIdempotencyRecord, AgentActionAudit, AgentJobRun, FailedAutomationAction, AgentConfig, AgentEnrollment, AgentMetricEvent
+**OAuth:** RefreshToken, McpAssistantSession, McpAuthorizationCode, McpRefreshToken
+**Analytics:** TaskRecommendationFeedback, UserDayContext, LearningRecommendation, UserPlanningPreferences, FeedbackRequest
+
+### Top 5 long-running backend flows
+
+1. `POST /ai/{surface}/generate` — LLM call + DB queries + quota + throttle + normalization
+2. `POST /agent/write/weekly_review` — Multi-table analysis + optional LLM + metric aggregation
+3. `POST /agent/write/plan_project` — Project decomposition + LLM planning
+4. `POST /feedback/admin/promote` — AI triage + GitHub search + issue creation
+5. `POST /ai/critique-task` — LLM critique + subtask suggestion + apply
+
+### External dependencies
+
+| Service | Purpose |
+|---------|---------|
+| PostgreSQL | Primary data store (Prisma ORM) |
+| OpenAI-compatible LLM | AI suggestions, critique, planning, decision assist |
+| SMTP (Nodemailer) | Email verification, password reset |
+| GitHub API | Feedback deduplication, issue search/creation |
+
+## Agent Runner (`agent-runner/`)
+
+A **Python worker** deployed on Railway cron with 7 job types:
+
+| Job | Trigger | Purpose |
+|-----|---------|---------|
+| `daily` | Cron | Plan today + ensure next action for each enrolled user |
+| `weekly` | Cron | Weekly review + safe apply |
+| `inbox` | Cron | Classify + apply capture items |
+| `watchdog` | Cron | Stale tasks + waiting follow-ups |
+| `decomposer` | Cron | Stuck projects + next actions |
+| `evaluator_daily` | Cron | Evaluate daily plan quality |
+| `evaluator_weekly` | Cron | Evaluate weekly system health |
+
+Architecture: reads enrollment from Postgres → exchanges refresh token for short-lived JWT → calls Node API via HTTP → persists results to AgentJobRun table. Supports dry-run, auto-apply policies, and delivery modes (log/email/slack).
+
+## Testing
+
+| Suite | Files | Runner | Scope |
+|-------|-------|--------|-------|
+| Unit | 17 `.test.ts` | Jest (SKIP_DB_SETUP=true) | Services, validators, engines |
+| Integration | 6 `.integration.test.ts` | Jest + Postgres | API contracts, DB flows |
+| MCP | Separate config | Jest | MCP protocol compliance |
+| UI | `tests/ui/*.spec.ts` | Playwright | Chromium desktop + mobile |
+| Eval | `evals/` | Custom | Agent/planner/decision quality |

--- a/docs/architecture/target-state.md
+++ b/docs/architecture/target-state.md
@@ -1,0 +1,159 @@
+# Target Architecture
+
+## Frontend target structure
+
+```
+client/
+├── app.js                          ← Thin: imports bootstrap + calls init()
+├── bootstrap/
+│   ├── initApp.js                  ← Top-level app initialization
+│   ├── initShell.js                ← Shell/layout (header, nav, theme)
+│   └── initGlobalListeners.js      ← Global event listeners, keyboard shortcuts
+├── platform/
+│   ├── events/
+│   │   ├── eventBus.js             ← Pub-sub (existing, moved here)
+│   │   └── eventTypes.js           ← Canonical event name constants
+│   ├── state/
+│   │   ├── createStore.js          ← Reusable store factory
+│   │   └── createSelector.js       ← Derived state helpers
+│   ├── dom/
+│   │   ├── query.js                ← DOM query utilities (from domSelectors.js)
+│   │   └── events.js               ← Event delegation helpers
+│   └── http/
+│       └── apiClient.js            ← Centralized API client (from utils/)
+├── features/
+│   ├── todos/
+│   │   ├── initTodosFeature.js     ← Owns todo listeners/subscriptions
+│   │   ├── todoActions.js          ← State mutations (extracted from stateActions.js)
+│   │   ├── todoSelectors.js        ← Derived state (filtered todos, etc.)
+│   │   ├── todoApi.js              ← API calls (from todosService.js)
+│   │   └── views/
+│   │       ├── todoListView.js     ← List rendering (from filterLogic.js)
+│   │       └── todoItemView.js     ← Row rendering + patches (from todosViewPatches.js)
+│   ├── projects/
+│   │   ├── initProjectsFeature.js
+│   │   ├── projectActions.js
+│   │   ├── projectSelectors.js
+│   │   ├── projectApi.js
+│   │   └── views/
+│   ├── drawer/
+│   │   ├── initDrawerFeature.js
+│   │   ├── drawerStore.js
+│   │   ├── drawerActions.js
+│   │   └── views/
+│   ├── command-palette/
+│   │   ├── initCommandPaletteFeature.js
+│   │   └── commandPaletteView.js
+│   ├── agent/
+│   │   ├── initAgentFeature.js
+│   │   ├── agentActions.js
+│   │   ├── agentApi.js
+│   │   └── agentPolling.js
+│   ├── assistant/
+│   │   ├── initAssistantFeature.js
+│   │   └── assistantApi.js
+│   └── capture/
+│       ├── initCaptureFeature.js
+│       └── captureApi.js
+├── shared/
+│   ├── components/
+│   └── constants/
+└── utils/                          ← Existing (no change)
+```
+
+## Backend target structure
+
+```
+src/
+├── app.ts                          ← Express assembly (existing, thinner)
+├── server.ts                       ← Entry point (existing)
+├── config.ts                       ← Environment config (existing)
+├── domains/
+│   ├── core/
+│   │   ├── todos/
+│   │   │   ├── todoService.ts
+│   │   │   ├── todoRepository.ts
+│   │   │   └── todoValidators.ts
+│   │   ├── projects/
+│   │   │   ├── projectService.ts
+│   │   │   └── projectRepository.ts
+│   │   └── users/
+│   │       ├── authService.ts
+│   │       └── userRepository.ts
+│   ├── assistant/
+│   │   ├── suggestions/
+│   │   ├── chat/
+│   │   └── prompts/
+│   ├── agent/
+│   │   ├── runs/
+│   │   │   ├── agentRunService.ts
+│   │   │   └── agentRunRepository.ts
+│   │   ├── actions/
+│   │   │   ├── coreActionHandler.ts
+│   │   │   ├── assistantActionHandler.ts
+│   │   │   └── agentActionHandler.ts
+│   │   ├── audits/
+│   │   └── executor.ts             ← Thin dispatcher (< 500 lines)
+│   └── mcp/
+│       ├── sessions/
+│       ├── tools/
+│       └── transport/
+├── infra/
+│   ├── db/
+│   │   └── prisma.ts
+│   ├── queue/                      ← If BullMQ adopted (pending ADR-005)
+│   ├── logging/
+│   │   └── logger.ts
+│   ├── metrics/
+│   │   └── metrics.ts
+│   └── config/
+│       └── env.ts
+├── routes/                         ← Existing (unchanged)
+├── middleware/                      ← Existing (unchanged)
+├── workers/
+│   └── agentWorker.ts              ← If local worker adopted (pending ADR-005)
+└── interfaces/                     ← Existing (unchanged)
+```
+
+## Conventions
+
+### Event naming
+
+Format: `{domain}.{entity}.{past-tense-verb}` or `{domain}.{action}`
+
+```
+todo.created        todo.updated        todo.deleted        todo.completed
+project.selected    project.created     project.deleted
+drawer.opened       drawer.closed
+capture.created
+agent.run.requested agent.run.started   agent.run.completed agent.run.failed
+```
+
+### State mutation rules
+
+1. State changes happen through named actions (`applyDomainAction`, `applyUiAction`, etc.)
+2. Direct `state.X = value` is allowed **within** the action function only
+3. Views read from selectors, not directly from `state`
+4. Cross-feature communication goes through EventBus, not direct function calls
+5. Direct function calls are allowed **within** a feature module
+
+### Frontend module ownership
+
+| Owner | Modules |
+|-------|---------|
+| Todos feature | todoActions, todoSelectors, todoApi, todoListView, todoItemView |
+| Projects feature | projectActions, projectSelectors, projectApi, projectViews |
+| Drawer feature | drawerStore, drawerActions, drawerViews |
+| Shell | bootstrap/*, platform/*, command palette, shortcuts, responsive layout |
+| AI/Assistant | aiWorkspace, onCreateAssist, taskDrawerAssist, homeAiService |
+| Agent | agentApi, agentPolling, agentStore |
+
+### Backend domain ownership
+
+| Domain | Services |
+|--------|----------|
+| Core (todos, projects, users) | todoService, projectService, authService, headingService |
+| Assistant | aiService, aiSuggestionStore, aiApplyService, aiNormalizationService, decisionAssist* |
+| Agent | agentExecutor, agentJobRunService, agentAuditService, agentIdempotencyService, agentMetricsService |
+| MCP | mcpOAuthService, mcpClientService, mcpAuth, mcpToolCatalog |
+| Infra | prismaClient, rateLimitMiddleware, errorHandling, config |


### PR DESCRIPTION
## Summary

- Architecture documentation: current-state and target-state with full inventories
- 4 ADRs: composition roots, event bus contract, agent worker model, domain-oriented backend
- Event naming conventions, state mutation rules, ownership maps

Docs only — no code changes.

Closes #383

## Test plan

- [ ] No code changes, nothing to test

🤖 Generated with [Claude Code](https://claude.com/claude-code)