### PR TITLE
fix(ui): content cleanup — back arrow, dead CSS, loading ellipsis

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2008,7 +2008,7 @@
                         <div id="adminContent">
                           <div class="loading">
                             <div class="spinner"></div>
-                            Loading admin tools...
+                            Loading admin tools…
                           </div>
                         </div>
                       </div>
@@ -2734,7 +2734,7 @@
                       <div id="todosContent">
                         <div class="loading">
                           <div class="spinner"></div>
-                          Loading todos...
+                          Loading todos…
                         </div>
                       </div>
                     </div>

--- a/client/styles.css
+++ b/client/styles.css
@@ -1115,9 +1115,7 @@ textarea:focus-visible,
   transform: translateY(0);
 }
 
-.btn-secondary {
-  background: var(--muted);
-}
+/* .btn-secondary old definition removed — superseded by line ~5842 */
 
 .btn-danger {
   background: var(--danger);
@@ -2268,6 +2266,10 @@ textarea:focus-visible,
 
 .pane-back-btn {
   font-size: 0.85rem;
+}
+
+.pane-back-btn::before {
+  content: "\2190\00a0";
 }
 
 /* --- Per-pane base styles (consistent layout, flat background) --- */


### PR DESCRIPTION
## Summary

- Add ← arrow to all "Back to Todos" buttons via CSS \`::before\` (no DOM changes, no test breakage)
- Remove dead \`.btn-secondary\` definition (line 1118, fully superseded by line 5842)
- Standardize loading ellipsis: \`...\` → \`…\` in 2 HTML loading messages
- Kept \`.mini-btn\` old definition (provides \`font-size: 0.82em\` not in the later def — NOT safe to remove)

🤖 Generated with [Claude Code](https://claude.com/claude-code)