### PR TITLE
feat(ui): add simple mode for task-only users

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1328,8 +1328,24 @@ window.setUiMode = function setUiMode(mode) {
     localStorage.setItem("todos:ui-mode", mode);
     localStorage.removeItem("simpleMode"); // clean up legacy key
   } catch {}
+  // Sync both UI controls (both are <select> elements now)
   const select = document.getElementById("uiModeSelect");
   if (select instanceof HTMLSelectElement) select.value = mode;
+  const toggle = document.getElementById("simpleModeToggle");
+  if (toggle instanceof HTMLSelectElement) toggle.value = mode;
+  // Redirect away from hidden workspace views by clicking the "All" button
+  if (isSimple) {
+    const active = document.querySelector(
+      ".workspace-view-item.projects-rail-item--active",
+    );
+    const view = active?.getAttribute("data-workspace-view");
+    if (view && ["home", "inbox", "unsorted"].includes(view)) {
+      const allBtn = document.querySelector(
+        '[data-workspace-view="all"].workspace-view-item',
+      );
+      if (allBtn instanceof HTMLElement) allBtn.click();
+    }
+  }
 };
 // AI workspace
 window.openAiWorkspaceForBrainDump = openAiWorkspaceForBrainDump;
@@ -1541,3 +1557,17 @@ initTheme();
 registerServiceWorker();
 bindDeclarativeHandlers();
 init();
+
+// After init, redirect simple-mode users away from hidden workspace views
+if (document.body.classList.contains("simple-mode")) {
+  const active = document.querySelector(
+    ".workspace-view-item.projects-rail-item--active",
+  );
+  const view = active?.getAttribute("data-workspace-view");
+  if (view && ["home", "inbox", "unsorted"].includes(view)) {
+    const allBtn = document.querySelector(
+      '[data-workspace-view="all"].workspace-view-item',
+    );
+    if (allBtn instanceof HTMLElement) allBtn.click();
+  }
+}

--- a/client/modules/quickEntry.js
+++ b/client/modules/quickEntry.js
@@ -625,6 +625,17 @@ export function inferTaskComposerDefaultProject() {
 
 export function openTaskComposer(triggerEl = null) {
   hooks.ensureTodosShellActive?.();
+  // In simple mode, focus the inline quick-add instead of the full composer
+  if (document.body.classList.contains("simple-mode")) {
+    const inlineInput =
+      document.getElementById("inlineQuickAddInput") ||
+      document.getElementById("todoInput");
+    if (inlineInput instanceof HTMLInputElement) {
+      inlineInput.focus();
+      inlineInput.scrollIntoView({ block: "center" });
+      return;
+    }
+  }
   const refs = getTaskComposerElements();
   if (!refs) return;
   const defaultProject = inferTaskComposerDefaultProject();

--- a/client/styles.css
+++ b/client/styles.css
@@ -9438,6 +9438,78 @@ body.simple-mode .todo-item {
   grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
+/* Sidebar: hide project tree sections, Home, Inbox, Unsorted, Projects button */
+body.simple-mode
+  .projects-rail__section:not(.projects-rail__section--workspace):not(
+    .projects-rail__section--utilities
+  ),
+body.simple-mode .projects-rail__spacer,
+body.simple-mode [data-workspace-view="home"],
+body.simple-mode [data-workspace-view="inbox"],
+body.simple-mode [data-workspace-view="unsorted"],
+body.simple-mode .projects-rail-projects-access,
+body.simple-mode .projects-rail-mobile-open {
+  display: none !important;
+}
+
+/* Task composer & inline quick-add: hide properties toggle, summary, and panel */
+body.simple-mode .quick-entry-properties-toggle,
+body.simple-mode .quick-entry-properties-summary,
+body.simple-mode #quickEntryPropertiesPanel,
+body.simple-mode .task-composer-sheet .expand-section,
+body.simple-mode .task-composer-sheet .notes-textarea {
+  display: none !important;
+}
+
+/* Todo row chips: keep only due date */
+body.simple-mode .todo-chip--status,
+body.simple-mode .todo-chip--context,
+body.simple-mode .todo-chip--project,
+body.simple-mode .todo-chip--priority {
+  display: none !important;
+}
+
+/* Edit modal: hide project and priority fields */
+body.simple-mode #editTodoModal .form-group:has(#editTodoProjectSelect),
+body.simple-mode #editTodoModal .form-group:has(#editTodoPriority) {
+  display: none !important;
+}
+
+/* Todo drawer Essentials: hide advanced fields, keep title + completed + due date */
+body.simple-mode .todo-drawer__field:has(#drawerStatusSelect),
+body.simple-mode .todo-drawer__field:has(#drawerStartDateInput),
+body.simple-mode .todo-drawer__field:has(#drawerScheduledDateInput),
+body.simple-mode .todo-drawer__field:has(#drawerReviewDateInput),
+body.simple-mode .todo-drawer__field:has(#drawerProjectSelect),
+body.simple-mode .todo-drawer__field:has(#drawerPrioritySelect),
+body.simple-mode .todo-drawer__field:has(#drawerContextInput),
+body.simple-mode .todo-drawer__field:has(#drawerEnergySelect),
+body.simple-mode .todo-drawer__field:has(#drawerEstimateInput) {
+  display: none !important;
+}
+
+/* Todo drawer Details: hide tags, waitingOn, depends, category, archived, meta */
+body.simple-mode .todo-drawer__field:has(#drawerTagsInput),
+body.simple-mode .todo-drawer__field:has(#drawerWaitingOnInput),
+body.simple-mode .todo-drawer__field:has(#drawerDependsOnInput),
+body.simple-mode .todo-drawer__field:has(#drawerCategoryInput),
+body.simple-mode .todo-drawer__field:has(#drawerArchivedToggle),
+body.simple-mode .todo-drawer__meta {
+  display: none !important;
+}
+
+/* Hide project-edit drawer and AI task-drawer assist */
+body.simple-mode .project-edit-drawer,
+body.simple-mode .todo-drawer-ai-list {
+  display: none !important;
+}
+
+/* Kebab menu: hide move-to-project, move-to-heading, AI breakdown */
+body.simple-mode .todo-kebab-project-label,
+body.simple-mode .todo-kebab-item[data-onclick*="aiBreakdownTodo"] {
+  display: none !important;
+}
+
 /* ==========================================================================
    Wireframe UX — Inline Quick Add, cleaner rows, hover states, mobile input
    ========================================================================== */


### PR DESCRIPTION
## Summary

- **Simple mode** gives casual users an ultra-minimal experience: title-only task creation, flat workspace navigation (All/Today/Upcoming/Completed), and simplified detail views
- Consolidates two competing toggle mechanisms into one unified system using `todos:ui-mode` localStorage key
- Replaces the Settings checkbox with a `<select>` dropdown; removes duplicate toggle
- In simple mode, the "+ New Task" CTA focuses the inline quick-add instead of opening the full composer sheet
- CSS-first approach using `:has()` selectors to hide 30+ advanced UI elements across sidebar, task composer, edit modal, todo drawer, and kebab menus

## What's hidden in simple mode

| Area | Hidden | Kept |
|------|--------|------|
| Sidebar | Project tree, Home, Inbox, Unsorted, Projects button | All tasks, Today, Upcoming, Completed, Settings |
| Task creation | Properties panel, status, priority, context, energy, tags | Title input + natural-language due date parsing |
| Todo rows | Status, context, project, priority chips | Due date chip |
| Todo drawer | Status, start/scheduled/review dates, project, priority, context, energy, estimate, tags, waitingOn, depends, category, archived | Title, completed, due date, description, notes, subtasks |
| Edit modal | Project, priority fields | Title, description, due date, notes |
| Kebab menu | Move to project, move to heading, AI breakdown | Open details, edit modal, delete |

## Test plan

- [x] All 211 UI tests pass (33 skipped visual)
- [x] 300 unit tests pass
- [x] Format, HTML lint, CSS lint all clean
- [ ] Toggle simple mode via Settings dropdown — sidebar collapses to 4 workspace views
- [ ] Toggle via Profile dropdown — same result, both controls stay in sync
- [ ] "+ New Task" CTA focuses inline input (no composer sheet)
- [ ] Todo rows show only due date chips
- [ ] Todo drawer shows Title + Completed + Due date in Essentials
- [ ] Switch to advanced mode — everything reappears
- [ ] Refresh page — mode persists from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)