### PR TITLE
refactor(ui): add todo selectors and actions modules

### DIFF
--- a/client/features/todos/initTodosFeature.js
+++ b/client/features/todos/initTodosFeature.js
@@ -7,6 +7,12 @@
 // =============================================================================
 
 import { state, hooks } from "../../modules/store.js";
+import {
+  getTodoById,
+  getSelectedTodo,
+  getAllTodos,
+  getOpenTodos,
+} from "./todoSelectors.js";
 
 const { escapeHtml, showMessage } = window.Utils || {};
 
@@ -202,6 +208,10 @@ function registerWindowBridge() {
 function wireHooks() {
   hooks.renderSubtasks = renderSubtasks;
   hooks.setPriority = setPriority;
+  hooks.getTodoById = getTodoById;
+  hooks.getSelectedTodo = getSelectedTodo;
+  hooks.getAllTodos = getAllTodos;
+  hooks.getOpenTodos = getOpenTodos;
 }
 
 // ---------------------------------------------------------------------------

--- a/client/features/todos/todoActions.js
+++ b/client/features/todos/todoActions.js
@@ -1,0 +1,67 @@
+// =============================================================================
+// todoActions.js — Named state mutation entry points for the todos domain.
+//
+// These actions encapsulate the most common todo state mutations that are
+// currently done via direct `state.todos` manipulation across modules.
+// They complement (not replace) the existing stateActions.js pattern.
+// =============================================================================
+
+import { state } from "../../modules/store.js";
+
+/**
+ * Replace a todo in the state array by ID (in-place update).
+ * @param {string} todoId
+ * @param {object} updatedTodo — the full updated todo object
+ * @returns {boolean} true if the todo was found and replaced
+ */
+export function replaceTodoInState(todoId, updatedTodo) {
+  const index = state.todos.findIndex((item) => item.id === todoId);
+  if (index < 0) return false;
+  state.todos[index] = updatedTodo;
+  return true;
+}
+
+/**
+ * Update specific fields on a todo in the state array.
+ * @param {string} todoId
+ * @param {object} patch — fields to merge into the todo
+ * @returns {object|null} the updated todo, or null if not found
+ */
+export function patchTodoInState(todoId, patch) {
+  const index = state.todos.findIndex((item) => item.id === todoId);
+  if (index < 0) return null;
+  state.todos[index] = { ...state.todos[index], ...patch };
+  return state.todos[index];
+}
+
+/**
+ * Remove a todo from the state array by ID.
+ * @param {string} todoId
+ * @returns {object|null} the removed todo, or null if not found
+ */
+export function removeTodoFromState(todoId) {
+  const index = state.todos.findIndex((item) => item.id === todoId);
+  if (index < 0) return null;
+  const [removed] = state.todos.splice(index, 1);
+  return removed;
+}
+
+/**
+ * Add a todo to the beginning of the state array.
+ * @param {object} todo
+ */
+export function prependTodoToState(todo) {
+  state.todos.unshift(todo);
+}
+
+/**
+ * Set the todos loading state.
+ * @param {'idle'|'loading'|'loaded'|'error'} loadState
+ * @param {string} [errorMessage]
+ */
+export function setTodosLoadState(loadState, errorMessage) {
+  state.todosLoadState = loadState;
+  if (errorMessage !== undefined) {
+    state.todosLoadErrorMessage = errorMessage;
+  }
+}

--- a/client/features/todos/todoSelectors.js
+++ b/client/features/todos/todoSelectors.js
@@ -1,0 +1,101 @@
+// =============================================================================
+// todoSelectors.js — Derived state helpers for the todos domain.
+//
+// Selectors provide a stable read interface over the shared state object.
+// They encapsulate common query patterns so callers don't need to know
+// the shape of `state.todos` or how filtering works.
+// =============================================================================
+
+import { state } from "../../modules/store.js";
+
+/**
+ * Get a single todo by ID, or null if not found.
+ * @param {string} todoId
+ * @returns {object|null}
+ */
+export function getTodoById(todoId) {
+  if (!todoId) return null;
+  return state.todos.find((t) => t.id === todoId) || null;
+}
+
+/**
+ * Get the currently selected todo (based on state.selectedTodoId).
+ * @returns {object|null}
+ */
+export function getSelectedTodo() {
+  if (!state.selectedTodoId) return null;
+  return getTodoById(state.selectedTodoId);
+}
+
+/**
+ * Get all todos (unfiltered).
+ * @returns {Array}
+ */
+export function getAllTodos() {
+  return state.todos;
+}
+
+/**
+ * Get the count of all loaded todos.
+ * @returns {number}
+ */
+export function getTodoCount() {
+  return state.todos.length;
+}
+
+/**
+ * Get all open (non-completed, non-archived) todos.
+ * @returns {Array}
+ */
+export function getOpenTodos() {
+  return state.todos.filter((t) => !t.completed && !t.archived);
+}
+
+/**
+ * Get the current todos loading state.
+ * @returns {'idle'|'loading'|'loaded'|'error'}
+ */
+export function getTodosLoadState() {
+  return state.todosLoadState || "idle";
+}
+
+/**
+ * Check if todos are currently loading.
+ * @returns {boolean}
+ */
+export function isTodosLoading() {
+  return state.todosLoadState === "loading";
+}
+
+/**
+ * Get the todos load error message, or null.
+ * @returns {string|null}
+ */
+export function getTodosLoadError() {
+  return state.todosLoadErrorMessage || null;
+}
+
+/**
+ * Get the set of currently selected (bulk-select) todo IDs.
+ * @returns {Set}
+ */
+export function getSelectedTodoIds() {
+  return state.selectedTodos;
+}
+
+/**
+ * Check if a specific todo is selected in bulk selection.
+ * @param {string} todoId
+ * @returns {boolean}
+ */
+export function isTodoSelected(todoId) {
+  return state.selectedTodos.has(todoId);
+}
+
+/**
+ * Get the count of selected todos.
+ * @returns {number}
+ */
+export function getSelectedTodoCount() {
+  return state.selectedTodos.size;
+}


### PR DESCRIPTION
## Summary

- Add `client/features/todos/todoSelectors.js` — derived state helpers for todos
- Add `client/features/todos/todoActions.js` — named mutation entry points
- Register key selectors as hooks for cross-module access
- Builds on existing `stateActions.js` pattern (extend, not replace)

No behavioral changes — new modules provide a stable read/write interface that will be adopted incrementally.

Closes #389

## Test plan

- [ ] Unit tests pass
- [ ] Typecheck passes  
- [ ] Format check passes
- [ ] No console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)