### PR TITLE
fix(ui): post-retro — landing cards, auto-dismiss 8s, simple mode nav, badge fix

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -145,8 +145,9 @@
                         Everything you need to stay on top of it
                       </h2>
 
-                      <div class="landing-feature">
-                        <div class="landing-feature__text">
+                      <div class="landing-features-grid">
+                        <div class="landing-feature-card">
+                          <div class="landing-feature-card__icon">⚡</div>
                           <h3>Get tasks out of your head, fast</h3>
                           <p>
                             Type naturally — "Call dentist tomorrow 2pm" — and
@@ -155,18 +156,9 @@
                             drag-and-drop.
                           </p>
                         </div>
-                        <div class="landing-feature__visual">
-                          <img
-                            src="/images/landing/hero-desktop.png"
-                            alt="Task list with quick entry, natural dates, and projects"
-                            class="landing-hero__img"
-                            loading="lazy"
-                          />
-                        </div>
-                      </div>
 
-                      <div class="landing-feature landing-feature--reverse">
-                        <div class="landing-feature__text">
+                        <div class="landing-feature-card">
+                          <div class="landing-feature-card__icon">🧠</div>
                           <h3>AI that helps you plan, not just list</h3>
                           <p>
                             Get instant feedback on vague tasks, turn goals into
@@ -174,18 +166,8 @@
                             actionable pieces — all powered by AI.
                           </p>
                         </div>
-                        <div class="landing-feature__visual">
-                          <img
-                            src="/images/landing/hero-desktop.png"
-                            alt="AI-powered task planning and critique"
-                            class="landing-hero__img"
-                            loading="lazy"
-                          />
-                        </div>
-                      </div>
-
-                      <div class="landing-feature">
-                        <div class="landing-feature__text">
+                        <div class="landing-feature-card">
+                          <div class="landing-feature-card__icon">💬</div>
                           <h3>Chat with AI to manage your tasks</h3>
                           <p>
                             Connect Claude or ChatGPT and manage your tasks
@@ -193,32 +175,14 @@
                             "Add a task to buy groceries" — just ask.
                           </p>
                         </div>
-                        <div class="landing-feature__visual">
-                          <img
-                            src="/images/landing/dark-mode.png"
-                            alt="Manage tasks through AI assistant conversation"
-                            class="landing-hero__img"
-                            loading="lazy"
-                          />
-                        </div>
-                      </div>
-
-                      <div class="landing-feature landing-feature--reverse">
-                        <div class="landing-feature__text">
+                        <div class="landing-feature-card">
+                          <div class="landing-feature-card__icon">🤖</div>
                           <h3>Autopilot for your productivity</h3>
                           <p>
                             Daily planning, weekly reviews, and stale task
                             cleanup run automatically in the background. Wake up
                             to a prioritized day, every day.
                           </p>
-                        </div>
-                        <div class="landing-feature__visual">
-                          <img
-                            src="/images/landing/dark-mode.png"
-                            alt="Automated daily planning and weekly reviews"
-                            class="landing-hero__img"
-                            loading="lazy"
-                          />
                         </div>
                       </div>
                     </div>
@@ -738,7 +702,7 @@
                           type="text"
                           id="searchInput"
                           class="search-input"
-                          placeholder="Search… (/) · ⌘K commands"
+                          placeholder="Search… (/)"
                           autocomplete="off"
                           data-oninput="filterTodos()"
                         />
@@ -917,7 +881,9 @@
                             />
                           </svg>
                           <span class="nav-label">Unsorted</span>
-                          <span class="projects-rail-item__count">0</span>
+                          <span class="projects-rail-item__count" hidden
+                            >0</span
+                          >
                         </button>
                         <button
                           type="button"
@@ -945,7 +911,9 @@
                             <path d="M13 18h8" />
                           </svg>
                           <span class="nav-label">All tasks</span>
-                          <span class="projects-rail-item__count">0</span>
+                          <span class="projects-rail-item__count" hidden
+                            >0</span
+                          >
                         </button>
                         <button
                           type="button"
@@ -1311,7 +1279,9 @@
                             />
                           </svg>
                           <span class="nav-label">Unsorted</span>
-                          <span class="projects-rail-item__count">0</span>
+                          <span class="projects-rail-item__count" hidden
+                            >0</span
+                          >
                         </button>
                         <button
                           type="button"
@@ -1339,7 +1309,9 @@
                             <path d="M13 18h8" />
                           </svg>
                           <span class="nav-label">All tasks</span>
-                          <span class="projects-rail-item__count">0</span>
+                          <span class="projects-rail-item__count" hidden
+                            >0</span
+                          >
                         </button>
                         <button
                           type="button"
@@ -1457,7 +1429,7 @@
                           type="text"
                           id="searchInputSheet"
                           class="search-input"
-                          placeholder="Search… (/) · ⌘K commands"
+                          placeholder="Search… (/)"
                           autocomplete="off"
                           data-oninput="syncSheetSearch()"
                         />
@@ -2491,7 +2463,7 @@
                                     id="todoEstimateInput"
                                     min="0"
                                     step="1"
-                                    placeholder="Min"
+                                    placeholder="Minutes"
                                   />
                                 </label>
                               </div>

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -568,9 +568,13 @@ function updateHeaderAndContextUI({
       now.getMonth(),
       now.getDate(),
     );
+    // Count tasks completed today. Prefer completedAt if available;
+    // fall back to updatedAt for tasks that don't have it yet.
     const doneToday = state.todos.filter((t) => {
-      if (!t.completed || !t.updatedAt) return false;
-      return new Date(t.updatedAt) >= todayStart;
+      if (!t.completed) return false;
+      const ts = t.completedAt || t.updatedAt;
+      if (!ts) return false;
+      return new Date(ts) >= todayStart;
     }).length;
     if (doneToday > 0) {
       doneBadge.textContent = `✓ ${doneToday} done today`;
@@ -1013,14 +1017,18 @@ function renderTodos() {
             total: 0,
             done: 0,
           };
-          const categoryHeader = categoryChanged
-            ? `
+          // Suppress category headers in Today/Upcoming views — section
+          // labels (Overdue/Due today/date headers) provide sufficient grouping
+          const suppressCategoryHeaders = isTodayView || isUpcomingView;
+          const categoryHeader =
+            !suppressCategoryHeaders && categoryChanged
+              ? `
           <li class="todo-group-header" data-category-group-key="${hooks.escapeHtml?.(categoryLabel)}">
             <span>\u{1F4C1} ${hooks.escapeHtml?.(categoryLabel)}</span>
             <span data-category-group-stats="true">${stats.done}/${stats.total} done</span>
           </li>
         `
-            : "";
+              : "";
           // Upcoming view: inject date group headers
           let dateHeader = "";
           if (isUpcomingView && todo.dueDate) {

--- a/client/styles.css
+++ b/client/styles.css
@@ -752,6 +752,53 @@ body:not(.is-todos-view) .container {
   direction: ltr;
 }
 
+.landing-features-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--s-4);
+}
+
+.landing-feature-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: var(--s-5);
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.landing-feature-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px
+    color-mix(in oklab, var(--text-primary) 6%, transparent);
+}
+
+.landing-feature-card__icon {
+  font-size: 2rem;
+  margin-bottom: var(--s-2);
+}
+
+.landing-feature-card h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0 0 var(--s-2);
+  color: var(--text-primary);
+}
+
+.landing-feature-card p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .landing-features-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .landing-feature__text h3 {
   font-size: 1.4rem;
   font-weight: 700;
@@ -6893,6 +6940,18 @@ body.is-todos-view .projects-rail-item__count {
   margin-top: 6px;
 }
 
+/* Hide empty warn/card sections when LLM returns empty containers */
+.home-priorities-body .lbl:has(+ .warn:empty),
+.home-priorities-body .warn:empty {
+  display: none;
+}
+
+/* Hide zero-count badges in the sidebar / project rail */
+.projects-rail-item__count:empty,
+.projects-rail-item__count[data-count="0"] {
+  display: none;
+}
+
 .lbl {
   font-size: 11px;
   font-weight: 500;
@@ -9452,7 +9511,6 @@ body.simple-mode
     .projects-rail__section--utilities
   ),
 body.simple-mode .projects-rail__spacer,
-body.simple-mode [data-workspace-view="home"],
 body.simple-mode [data-workspace-view="inbox"],
 body.simple-mode [data-workspace-view="unsorted"],
 body.simple-mode .projects-rail-projects-access,

--- a/client/utils/utils.js
+++ b/client/utils/utils.js
@@ -21,12 +21,26 @@
     };
     el.appendChild(dismissBtn);
     el.className = "message " + type + " show";
-    // Auto-dismiss success messages after 5 seconds
+    // Auto-dismiss success messages after 8 seconds; pause on hover
     if (type === "success") {
       clearTimeout(el._autoDismissTimer);
-      el._autoDismissTimer = setTimeout(function () {
-        el.classList.remove("show");
-      }, 5000);
+      var remaining = 8000;
+      var startTime = Date.now();
+      function startDismissTimer() {
+        el._autoDismissTimer = setTimeout(function () {
+          el.classList.remove("show");
+        }, remaining);
+        startTime = Date.now();
+      }
+      el.onmouseenter = function () {
+        clearTimeout(el._autoDismissTimer);
+        remaining -= Date.now() - startTime;
+        if (remaining < 1000) remaining = 1000;
+      };
+      el.onmouseleave = function () {
+        startDismissTimer();
+      };
+      startDismissTimer();
     }
   }
 


### PR DESCRIPTION
## Context

Post-shipping retrospective found 3 issues that hurt UX and 3 that were neutral-to-confusing. This fixes all 6.

## Changes

**Hurts → Fixed:**
- Landing page: 4 repeated screenshots → unique icon+text feature cards
- Auto-dismiss: 5s → 8s with hover-to-pause

**Traps → Fixed:**
- Simple mode: Home nav button now stays visible (was hidden)
- Done-today badge: uses completedAt instead of updatedAt

**Neutral → Polished:**
- Search placeholder: removed ⌘K hint (truncated on mobile)
- Today/Upcoming: suppress category headers when section labels active

## Test plan

- [x] All lint/format/unit checks pass
- [ ] Landing page shows 4 unique feature cards, no repeated images
- [ ] Success messages stay 8s, pause on hover
- [ ] Simple mode: Home button visible in sidebar
- [ ] Today view: no duplicate category headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)