### PR TITLE
fix(ui): move admin into Todos shell as embedded pane

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -140,6 +140,7 @@ import {
   renderSidebarNavigation,
   setSettingsPaneVisible,
   setFeedbackPaneVisible,
+  setAdminPaneVisible,
   setTodosViewBodyState,
   readStoredRailCollapsedState,
   persistRailCollapsedState,
@@ -649,6 +650,7 @@ const { ensureTodosShellActive, selectWorkspaceView, switchView } =
     setTodosViewBodyState,
     setSettingsPaneVisible,
     setFeedbackPaneVisible,
+    setAdminPaneVisible,
     syncSidebarNavState,
     readStoredAiWorkspaceCollapsedState,
     setAiWorkspaceCollapsed,
@@ -1131,6 +1133,7 @@ function bindDockHandlers() {
   hooks.setTodosViewBodyState = setTodosViewBodyState;
   hooks.setSettingsPaneVisible = setSettingsPaneVisible;
   hooks.setFeedbackPaneVisible = setFeedbackPaneVisible;
+  hooks.setAdminPaneVisible = setAdminPaneVisible;
   hooks.setProjectsRailCollapsed = setProjectsRailCollapsed;
   hooks.readStoredRailCollapsedState = readStoredRailCollapsedState;
   hooks.readStoredAiWorkspaceVisibleState = readStoredAiWorkspaceVisibleState;

--- a/client/index.html
+++ b/client/index.html
@@ -1482,6 +1482,35 @@
                         </form>
                       </div>
                     </section>
+                    <section id="adminPane" class="admin-pane" hidden>
+                      <div class="admin-pane__shell">
+                        <div class="admin-pane__header">
+                          <div class="admin-pane__actions">
+                            <button
+                              type="button"
+                              class="btn btn-secondary admin-back-btn"
+                              data-onclick="switchView('todos', this)"
+                            >
+                              Back to Todos
+                            </button>
+                          </div>
+                          <h2>Admin</h2>
+                        </div>
+                        <div
+                          class="message"
+                          id="adminMessage"
+                          role="status"
+                          aria-live="polite"
+                          aria-atomic="true"
+                        ></div>
+                        <div id="adminContent">
+                          <div class="loading">
+                            <div class="spinner"></div>
+                            Loading admin tools...
+                          </div>
+                        </div>
+                      </div>
+                    </section>
                     <div class="todos-mobile-top-bar">
                       <button
                         class="todos-mobile-hamburger"
@@ -2500,22 +2529,7 @@
                 </div>
               </div>
 
-              <!-- Admin View -->
-              <div id="adminView" class="view">
-                <div
-                  class="message"
-                  id="adminMessage"
-                  role="status"
-                  aria-live="polite"
-                  aria-atomic="true"
-                ></div>
-                <div id="adminContent">
-                  <div class="loading">
-                    <div class="spinner"></div>
-                    Loading admin tools...
-                  </div>
-                </div>
-              </div>
+              <!-- Admin View — moved to adminPane inside todosView -->
             </div>
           </div>
         </div>

--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -736,10 +736,10 @@ export function showAppView() {
   hooks.setTodosViewBodyState?.(true);
   hooks.setSettingsPaneVisible?.(false);
   hooks.setFeedbackPaneVisible?.(false);
+  hooks.setAdminPaneVisible?.(false);
   document.getElementById("authView").classList.remove("active");
   document.getElementById("todosView").classList.add("active");
   document.getElementById("profileView")?.classList.remove("active");
-  document.getElementById("adminView")?.classList.remove("active");
   document.getElementById("navTabs").style.display = "flex";
   document.getElementById("userBar").style.display = "flex";
   document.querySelectorAll(".nav-tab")[0].classList.add("active");
@@ -800,10 +800,10 @@ export function showAuthView() {
   hooks.setTodosViewBodyState?.(false);
   hooks.setSettingsPaneVisible?.(false);
   hooks.setFeedbackPaneVisible?.(false);
+  hooks.setAdminPaneVisible?.(false);
   document.getElementById("authView").classList.add("active");
   document.getElementById("todosView").classList.remove("active");
   document.getElementById("profileView").classList.remove("active");
-  document.getElementById("adminView").classList.remove("active");
   document.getElementById("navTabs").style.display = "none";
   document.getElementById("userBar").style.display = "none";
   document.getElementById("adminNavTab").style.display = "none";

--- a/client/modules/railUi.js
+++ b/client/modules/railUi.js
@@ -197,6 +197,17 @@ export function setFeedbackPaneVisible(isVisible) {
   }
 }
 
+export function setAdminPaneVisible(isVisible) {
+  const adminPane = document.getElementById("adminPane");
+  const todosView = document.getElementById("todosView");
+  if (!(adminPane instanceof HTMLElement)) return;
+
+  adminPane.hidden = !isVisible;
+  if (todosView instanceof HTMLElement) {
+    todosView.classList.toggle("todos-view--admin-active", isVisible);
+  }
+}
+
 export function setTodosViewBodyState(isTodosView) {
   document.body.classList.toggle("is-todos-view", isTodosView);
   syncProjectsRailHost();

--- a/client/modules/workspaceController.js
+++ b/client/modules/workspaceController.js
@@ -23,6 +23,7 @@ export function createWorkspaceController({
   setTodosViewBodyState,
   setSettingsPaneVisible,
   setFeedbackPaneVisible,
+  setAdminPaneVisible,
   syncSidebarNavState,
   readStoredAiWorkspaceCollapsedState,
   setAiWorkspaceCollapsed,
@@ -38,8 +39,9 @@ export function createWorkspaceController({
     const requestedView = view === "profile" ? "settings" : view;
     const isSettingsView = requestedView === "settings";
     const isFeedbackView = requestedView === "feedback";
+    const isAdminView = requestedView === "admin";
     const primaryView =
-      isSettingsView || isFeedbackView ? "todos" : requestedView;
+      isSettingsView || isFeedbackView || isAdminView ? "todos" : requestedView;
 
     document
       .querySelectorAll(".view")
@@ -73,6 +75,7 @@ export function createWorkspaceController({
     setTodosViewBodyState(primaryView === "todos");
     setSettingsPaneVisible(isSettingsView);
     setFeedbackPaneVisible(isFeedbackView);
+    setAdminPaneVisible(isAdminView);
     syncSidebarNavState(requestedView);
 
     if (isSettingsView) {
@@ -105,7 +108,7 @@ export function createWorkspaceController({
       return;
     }
 
-    if (requestedView === "admin") {
+    if (isAdminView) {
       closeCommandPalette({ restoreFocus: false });
       closeProjectCrudModal({ restoreFocus: false });
       closeProjectEditDrawer({ restoreFocus: false });

--- a/client/styles.css
+++ b/client/styles.css
@@ -1667,11 +1667,42 @@ textarea:focus-visible,
   display: block;
 }
 
+.admin-pane {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+}
+
+.admin-pane__shell {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.admin-pane__header {
+  margin-bottom: var(--s-4);
+}
+
+.admin-pane__actions {
+  margin-bottom: var(--s-2);
+}
+
+#todosView.todos-view--admin-active .admin-pane {
+  display: block;
+}
+
 #todosView.todos-view--settings-active .todos-top-bar,
 #todosView.todos-view--settings-active #todosScrollRegion,
 #todosView.todos-view--feedback-active .todos-top-bar,
 #todosView.todos-view--feedback-active #todosScrollRegion,
-#todosView.todos-view--feedback-active #aiWorkspace {
+#todosView.todos-view--feedback-active #aiWorkspace,
+#todosView.todos-view--admin-active .todos-top-bar,
+#todosView.todos-view--admin-active #todosScrollRegion,
+#todosView.todos-view--admin-active #aiWorkspace {
   display: none;
 }
 

--- a/tests/ui/admin-feedback-queue.spec.ts
+++ b/tests/ui/admin-feedback-queue.spec.ts
@@ -399,7 +399,7 @@ test.describe("Admin feedback queue", () => {
       );
     });
 
-    await expect(page.locator("#adminView")).toHaveClass(/active/);
+    await expect(page.locator("#adminPane")).not.toHaveAttribute("hidden");
     await expect(page.locator("#adminContent")).toContainText(
       "Feedback Automation",
     );


### PR DESCRIPTION
## Summary

Same pattern as the recent feedback fix — the admin view was a standalone top-level view disconnected from the Todos shell. On desktop, this meant losing the rail, header, and navigation.

- Move admin into `#adminPane` inside `#todosView` (same as settings/feedback)
- `switchView('admin')` activates Todos shell + admin pane
- Add "Back to Todos" button, `setAdminPaneVisible()`, CSS for `.admin-pane`
- Remove old standalone `#adminView`

## Test plan

- [x] Typecheck passes
- [x] Format/lint passes
- [x] No console errors on load
- [x] Unit tests pass
- [ ] CI UI tests pass
- [ ] Manual: admin panel shows inside Todos shell with rail visible on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)