### PR TITLE
refactor(ui): add focus preservation utility for rendering discipline

### DIFF
--- a/client/modules/todosViewPatches.js
+++ b/client/modules/todosViewPatches.js
@@ -376,3 +376,76 @@ export function patchBulkToolbar() {
     refs.selectAll.checked = allSelected;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Focus preservation — save/restore focus across DOM updates.
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture the currently focused element's identity so it can be restored
+ * after a DOM rewrite. Returns a restore function.
+ *
+ * Usage:
+ *   const restoreFocus = saveFocusState();
+ *   // ... perform DOM update ...
+ *   restoreFocus();
+ *
+ * @returns {() => void}
+ */
+export function saveFocusState() {
+  const active = document.activeElement;
+  if (!active || active === document.body) {
+    return () => {};
+  }
+
+  const todoId =
+    active.closest("[data-todo-id]")?.getAttribute("data-todo-id") || null;
+  const tagName = active.tagName;
+  const inputName =
+    active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
+      ? active.name || active.id
+      : null;
+  const selectionStart =
+    active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
+      ? active.selectionStart
+      : null;
+  const selectionEnd =
+    active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement
+      ? active.selectionEnd
+      : null;
+
+  return () => {
+    if (!todoId && !inputName) return;
+
+    let target = null;
+    if (todoId && inputName) {
+      const row = getTodoRow(todoId);
+      target = row?.querySelector(
+        `${tagName}[name="${inputName}"], ${tagName}#${inputName}`,
+      );
+    } else if (inputName) {
+      target =
+        document.querySelector(
+          `${tagName}[name="${inputName}"], ${tagName}#${inputName}`,
+        ) || null;
+    } else if (todoId) {
+      const row = getTodoRow(todoId);
+      target = row?.querySelector(tagName) || row;
+    }
+
+    if (target instanceof HTMLElement) {
+      target.focus();
+      if (
+        selectionStart !== null &&
+        (target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement)
+      ) {
+        try {
+          target.setSelectionRange(selectionStart, selectionEnd);
+        } catch {
+          // setSelectionRange not supported for some input types
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- Add `saveFocusState()` to `todosViewPatches.js`
- Captures active element identity (todo row, input name, cursor position)
- Returns restore function for focus preservation across DOM rewrites
- Enables inline edit focus preservation without a rendering framework

Closes #392

## Test plan

- [ ] Format check passes
- [ ] Unit tests pass
- [ ] No behavioral changes (utility not yet wired into render paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)