### PR TITLE
refactor(api): add action registry for agentExecutor decomposition

### DIFF
--- a/src/domains/agent/actions/actionRegistry.ts
+++ b/src/domains/agent/actions/actionRegistry.ts
@@ -1,0 +1,60 @@
+/**
+ * Action registry — maps agent action names to domain-scoped handlers.
+ *
+ * This registry enables incremental decomposition of agentExecutor.ts.
+ * Actions can be registered here and the executor will delegate to them
+ * instead of handling them inline.
+ *
+ * Usage:
+ *   registerAction('list_tasks', async (params, context) => { ... });
+ *   const handler = getActionHandler('list_tasks');
+ *   if (handler) { return await handler(params, context); }
+ */
+
+export interface ActionContext {
+  userId: string;
+  requestId: string;
+  actor: string;
+  surface: "agent" | "mcp";
+  idempotencyKey?: string;
+}
+
+export interface ActionResult {
+  status: number;
+  body: unknown;
+}
+
+export type ActionHandler = (
+  params: Record<string, unknown>,
+  context: ActionContext,
+) => Promise<ActionResult>;
+
+const registry = new Map<string, ActionHandler>();
+
+/**
+ * Register a handler for an agent action.
+ */
+export function registerAction(action: string, handler: ActionHandler): void {
+  registry.set(action, handler);
+}
+
+/**
+ * Get the registered handler for an action, or undefined if not registered.
+ */
+export function getActionHandler(action: string): ActionHandler | undefined {
+  return registry.get(action);
+}
+
+/**
+ * Check if an action has a registered handler.
+ */
+export function hasActionHandler(action: string): boolean {
+  return registry.has(action);
+}
+
+/**
+ * Get all registered action names.
+ */
+export function getRegisteredActions(): string[] {
+  return Array.from(registry.keys());
+}


### PR DESCRIPTION
## Summary

- Add `src/domains/agent/actions/actionRegistry.ts` — handler registry pattern
- `registerAction()`, `getActionHandler()`, `hasActionHandler()`
- Enables incremental extraction of action handlers from the 3,428-line `agentExecutor.ts`
- No action handlers moved yet — this establishes the pattern

The executor can be updated to check the registry before its inline switch/case, allowing actions to be extracted one domain at a time without a big-bang rewrite.

Closes #407

## Test plan

- [ ] Typecheck passes
- [ ] Unit tests pass
- [ ] No behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)