### PR TITLE
refactor(ui): add feature barrel exports for drawer, assistant, projects

### DIFF
--- a/client/features/assistant/index.js
+++ b/client/features/assistant/index.js
@@ -1,0 +1,60 @@
+// =============================================================================
+// assistant feature barrel — re-exports from aiWorkspace.js
+//
+// New code should import from this barrel:
+//   import { critiqueDraftWithAi } from '../features/assistant/index.js';
+//
+// The aiWorkspace.js monolith (1,517 lines) will be split incrementally:
+// - critiquePanel.js (task critique flow)
+// - planPanel.js (plan generation/draft)
+// - brainDumpPanel.js (brain dump → plan flow)
+// =============================================================================
+
+export {
+  // Workspace visibility
+  getAiWorkspaceElements,
+  syncAiWorkspaceVisibility,
+  setAiWorkspaceVisible,
+  setAiWorkspaceCollapsed,
+  toggleAiWorkspace,
+  focusAiWorkspaceTarget,
+  // Workspace actions
+  openAiWorkspaceForBrainDump,
+  openAiWorkspaceForGoalPlan,
+  // Data loading
+  loadAiSuggestions,
+  loadAiUsage,
+  loadAiFeedbackSummary,
+  loadAiInsights,
+  // Rendering
+  renderAiUsageSummary,
+  renderAiPerformanceInsights,
+  renderAiFeedbackInsights,
+  renderAiSuggestionHistory,
+  // Critique
+  renderCritiquePanel,
+  critiqueDraftWithAi,
+  applyCritiqueSuggestion,
+  applyCritiqueSuggestionMode,
+  dismissCritiqueSuggestion,
+  setCritiqueFeedbackReason,
+  updateCritiqueDraftButtonState,
+  // Plan
+  renderPlanPanel,
+  generatePlanWithAi,
+  draftPlanFromBrainDumpWithAi,
+  clearBrainDumpInput,
+  addPlanTasksToTodos,
+  dismissPlanSuggestion,
+  resetPlanDraft,
+  // Plan draft editing
+  setPlanDraftTaskSelected,
+  updatePlanDraftTaskTitle,
+  updatePlanDraftTaskDescription,
+  updatePlanDraftTaskDueDate,
+  updatePlanDraftTaskProject,
+  updatePlanDraftTaskPriority,
+  selectAllPlanDraftTasks,
+  selectNoPlanDraftTasks,
+  retryMarkPlanSuggestionAccepted,
+} from "../../modules/aiWorkspace.js";

--- a/client/features/drawer/index.js
+++ b/client/features/drawer/index.js
@@ -1,0 +1,68 @@
+// =============================================================================
+// drawer feature barrel — re-exports from drawerUi.js and drawerStore.js
+//
+// New code should import from this barrel:
+//   import { openTodoDrawer, closeTodoDrawer } from '../features/drawer/index.js';
+//
+// The drawerUi.js monolith (2,146 lines) will be split incrementally:
+// - drawerView.js (rendering)
+// - drawerDraft.js (draft management)
+// - drawerKebab.js (kebab menu)
+// - drawerAssist.js (AI suggestions)
+// =============================================================================
+
+export {
+  // Drawer lifecycle
+  openTodoDrawer,
+  closeTodoDrawer,
+  syncTodoDrawerStateWithRender,
+  toggleDrawerDetailsPanel,
+  deleteTodoFromDrawer,
+  getTodoDrawerElements,
+  initializeDrawerDraft,
+  setDrawerSaveState,
+  lockBodyScrollForDrawer,
+  unlockBodyScrollForDrawer,
+  bindTodoDrawerHandlers,
+  // Drawer event handlers
+  onDrawerTitleInput,
+  onDrawerTitleBlur,
+  onDrawerTitleKeydown,
+  onDrawerCompletedChange,
+  onDrawerDueDateChange,
+  onDrawerProjectChange,
+  onDrawerPriorityChange,
+  onDrawerDescriptionInput,
+  onDrawerDescriptionBlur,
+  onDrawerDescriptionKeydown,
+  onDrawerNotesInput,
+  onDrawerNotesBlur,
+  onDrawerNotesKeydown,
+  onDrawerCategoryInput,
+  onDrawerCategoryBlur,
+  renderTodoDrawerContent,
+  saveDrawerPatch,
+  // Kebab menu
+  getKebabTriggerForTodo,
+  closeTodoKebabMenu,
+  toggleTodoKebab,
+  openTodoFromKebab,
+  openEditTodoFromKebab,
+  openDrawerDangerZone,
+  // Task drawer assist
+  markTaskDrawerDismissed,
+  clearTaskDrawerDismissed,
+  isTaskDrawerDismissed,
+  resetTaskDrawerAssistState,
+  loadTaskDrawerDecisionAssist,
+  applyTaskDrawerSuggestion,
+  dismissTaskDrawerSuggestions,
+  undoTaskDrawerSuggestion,
+} from "../../modules/drawerUi.js";
+
+export {
+  getDrawerState,
+  isDrawerOpen,
+  getDrawerEntityId,
+  isDrawerDetailsExpanded,
+} from "./drawerStore.js";

--- a/client/features/projects/index.js
+++ b/client/features/projects/index.js
@@ -1,0 +1,62 @@
+// =============================================================================
+// projects feature barrel — re-exports from projectsState.js and initProjectsFeature.js
+//
+// New code should import from this barrel:
+//   import { loadProjects, createProject } from '../features/projects/index.js';
+//
+// The projectsState.js monolith (1,391 lines) will be split incrementally:
+// - projectCrud.js (create/rename/delete/archive)
+// - projectHeadings.js (heading management)
+// - projectCatalog.js (catalog refresh, rail data)
+// - projectDialogs.js (edit drawer + delete dialog)
+// =============================================================================
+
+export {
+  // CRUD
+  loadCustomProjects,
+  saveCustomProjects,
+  loadProjects,
+  createProject,
+  createSubproject,
+  renameProjectByName,
+  deleteProjectByName,
+  archiveProject,
+  unarchiveProject,
+  createProjectByName,
+  // Selection
+  getSelectedProjectRecord,
+  getProjectRecordByName,
+  updateCategoryFilter,
+  // Headings
+  getProjectHeadings,
+  loadHeadingsForProject,
+  scheduleLoadSelectedProjectHeadings,
+  createHeadingForSelectedProject,
+  renderProjectHeadingCreateButton,
+  // Catalog
+  getAllProjects,
+  getProjectsForRail,
+  refreshProjectCatalog,
+  buildOpenTodoCountMapByProject,
+  updateProjectSelectOptions,
+  renderProjectOptions,
+  // Project edit drawer
+  openProjectEditDrawer,
+  closeProjectEditDrawer,
+  submitProjectEditDrawer,
+  // Project delete dialog
+  openProjectDeleteDialog,
+  closeProjectDeleteDialog,
+  confirmDeleteSelectedProject,
+  // Project CRUD modal
+  openProjectCrudModal,
+  closeProjectCrudModal,
+  submitProjectCrudModal,
+} from "../../modules/projectsState.js";
+
+export {
+  initProjectsFeature,
+  moveProjectHeading,
+  reorderProjectHeadings,
+  moveTodoToHeading,
+} from "./initProjectsFeature.js";


### PR DESCRIPTION
## Summary

- \`client/features/drawer/index.js\` — barrel for drawerUi.js (2,146 lines) + drawerStore
- \`client/features/assistant/index.js\` — barrel for aiWorkspace.js (1,517 lines)
- \`client/features/projects/index.js\` — barrel for projectsState.js (1,391 lines) + initProjectsFeature

Establishes stable import paths for the three largest frontend modules. New code imports from feature barrels; actual file splitting follows incrementally.

Closes #438, #441, #440

## Test plan

- [x] Format check passes
- [x] Unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)