### PR TITLE
fix(ui): unblock first-run usability — placeholders, empty CTA, tap targets

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1069,13 +1069,7 @@
                         >
                       </div>
                       <div id="projectsRailList" class="projects-rail__list">
-                        <div
-                          class="projects-rail-item"
-                          data-project-key="sample-project"
-                        >
-                          <span>Sample Project</span>
-                          <span class="projects-rail-item__count">0</span>
-                        </div>
+                        <!-- Populated by JS — no placeholder needed -->
                       </div>
                     </div>
                     <div class="projects-rail__spacer" aria-hidden="true"></div>
@@ -1559,10 +1553,7 @@
                         </button>
                       </div>
                       <div class="projects-rail__list">
-                        <div class="projects-rail-item">
-                          <span>Sample Project</span>
-                          <span class="projects-rail-item__count">0</span>
-                        </div>
+                        <!-- Populated by JS -->
                       </div>
                     </div>
                     <div

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -988,12 +988,19 @@ export function renderHomeDashboard() {
   }
   void loadPrioritiesBrief();
 
+  const hasTasks = state.todos && state.todos.length > 0;
+  const emptyStateCta = hasTasks
+    ? ""
+    : `<div class="home-empty-cta">
+        <p class="home-empty-cta__heading">Welcome to your workspace</p>
+        <p class="home-empty-cta__sub">Add your first task to get started. Use the <strong>+ New Task</strong> button below, or press <kbd>/</kbd> to quick-add.</p>
+        <button type="button" class="btn" data-onclick="openTaskComposer()">+ Add your first task</button>
+      </div>`;
+
   return `
     <section class="home-dashboard" data-testid="home-dashboard">
       ${renderPrioritiesTileShell()}
-      <div class="home-dashboard__header">
-        <h2 class="home-dashboard__title">Home</h2>
-      </div>
+      ${emptyStateCta}
     </section>`;
 }
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -5501,6 +5501,14 @@ body.is-drawer-open {
   font-size: 1.1rem;
 }
 
+@media (max-width: 768px) {
+  .btn-icon {
+    width: 44px;
+    height: 44px;
+    font-size: 1.2rem;
+  }
+}
+
 .btn-icon:hover {
   background: var(--card-bg);
 }
@@ -7655,6 +7663,35 @@ body.is-todos-view .projects-rail__header {
   letter-spacing: -0.02em;
   margin: 0;
   color: var(--text-primary);
+}
+
+.home-empty-cta {
+  text-align: center;
+  padding: var(--s-6) var(--s-4);
+  max-width: 440px;
+  margin: var(--s-4) auto;
+}
+
+.home-empty-cta__heading {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--s-2);
+}
+
+.home-empty-cta__sub {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 var(--s-4);
+}
+
+.home-empty-cta__sub kbd {
+  background: var(--surface-2);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: inherit;
+  font-size: 0.9em;
 }
 
 .home-dashboard__new-task {


### PR DESCRIPTION
## Summary

Fixes the top 3 trust-breakers for new users:

1. **Remove "Sample Project" placeholder** — hardcoded HTML in 2 sidebar locations that never gets replaced if JS fails. Users saw dead project with no way to remove it.
2. **Home empty state CTA** — "Welcome to your workspace" + "Add your first task" button when 0 tasks. Previously empty tiles with no guidance.
3. **44px tap targets on mobile** — \`.btn-icon\` increased from 34px to 44px on mobile. Affects drawer close, kebab, all icon buttons.

## Acceptance criteria

- [x] Fresh account never shows "Sample Project"
- [x] 0-task user sees CTA with action button on Home
- [x] Mobile icon buttons are 44x44px minimum
- [x] All lint/format/unit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)