### PR TITLE
fix(ui): simplify task creation — collapse advanced fields behind More options

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2399,116 +2399,124 @@
                                 Critique Draft (AI)
                               </button>
                             </div>
-                            <div class="field-row task-composer-fields">
-                              <label
-                                class="task-composer-inline-field"
-                                for="todoStartDateInput"
-                              >
-                                <span>Start</span>
-                                <input
-                                  type="datetime-local"
-                                  id="todoStartDateInput"
-                                />
-                              </label>
-                              <label
-                                class="task-composer-inline-field"
-                                for="todoScheduledDateInput"
-                              >
-                                <span>Scheduled</span>
-                                <input
-                                  type="datetime-local"
-                                  id="todoScheduledDateInput"
-                                />
-                              </label>
-                              <label
-                                class="task-composer-inline-field"
-                                for="todoReviewDateInput"
-                              >
-                                <span>Review</span>
-                                <input
-                                  type="datetime-local"
-                                  id="todoReviewDateInput"
-                                />
-                              </label>
-                            </div>
-                            <div class="field-row task-composer-fields">
-                              <label
-                                class="task-composer-inline-field"
-                                for="todoContextInput"
-                              >
-                                <span>Context</span>
-                                <input
-                                  type="text"
-                                  id="todoContextInput"
-                                  maxlength="100"
-                                  placeholder="@computer"
-                                />
-                              </label>
-                              <label
-                                class="task-composer-inline-field"
-                                for="todoEnergySelect"
-                              >
-                                <span>Energy</span>
-                                <select id="todoEnergySelect">
-                                  <option value="" selected>None</option>
-                                  <option value="low">Low</option>
-                                  <option value="medium">Medium</option>
-                                  <option value="high">High</option>
-                                </select>
-                              </label>
-                              <label
-                                class="task-composer-inline-field"
-                                for="todoEstimateInput"
-                              >
-                                <span>Estimate</span>
-                                <input
-                                  type="number"
-                                  id="todoEstimateInput"
-                                  min="0"
-                                  step="1"
-                                  placeholder="Min"
-                                />
-                              </label>
-                            </div>
-                            <div class="field-row task-composer-fields">
-                              <label
-                                class="task-composer-inline-field task-composer-inline-field--wide"
-                                for="todoTagsInput"
-                              >
-                                <span>Tags</span>
-                                <input
-                                  type="text"
-                                  id="todoTagsInput"
-                                  maxlength="512"
-                                  placeholder="comma, separated, tags"
-                                />
-                              </label>
-                              <label
-                                class="task-composer-inline-field task-composer-inline-field--wide"
-                                for="todoWaitingOnInput"
-                              >
-                                <span>Waiting on</span>
-                                <input
-                                  type="text"
-                                  id="todoWaitingOnInput"
-                                  maxlength="255"
-                                  placeholder="Person, vendor, approval..."
-                                />
-                              </label>
-                            </div>
-                            <div class="field-row task-composer-fields">
-                              <label
-                                class="task-composer-inline-field task-composer-inline-field--wide"
-                                for="todoDependsOnInput"
-                              >
-                                <span>Depends on task IDs</span>
-                                <textarea
-                                  id="todoDependsOnInput"
-                                  rows="2"
-                                  placeholder="comma-separated task UUIDs"
-                                ></textarea>
-                              </label>
-                            </div>
+                            <details class="task-composer-advanced">
+                              <summary class="task-composer-advanced__toggle">
+                                More options
+                              </summary>
+                              <div class="field-row task-composer-fields">
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoStartDateInput"
+                                >
+                                  <span>Start</span>
+                                  <input
+                                    type="datetime-local"
+                                    id="todoStartDateInput"
+                                    title="When to begin working on this task"
+                                  />
+                                </label>
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoScheduledDateInput"
+                                >
+                                  <span>Scheduled</span>
+                                  <input
+                                    type="datetime-local"
+                                    id="todoScheduledDateInput"
+                                    title="Date this task is scheduled to appear in your plan"
+                                  />
+                                </label>
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoReviewDateInput"
+                                >
+                                  <span>Review</span>
+                                  <input
+                                    type="datetime-local"
+                                    id="todoReviewDateInput"
+                                    title="When to check progress on this task"
+                                  />
+                                </label>
+                              </div>
+                              <div class="field-row task-composer-fields">
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoContextInput"
+                                >
+                                  <span>Context</span>
+                                  <input
+                                    type="text"
+                                    id="todoContextInput"
+                                    maxlength="100"
+                                    placeholder="@computer"
+                                  />
+                                </label>
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoEnergySelect"
+                                >
+                                  <span>Energy</span>
+                                  <select id="todoEnergySelect">
+                                    <option value="" selected>None</option>
+                                    <option value="low">Low</option>
+                                    <option value="medium">Medium</option>
+                                    <option value="high">High</option>
+                                  </select>
+                                </label>
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoEstimateInput"
+                                >
+                                  <span>Estimate</span>
+                                  <input
+                                    type="number"
+                                    id="todoEstimateInput"
+                                    min="0"
+                                    step="1"
+                                    placeholder="Min"
+                                  />
+                                </label>
+                              </div>
+                              <div class="field-row task-composer-fields">
+                                <label
+                                  class="task-composer-inline-field task-composer-inline-field--wide"
+                                  for="todoTagsInput"
+                                >
+                                  <span>Tags</span>
+                                  <input
+                                    type="text"
+                                    id="todoTagsInput"
+                                    maxlength="512"
+                                    placeholder="comma, separated, tags"
+                                  />
+                                </label>
+                                <label
+                                  class="task-composer-inline-field task-composer-inline-field--wide"
+                                  for="todoWaitingOnInput"
+                                >
+                                  <span>Waiting on</span>
+                                  <input
+                                    type="text"
+                                    id="todoWaitingOnInput"
+                                    maxlength="255"
+                                    placeholder="Person, vendor, approval..."
+                                  />
+                                </label>
+                              </div>
+                              <div class="field-row task-composer-fields">
+                                <label
+                                  class="task-composer-inline-field task-composer-inline-field--wide"
+                                  for="todoDependsOnInput"
+                                >
+                                  <span>Depends on task IDs</span>
+                                  <textarea
+                                    id="todoDependsOnInput"
+                                    rows="2"
+                                    placeholder="comma-separated task UUIDs"
+                                  ></textarea>
+                                </label>
+                              </div>
+                            </details>
                           </div>
                           <div>
                             <button
@@ -2527,7 +2535,7 @@
                             <textarea
                               id="todoNotesInput"
                               class="notes-textarea"
-                              placeholder="Add detailed notes here..."
+                              placeholder="Add detailed notes here…"
                               style="display: none; margin-top: 8px"
                             ></textarea>
                           </div>

--- a/client/styles.css
+++ b/client/styles.css
@@ -7353,6 +7353,33 @@ body.is-todos-view .projects-rail-item__count {
   align-items: center;
 }
 
+.task-composer-advanced {
+  border-top: 1px solid var(--border-color);
+  margin-top: var(--s-2);
+  padding-top: var(--s-2);
+}
+
+.task-composer-advanced__toggle {
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  padding: var(--s-1) 0;
+  user-select: none;
+  list-style: none;
+}
+
+.task-composer-advanced__toggle::-webkit-details-marker {
+  display: none;
+}
+
+.task-composer-advanced__toggle::before {
+  content: "▸ ";
+}
+
+.task-composer-advanced[open] > .task-composer-advanced__toggle::before {
+  content: "▾ ";
+}
+
 .task-composer-fields > select {
   min-width: 0;
   flex: 1 1 220px;


### PR DESCRIPTION
## Summary

- Wrap 9 advanced fields behind \`<details>\` "More options" toggle
- Default composer view: Title, Project, Due date, Status, Priority only
- Add tooltip help text to ambiguous date fields (Start, Scheduled, Review)
- Uses native \`<details>\`/\`<summary>\` — no JS needed

## Acceptance criteria

- [x] Opening Properties shows only essential fields
- [x] "More options" reveals Start/Scheduled/Review/Context/Energy/Estimate/Tags/WaitingOn/DependsOn
- [x] Date fields have title tooltips explaining their purpose
- [x] HTML validates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)