### PR TITLE
fix(db): add missing migration for social_accounts table

### DIFF
--- a/prisma/migrations/20260323045248_add_social_accounts/migration.sql
+++ b/prisma/migrations/20260323045248_add_social_accounts/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "social_accounts" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "provider" VARCHAR(20) NOT NULL,
+    "provider_subject" VARCHAR(255) NOT NULL,
+    "email_at_provider" VARCHAR(255),
+    "email_verified_at_provider" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "social_accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "social_accounts_user_id_idx" ON "social_accounts"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "social_accounts_provider_provider_subject_key" ON "social_accounts"("provider", "provider_subject");
+
+-- AddForeignKey
+ALTER TABLE "social_accounts" ADD CONSTRAINT "social_accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary

The \`SocialAccount\` model was added to the Prisma schema but no migration was created. Adds the \`social_accounts\` table with provider/subject unique constraint, user FK, and index.

## Test plan

- [ ] Integration tests pass
- [ ] Railway deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)