### PR TITLE
feat(api): async agent run execution with polling

### DIFF
--- a/client/features/agent/agentRunPolling.js
+++ b/client/features/agent/agentRunPolling.js
@@ -1,0 +1,85 @@
+// =============================================================================
+// agentRunPolling.js — Client-side polling for async agent run status.
+//
+// Usage:
+//   import { submitAgentRun } from './agentRunPolling.js';
+//   const result = await submitAgentRun('plan_today', { date: '2026-03-21' });
+//   // result = { ok: true, runId, status: 'completed', result: { ... } }
+// =============================================================================
+
+import { hooks } from "../../modules/store.js";
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = 90; // 3 minutes max
+const TERMINAL_STATES = new Set(["completed", "failed", "succeeded"]);
+
+/**
+ * Submit an agent action for async execution and poll until completion.
+ *
+ * @param {string} action — agent action name (e.g., 'plan_today')
+ * @param {object} [params] — action parameters
+ * @param {object} [options]
+ * @param {(status: object) => void} [options.onStatusChange] — called on each poll
+ * @param {AbortSignal} [options.signal] — abort signal to cancel polling
+ * @returns {Promise<object>} — final run status
+ */
+export async function submitAgentRun(action, params = {}, options = {}) {
+  const { onStatusChange, signal } = options;
+
+  // Submit the run
+  const submitResponse = await hooks.apiCall(`${hooks.API_URL}/agent/runs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, params }),
+  });
+
+  if (!submitResponse || !submitResponse.ok) {
+    const error = submitResponse
+      ? await submitResponse.json().catch(() => ({}))
+      : {};
+    throw new Error(error.error || "Failed to submit agent run");
+  }
+
+  const { runId } = await submitResponse.json();
+
+  // Poll for completion
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    if (signal?.aborted) {
+      throw new Error("Agent run polling aborted");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+
+    const statusResponse = await hooks.apiCall(
+      `${hooks.API_URL}/agent/runs/${runId}`,
+    );
+
+    if (!statusResponse || !statusResponse.ok) {
+      continue; // Retry on transient errors
+    }
+
+    const { run } = await statusResponse.json();
+    onStatusChange?.(run);
+
+    if (TERMINAL_STATES.has(run.status)) {
+      return run;
+    }
+  }
+
+  throw new Error("Agent run polling timed out");
+}
+
+/**
+ * Get the current status of an agent run.
+ *
+ * @param {string} runId
+ * @returns {Promise<object|null>}
+ */
+export async function getAgentRunStatus(runId) {
+  const response = await hooks.apiCall(`${hooks.API_URL}/agent/runs/${runId}`);
+
+  if (!response || !response.ok) return null;
+
+  const { run } = await response.json();
+  return run;
+}

--- a/src/domains/agent/runs/agentRunQueue.ts
+++ b/src/domains/agent/runs/agentRunQueue.ts
@@ -1,0 +1,113 @@
+/**
+ * Agent run queue — in-process async execution for on-demand agent runs.
+ *
+ * This is a lightweight in-process queue that runs agent actions outside
+ * the HTTP request cycle. It can be replaced with BullMQ when Redis is
+ * available (per ADR-005, Option A).
+ *
+ * For now, this uses setImmediate() to defer execution after the HTTP
+ * response is sent, which is sufficient to unblock the Express event loop
+ * for the 202 response.
+ */
+
+import type { AgentExecutor } from "../../../agent/agentExecutor";
+import type { AgentJobRunService } from "../../../services/agentJobRunService";
+import { createLogger } from "../../../infra/logging/logger";
+
+const log = createLogger("agentRunQueue");
+
+export interface EnqueuedRun {
+  runId: string;
+  userId: string;
+  action: string;
+  params: Record<string, unknown>;
+  requestId: string;
+  actor: string;
+}
+
+export function createAgentRunQueue(deps: {
+  agentExecutor: AgentExecutor;
+  jobRunService: AgentJobRunService;
+}) {
+  const { agentExecutor, jobRunService } = deps;
+
+  /**
+   * Enqueue an agent action for async execution.
+   * The action runs after the current event loop tick, allowing the
+   * HTTP handler to return 202 immediately.
+   */
+  function enqueue(run: EnqueuedRun): void {
+    setImmediate(async () => {
+      const startTime = Date.now();
+      log.info("agent run started", {
+        runId: run.runId,
+        action: run.action,
+        userId: run.userId,
+        requestId: run.requestId,
+      });
+
+      try {
+        const result = await agentExecutor.execute(
+          run.action as never,
+          run.params,
+          {
+            userId: run.userId,
+            requestId: run.requestId,
+            actor: run.actor,
+            surface: "agent" as const,
+          },
+        );
+
+        const durationMs = Date.now() - startTime;
+
+        if (result.status >= 200 && result.status < 300) {
+          await jobRunService.completeRun(run.userId, run.action, run.runId, {
+            result: result.body,
+            durationMs,
+          });
+          log.info("agent run completed", {
+            runId: run.runId,
+            action: run.action,
+            durationMs,
+          });
+        } else {
+          const errorMessage =
+            typeof result.body === "object" && result.body !== null
+              ? (result.body as Record<string, unknown>).error ||
+                (result.body as Record<string, unknown>).message ||
+                `HTTP ${result.status}`
+              : `HTTP ${result.status}`;
+          await jobRunService.failRun(
+            run.userId,
+            run.action,
+            run.runId,
+            String(errorMessage),
+          );
+          log.error("agent run failed", {
+            runId: run.runId,
+            action: run.action,
+            status: result.status,
+            durationMs,
+          });
+        }
+      } catch (error) {
+        const durationMs = Date.now() - startTime;
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        await jobRunService
+          .failRun(run.userId, run.action, run.runId, errorMessage)
+          .catch((e) =>
+            log.error("failed to record run failure", { error: String(e) }),
+          );
+        log.error("agent run exception", {
+          runId: run.runId,
+          action: run.action,
+          error: errorMessage,
+          durationMs,
+        });
+      }
+    });
+  }
+
+  return { enqueue };
+}

--- a/src/routes/agentRouter.ts
+++ b/src/routes/agentRouter.ts
@@ -1,12 +1,16 @@
+import { randomUUID } from "crypto";
 import { Request, Response, Router } from "express";
 import { AuthService } from "../services/authService";
 import { agentAuthMiddleware } from "../middleware/agentAuthMiddleware";
 import { getAgentRequestContext } from "../agent/agentContext";
 import { AgentActionName, AgentExecutor } from "../agent/agentExecutor";
+import { AgentJobRunService } from "../services/agentJobRunService";
+import { createAgentRunQueue } from "../domains/agent/runs/agentRunQueue";
 
 interface AgentRouterDeps {
   agentExecutor: AgentExecutor;
   authService?: AuthService;
+  jobRunService?: AgentJobRunService;
 }
 
 function getAgentUserId(req: Request): string {
@@ -41,6 +45,7 @@ function createAgentActionHandler(
 export function createAgentRouter({
   agentExecutor,
   authService,
+  jobRunService,
 }: AgentRouterDeps): Router {
   const router = Router();
 
@@ -412,6 +417,85 @@ export function createAgentRouter({
     "/write/update_action_policy",
     createAgentActionHandler(agentExecutor, "update_action_policy"),
   );
+
+  // -------------------------------------------------------------------------
+  // Async run endpoints — enqueue agent actions and return 202 Accepted.
+  // The run executes outside the HTTP request cycle.
+  // -------------------------------------------------------------------------
+  if (jobRunService) {
+    const runQueue = createAgentRunQueue({ agentExecutor, jobRunService });
+
+    router.post("/runs", async (req: Request, res: Response) => {
+      const { action, params } = req.body;
+      if (!action || typeof action !== "string") {
+        return res
+          .status(400)
+          .json({ error: "Missing required field: action" });
+      }
+
+      const userId = getAgentUserId(req);
+      const requestContext = getAgentRequestContext(req);
+      const runId = randomUUID();
+
+      const { claimed, run } = await jobRunService.claimRun(
+        userId,
+        action,
+        runId,
+      );
+      if (!claimed) {
+        return res.status(409).json({ error: "Run already claimed" });
+      }
+
+      runQueue.enqueue({
+        runId,
+        userId,
+        action,
+        params: params || {},
+        requestId: requestContext.requestId,
+        actor: requestContext.actor,
+      });
+
+      res.status(202).json({
+        ok: true,
+        runId,
+        status: "running",
+        action,
+        trace: {
+          requestId: requestContext.requestId,
+          timestamp: new Date().toISOString(),
+        },
+      });
+    });
+
+    router.get("/runs/:runId", async (req: Request, res: Response) => {
+      const userId = getAgentUserId(req);
+      const { runId } = req.params;
+
+      // Find run by checking all runs for the user with this runId as periodKey
+      const runs = await jobRunService.listRuns(userId, { limit: 100 });
+      const run = runs.find((r) => r.periodKey === runId);
+
+      if (!run) {
+        return res.status(404).json({ error: "Run not found" });
+      }
+
+      res.json({
+        ok: true,
+        run: {
+          id: run.id,
+          runId: run.periodKey,
+          action: run.jobName,
+          status: run.status,
+          retryCount: run.retryCount,
+          startedAt: run.claimedAt?.toISOString(),
+          completedAt: run.completedAt?.toISOString() || null,
+          failedAt: run.failedAt?.toISOString() || null,
+          errorMessage: run.errorMessage || null,
+          result: run.metadata || null,
+        },
+      });
+    });
+  }
 
   return router;
 }


### PR DESCRIPTION
## Summary

Phase D implementation per ADR-005 (Option A):

**Backend:**
- `src/domains/agent/runs/agentRunQueue.ts` — in-process async queue
- `POST /agent/runs` → 202 Accepted with runId
- `GET /agent/runs/:runId` → run status

**Frontend:**
- `client/features/agent/agentRunPolling.js` — submitAgentRun() with polling

Closes #397, #398, #399

## Test plan

- [ ] Typecheck + unit tests pass
- [ ] Existing sync endpoints unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)