### PR TITLE
fix(ui): UX polish from Comet visual review

### DIFF
--- a/client/modules/homePrioritiesTile.js
+++ b/client/modules/homePrioritiesTile.js
@@ -120,8 +120,7 @@ function _buildMetaHtml() {
     return `
       <div class="home-priorities-status" aria-live="polite">
         Refreshing priorities…
-      </div>
-      ${stampHtml}`;
+      </div>`;
   }
 
   if (_error && _html) {
@@ -265,7 +264,7 @@ export function renderPrioritiesTileShell() {
                 class="mini-btn home-priorities-refresh-btn"
                 data-onclick="refreshPrioritiesTile()"
                 aria-label="Refresh priorities"
-                title="Refresh">&#8635;</button>
+                title="Recalculate priorities">&#8635;</button>
       </div>
       <div class="home-tile__body home-priorities-body" id="${TILE_BODY_ID}">
         ${_buildBodyHtml()}

--- a/client/modules/railUi.js
+++ b/client/modules/railUi.js
@@ -503,7 +503,7 @@ function renderProjectsRailRowHtml(
     `<button type="button" class="projects-rail-item${isActive ? " projects-rail-item--active" : ""}" data-project-key="${escapeHtml(projectName)}"${isActive ? ' aria-current="page"' : ""}>` +
     svgIcon +
     `<span class="projects-rail-item__label" title="${escapeHtml(leafName)}">${escapeHtml(leafName)}</span>` +
-    `<span class="projects-rail-item__count">${count}</span>` +
+    `<span class="projects-rail-item__count"${count === 0 ? " hidden" : ""}>${count}</span>` +
     `</button></div>`
   );
 }
@@ -551,6 +551,7 @@ function patchProjectsRailRowElement(
   }
   if (countEl instanceof HTMLElement) {
     countEl.textContent = String(count);
+    countEl.hidden = count === 0;
   }
 }
 
@@ -827,9 +828,11 @@ export function renderProjectsRail() {
   );
   if (desktopAllCount instanceof HTMLElement) {
     desktopAllCount.textContent = String(allCount);
+    desktopAllCount.hidden = allCount === 0;
   }
   if (desktopUnsortedCount instanceof HTMLElement) {
     desktopUnsortedCount.textContent = String(unsortedCount);
+    desktopUnsortedCount.hidden = unsortedCount === 0;
   }
   const sheetAllCount = refs.sheetAllTasksButton.querySelector(
     ".projects-rail-item__count",
@@ -839,9 +842,11 @@ export function renderProjectsRail() {
   );
   if (sheetAllCount instanceof HTMLElement) {
     sheetAllCount.textContent = String(allCount);
+    sheetAllCount.hidden = allCount === 0;
   }
   if (sheetUnsortedCount instanceof HTMLElement) {
     sheetUnsortedCount.textContent = String(unsortedCount);
+    sheetUnsortedCount.hidden = unsortedCount === 0;
   }
 
   refs.allTasksButton.setAttribute("data-project-key", "");

--- a/client/modules/taskDrawerAssist.js
+++ b/client/modules/taskDrawerAssist.js
@@ -426,7 +426,7 @@ function renderTodoChips(todo, { isOverdue, dueDateStr }) {
     scheduled: "🗓 Scheduled",
     someday: "☁️ Someday",
     in_progress: "▶ In Progress",
-    next: "→ Next",
+    next: "Up Next",
     cancelled: "✗ Cancelled",
   };
   if (STATUS_LABELS[status]) {

--- a/client/utils/theme.js
+++ b/client/utils/theme.js
@@ -1,8 +1,14 @@
 (function initThemeModule(globalScope) {
   function syncThemeLabel(isDark) {
     var icon = isDark ? "☀️" : "🌙";
-    var toggleBtn = document.querySelector(".theme-toggle");
-    if (toggleBtn) toggleBtn.textContent = icon;
+    var toggleBtns = document.querySelectorAll(
+      '[data-onclick="toggleTheme()"]',
+    );
+    for (var i = 0; i < toggleBtns.length; i++) {
+      var btn = toggleBtns[i];
+      btn.setAttribute("aria-pressed", String(isDark));
+      if (btn.classList.contains("theme-toggle")) btn.textContent = icon;
+    }
     var sidebarLabel = document.querySelector(".app-sidebar__theme-label");
     if (sidebarLabel) sidebarLabel.textContent = icon + " Theme";
   }

--- a/src/routes/prioritiesBriefRouter.ts
+++ b/src/routes/prioritiesBriefRouter.ts
@@ -127,7 +127,7 @@ export function createPrioritiesBriefRouter({
 Output ONLY the inner HTML — no outer wrapper, no markdown fences, no explanation.
 Use only these CSS classes (already defined in the app's stylesheet):
 
-  .lbl             — section label: <div class="lbl">Section title</div>
+  .lbl             — section label: <div class="lbl">Section title</div>  (use sentence case for all labels)
   .urgent          — red urgent banner:
                      <div class="urgent"><div class="dot-lg r"></div><div><strong>Date — Task.</strong> One sentence context.</div></div>
   .warn            — amber warning:
@@ -135,7 +135,7 @@ Use only these CSS classes (already defined in the app's stylesheet):
   .track           — 3-column grid: <div class="track"><div>col1</div><div>col2</div><div>col3</div></div>
   .col-head.now    — amber header:  <div class="col-head now">This week</div>
   .col-head.soon   — blue header:   <div class="col-head soon">Next 14 days</div>
-  .col-head.after  — gray header:   <div class="col-head after">After [month]</div>
+  .col-head.after  — gray header:   <div class="col-head after">Later</div>
   .col-body        — column body:   <div class="col-body">...</div>
   .item            — row in column: <div class="item"><div class="dot r"></div>Task title (Xm)</div>
   dot colors:        r=red  a=amber  g=green  b=blue  p=purple
@@ -147,12 +147,15 @@ Output structure (omit a section if nothing to show):
    Never show a task as urgent if its due date is more than 7 days from today, even if it has priority=urgent.
    Include the due date and one concrete reason why it matters.
 2. Three-column track with label "What to do across three tracks" —
-   put ALL open tasks in This week / Next 14 days / After [next month name].
-   Tasks with no due date: place in "This week" if priority is high/urgent, otherwise "After [month]".
+   put ALL open tasks in This week / Next 14 days / Later.
+   Use "Later" as the third column header (not a specific month name).
+   Tasks with no due date: place in "This week" if priority is high/urgent, otherwise "Later".
    Append "(no due date)" after the task title for dateless tasks.
 3. Warn card — only for projects with open_tasks:0 that do NOT have child projects with tasks. Max 2.
+   If there are no warnings, omit the entire section including any labels.
 4. Single most impactful card — pick ONE task, write opinionated 2-3 sentence reasoning.
    Name the actual dependency or risk. Be direct. Do not hedge.
+   If there are no open tasks, omit this section entirely — do not render an empty card.
 
 Rules:
 - Use actual task titles. Use actual due dates. Name who is blocking it.

--- a/tests/ui/todo-drawer-edit.spec.ts
+++ b/tests/ui/todo-drawer-edit.spec.ts
@@ -539,6 +539,13 @@ test.describe("Todo drawer essentials editing", () => {
     await page.locator("#todoStatusSelect").selectOption("scheduled");
     await page.locator("#todoProjectSelect").selectOption("Work");
     await page.locator("#todoDueDateInput").fill("2026-06-01T12:00");
+
+    // Open the advanced fields section (collapsed by default after #506)
+    const advancedDetails = page.locator("details.task-composer-advanced");
+    if (await advancedDetails.count()) {
+      await advancedDetails.locator("summary").click();
+    }
+
     await page.locator("#todoStartDateInput").fill("2026-05-30T09:00");
     await page.locator("#todoScheduledDateInput").fill("2026-05-31T10:00");
     await page.locator("#todoReviewDateInput").fill("2026-06-02T08:30");


### PR DESCRIPTION
## Summary

Addresses findings from the Comet evidence-based UX critique (v1.6.0 review):

- **Fix loading state overlap**: hide stale timestamp while "Refreshing priorities..." is shown, preventing confusing dual-message display
- **Hide zero-count badges**: sidebar project and workspace view counts no longer show "0" badges — reduces visual noise
- **Dark mode ARIA fix**: all theme toggle buttons now use `aria-pressed` instead of missing attribute, so screen readers correctly announce on/off state
- **Status chip clarity**: rename "→ Next" to "Up Next" — clearer meaning for users unfamiliar with GTD
- **Refresh tooltip**: "Refresh" → "Recalculate priorities" — explains what the button actually does
- **LLM prompt improvements**: use "Later" instead of hardcoded month name (fixes the "After April" stale label), enforce sentence-case labels, explicitly omit empty warn/impactful sections
- **Test fix**: open collapsed advanced `<details>` before filling fields (pre-existing breakage from #506)

## Items already fixed in prior PRs (skipped)
- Duplicate mode controls (#501)
- Admin icon visibility (CSS-gated)
- Bottom bar tooltips (already present)
- Progressive disclosure in task modal (#506)

## Test plan
- [x] `npx tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run lint:html` — pass
- [x] `npm run lint:css` — pass
- [x] `npm run test:unit` — 300 passed
- [x] `CI=1 npm run test:ui:fast` — 211 passed, 0 failed
- [x] DOM verification via preview server: placeholder, aria-pressed, hidden badges confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)