### PR TITLE
feat(ui): PR F — view-specific empty states

### DIFF
--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -1067,11 +1067,40 @@ function renderTodos() {
         })
         .join("");
 
-  container.innerHTML = `
-                <ul class="todos-list">
-                    ${rows}
-                </ul>
-            `;
+  // View-specific empty state when filter yields no results
+  // All content below is hardcoded — no user input, safe for innerHTML
+  if (filteredTodos.length === 0 && state.todos.length > 0) {
+    const viewMessages = {
+      today: {
+        heading: "All clear for today",
+        sub: "No tasks due today or overdue. Enjoy the moment.",
+      },
+      upcoming: {
+        heading: "Nothing coming up",
+        sub: "No tasks due in the next two weeks.",
+      },
+      completed: {
+        heading: "No completed tasks yet",
+        sub: "Completed tasks will appear here.",
+      },
+      someday: {
+        heading: "No someday tasks",
+        sub: "Tasks without a due date appear here.",
+      },
+    };
+    const msg = viewMessages[state.currentDateView] || {
+      heading: "No matching tasks",
+      sub: "Try adjusting your filters.",
+    };
+    container.innerHTML =
+      '<div class="empty-state"><h3>' +
+      msg.heading +
+      "</h3><p>" +
+      msg.sub +
+      "</p></div>";
+  } else {
+    container.innerHTML = '<ul class="todos-list">' + rows + "</ul>";
+  }
 
   if (state.selectedTodoId && !hooks.getTodoById?.(state.selectedTodoId)) {
     state.isTodoDrawerOpen = false;


### PR DESCRIPTION
## Summary

Context-aware empty states per view:
- Today: "All clear for today"
- Upcoming: "Nothing coming up"
- Completed/Someday/Default: specific messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)