### PR TITLE
fix(ui): show app immediately after social login callback

### DIFF
--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -965,9 +965,9 @@ export function handleSocialCallback() {
       // Clean URL
       window.history.replaceState({}, document.title, "/");
 
-      // Load profile and show app
+      // Show app immediately, then load profile in background
+      showAppView();
       loadUserProfile().then(() => {
-        showAppView();
         initOnboarding();
       });
     }


### PR DESCRIPTION
## Summary

After Google OAuth redirect (\`/?auth=success&token=...\`), \`showAppView()\` was deferred inside \`loadUserProfile().then()\`. If the profile load was slow or failed, the user was stuck on the landing page seeing the auth form.

Fix: call \`showAppView()\` immediately after setting auth tokens. Profile loads in the background.

## Test plan

- [ ] Google login → app shows immediately, not stuck on landing page
- [ ] Profile data loads in background (name, avatar appear after a moment)
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)