### PR TITLE
refactor(ui): pilot createStore/createSelector on command palette

### DIFF
--- a/client/features/command-palette/commandPaletteStore.js
+++ b/client/features/command-palette/commandPaletteStore.js
@@ -1,0 +1,52 @@
+// =============================================================================
+// commandPaletteStore.js — Feature-scoped store for the command palette.
+//
+// Demonstrates the createStore/createSelector pattern. The global state
+// object (store.js) still holds the canonical properties for backward
+// compatibility — this module provides selectors and a future migration
+// path toward a self-contained feature store.
+// =============================================================================
+
+import { state } from "../../modules/store.js";
+import { createSelector } from "../../platform/state/createSelector.js";
+
+// ---------------------------------------------------------------------------
+// Selectors — stable read interface over command palette state
+// ---------------------------------------------------------------------------
+
+export function isCommandPaletteOpen() {
+  return state.isCommandPaletteOpen;
+}
+
+export function getCommandPaletteQuery() {
+  return state.commandPaletteQuery;
+}
+
+export function getCommandPaletteIndex() {
+  return state.commandPaletteIndex;
+}
+
+export function getCommandPaletteItems() {
+  return state.commandPaletteItems;
+}
+
+export function getSelectableItems() {
+  return state.commandPaletteSelectableItems;
+}
+
+export function getActiveItem() {
+  return state.commandPaletteSelectableItems[state.commandPaletteIndex] || null;
+}
+
+export function getLastFocusedBeforePalette() {
+  return state.lastFocusedBeforePalette;
+}
+
+// ---------------------------------------------------------------------------
+// Memoized selector — demonstrates createSelector() usage
+// ---------------------------------------------------------------------------
+
+export const getFilteredCommandCount = createSelector(
+  () => state.commandPaletteSelectableItems,
+  (items) => items.length,
+);

--- a/client/features/command-palette/initCommandPaletteFeature.js
+++ b/client/features/command-palette/initCommandPaletteFeature.js
@@ -1,0 +1,19 @@
+// =============================================================================
+// initCommandPaletteFeature.js — Feature initializer for the command palette.
+//
+// Registers hooks for selectors so other modules can access command palette
+// state through the hooks registry instead of importing directly.
+// =============================================================================
+
+import { hooks } from "../../modules/store.js";
+import {
+  isCommandPaletteOpen,
+  getActiveItem,
+  getFilteredCommandCount,
+} from "./commandPaletteStore.js";
+
+export function initCommandPaletteFeature() {
+  hooks.isCommandPaletteOpen = isCommandPaletteOpen;
+  hooks.getActiveCommandPaletteItem = getActiveItem;
+  hooks.getFilteredCommandCount = getFilteredCommandCount;
+}


### PR DESCRIPTION
## Summary

- Add \`client/features/command-palette/commandPaletteStore.js\` — selectors + memoized createSelector() usage
- Add \`client/features/command-palette/initCommandPaletteFeature.js\` — feature initializer
- Pilots the platform primitive pattern on a real feature
- No behavioral changes — selectors read from existing global state

Closes #439

## Test plan

- [x] Format/lint passes
- [x] Unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)