### PR TITLE
feat(ui): add frontend platform primitives and event type constants

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -447,6 +447,7 @@ import {
   dismissHomeFocusSuggestion,
 } from "./modules/homeAiService.js";
 import { EventBus } from "./modules/eventBus.js";
+import { TODOS_CHANGED, TODOS_RENDER } from "./platform/events/eventTypes.js";
 import {
   initOnboarding,
   isOnboardingActive,
@@ -649,7 +650,7 @@ const { ensureTodosShellActive, selectWorkspaceView, switchView } =
     setSelectedProjectKey,
     setDateView,
     dispatchTodosChanged: (payload) =>
-      EventBus.dispatch("todos:changed", payload),
+      EventBus.dispatch(TODOS_CHANGED, payload),
     closeProjectEditDrawer,
     closeProjectDeleteDialog,
     closeProjectsRailSheet,
@@ -1106,7 +1107,7 @@ document.addEventListener("keydown", function (e) {
     // Allow Esc to clear search
     if (e.key === "Escape" && e.target.id === "searchInput") {
       e.target.value = "";
-      EventBus.dispatch("todos:changed");
+      EventBus.dispatch(TODOS_CHANGED);
       e.target.blur();
     }
     return;
@@ -1476,11 +1477,11 @@ function bindDeclarativeHandlers() {
   // todosService / projectsState / drawerUi → filterLogic
   // domain modules dispatch directly via EventBus; EventBus delivers to subscribers
   hooks.applyFiltersAndRender = (payload) =>
-    EventBus.dispatch("todos:changed", payload);
+    EventBus.dispatch(TODOS_CHANGED, payload);
 
   // Subscribe renderers
-  EventBus.subscribe("todos:changed", applyFiltersAndRender);
-  EventBus.subscribe("todos:render", renderTodos);
+  EventBus.subscribe(TODOS_CHANGED, applyFiltersAndRender);
+  EventBus.subscribe(TODOS_RENDER, renderTodos);
   hooks.updateCategoryFilter = updateCategoryFilter;
   hooks.shouldUseServerVisibleTodos = shouldUseServerVisibleTodos;
   // todosService / filterLogic → projectsState

--- a/client/platform/events/eventBus.js
+++ b/client/platform/events/eventBus.js
@@ -1,0 +1,5 @@
+// =============================================================================
+// eventBus.js — Platform-canonical location for the EventBus.
+// Re-exports from modules/eventBus.js to avoid breaking existing imports.
+// =============================================================================
+export { EventBus } from "../../modules/eventBus.js";

--- a/client/platform/events/eventTypes.js
+++ b/client/platform/events/eventTypes.js
@@ -1,0 +1,8 @@
+// =============================================================================
+// eventTypes.js — Canonical event name constants.
+// Use these instead of string literals when dispatching/subscribing via EventBus.
+// =============================================================================
+
+// --- Todos lifecycle ---
+export const TODOS_CHANGED = "todos:changed";
+export const TODOS_RENDER = "todos:render";

--- a/client/platform/state/createSelector.js
+++ b/client/platform/state/createSelector.js
@@ -1,0 +1,41 @@
+// =============================================================================
+// createSelector.js — Memoized derived-state helpers.
+//
+// Usage:
+//   const getVisibleTodos = createSelector(
+//     (state) => state.todos,
+//     (state) => state.currentDateView,
+//     (todos, dateView) => todos.filter(t => matchesDateView(t, dateView))
+//   );
+//   const result = getVisibleTodos(store.getState());
+// =============================================================================
+
+/**
+ * Creates a memoized selector that recomputes only when inputs change.
+ * Accepts 1–4 input selectors + a result function.
+ *
+ * @param  {...Function} args  Input selectors followed by a combiner function.
+ * @returns {Function}         Memoized selector: (state) => result.
+ */
+export function createSelector(...args) {
+  const combiner = args.pop();
+  const inputSelectors = args;
+  let lastInputs = null;
+  let lastResult = undefined;
+
+  return function memoizedSelector(state) {
+    const inputs = inputSelectors.map((sel) => sel(state));
+
+    if (
+      lastInputs !== null &&
+      inputs.length === lastInputs.length &&
+      inputs.every((val, i) => val === lastInputs[i])
+    ) {
+      return lastResult;
+    }
+
+    lastInputs = inputs;
+    lastResult = combiner(...inputs);
+    return lastResult;
+  };
+}

--- a/client/platform/state/createStore.js
+++ b/client/platform/state/createStore.js
@@ -1,0 +1,39 @@
+// =============================================================================
+// createStore.js — Minimal store factory for feature-scoped state.
+//
+// Usage:
+//   const store = createStore({ count: 0 });
+//   const unsub = store.subscribe((state) => console.log(state.count));
+//   store.update((s) => { s.count += 1; });      // notifies subscribers
+//   const current = store.getState();             // { count: 1 }
+//   unsub();                                       // removes listener
+// =============================================================================
+
+/**
+ * Creates a minimal observable store.
+ *
+ * @param {T} initialState  Plain object representing the initial state.
+ * @returns {{ getState: () => T, update: (fn: (state: T) => void) => void, subscribe: (fn: (state: T) => () => void) }}
+ */
+export function createStore(initialState) {
+  const state = { ...initialState };
+  const listeners = new Set();
+
+  function getState() {
+    return state;
+  }
+
+  function update(mutator) {
+    mutator(state);
+    for (const listener of listeners) {
+      listener(state);
+    }
+  }
+
+  function subscribe(listener) {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }
+
+  return { getState, update, subscribe };
+}


### PR DESCRIPTION
## Summary

- Add `client/platform/` layer with reusable primitives for the frontend refactor
- `events/eventTypes.js` — canonical event name constants replacing string literals
- `events/eventBus.js` — re-export from existing `modules/eventBus.js`
- `state/createStore.js` — minimal observable store factory for feature-scoped state
- `state/createSelector.js` — memoized derived-state helpers
- Replace `"todos:changed"` / `"todos:render"` string literals in `app.js` with `TODOS_CHANGED` / `TODOS_RENDER` constants

No behavioral changes — existing code continues working unchanged.

Closes #384

## Test plan

- [ ] Unit tests pass (296/296)
- [ ] Typecheck passes
- [ ] Format check passes
- [ ] Fast UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)