### PR TITLE
fix(db): remove duplicate columns from phone login migration

### DIFF
--- a/prisma/migrations/20260322134159_add_phone_social_login/migration.sql
+++ b/prisma/migrations/20260322134159_add_phone_social_login/migration.sql
@@ -5,9 +5,5 @@ ALTER TABLE "users" ALTER COLUMN "password" DROP NOT NULL;
 -- AddColumn: phone number for phone login
 ALTER TABLE "users" ADD COLUMN "phone_e164" VARCHAR(20);
 
--- AddColumn: onboarding tracking
-ALTER TABLE "users" ADD COLUMN "onboarding_completed_at" TIMESTAMP(3);
-ALTER TABLE "users" ADD COLUMN "onboarding_step" VARCHAR(50);
-
 -- CreateIndex
 CREATE UNIQUE INDEX "users_phone_e164_key" ON "users"("phone_e164");


### PR DESCRIPTION
## Summary

The phone_e164 migration (PR #481) incorrectly included \`onboarding_completed_at\` and \`onboarding_step\` columns that already exist from migration \`20260318000000_add_onboarding_fields\`.

Error: \`column "onboarding_completed_at" of relation "users" already exists\`

Fix: remove the duplicate ALTER TABLE statements, keeping only the phone/social login changes.

## Test plan

- [ ] Integration tests pass (this fixes the migration error)
- [ ] Railway deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)