### PR TITLE
feat(ui): restore calm todos workspace

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="app-version" content="1.6.0" />
-    <title>Todo App - Complete</title>
+    <title>Todo App</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
@@ -26,7 +26,7 @@
                   align-items: center;
                 "
               >
-                <h1>📝 Todo App</h1>
+                <h1>Todo App</h1>
                 <button
                   class="theme-toggle"
                   data-onclick="toggleTheme()"
@@ -86,7 +86,7 @@
                   <!-- Nav -->
                   <nav class="landing-nav" id="landingNav">
                     <div class="landing-nav__inner">
-                      <a href="#" class="landing-nav__logo">📝 Todo App</a>
+                      <a href="#" class="landing-nav__logo">Todo App</a>
                       <div class="landing-nav__links">
                         <a href="#landing-features" class="landing-nav__link"
                           >Features</a
@@ -111,9 +111,10 @@
                         Your tasks,&nbsp;your&nbsp;way.
                       </h1>
                       <p class="landing-hero__sub">
-                        The AI-powered task manager that connects to Claude and
-                        ChatGPT. Plan your day, critique your tasks, and let
-                        autonomous agents keep your projects on track.
+                        A calm workspace for planning your day, organizing
+                        projects, and getting clear on what matters next. AI is
+                        there when you need a second brain, not another
+                        dashboard to manage.
                       </p>
                       <div class="landing-hero__ctas">
                         <a
@@ -130,7 +131,7 @@
                       <div class="landing-hero__screenshot">
                         <img
                           src="/images/landing/hero-desktop.png"
-                          alt="Todo App — task list with projects, priorities, and due dates"
+                          alt="Todo App task list with projects, priorities, and due dates"
                           class="landing-hero__img"
                           loading="eager"
                         />
@@ -150,7 +151,7 @@
                           <div class="landing-feature-card__icon">⚡</div>
                           <h3>Get tasks out of your head, fast</h3>
                           <p>
-                            Type naturally — "Call dentist tomorrow 2pm" — and
+                            Type naturally - "Call dentist tomorrow 2pm" - and
                             the app figures out the date. Organize into
                             projects, set priorities, and reorder with
                             drag-and-drop.
@@ -163,7 +164,8 @@
                           <p>
                             Get instant feedback on vague tasks, turn goals into
                             step-by-step plans, and break big projects into
-                            actionable pieces — all powered by AI.
+                            actionable pieces, without pulling focus away from
+                            your list.
                           </p>
                         </div>
                         <div class="landing-feature-card">
@@ -2227,6 +2229,17 @@
                             data-testid="ai-on-create-row"
                             hidden
                           ></div>
+                          <div class="task-composer-inline-actions">
+                            <button
+                              id="critiqueDraftButton"
+                              class="mini-btn task-composer-ai-trigger"
+                              data-onclick="critiqueDraftWithAi()"
+                              type="button"
+                              hidden
+                            >
+                              Critique Draft (AI)
+                            </button>
+                          </div>
                           <div
                             id="quickEntryPropertiesPanel"
                             class="quick-entry-properties-panel task-composer-properties"
@@ -2239,41 +2252,6 @@
                               <select id="todoProjectSelect">
                                 <option value="">No project</option>
                               </select>
-                              <button
-                                id="quickEntryCreateProjectButton"
-                                class="add-btn"
-                                data-onclick="createProject()"
-                                style="width: auto; padding: 10px 14px"
-                                type="button"
-                              >
-                                + Project
-                              </button>
-                              <button
-                                id="quickEntryCreateSubprojectButton"
-                                class="add-btn"
-                                data-onclick="createSubproject()"
-                                style="
-                                  width: auto;
-                                  padding: 10px 14px;
-                                  background: #0f766e;
-                                "
-                                type="button"
-                              >
-                                + Subproject
-                              </button>
-                              <button
-                                id="quickEntryRenameProjectButton"
-                                class="add-btn"
-                                data-onclick="renameProjectTree()"
-                                style="
-                                  width: auto;
-                                  padding: 10px 14px;
-                                  background: #334155;
-                                "
-                                type="button"
-                              >
-                                Rename Project
-                              </button>
                               <div class="task-composer-due-wrap">
                                 <label for="todoDueDateInput" class="sr-only"
                                   >Todo due date</label
@@ -2378,17 +2356,40 @@
                                   </button>
                                 </div>
                               </div>
-                              <button
-                                id="critiqueDraftButton"
-                                class="add-btn"
-                                data-onclick="critiqueDraftWithAi()"
-                                type="button"
-                                hidden
-                                style="background: #334155; width: auto"
-                              >
-                                Critique Draft (AI)
-                              </button>
                             </div>
+                            <details class="task-composer-project-actions">
+                              <summary
+                                class="task-composer-project-actions__toggle"
+                              >
+                                Project actions
+                              </summary>
+                              <div class="task-composer-project-actions__body">
+                                <button
+                                  id="quickEntryCreateProjectButton"
+                                  class="mini-btn task-composer-project-action"
+                                  data-onclick="createProject()"
+                                  type="button"
+                                >
+                                  New project
+                                </button>
+                                <button
+                                  id="quickEntryCreateSubprojectButton"
+                                  class="mini-btn task-composer-project-action"
+                                  data-onclick="createSubproject()"
+                                  type="button"
+                                >
+                                  New subproject
+                                </button>
+                                <button
+                                  id="quickEntryRenameProjectButton"
+                                  class="mini-btn task-composer-project-action"
+                                  data-onclick="renameProjectTree()"
+                                  type="button"
+                                >
+                                  Rename selected project
+                                </button>
+                              </div>
+                            </details>
                             <details class="task-composer-advanced">
                               <summary class="task-composer-advanced__toggle">
                                 More options
@@ -2564,7 +2565,7 @@
                             aria-controls="aiWorkspaceBody"
                           >
                             <span class="ai-workspace-toggle__title"
-                              >AI Assistant</span
+                              >Planning assistant</span
                             >
                             <span
                               id="aiWorkspaceToggleChevron"
@@ -2575,7 +2576,7 @@
                           <span
                             id="aiWorkspaceStatus"
                             class="ai-workspace-status-chip"
-                            >Ready</span
+                            >Available</span
                           >
                           <div class="ai-workspace-header-actions">
                             <button
@@ -2584,7 +2585,7 @@
                               type="button"
                               data-onclick="openAiWorkspaceForBrainDump()"
                             >
-                              Draft tasks
+                              Draft ideas
                             </button>
                             <button
                               id="aiWorkspacePlanButton"
@@ -2592,7 +2593,7 @@
                               type="button"
                               data-onclick="openAiWorkspaceForGoalPlan()"
                             >
-                              Plan from goal
+                              Plan a goal
                             </button>
                           </div>
                         </div>
@@ -2644,7 +2645,7 @@
                               </button>
                             </div>
                             <div class="ai-brain-dump-helper">
-                              We'll draft tasks - you can edit before applying.
+                              Draft a first pass, then edit before applying.
                             </div>
                           </div>
                           <div

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -734,6 +734,79 @@ export function renderHomeTaskTile({
   `;
 }
 
+function getHomeBriefHeadline(model, focusTask) {
+  const dueSoonCount = model.dueSoon.length;
+  const staleCount = getStaleRiskTodos(6).length;
+  if (!focusTask && dueSoonCount === 0 && staleCount === 0) {
+    return "Your list looks settled. Use Home to keep the day intentionally small.";
+  }
+  if (!focusTask) {
+    return `There ${dueSoonCount === 1 ? "is" : "are"} ${dueSoonCount} task${dueSoonCount === 1 ? "" : "s"} coming up soon${staleCount ? ` and ${staleCount} backlog item${staleCount === 1 ? "" : "s"} worth a quick cleanup` : ""}.`;
+  }
+  const reason = getHomeTopFocusReason(focusTask);
+  const reasonText = reason ? `${reason.toLowerCase()} and ` : "";
+  return `Start with ${escapeHtml(String(focusTask.title || "your next task"))}. It's ${reasonText}a good anchor for the rest of the day.`;
+}
+
+function buildHomeFocusItems(model) {
+  const aiFocusItems = buildHomeAiTopFocusItems();
+  if (aiFocusItems.length > 0) return aiFocusItems.slice(0, 3);
+  return takeExclusiveTodos(
+    [...model.dueSoon, ...model.nextActionTodos, ...getStaleRiskTodos(6)],
+    3,
+    new Set(),
+  );
+}
+
+function renderHomeBriefCard(model) {
+  const focusItems = buildHomeFocusItems(model);
+  const focusTask = focusItems[0] || null;
+  const dueSoonCount = model.dueSoon.length;
+  const staleCount = getStaleRiskTodos(6).length;
+
+  return `
+    <section class="home-brief-card" data-testid="home-brief-card">
+      <div class="home-brief-card__eyebrow">Daily brief</div>
+      <div class="home-brief-card__header">
+        <div class="home-brief-card__copy">
+          <h2 class="home-brief-card__title">Today's focus</h2>
+          <p class="home-brief-card__summary">${getHomeBriefHeadline(
+            model,
+            focusTask,
+          )}</p>
+        </div>
+        <div class="home-brief-card__stats" aria-label="Daily summary">
+          <div class="home-brief-card__stat">
+            <span class="home-brief-card__stat-value">${dueSoonCount}</span>
+            <span class="home-brief-card__stat-label">Due soon</span>
+          </div>
+          <div class="home-brief-card__stat">
+            <span class="home-brief-card__stat-value">${staleCount}</span>
+            <span class="home-brief-card__stat-label">Needs cleanup</span>
+          </div>
+        </div>
+      </div>
+      ${
+        focusTask
+          ? `<button
+              type="button"
+              class="home-brief-card__primary"
+              data-onclick="openTodoFromHomeTile('${escapeHtml(String(focusTask.id))}')"
+            >
+              <span class="home-brief-card__primary-label">Strongest next action</span>
+              <span class="home-brief-card__primary-title">${escapeHtml(String(focusTask.title || "Untitled task"))}</span>
+              <span class="home-brief-card__primary-meta">${escapeHtml(
+                getHomeTopFocusReason(focusTask) ||
+                  "Open the task and keep momentum.",
+              )}</span>
+            </button>`
+          : ""
+      }
+      ${renderPrioritiesTileShell()}
+    </section>
+  `;
+}
+
 export function renderProjectsToNudgeTile(items = []) {
   const folderIcon = `<svg class="home-project-row__icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>`;
   return `
@@ -987,6 +1060,8 @@ export function renderHomeDashboard() {
     return `<section class="home-dashboard" data-testid="home-dashboard"></section>`;
   }
   void loadPrioritiesBrief();
+  const model = getHomeDashboardModel();
+  const staleRiskTodos = getStaleRiskTodos(3);
 
   const hasTasks = state.todos && state.todos.length > 0;
   const emptyStateCta = hasTasks
@@ -999,7 +1074,31 @@ export function renderHomeDashboard() {
 
   return `
     <section class="home-dashboard" data-testid="home-dashboard">
-      ${renderPrioritiesTileShell()}
+      ${hasTasks ? renderHomeBriefCard(model) : ""}
+      ${
+        hasTasks
+          ? `<div class="home-dashboard__support-grid">
+              ${renderHomeTaskTile({
+                key: "due_soon",
+                title: "Due soon",
+                subtitle:
+                  "Keep the horizon visible without turning it into a dashboard.",
+                items: model.dueSoon,
+                groupedItems: model.dueSoonGroups,
+                seeAllLabel: "See all",
+                emptyText: "Nothing urgent is coming up.",
+              })}
+              ${renderHomeTaskTile({
+                key: "stale_risks",
+                title: "Backlog hygiene",
+                subtitle: "A short list to keep the system feeling clean.",
+                items: staleRiskTodos,
+                seeAllLabel: "Review list",
+                emptyText: "Backlog looks calm right now.",
+              })}
+            </div>`
+          : ""
+      }
       ${emptyStateCta}
     </section>`;
 }

--- a/client/modules/homePrioritiesTile.js
+++ b/client/modules/homePrioritiesTile.js
@@ -258,7 +258,7 @@ export function renderPrioritiesTileShell() {
     <section class="home-tile home-tile--priorities" data-testid="home-priorities-tile">
       <div class="home-tile__header">
         <div class="home-tile__title-row">
-          <h3 class="home-tile__title">Next priorities</h3>
+          <h3 class="home-tile__title">Today's focus</h3>
         </div>
         <button type="button"
                 class="mini-btn home-priorities-refresh-btn"

--- a/client/modules/quickEntry.js
+++ b/client/modules/quickEntry.js
@@ -643,6 +643,9 @@ export function openTaskComposer(triggerEl = null) {
     triggerEl,
     defaultProject,
   });
+  if (!String(refs.titleInput?.value || "").trim()) {
+    setQuickEntryPropertiesOpen(false, { persist: false });
+  }
   if (refs.projectSelect && !String(refs.titleInput?.value || "").trim()) {
     refs.projectSelect.value = state.taskComposerDefaultProject || "";
   }
@@ -728,7 +731,7 @@ export function resetTaskComposerFields() {
   if (notesIcon instanceof HTMLElement) {
     notesIcon.classList.remove("expanded");
   }
-  setQuickEntryPropertiesOpen(true, { persist: false });
+  setQuickEntryPropertiesOpen(false, { persist: false });
   hooks.setPriority?.("medium");
   updateTaskComposerDueClearButton();
 }

--- a/client/styles.css
+++ b/client/styles.css
@@ -9776,3 +9776,277 @@ body.dark-mode .undo-toast {
   background: var(--surface-2);
   color: var(--text-primary);
 }
+
+/* Calm restoration overrides */
+
+body.is-todos-view .home-dashboard {
+  max-width: 980px;
+  gap: 18px;
+  padding: 24px 28px 40px;
+}
+
+body.is-todos-view .home-dashboard__support-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+body.is-todos-view .home-brief-card {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+  border: 1px solid color-mix(in oklab, var(--border-color) 72%, transparent);
+  border-radius: 24px;
+  background:
+    radial-gradient(
+      circle at top right,
+      color-mix(in oklab, var(--accent) 10%, transparent),
+      transparent 34%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--surface) 98%, var(--surface-2)) 0%,
+      color-mix(in oklab, var(--surface) 92%, var(--surface-2)) 100%
+    );
+  box-shadow: 0 18px 36px rgb(15 23 42 / 6%);
+}
+
+.home-brief-card__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+}
+
+.home-brief-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.home-brief-card__copy {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.home-brief-card__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+}
+
+.home-brief-card__summary {
+  margin: 0;
+  max-width: 54ch;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.home-brief-card__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(92px, 1fr));
+  gap: 10px;
+  min-width: 220px;
+}
+
+.home-brief-card__stat {
+  display: grid;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in oklab, var(--border-color) 68%, transparent);
+  background: color-mix(in oklab, var(--surface) 88%, var(--surface-2));
+}
+
+.home-brief-card__stat-value {
+  font-size: 1.25rem;
+  font-weight: var(--fw-semibold);
+  letter-spacing: -0.02em;
+}
+
+.home-brief-card__stat-label {
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+}
+
+.home-brief-card__primary {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border-color));
+  background: color-mix(in oklab, var(--surface) 92%, white 8%);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.home-brief-card__primary:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--accent) 40%, var(--border-color));
+  box-shadow: 0 10px 22px rgb(15 23 42 / 7%);
+}
+
+.home-brief-card__primary-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+}
+
+.home-brief-card__primary-title {
+  font-size: 1.05rem;
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.home-brief-card__primary-meta {
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+}
+
+body.is-todos-view .home-brief-card .home-tile--priorities {
+  margin: 0;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: color-mix(in oklab, var(--surface) 88%, var(--surface-2));
+  box-shadow: none;
+}
+
+body.is-todos-view .home-brief-card .home-tile__title {
+  font-size: 1rem;
+}
+
+body.is-todos-view .home-priorities-body {
+  min-height: 0;
+}
+
+body.is-todos-view .home-tile[data-home-tile="due_soon"],
+body.is-todos-view .home-tile[data-home-tile="stale_risks"] {
+  min-height: 100%;
+}
+
+body.is-todos-view .home-tile__subtitle {
+  max-width: 40ch;
+}
+
+body.is-todos-view .home-task-row {
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+}
+
+body.is-todos-view .task-composer-sheet__header {
+  align-items: flex-start;
+}
+
+body.is-todos-view .task-composer-properties {
+  gap: 12px;
+}
+
+body.is-todos-view .task-composer-properties[hidden],
+body.is-todos-view .quick-entry-properties-panel[hidden] {
+  display: none !important;
+}
+
+body.is-todos-view .task-composer-inline-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+body.is-todos-view .task-composer-ai-trigger {
+  background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
+  color: var(--text-secondary);
+  border-color: color-mix(in oklab, var(--border-color) 85%, transparent);
+}
+
+body.is-todos-view .task-composer-project-actions {
+  border-top: 1px solid
+    color-mix(in oklab, var(--border-color) 68%, transparent);
+  padding-top: 10px;
+}
+
+body.is-todos-view .task-composer-project-actions__toggle {
+  cursor: pointer;
+  list-style: none;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+}
+
+body.is-todos-view
+  .task-composer-project-actions__toggle::-webkit-details-marker {
+  display: none;
+}
+
+body.is-todos-view .task-composer-project-actions__toggle::before {
+  content: "▸ ";
+}
+
+body.is-todos-view
+  .task-composer-project-actions[open]
+  > .task-composer-project-actions__toggle::before {
+  content: "▾ ";
+}
+
+body.is-todos-view .task-composer-project-actions__body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+body.is-todos-view .task-composer-project-action {
+  width: auto;
+}
+
+body.is-todos-view .ai-workspace {
+  padding: 12px 14px;
+  border-radius: 18px;
+  border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+  box-shadow: none;
+}
+
+body.is-todos-view .ai-workspace-header {
+  gap: 10px;
+}
+
+body.is-todos-view .ai-workspace-toggle {
+  background: color-mix(in oklab, var(--surface) 96%, var(--surface-2));
+}
+
+body.is-todos-view .ai-workspace-status-chip {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+body.is-todos-view .ai-workspace-header-actions .mini-btn {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: color-mix(in oklab, var(--border-color) 80%, transparent);
+}
+
+@media (max-width: 900px) {
+  body.is-todos-view .home-dashboard__support-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-brief-card__header {
+    flex-direction: column;
+  }
+
+  .home-brief-card__stats {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -712,19 +712,20 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await expect(page.locator('[data-testid="home-dashboard"]')).toBeVisible();
     await expectWorkspaceViewActive(page, "home");
     await expect(page.locator("#todosListHeaderTitle")).toHaveText("Home");
+    await expect(page.locator('[data-testid="home-brief-card"]')).toBeVisible();
     await expect(
       page.locator('[data-testid="home-priorities-tile"]'),
     ).toBeVisible();
     await expect(
       page.locator('[data-testid="home-priorities-tile"]'),
-    ).toContainText("Next priorities");
+    ).toContainText("Today's focus");
     await expect(
       page.locator('[data-testid="home-priorities-tile"]'),
     ).toContainText(
       /Prepare launch checklist|Send overdue invoice|Nothing urgent right now/,
     );
-    await expect(page.locator('[data-home-tile="todays_plan"]')).toHaveCount(0);
-    await expect(page.locator('[data-home-tile="upcoming"]')).toHaveCount(0);
+    await expect(page.locator('[data-home-tile="due_soon"]')).toBeVisible();
+    await expect(page.locator('[data-home-tile="stale_risks"]')).toBeVisible();
   });
 
   test("New Task opens bottom sheet; Enter creates task and closes sheet", async ({
@@ -754,6 +755,7 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await clickWorkspaceView(page, "unsorted");
     await openTaskComposerSheet(page);
     await page.locator("#todoInput").fill("Project scoped task");
+    await page.locator("#quickEntryPropertiesToggle").click();
     await page.locator("#todoProjectSelect").selectOption({ label: "Work" });
     await page.locator("#taskComposerAddButton").click();
 
@@ -770,6 +772,24 @@ test.describe("Home focus dashboard + sheet composer", () => {
       page.locator(".todo-item").filter({ hasText: "Project scoped task" }),
     ).toBeVisible();
   });
+
+  test("Task composer opens in a compact default state", async ({ page }) => {
+    await openTaskComposerSheet(page);
+    await expect(page.locator("#quickEntryPropertiesPanel")).toBeHidden();
+    await expect(
+      page.locator(".task-composer-project-actions"),
+    ).not.toHaveAttribute("open", "");
+    await expect(page.locator("#todoInput")).toBeVisible();
+  });
+
+  test("All tasks keeps the list surface primary", async ({ page }) => {
+    await clickWorkspaceView(page, "all");
+    await expect(page.locator("#todosListHeader")).toBeVisible();
+    await expect(page.locator("#inlineQuickAdd")).toBeVisible();
+    await expect(page.locator('[data-testid="home-dashboard"]')).toHaveCount(0);
+    await expect(page.locator("#aiWorkspace")).toBeHidden();
+  });
+
   test("Today and Upcoming still navigate on the planner surface", async ({
     page,
   }) => {

--- a/tests/ui/todo-drawer-edit.spec.ts
+++ b/tests/ui/todo-drawer-edit.spec.ts
@@ -536,16 +536,15 @@ test.describe("Todo drawer essentials editing", () => {
     );
 
     await page.locator("#todoInput").fill("Plan travel");
+    await page.locator("#quickEntryPropertiesToggle").click();
     await page.locator("#todoStatusSelect").selectOption("scheduled");
     await page.locator("#todoProjectSelect").selectOption("Work");
     await page.locator("#todoDueDateInput").fill("2026-06-01T12:00");
-
     // Open the advanced fields section (collapsed by default after #506)
     const advancedDetails = page.locator("details.task-composer-advanced");
     if (await advancedDetails.count()) {
       await advancedDetails.locator("summary").click();
     }
-
     await page.locator("#todoStartDateInput").fill("2026-05-30T09:00");
     await page.locator("#todoScheduledDateInput").fill("2026-05-31T10:00");
     await page.locator("#todoReviewDateInput").fill("2026-06-02T08:30");


### PR DESCRIPTION
## Summary
- restore a calmer authenticated todos experience with a daily brief Home layout
- simplify the default list workspace and make AI secondary by default
- keep the task composer compact by default and update UI coverage for the calmer flows

## Verification
- npx tsc --noEmit
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- CI=1 npm run test:ui:fast