### PR TITLE
fix(ui): move feedback into Todos shell as embedded pane

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -139,6 +139,7 @@ import {
   syncProjectsRailHost,
   renderSidebarNavigation,
   setSettingsPaneVisible,
+  setFeedbackPaneVisible,
   setTodosViewBodyState,
   readStoredRailCollapsedState,
   persistRailCollapsedState,
@@ -647,6 +648,7 @@ const { ensureTodosShellActive, selectWorkspaceView, switchView } =
     updateUserDisplay,
     setTodosViewBodyState,
     setSettingsPaneVisible,
+    setFeedbackPaneVisible,
     syncSidebarNavState,
     readStoredAiWorkspaceCollapsedState,
     setAiWorkspaceCollapsed,
@@ -1128,6 +1130,7 @@ function bindDockHandlers() {
   hooks.clearPlanDraftState = clearPlanDraftState;
   hooks.setTodosViewBodyState = setTodosViewBodyState;
   hooks.setSettingsPaneVisible = setSettingsPaneVisible;
+  hooks.setFeedbackPaneVisible = setFeedbackPaneVisible;
   hooks.setProjectsRailCollapsed = setProjectsRailCollapsed;
   hooks.readStoredRailCollapsedState = readStoredRailCollapsedState;
   hooks.readStoredAiWorkspaceVisibleState = readStoredAiWorkspaceVisibleState;

--- a/client/index.html
+++ b/client/index.html
@@ -1296,6 +1296,192 @@
                         </form>
                       </div>
                     </section>
+                    <section id="feedbackPane" class="feedback-pane" hidden>
+                      <div class="feedback-pane__shell">
+                        <div class="feedback-view__header">
+                          <div class="feedback-view__actions">
+                            <button
+                              type="button"
+                              class="btn btn-secondary feedback-back-btn"
+                              data-onclick="switchView('todos', this)"
+                            >
+                              Back to Todos
+                            </button>
+                          </div>
+                          <p class="feedback-view__eyebrow">
+                            Friends-and-family beta
+                          </p>
+                          <h2>Feedback</h2>
+                          <p class="feedback-view__lede">
+                            Share bugs, rough edges, or ideas without needing
+                            GitHub.
+                          </p>
+                        </div>
+
+                        <div
+                          class="message"
+                          id="feedbackMessage"
+                          role="status"
+                          aria-live="polite"
+                          aria-atomic="true"
+                        ></div>
+
+                        <div
+                          id="feedbackConfirmation"
+                          class="feedback-confirmation"
+                          hidden
+                        >
+                          <h3 id="feedbackConfirmationTitle">Feedback sent</h3>
+                          <p id="feedbackConfirmationBody"></p>
+                          <p
+                            id="feedbackConfirmationMeta"
+                            class="feedback-confirmation__meta"
+                          ></p>
+                          <div class="feedback-confirmation__actions">
+                            <button
+                              type="button"
+                              class="btn btn-secondary"
+                              data-onclick="switchView('todos', this)"
+                            >
+                              Back to Todos
+                            </button>
+                            <button
+                              type="button"
+                              class="btn btn-secondary"
+                              data-onclick="resetFeedbackFormView()"
+                            >
+                              Send another
+                            </button>
+                          </div>
+                        </div>
+
+                        <form
+                          id="feedbackForm"
+                          data-onsubmit="handleFeedbackSubmit(event)"
+                        >
+                          <div class="feedback-grid">
+                            <div class="feedback-card">
+                              <div class="form-group">
+                                <label for="feedbackType"
+                                  >Submission type</label
+                                >
+                                <select
+                                  id="feedbackType"
+                                  data-onchange="handleFeedbackTypeChange(event)"
+                                >
+                                  <option value="bug">Bug report</option>
+                                  <option value="feature">
+                                    Feature request
+                                  </option>
+                                </select>
+                              </div>
+                              <div class="form-group">
+                                <label for="feedbackTitle">Title</label>
+                                <input
+                                  id="feedbackTitle"
+                                  type="text"
+                                  maxlength="200"
+                                  required
+                                  placeholder="Short summary"
+                                />
+                              </div>
+                              <div class="form-group">
+                                <label
+                                  id="feedbackQuestionOneLabel"
+                                  for="feedbackQuestionOne"
+                                  >What happened?</label
+                                >
+                                <textarea
+                                  id="feedbackQuestionOne"
+                                  rows="4"
+                                  required
+                                ></textarea>
+                              </div>
+                              <div class="form-group">
+                                <label
+                                  id="feedbackQuestionTwoLabel"
+                                  for="feedbackQuestionTwo"
+                                  >What did you expect?</label
+                                >
+                                <textarea
+                                  id="feedbackQuestionTwo"
+                                  rows="4"
+                                  required
+                                ></textarea>
+                              </div>
+                              <div class="form-group">
+                                <label
+                                  id="feedbackQuestionThreeLabel"
+                                  for="feedbackQuestionThree"
+                                  >What were you doing right before it
+                                  happened?</label
+                                >
+                                <textarea
+                                  id="feedbackQuestionThree"
+                                  rows="4"
+                                  required
+                                ></textarea>
+                              </div>
+                            </div>
+
+                            <aside class="feedback-card feedback-card--context">
+                              <h3>Optional screenshot</h3>
+                              <div class="form-group">
+                                <label for="feedbackScreenshotUrl"
+                                  >Screenshot URL</label
+                                >
+                                <input
+                                  id="feedbackScreenshotUrl"
+                                  type="url"
+                                  inputmode="url"
+                                  placeholder="https://example.com/screenshot.png"
+                                />
+                              </div>
+                              <div class="form-group">
+                                <label for="feedbackAttachment"
+                                  >Screenshot file metadata</label
+                                >
+                                <input
+                                  id="feedbackAttachment"
+                                  type="file"
+                                  accept="image/*"
+                                  data-onchange="handleFeedbackAttachmentChange(event)"
+                                />
+                                <p
+                                  id="feedbackAttachmentSummary"
+                                  class="feedback-helper"
+                                >
+                                  No screenshot file selected.
+                                </p>
+                              </div>
+
+                              <h3>Captured context</h3>
+                              <dl class="feedback-context-list">
+                                <div class="feedback-context-row">
+                                  <dt>Current page</dt>
+                                  <dd id="feedbackContextPage"></dd>
+                                </div>
+                                <div class="feedback-context-row">
+                                  <dt>App version</dt>
+                                  <dd id="feedbackContextVersion"></dd>
+                                </div>
+                                <div class="feedback-context-row">
+                                  <dt>User</dt>
+                                  <dd id="feedbackContextUser"></dd>
+                                </div>
+                              </dl>
+
+                              <button
+                                type="submit"
+                                class="btn feedback-submit-btn"
+                              >
+                                Send feedback
+                              </button>
+                            </aside>
+                          </div>
+                        </form>
+                      </div>
+                    </section>
                     <div class="todos-mobile-top-bar">
                       <button
                         class="todos-mobile-hamburger"
@@ -2296,168 +2482,6 @@
                 >
                   + New Task
                 </button>
-              </div>
-
-              <!-- Feedback View -->
-              <div id="feedbackView" class="view">
-                <section class="feedback-view">
-                  <div class="feedback-view__header">
-                    <p class="feedback-view__eyebrow">
-                      Friends-and-family beta
-                    </p>
-                    <h2>Feedback</h2>
-                    <p class="feedback-view__lede">
-                      Share bugs, rough edges, or ideas without needing GitHub.
-                    </p>
-                  </div>
-
-                  <div
-                    class="message"
-                    id="feedbackMessage"
-                    role="status"
-                    aria-live="polite"
-                    aria-atomic="true"
-                  ></div>
-
-                  <div
-                    id="feedbackConfirmation"
-                    class="feedback-confirmation"
-                    hidden
-                  >
-                    <h3 id="feedbackConfirmationTitle">Feedback sent</h3>
-                    <p id="feedbackConfirmationBody"></p>
-                    <p
-                      id="feedbackConfirmationMeta"
-                      class="feedback-confirmation__meta"
-                    ></p>
-                    <button
-                      type="button"
-                      class="btn btn-secondary"
-                      data-onclick="resetFeedbackFormView()"
-                    >
-                      Send another
-                    </button>
-                  </div>
-
-                  <form
-                    id="feedbackForm"
-                    data-onsubmit="handleFeedbackSubmit(event)"
-                  >
-                    <div class="feedback-grid">
-                      <div class="feedback-card">
-                        <div class="form-group">
-                          <label for="feedbackType">Submission type</label>
-                          <select
-                            id="feedbackType"
-                            data-onchange="handleFeedbackTypeChange(event)"
-                          >
-                            <option value="bug">Bug report</option>
-                            <option value="feature">Feature request</option>
-                          </select>
-                        </div>
-                        <div class="form-group">
-                          <label for="feedbackTitle">Title</label>
-                          <input
-                            id="feedbackTitle"
-                            type="text"
-                            maxlength="200"
-                            required
-                            placeholder="Short summary"
-                          />
-                        </div>
-                        <div class="form-group">
-                          <label
-                            id="feedbackQuestionOneLabel"
-                            for="feedbackQuestionOne"
-                            >What happened?</label
-                          >
-                          <textarea
-                            id="feedbackQuestionOne"
-                            rows="4"
-                            required
-                          ></textarea>
-                        </div>
-                        <div class="form-group">
-                          <label
-                            id="feedbackQuestionTwoLabel"
-                            for="feedbackQuestionTwo"
-                            >What did you expect?</label
-                          >
-                          <textarea
-                            id="feedbackQuestionTwo"
-                            rows="4"
-                            required
-                          ></textarea>
-                        </div>
-                        <div class="form-group">
-                          <label
-                            id="feedbackQuestionThreeLabel"
-                            for="feedbackQuestionThree"
-                            >What were you doing right before it
-                            happened?</label
-                          >
-                          <textarea
-                            id="feedbackQuestionThree"
-                            rows="4"
-                            required
-                          ></textarea>
-                        </div>
-                      </div>
-
-                      <aside class="feedback-card feedback-card--context">
-                        <h3>Optional screenshot</h3>
-                        <div class="form-group">
-                          <label for="feedbackScreenshotUrl"
-                            >Screenshot URL</label
-                          >
-                          <input
-                            id="feedbackScreenshotUrl"
-                            type="url"
-                            inputmode="url"
-                            placeholder="https://example.com/screenshot.png"
-                          />
-                        </div>
-                        <div class="form-group">
-                          <label for="feedbackAttachment"
-                            >Screenshot file metadata</label
-                          >
-                          <input
-                            id="feedbackAttachment"
-                            type="file"
-                            accept="image/*"
-                            data-onchange="handleFeedbackAttachmentChange(event)"
-                          />
-                          <p
-                            id="feedbackAttachmentSummary"
-                            class="feedback-helper"
-                          >
-                            No screenshot file selected.
-                          </p>
-                        </div>
-
-                        <h3>Captured context</h3>
-                        <dl class="feedback-context-list">
-                          <div class="feedback-context-row">
-                            <dt>Current page</dt>
-                            <dd id="feedbackContextPage"></dd>
-                          </div>
-                          <div class="feedback-context-row">
-                            <dt>App version</dt>
-                            <dd id="feedbackContextVersion"></dd>
-                          </div>
-                          <div class="feedback-context-row">
-                            <dt>User</dt>
-                            <dd id="feedbackContextUser"></dd>
-                          </div>
-                        </dl>
-
-                        <button type="submit" class="btn feedback-submit-btn">
-                          Send feedback
-                        </button>
-                      </aside>
-                    </div>
-                  </form>
-                </section>
               </div>
 
               <!-- Profile View -->

--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -735,9 +735,9 @@ export async function logout() {
 export function showAppView() {
   hooks.setTodosViewBodyState?.(true);
   hooks.setSettingsPaneVisible?.(false);
+  hooks.setFeedbackPaneVisible?.(false);
   document.getElementById("authView").classList.remove("active");
   document.getElementById("todosView").classList.add("active");
-  document.getElementById("feedbackView")?.classList.remove("active");
   document.getElementById("profileView")?.classList.remove("active");
   document.getElementById("adminView")?.classList.remove("active");
   document.getElementById("navTabs").style.display = "flex";
@@ -799,9 +799,9 @@ export function showAppView() {
 export function showAuthView() {
   hooks.setTodosViewBodyState?.(false);
   hooks.setSettingsPaneVisible?.(false);
+  hooks.setFeedbackPaneVisible?.(false);
   document.getElementById("authView").classList.add("active");
   document.getElementById("todosView").classList.remove("active");
-  document.getElementById("feedbackView")?.classList.remove("active");
   document.getElementById("profileView").classList.remove("active");
   document.getElementById("adminView").classList.remove("active");
   document.getElementById("navTabs").style.display = "none";

--- a/client/modules/railUi.js
+++ b/client/modules/railUi.js
@@ -186,6 +186,17 @@ export function setSettingsPaneVisible(isVisible) {
   }
 }
 
+export function setFeedbackPaneVisible(isVisible) {
+  const feedbackPane = document.getElementById("feedbackPane");
+  const todosView = document.getElementById("todosView");
+  if (!(feedbackPane instanceof HTMLElement)) return;
+
+  feedbackPane.hidden = !isVisible;
+  if (todosView instanceof HTMLElement) {
+    todosView.classList.toggle("todos-view--feedback-active", isVisible);
+  }
+}
+
 export function setTodosViewBodyState(isTodosView) {
   document.body.classList.toggle("is-todos-view", isTodosView);
   syncProjectsRailHost();

--- a/client/modules/workspaceController.js
+++ b/client/modules/workspaceController.js
@@ -22,6 +22,7 @@ export function createWorkspaceController({
   updateUserDisplay,
   setTodosViewBodyState,
   setSettingsPaneVisible,
+  setFeedbackPaneVisible,
   syncSidebarNavState,
   readStoredAiWorkspaceCollapsedState,
   setAiWorkspaceCollapsed,
@@ -36,7 +37,9 @@ export function createWorkspaceController({
   function switchView(view, triggerEl = null) {
     const requestedView = view === "profile" ? "settings" : view;
     const isSettingsView = requestedView === "settings";
-    const primaryView = isSettingsView ? "todos" : requestedView;
+    const isFeedbackView = requestedView === "feedback";
+    const primaryView =
+      isSettingsView || isFeedbackView ? "todos" : requestedView;
 
     document
       .querySelectorAll(".view")
@@ -56,12 +59,11 @@ export function createWorkspaceController({
     }
 
     if (
-      !isSettingsView &&
-      (!(triggerEl instanceof HTMLElement) ||
-        !triggerEl.classList.contains("nav-tab"))
+      !(triggerEl instanceof HTMLElement) ||
+      !triggerEl.classList.contains("nav-tab")
     ) {
       const matchingTab = document.querySelector(
-        `.nav-tab[data-onclick*="switchView('${primaryView}'"]`,
+        `.nav-tab[data-onclick*="switchView('${requestedView}'"]`,
       );
       if (matchingTab instanceof HTMLElement) {
         matchingTab.classList.add("active");
@@ -70,6 +72,7 @@ export function createWorkspaceController({
 
     setTodosViewBodyState(primaryView === "todos");
     setSettingsPaneVisible(isSettingsView);
+    setFeedbackPaneVisible(isFeedbackView);
     syncSidebarNavState(requestedView);
 
     if (isSettingsView) {

--- a/client/styles.css
+++ b/client/styles.css
@@ -1641,8 +1641,37 @@ textarea:focus-visible,
   display: block;
 }
 
+.feedback-pane {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--accent) 5%, var(--card-bg)) 0%,
+      var(--card-bg) 180px
+    ),
+    var(--card-bg);
+}
+
+.feedback-pane__shell {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+#todosView.todos-view--feedback-active .feedback-pane {
+  display: block;
+}
+
 #todosView.todos-view--settings-active .todos-top-bar,
-#todosView.todos-view--settings-active #todosScrollRegion {
+#todosView.todos-view--settings-active #todosScrollRegion,
+#todosView.todos-view--feedback-active .todos-top-bar,
+#todosView.todos-view--feedback-active #todosScrollRegion,
+#todosView.todos-view--feedback-active #aiWorkspace {
   display: none;
 }
 
@@ -3574,14 +3603,14 @@ body.is-todos-view .floating-new-task-cta {
   margin-bottom: 30px;
 }
 
-.feedback-view {
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: var(--s-3) 0 var(--s-6);
-}
-
 .feedback-view__header {
   margin-bottom: var(--s-5);
+}
+
+.feedback-view__actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: var(--s-3);
 }
 
 .feedback-view__eyebrow {
@@ -3661,6 +3690,13 @@ body.is-todos-view .floating-new-task-cta {
 
 .feedback-confirmation__meta {
   color: var(--text-secondary);
+}
+
+.feedback-confirmation__actions {
+  display: flex;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+  margin-top: var(--s-3);
 }
 
 .profile-section h3 {

--- a/tests/ui/feedback-flow.spec.ts
+++ b/tests/ui/feedback-flow.spec.ts
@@ -43,12 +43,25 @@ test.describe("Feedback flow", () => {
       email: "user@example.com",
     });
 
+    await page.waitForFunction(() => {
+      const switchView = (
+        window as Window & {
+          switchView?: (view: string) => void;
+        }
+      ).switchView;
+      return (
+        typeof switchView === "function" &&
+        document.getElementById("todosView")?.classList.contains("active")
+      );
+    });
     await page.evaluate(() =>
       (window as Window & { switchView: (view: string) => void }).switchView(
         "feedback",
       ),
     );
-    await expect(page.locator("#feedbackView")).toHaveClass(/active/);
+    await expect(page.locator("#todosView")).toHaveClass(/active/);
+    await expect(page.locator("#feedbackPane")).toBeVisible();
+    await expect(page.locator("#todosScrollRegion")).toBeHidden();
 
     await page.locator("#feedbackType").selectOption("feature");
     await page.locator("#feedbackTitle").fill("Make planning easier");
@@ -94,5 +107,12 @@ test.describe("Feedback flow", () => {
       type: "image/png",
       size: 10,
     });
+
+    await page
+      .locator("#feedbackConfirmation")
+      .getByRole("button", { name: "Back to Todos" })
+      .click();
+    await expect(page.locator("#feedbackPane")).toBeHidden();
+    await expect(page.locator("#todosScrollRegion")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

The feedback screen was built as a standalone top-level view (`#feedbackView`), disconnected from the shell framing, rail, and navigation model. This moves it into the Todos main zone as an embedded pane.

- `switchView('feedback')` now activates the Todos shell + feedback pane (same pattern as settings)
- Add explicit "Back to Todos" action at top of pane and after successful submission
- Remove the old disconnected `#feedbackView` page
- Update workspace controller, rail UI, and auth UI for the new pane model
- Update feedback flow UI test

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run format:check` — passes
- [x] `npm run lint:html` — passes
- [x] `npm run lint:css` — passes
- [x] `npm run test:unit` — passes
- [ ] `CI=1 npm run test:ui:fast` — CI will run this
- [ ] Manual: feedback form opens inside Todos shell with rail visible, Back to Todos works

🤖 Generated with [Claude Code](https://claude.com/claude-code)