### PR TITLE
fix(ui): accessibility + system feedback — aria-labels, auto-dismiss

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -31,6 +31,7 @@
                   class="theme-toggle"
                   data-onclick="toggleTheme()"
                   title="Toggle dark mode"
+                  aria-label="Toggle dark mode"
                 >
                   🌙
                 </button>

--- a/client/utils/utils.js
+++ b/client/utils/utils.js
@@ -21,6 +21,13 @@
     };
     el.appendChild(dismissBtn);
     el.className = "message " + type + " show";
+    // Auto-dismiss success messages after 5 seconds
+    if (type === "success") {
+      clearTimeout(el._autoDismissTimer);
+      el._autoDismissTimer = setTimeout(function () {
+        el.classList.remove("show");
+      }, 5000);
+    }
   }
 
   function hideMessage(id) {


### PR DESCRIPTION
## Summary

- Add \`aria-label\` to theme toggle button (was title-only)
- Auto-dismiss success messages after 5 seconds (error messages stay until dismissed)
- Focus restoration from drawer: already implemented, no change needed

## Acceptance criteria

- [x] Theme toggle announces correctly to screen readers
- [x] Success messages auto-fade after 5s
- [x] Error messages persist until dismissed
- [x] All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)