### PR TITLE
fix(ui): add admin button to bottom dock for desktop navigation

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2607,6 +2607,29 @@
         </button>
         <button
           type="button"
+          class="dock-icon-btn dock-admin-btn"
+          data-onclick="switchView('admin', this)"
+          aria-label="Admin"
+          title="Admin"
+        >
+          <svg
+            class="dock-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+          </svg>
+        </button>
+        <button
+          type="button"
           class="dock-icon-btn"
           data-onclick="toggleTheme()"
           aria-label="Toggle dark mode"

--- a/client/styles.css
+++ b/client/styles.css
@@ -2004,6 +2004,14 @@ body.is-admin-user button.admin-rail-btn {
   display: flex;
 }
 
+.dock-admin-btn {
+  display: none;
+}
+
+body.is-admin-user .dock-admin-btn {
+  display: inline-flex;
+}
+
 .rail-search-container {
   padding: 4px 8px 6px;
   display: flex;


### PR DESCRIPTION
## Summary

- Add shield icon button to bottom dock for admin pane navigation
- Hidden for non-admin users via \`body.is-admin-user .dock-admin-btn\` CSS gate
- Dock order: Settings | Feedback | **Admin** | Theme | Profile

The admin pane previously had no obvious desktop entry point — the rail footer button is only visible when the rail is expanded.

## Test plan

- [ ] All lint/format checks pass
- [ ] Unit tests pass
- [ ] UI tests pass
- [ ] Manual: admin shield icon appears in dock for admin users, hidden for non-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)