### PR TITLE
fix(db): add migration for phone/social login schema changes

### DIFF
--- a/prisma/migrations/20260322134159_add_phone_social_login/migration.sql
+++ b/prisma/migrations/20260322134159_add_phone_social_login/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable: make email and password nullable for social/phone login
+ALTER TABLE "users" ALTER COLUMN "email" DROP NOT NULL;
+ALTER TABLE "users" ALTER COLUMN "password" DROP NOT NULL;
+
+-- AddColumn: phone number for phone login
+ALTER TABLE "users" ADD COLUMN "phone_e164" VARCHAR(20);
+
+-- AddColumn: onboarding tracking
+ALTER TABLE "users" ADD COLUMN "onboarding_completed_at" TIMESTAMP(3);
+ALTER TABLE "users" ADD COLUMN "onboarding_step" VARCHAR(50);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_phone_e164_key" ON "users"("phone_e164");


### PR DESCRIPTION
## Summary

PR #478 added \`phoneE164\` column and made \`email\`/\`password\` nullable in the Prisma schema but did not include a migration. Integration tests fail with:

\`\`\`
The column \`users.phone_e164\` does not exist in the current database.
\`\`\`

This adds the missing migration:
- Make \`email\` and \`password\` nullable (for social/phone login)
- Add \`phone_e164\` column with unique index
- Add \`onboarding_completed_at\` and \`onboarding_step\` columns

## Test plan

- [ ] Integration tests pass (this is the fix)
- [ ] Unit tests pass
- [ ] Railway deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)