### PR TITLE
refactor(api): integrate actionRegistry into agentExecutor dispatch

### DIFF
--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -1,4 +1,5 @@
 import { mapError } from "../errorHandling";
+import { getActionHandler } from "../domains/agent/actions/actionRegistry";
 import { IProjectService } from "../interfaces/IProjectService";
 import { ITodoService } from "../interfaces/ITodoService";
 import agentManifest from "./agent-manifest.json";
@@ -706,6 +707,21 @@ export class AgentExecutor {
     context: AgentExecutionContext,
   ): Promise<AgentExecutionResult> {
     const readOnly = READ_ONLY_ACTIONS.has(action);
+
+    // Check the action registry first — registered handlers take priority
+    // over the inline switch/case. This enables incremental extraction.
+    const registeredHandler = getActionHandler(action);
+    if (registeredHandler) {
+      try {
+        const result = await registeredHandler(
+          (input as Record<string, unknown>) ?? {},
+          context,
+        );
+        return result as AgentExecutionResult;
+      } catch (error) {
+        return this.failure(action, readOnly, context, error);
+      }
+    }
 
     try {
       switch (action) {


### PR DESCRIPTION
## Summary

- Wire actionRegistry into agentExecutor.execute() dispatch loop
- Registry check happens before the switch/case — registered handlers take priority
- No actions moved yet — this enables incremental extraction
- Pattern: call \`registerAction('list_tasks', handler)\` in domain files; executor delegates automatically

Closes #442

## Test plan

- [x] Typecheck passes
- [x] Unit tests pass (296/296)
- [ ] CI passes
- [ ] Existing agent/MCP behavior unchanged (no actions registered yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)