### PR TITLE
fix(ui): remove duplicate display mode control + unify storage migration

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1254,12 +1254,7 @@ function bindDockHandlers() {
 // (modules do not expose top-level declarations to global scope).
 // ---------------------------------------------------------------------------
 window.toggleTheme = toggleTheme;
-window.toggleSimpleMode = function (enabled) {
-  document.body.classList.toggle("simple-mode", enabled);
-  try {
-    localStorage.setItem("simpleMode", enabled ? "1" : "0");
-  } catch {}
-};
+// toggleSimpleMode removed — single control is #uiModeSelect via setUiMode()
 window.openProjectsFromTopbar = openProjectsFromTopbar;
 // Auth forms
 window.switchAuthTab = switchAuthTab;
@@ -1331,6 +1326,7 @@ window.setUiMode = function setUiMode(mode) {
   document.body.classList.toggle("simple-mode", isSimple);
   try {
     localStorage.setItem("todos:ui-mode", mode);
+    localStorage.removeItem("simpleMode"); // clean up legacy key
   } catch {}
   const select = document.getElementById("uiModeSelect");
   if (select instanceof HTMLSelectElement) select.value = mode;
@@ -1506,20 +1502,19 @@ function init() {
 
 // Initialize theme immediately
 initTheme();
-// Initialize simple mode from localStorage
-(function initSimpleMode() {
-  const enabled = localStorage.getItem("simpleMode") === "1";
-  if (enabled) document.body.classList.add("simple-mode");
-  const toggle = document.getElementById("simpleModeToggle");
-  if (toggle instanceof HTMLInputElement) toggle.checked = enabled;
-})();
-// Initialize UI mode from localStorage
+// Initialize UI mode from localStorage (canonical key: todos:ui-mode)
 (function initUiMode() {
   try {
-    const mode = localStorage.getItem("todos:ui-mode") || "advanced";
-    if (mode === "simple") {
-      document.body.classList.add("simple-mode");
+    let mode = localStorage.getItem("todos:ui-mode");
+    // One-time migration from legacy key
+    if (!mode) {
+      const legacy = localStorage.getItem("simpleMode");
+      if (legacy === "1") mode = "simple";
+      if (legacy !== null) localStorage.removeItem("simpleMode");
     }
+    mode = mode || "advanced";
+    localStorage.setItem("todos:ui-mode", mode);
+    if (mode === "simple") document.body.classList.add("simple-mode");
     const select = document.getElementById("uiModeSelect");
     if (select instanceof HTMLSelectElement) select.value = mode;
   } catch {}

--- a/client/index.html
+++ b/client/index.html
@@ -1593,22 +1593,7 @@
                           </div>
                           <h2>Settings</h2>
                         </div>
-                        <div class="settings-pane__section">
-                          <h3>Display</h3>
-                          <label class="settings-toggle">
-                            <input
-                              type="checkbox"
-                              id="simpleModeToggle"
-                              data-onchange="toggleSimpleMode(this.checked)"
-                            />
-                            <span>Simple mode</span>
-                            <span class="settings-toggle__hint"
-                              >Hide projects sidebar, AI suggestions, drag
-                              handles, and bulk selection for a cleaner
-                              experience.</span
-                            >
-                          </label>
-                        </div>
+                        <!-- Display mode control: single #uiModeSelect in Interface section below -->
                         <div
                           class="message"
                           id="profileMessage"

--- a/client/utils/storageKeys.js
+++ b/client/utils/storageKeys.js
@@ -12,4 +12,5 @@ export const STORAGE_KEYS = {
   FEATURE_TASK_DRAWER_ASSIST: "feature.taskDrawerDecisionAssist",
   TASK_DRAWER_DISMISSED_PREFIX: "taskDrawerAssist:dismissed:",
   UI_MODE: "todos:ui-mode",
+  THEME: "theme",
 };


### PR DESCRIPTION
## Summary

**Problem:** Two display mode controls in Settings — a checkbox (#simpleModeToggle) and a dropdown (#uiModeSelect) — both toggling the same \`body.simple-mode\` class but with different localStorage keys and sync logic.

**Fix:**
- Remove the duplicate checkbox (\`#simpleModeToggle\`) and its "Display" section
- Keep the dropdown (\`#uiModeSelect\`) with descriptive labels
- Unify storage: canonical key \`todos:ui-mode\`, one-time migration from legacy \`simpleMode\` key
- Remove old \`toggleSimpleMode()\` and \`initSimpleMode()\`
- Register \`THEME\` key in storageKeys.js

## Verification checklist

- [x] Only one UI mode dropdown in Settings
- [x] Legacy \`simpleMode\` key migrated and deleted on load
- [x] Display mode persists across reload
- [x] No tests reference \`simpleModeToggle\`
- [x] No console errors
- [x] All lint/format/unit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)