### PR TITLE
refactor(ui): adopt EventBus constants across all modules

### DIFF
--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -5,6 +5,8 @@
 // =============================================================================
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import { STATE_CHANGED } from "../platform/events/eventReasons.js";
 import { clearHomeListDrilldown, clearFilters } from "./filterLogic.js";
 import {
   closeProjectCrudModal,
@@ -774,7 +776,7 @@ export function showAppView() {
   loadCustomProjects();
   state.currentWorkspaceView = "home";
   clearHomeListDrilldown();
-  EventBus.dispatch("todos:changed", { reason: "state-changed" });
+  EventBus.dispatch(TODOS_CHANGED, { reason: STATE_CHANGED });
   updateCategoryFilter();
   loadProjects();
   loadTodos();

--- a/client/modules/drawerUi.js
+++ b/client/modules/drawerUi.js
@@ -6,6 +6,8 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import { TODO_UPDATED, UNDO_APPLIED } from "../platform/events/eventReasons.js";
 import { runAsyncLifecycle } from "./asyncLifecycle.js";
 import { applyAsyncAction, applyUiAction } from "./stateActions.js";
 import { callAgentAction } from "./agentApiClient.js";
@@ -668,7 +670,7 @@ export async function saveDrawerPatch(patch, { validateTitle = false } = {}) {
         patchHeaderCountsFromVisibleTodos();
       }
     } else {
-      EventBus.dispatch("todos:changed", { reason: "todo-updated" });
+      EventBus.dispatch(TODOS_CHANGED, { reason: TODO_UPDATED });
     }
     syncTodoDrawerStateWithRender();
     restoreDrawerFocusState(focusState);
@@ -1532,7 +1534,7 @@ export async function applyTaskDrawerSuggestion(
     clearTaskDrawerDismissed(state.selectedTodoId);
     state.taskDrawerAssistState.lastUndoSuggestionId = "";
     await loadTaskDrawerDecisionAssist(state.selectedTodoId, false);
-    EventBus.dispatch("todos:changed", { reason: "todo-updated" });
+    EventBus.dispatch(TODOS_CHANGED, { reason: TODO_UPDATED });
   } catch (error) {
     console.error("Task drawer AI apply failed:", error);
     state.taskDrawerAssistState.error = "Could not apply suggestion.";
@@ -1587,7 +1589,7 @@ export function undoTaskDrawerSuggestion(suggestionId) {
       selectedTodoIdsCount: 1,
     });
   }
-  EventBus.dispatch("todos:changed", { reason: "undo-applied" });
+  EventBus.dispatch(TODOS_CHANGED, { reason: UNDO_APPLIED });
   syncTodoDrawerStateWithRender();
 }
 

--- a/client/modules/onCreateAssist.js
+++ b/client/modules/onCreateAssist.js
@@ -5,6 +5,8 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import { TODO_UPDATED } from "../platform/events/eventReasons.js";
 import { runAsyncLifecycle } from "./asyncLifecycle.js";
 import { getAllProjects } from "./projectsState.js";
 import { applyFiltersAndRender } from "./filterLogic.js";
@@ -1015,7 +1017,7 @@ async function applyLiveOnCreateSuggestion(suggestion, confirmed = false) {
     if (index >= 0) {
       state.todos[index] = data.todo;
     }
-    EventBus.dispatch("todos:changed", { reason: "todo-updated" });
+    EventBus.dispatch(TODOS_CHANGED, { reason: TODO_UPDATED });
   }
   clearOnCreateDismissed(state.onCreateAssistState.liveTodoId);
   const refreshedTodo =

--- a/client/modules/onboardingFlow.js
+++ b/client/modules/onboardingFlow.js
@@ -8,6 +8,8 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import { ONBOARDING_COMPLETE } from "../platform/events/eventReasons.js";
 
 const { escapeHtml } = window.Utils || {};
 
@@ -123,7 +125,7 @@ async function _markComplete() {
   }
 
   // Refresh the home dashboard now that onboarding is done
-  EventBus.dispatch("todos:changed", { reason: "onboarding-complete" });
+  EventBus.dispatch(TODOS_CHANGED, { reason: ONBOARDING_COMPLETE });
 }
 
 // ---------------------------------------------------------------------------

--- a/client/modules/overlayManager.js
+++ b/client/modules/overlayManager.js
@@ -7,6 +7,8 @@
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import { TODO_UPDATED } from "../platform/events/eventReasons.js";
 
 const DomSelectors = window.DomSelectors || {};
 
@@ -409,7 +411,7 @@ export async function saveEditedTodo() {
 
   try {
     await hooks.applyTodoPatch(state.editingTodoId, payload);
-    EventBus.dispatch("todos:changed", { reason: "todo-updated" });
+    EventBus.dispatch(TODOS_CHANGED, { reason: TODO_UPDATED });
     hooks.syncTodoDrawerStateWithRender?.();
     closeEditTodoModal({ restoreFocus: false });
     showMessage("todosMessage", "Task updated", "success");

--- a/client/modules/projectsState.js
+++ b/client/modules/projectsState.js
@@ -4,6 +4,11 @@
 // =============================================================================
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import {
+  PROJECT_SELECTED,
+  STATE_CHANGED,
+} from "../platform/events/eventReasons.js";
 import { applyUiAction } from "./stateActions.js";
 import { toDateInputValue, toIsoFromDateInput } from "./todosService.js";
 
@@ -159,7 +164,7 @@ async function loadHeadingsForProject(projectName = getSelectedProjectKey()) {
 function scheduleLoadSelectedProjectHeadings() {
   window.requestAnimationFrame(() => {
     loadHeadingsForProject(getSelectedProjectKey()).then(() => {
-      EventBus.dispatch("todos:changed", { reason: "project-selected" });
+      EventBus.dispatch(TODOS_CHANGED, { reason: PROJECT_SELECTED });
     });
   });
 }
@@ -205,7 +210,7 @@ async function createHeadingForSelectedProject() {
       return;
     }
     await loadHeadingsForProject(selectedProject);
-    EventBus.dispatch("todos:changed", { reason: "state-changed" });
+    EventBus.dispatch(TODOS_CHANGED, { reason: STATE_CHANGED });
     hooks.showMessage?.(
       "todosMessage",
       `Heading "${headingName}" created`,
@@ -877,7 +882,7 @@ async function renameProjectByName(fromProjectName, toProjectName) {
   if (activeProject === selectedPath) {
     hooks.selectProjectFromRail?.(renamedPath);
   } else {
-    EventBus.dispatch("todos:changed", { reason: "project-selected" });
+    EventBus.dispatch(TODOS_CHANGED, { reason: PROJECT_SELECTED });
     hooks.updateHeaderFromVisibleTodos?.(hooks.getVisibleTodos?.() ?? []);
   }
 
@@ -924,7 +929,7 @@ async function deleteProjectByName(
   }
 
   removeProjectLocally(normalized, { taskDisposition });
-  EventBus.dispatch("todos:changed", { reason: "project-selected" });
+  EventBus.dispatch(TODOS_CHANGED, { reason: PROJECT_SELECTED });
   hooks.updateHeaderFromVisibleTodos?.(hooks.getVisibleTodos?.() ?? []);
 
   hooks.showMessage?.(
@@ -1019,7 +1024,7 @@ async function submitProjectEditDrawer() {
         if (activeProject === selectedPath) {
           hooks.selectProjectFromRail?.(renamedPath);
         } else {
-          EventBus.dispatch("todos:changed", { reason: "project-selected" });
+          EventBus.dispatch(TODOS_CHANGED, { reason: PROJECT_SELECTED });
           hooks.updateHeaderFromVisibleTodos?.(hooks.getVisibleTodos?.() ?? []);
         }
       }


### PR DESCRIPTION
## Summary

Replace all remaining string literal EventBus dispatches with constants from \`eventTypes.js\` and \`eventReasons.js\`:

| Module | Dispatches updated |
|--------|--------------------|
| projectsState.js | 5 (project-selected, state-changed) |
| drawerUi.js | 3 (todo-updated, undo-applied) |
| authUi.js | 1 (state-changed) |
| onCreateAssist.js | 1 (todo-updated) |
| overlayManager.js | 1 (todo-updated) |
| onboardingFlow.js | 1 (onboarding-complete) |

**Zero** string literal \`"todos:changed"\` dispatches remain in \`client/modules/\`.

Closes #436

## Test plan

- [x] No console errors on page load
- [x] Format check passes
- [x] Unit tests pass
- [ ] CI UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)