### PR TITLE
refactor(ui): extract declarative handler system and service worker from app.js

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -449,6 +449,10 @@ import {
 import { EventBus } from "./modules/eventBus.js";
 import { TODOS_CHANGED, TODOS_RENDER } from "./platform/events/eventTypes.js";
 import {
+  bindDeclarativeHandlers,
+  registerServiceWorker,
+} from "./bootstrap/initGlobalListeners.js";
+import {
   initOnboarding,
   isOnboardingActive,
   advanceOnboarding,
@@ -470,23 +474,7 @@ const API_URL =
 // trailing edge (ms after the last call), so single-event triggers (e.g.
 // Playwright fill()) respond instantly while rapid keystrokes are batched.
 const FILTER_INPUT_DEBOUNCE_MS = 180;
-const debounce = (fn, ms) => {
-  let t;
-  return (...args) => {
-    const leading = !t;
-    clearTimeout(t);
-    t = setTimeout(() => {
-      t = null;
-      if (!leading) fn(...args);
-    }, ms);
-    if (leading) fn(...args);
-  };
-};
-
-const DEBOUNCED_INPUT_EXPRESSIONS = new Set([
-  "filterTodos()",
-  "syncSheetSearch()",
-]);
+// debounce + DEBOUNCED_INPUT_EXPRESSIONS moved to bootstrap/initGlobalListeners.js
 
 // ---------------------------------------------------------------------------
 // Module consumption — extracted pure-function modules loaded before app.js
@@ -1310,162 +1298,9 @@ function bindDockHandlers() {
 // showMessage, hideMessage, escapeHtml — from utils/utils.js
 // toggleTheme, initTheme — from utils/theme.js
 
-// ========== PHASE E: SERVICE WORKER REGISTRATION ==========
-if ("serviceWorker" in navigator) {
-  window.addEventListener("load", async () => {
-    const shouldRegister =
-      window.location.protocol === "https:" &&
-      window.location.hostname !== "localhost";
+// Service worker registration moved to bootstrap/initGlobalListeners.js
 
-    if (!shouldRegister) {
-      const registrations = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(
-        registrations.map((registration) => registration.unregister()),
-      );
-      return;
-    }
-
-    navigator.serviceWorker
-      .register("/service-worker.js")
-      .then((registration) => {
-        console.log(
-          "Service Worker registered successfully:",
-          registration.scope,
-        );
-      })
-      .catch((error) => {
-        console.log("Service Worker registration failed:", error);
-      });
-  });
-}
-
-function invokeBoundExpression(expression, event, element) {
-  const source = expression.trim().replace(/;$/, "");
-  if (!source) return;
-
-  const eventMethodMatch = source.match(/^event\.([A-Za-z_$][\w$]*)\(\)$/);
-  if (eventMethodMatch) {
-    const methodName = eventMethodMatch[1];
-    const method = event?.[methodName];
-    if (typeof method === "function") {
-      method.call(event);
-    }
-    return;
-  }
-
-  const callMatch = source.match(/^([A-Za-z_$][\w$]*)\((.*)\)$/);
-  if (!callMatch) return;
-
-  const functionName = callMatch[1];
-  const rawArgs = callMatch[2].trim();
-  const target = window[functionName];
-  if (typeof target !== "function") return;
-
-  const tokens =
-    rawArgs === "" ? [] : rawArgs.match(/'[^']*'|\"[^\"]*\"|[^,]+/g) || [];
-  const args = tokens.map((token) => {
-    const arg = token.trim();
-    if (arg === "event") return event;
-    if (arg === "this") return element;
-    if (arg === "this.value") {
-      if (
-        element instanceof HTMLInputElement ||
-        element instanceof HTMLSelectElement ||
-        element instanceof HTMLTextAreaElement
-      ) {
-        return element.value;
-      }
-      return "";
-    }
-    if (arg === "this.checked") {
-      if (element instanceof HTMLInputElement) {
-        return element.checked;
-      }
-      return false;
-    }
-    if (/^'.*'$/.test(arg) || /^\".*\"$/.test(arg)) return arg.slice(1, -1);
-    if (arg === "true") return true;
-    if (arg === "false") return false;
-    if (/^-?\d+(\.\d+)?$/.test(arg)) return Number(arg);
-    return arg;
-  });
-
-  target(...args);
-}
-
-function bindDeclarativeHandlers() {
-  if (window.__declarativeHandlersBound) {
-    return;
-  }
-  window.__declarativeHandlersBound = true;
-
-  // Only search/filter inputs are debounced; other input handlers stay
-  // immediate so task composition and assist surfaces remain responsive.
-  const inputDebouncedInvokers = new Map();
-
-  const events = [
-    "click",
-    "submit",
-    "input",
-    "change",
-    "keypress",
-    "dragstart",
-    "dragover",
-    "drop",
-    "dragend",
-  ];
-
-  for (const eventType of events) {
-    const attribute = `on${eventType}`;
-    document.addEventListener(eventType, (event) => {
-      const rawTarget = event.target;
-      const target =
-        rawTarget instanceof Element
-          ? rawTarget
-          : rawTarget instanceof Node
-            ? rawTarget.parentElement
-            : null;
-      let element = target?.closest(`[data-${attribute}]`) || null;
-      if (!element && (eventType === "dragover" || eventType === "drop")) {
-        const clientX = Number(event.clientX);
-        const clientY = Number(event.clientY);
-        if (Number.isFinite(clientX) && Number.isFinite(clientY)) {
-          const pointTarget = document.elementFromPoint(clientX, clientY);
-          if (pointTarget instanceof Element) {
-            element = pointTarget.closest(`[data-${attribute}]`);
-          }
-        }
-      }
-      if (!element && eventType === "drop") {
-        const fallbackDropTarget = document.querySelector(
-          ".todo-item--heading-drop-target, .todo-item.drag-over, .todo-heading-divider--drag-over-before, .todo-heading-divider--drag-over-after",
-        );
-        if (fallbackDropTarget instanceof Element) {
-          element = fallbackDropTarget.closest(`[data-${attribute}]`);
-        }
-      }
-      if (!element) return;
-      const expression = element.dataset[attribute];
-      if (!expression) return;
-      if (
-        eventType === "input" &&
-        DEBOUNCED_INPUT_EXPRESSIONS.has(expression)
-      ) {
-        let fn = inputDebouncedInvokers.get(expression);
-        if (!fn) {
-          fn = debounce(
-            (expr, ev, el) => invokeBoundExpression(expr, ev, el),
-            FILTER_INPUT_DEBOUNCE_MS,
-          );
-          inputDebouncedInvokers.set(expression, fn);
-        }
-        fn(expression, event, element);
-      } else {
-        invokeBoundExpression(expression, event, element);
-      }
-    });
-  }
-}
+// invokeBoundExpression + bindDeclarativeHandlers moved to bootstrap/initGlobalListeners.js
 
 // ---------------------------------------------------------------------------
 // Hook wiring — called after all modules are imported so cross-module
@@ -1859,5 +1694,6 @@ function init() {
 initTheme();
 
 // Initialize on load
+registerServiceWorker();
 bindDeclarativeHandlers();
 init();

--- a/client/bootstrap/initGlobalListeners.js
+++ b/client/bootstrap/initGlobalListeners.js
@@ -1,0 +1,183 @@
+// =============================================================================
+// initGlobalListeners.js — Declarative DOM event delegation and service worker.
+//
+// Extracted from app.js to separate the event dispatch infrastructure from
+// domain-specific wiring. The declarative handler system resolves `data-onclick`,
+// `data-onsubmit`, etc. attributes by calling `window[functionName](args)`.
+// =============================================================================
+
+const FILTER_INPUT_DEBOUNCE_MS = 180;
+
+const debounce = (fn, ms) => {
+  let t;
+  return (...args) => {
+    const leading = !t;
+    clearTimeout(t);
+    t = setTimeout(() => {
+      t = null;
+      if (!leading) fn(...args);
+    }, ms);
+    if (leading) fn(...args);
+  };
+};
+
+const DEBOUNCED_INPUT_EXPRESSIONS = new Set([
+  "filterTodos()",
+  "syncSheetSearch()",
+]);
+
+function invokeBoundExpression(expression, event, element) {
+  const source = expression.trim().replace(/;$/, "");
+  if (!source) return;
+
+  const eventMethodMatch = source.match(/^event\.([A-Za-z_$][\w$]*)\(\)$/);
+  if (eventMethodMatch) {
+    const methodName = eventMethodMatch[1];
+    const method = event?.[methodName];
+    if (typeof method === "function") {
+      method.call(event);
+    }
+    return;
+  }
+
+  const callMatch = source.match(/^([A-Za-z_$][\w$]*)\((.*)\)$/);
+  if (!callMatch) return;
+
+  const functionName = callMatch[1];
+  const rawArgs = callMatch[2].trim();
+  const target = window[functionName];
+  if (typeof target !== "function") return;
+
+  const tokens =
+    rawArgs === "" ? [] : rawArgs.match(/'[^']*'|\"[^\"]*\"|[^,]+/g) || [];
+  const args = tokens.map((token) => {
+    const arg = token.trim();
+    if (arg === "event") return event;
+    if (arg === "this") return element;
+    if (arg === "this.value") {
+      if (
+        element instanceof HTMLInputElement ||
+        element instanceof HTMLSelectElement ||
+        element instanceof HTMLTextAreaElement
+      ) {
+        return element.value;
+      }
+      return "";
+    }
+    if (arg === "this.checked") {
+      if (element instanceof HTMLInputElement) {
+        return element.checked;
+      }
+      return false;
+    }
+    if (/^'.*'$/.test(arg) || /^\".*\"$/.test(arg)) return arg.slice(1, -1);
+    if (arg === "true") return true;
+    if (arg === "false") return false;
+    if (/^-?\d+(\.\d+)?$/.test(arg)) return Number(arg);
+    return arg;
+  });
+
+  target(...args);
+}
+
+export function bindDeclarativeHandlers() {
+  if (window.__declarativeHandlersBound) {
+    return;
+  }
+  window.__declarativeHandlersBound = true;
+
+  const inputDebouncedInvokers = new Map();
+
+  const events = [
+    "click",
+    "submit",
+    "input",
+    "change",
+    "keypress",
+    "dragstart",
+    "dragover",
+    "drop",
+    "dragend",
+  ];
+
+  for (const eventType of events) {
+    const attribute = `on${eventType}`;
+    document.addEventListener(eventType, (event) => {
+      const rawTarget = event.target;
+      const target =
+        rawTarget instanceof Element
+          ? rawTarget
+          : rawTarget instanceof Node
+            ? rawTarget.parentElement
+            : null;
+      let element = target?.closest(`[data-${attribute}]`) || null;
+      if (!element && (eventType === "dragover" || eventType === "drop")) {
+        const clientX = Number(event.clientX);
+        const clientY = Number(event.clientY);
+        if (Number.isFinite(clientX) && Number.isFinite(clientY)) {
+          const pointTarget = document.elementFromPoint(clientX, clientY);
+          if (pointTarget instanceof Element) {
+            element = pointTarget.closest(`[data-${attribute}]`);
+          }
+        }
+      }
+      if (!element && eventType === "drop") {
+        const fallbackDropTarget = document.querySelector(
+          ".todo-item--heading-drop-target, .todo-item.drag-over, .todo-heading-divider--drag-over-before, .todo-heading-divider--drag-over-after",
+        );
+        if (fallbackDropTarget instanceof Element) {
+          element = fallbackDropTarget.closest(`[data-${attribute}]`);
+        }
+      }
+      if (!element) return;
+      const expression = element.dataset[attribute];
+      if (!expression) return;
+      if (
+        eventType === "input" &&
+        DEBOUNCED_INPUT_EXPRESSIONS.has(expression)
+      ) {
+        let fn = inputDebouncedInvokers.get(expression);
+        if (!fn) {
+          fn = debounce(
+            (expr, ev, el) => invokeBoundExpression(expr, ev, el),
+            FILTER_INPUT_DEBOUNCE_MS,
+          );
+          inputDebouncedInvokers.set(expression, fn);
+        }
+        fn(expression, event, element);
+      } else {
+        invokeBoundExpression(expression, event, element);
+      }
+    });
+  }
+}
+
+export function registerServiceWorker() {
+  if (!("serviceWorker" in navigator)) return;
+
+  window.addEventListener("load", async () => {
+    const shouldRegister =
+      window.location.protocol === "https:" &&
+      window.location.hostname !== "localhost";
+
+    if (!shouldRegister) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(
+        registrations.map((registration) => registration.unregister()),
+      );
+      return;
+    }
+
+    navigator.serviceWorker
+      .register("/service-worker.js")
+      .then((registration) => {
+        console.log(
+          "Service Worker registered successfully:",
+          registration.scope,
+        );
+      })
+      .catch((error) => {
+        console.log("Service Worker registration failed:", error);
+      });
+  });
+}


### PR DESCRIPTION
## Summary

- Extract event delegation infrastructure from `app.js` into `client/bootstrap/initGlobalListeners.js`:
  - `invokeBoundExpression()` — resolves `data-onclick`, `data-onsubmit`, etc. to `window[fn](args)`
  - `bindDeclarativeHandlers()` — attaches delegated listeners on `document` for 9 event types
  - `debounce()` + `DEBOUNCED_INPUT_EXPRESSIONS` — debouncing for filter inputs
  - `registerServiceWorker()` — PWA service worker lifecycle
- `app.js` imports and calls these as part of its init sequence

First step toward making `app.js` a thin composition root. Domain-specific helper functions (moveTodoToHeading, aiBreakdownTodo, etc.) will move to feature initializers in PRs 5-6.

`app.js`: 1,797 → 1,699 lines

Closes #386

## Test plan

- [ ] All unit tests pass (296/296)
- [ ] Typecheck passes
- [ ] Format check passes
- [ ] Fast UI tests pass — declarative handlers still work
- [ ] Manual: click/submit/input/drag-drop interactions work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)