### PR TITLE
fix(types): add fallback declaration for cookie-parser

### DIFF
--- a/src/types/cookie-parser.d.ts
+++ b/src/types/cookie-parser.d.ts
@@ -1,0 +1,16 @@
+// Fallback declaration for cookie-parser when @types/cookie-parser
+// is not resolved (e.g., CI caching issues). Prefer the real types
+// from @types/cookie-parser when available.
+declare module "cookie-parser" {
+  import { RequestHandler } from "express";
+  function cookieParser(
+    secret?: string | string[],
+    options?: cookieParser.CookieParseOptions,
+  ): RequestHandler;
+  namespace cookieParser {
+    interface CookieParseOptions {
+      decode?: (val: string) => string;
+    }
+  }
+  export = cookieParser;
+}


### PR DESCRIPTION
## Summary

CI builds fail with:
\`\`\`
src/app.ts(4,26): error TS7016: Could not find a declaration file for module 'cookie-parser'
\`\`\`

Add a fallback \`.d.ts\` declaration so TypeScript compiles regardless of whether \`@types/cookie-parser\` resolves from node_modules.

## Test plan

- [x] Typecheck passes locally
- [ ] CI typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)