### PR TITLE
feat(ui): customer delight — done-today counter, onboarding re-entry

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1394,6 +1394,23 @@ window.applyHomeFocusSuggestion = applyHomeFocusSuggestion;
 window.dismissHomeFocusSuggestion = dismissHomeFocusSuggestion;
 // Onboarding flow
 window.initOnboarding = initOnboarding;
+window.restartOnboarding = async function () {
+  try {
+    await hooks.apiCall(`${hooks.API_URL}/users/me/onboarding/restart`, {
+      method: "POST",
+    });
+    // Reset client state and re-init
+    if (state.currentUser) {
+      state.currentUser.onboardingCompletedAt = null;
+      state.currentUser.onboardingStep = 0;
+    }
+    hooks.selectWorkspaceView?.("home");
+    window.location.reload();
+  } catch (e) {
+    console.error("Restart onboarding failed:", e);
+    hooks.showMessage?.("profileMessage", "Could not restart tour", "error");
+  }
+};
 window.isOnboardingActive = isOnboardingActive;
 window.advanceOnboarding = advanceOnboarding;
 window.dismissOnboarding = dismissOnboarding;

--- a/client/index.html
+++ b/client/index.html
@@ -1764,6 +1764,23 @@
                             Simple mode hides projects, headings, AI panels, and
                             tracks for a focused task list experience.
                           </p>
+                          <div style="margin-top: 12px">
+                            <button
+                              type="button"
+                              class="mini-btn"
+                              data-onclick="restartOnboarding()"
+                            >
+                              Restart setup tour
+                            </button>
+                            <span
+                              style="
+                                margin-left: 8px;
+                                font-size: 0.82em;
+                                color: var(--text-muted);
+                              "
+                              >Re-run the 4-step onboarding guide</span
+                            >
+                          </div>
                         </div>
 
                         <div
@@ -2682,6 +2699,11 @@
                           ></span>
                         </div>
                         <div class="todos-list-header__actions">
+                          <span
+                            id="doneTodayBadge"
+                            class="done-today-badge"
+                            hidden
+                          ></span>
                           <div
                             id="todosListHeaderCount"
                             class="todos-list-header__count"

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -558,6 +558,27 @@ function updateHeaderAndContextUI({
 
   hooks.syncProjectHeaderActions?.();
   hooks.updateTopbarProjectsButton?.(projectName);
+
+  // Done-today badge
+  const doneBadge = document.getElementById("doneTodayBadge");
+  if (doneBadge instanceof HTMLElement) {
+    const now = new Date();
+    const todayStart = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+    );
+    const doneToday = state.todos.filter((t) => {
+      if (!t.completed || !t.updatedAt) return false;
+      return new Date(t.updatedAt) >= todayStart;
+    }).length;
+    if (doneToday > 0) {
+      doneBadge.textContent = `✓ ${doneToday} done today`;
+      doneBadge.hidden = false;
+    } else {
+      doneBadge.hidden = true;
+    }
+  }
 }
 
 function getOpenTodos() {

--- a/client/styles.css
+++ b/client/styles.css
@@ -2372,6 +2372,16 @@ textarea:focus-visible,
   white-space: nowrap;
 }
 
+.done-today-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--success);
+  white-space: nowrap;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--success) 10%, transparent);
+}
+
 .todos-list-header__actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

1. **✓ N done today** badge — green pill in task list header, counts tasks completed today. Hidden at 0.
2. **Restart setup tour** — button in Settings that resets onboarding and reloads. Users who skipped onboarding can now re-run it.

## Test plan

- [x] All lint/format/unit checks pass
- [ ] Complete a task → "✓ 1 done today" appears
- [ ] Restart tour → onboarding modal reappears on Home view

🤖 Generated with [Claude Code](https://claude.com/claude-code)