### PR TITLE
fix(ui): social login stuck on landing page — token param conflict

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1443,9 +1443,14 @@ function init() {
     );
   }
 
-  // Check for reset token in URL
+  // Handle social login callback before anything else — the URL contains
+  // ?auth=success&token=...&refreshToken=... after Google/Apple OAuth redirect.
+  handleSocialCallback();
+
+  // Check for password-reset token in URL (only when NOT a social auth callback)
   const urlParams = new URLSearchParams(window.location.search);
-  const resetToken = urlParams.get("token");
+  const isSocialCallback = urlParams.has("auth");
+  const resetToken = !isSocialCallback ? urlParams.get("token") : null;
 
   if (resetToken) {
     showResetPassword(resetToken);
@@ -1483,7 +1488,7 @@ function init() {
   renderProjectHeadingCreateButton();
   renderQuickEntryNaturalDueChip();
   handleVerificationStatusFromUrl();
-  handleSocialCallback();
+  // handleSocialCallback() moved earlier in init() — before resetToken check
   initSocialLogin();
   bindRailSearchFocusBehavior();
 }


### PR DESCRIPTION
## Summary

**Root cause:** After Google OAuth redirect (\`/?auth=success&token=JWT&refreshToken=...\`), \`init()\` called \`urlParams.get("token")\` which matched the JWT auth token, treated it as a password reset token, called \`showResetPassword()\`, and returned early. \`handleSocialCallback()\` never ran.

**Fix:** 
- Call \`handleSocialCallback()\` first in \`init()\`, before the reset token check
- Skip the reset token check when \`?auth=\` param is present (social login callback)

## Test plan

- [ ] Google login → app shows immediately (not stuck on landing/set-password)
- [ ] Password reset links (\`/?token=RESET_TOKEN\`) still work
- [ ] Normal email/password login still works
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)