### PR TITLE
[codex] Ship Soul MVP with calm onboarding and recovery flows

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -215,6 +215,9 @@ import {
   handleAdminBootstrap,
   resendVerification,
   handleUpdateProfile,
+  handleSaveSoulPreferences,
+  loadUserPlanningPreferences,
+  populateSoulPreferencesForm,
   logout,
   showAppView,
   showAuthView,
@@ -298,6 +301,12 @@ import {
   openHomeTileList,
   openHomeProject,
   openTodoFromHomeTile,
+  startSmallerForTodo,
+  moveTodoLater,
+  markTodoNotNow,
+  dropTodoFromList,
+  startRescueMode,
+  setNormalDayMode,
   retryTodaysPlan,
   setUpcomingTab,
   getHomeDrilldownLabel,
@@ -474,8 +483,18 @@ import {
   advanceOnboarding,
   dismissOnboarding,
   toggleOnboardingArea,
+  setOnboardingTone,
   onboardingStep1Next,
+  toggleOnboardingFailureMode,
+  toggleOnboardingGoodDayTheme,
+  setOnboardingPlanningStyle,
+  setOnboardingEnergyPattern,
+  setOnboardingDailyRitual,
+  backOnboardingStep,
+  finishOnboardingStep2,
   onboardingAddTask,
+  finishOnboardingExamples,
+  skipOnboardingExamples,
   onboardingSetDueDate,
 } from "./modules/onboardingFlow.js";
 
@@ -1094,6 +1113,7 @@ function bindDockHandlers() {
   hooks.loadTodos = loadTodos;
   hooks.addTodo = addTodo;
   hooks.addTodoFromInlineInput = addTodoFromInlineInput;
+  hooks.addUndoAction = addUndoAction;
   hooks.renderTodos = renderTodos;
   hooks.validateTodoTitle = validateTodoTitle;
   hooks.toDateInputValue = toDateInputValue;
@@ -1167,6 +1187,8 @@ function bindDockHandlers() {
   hooks.loadAiFeedbackSummary = loadAiFeedbackSummary;
   hooks.readStoredQuickEntryPropertiesOpenState =
     readStoredQuickEntryPropertiesOpenState;
+  hooks.loadUserPlanningPreferences = loadUserPlanningPreferences;
+  hooks.populateSoulPreferencesForm = populateSoulPreferencesForm;
   hooks.updateCritiqueDraftButtonState = updateCritiqueDraftButtonState;
   // railUi cross-module hooks
   hooks.DialogManager = DialogManager;
@@ -1320,6 +1342,7 @@ window.closeShortcutsOverlay = closeShortcutsOverlay;
 window.handleAdminBootstrap = handleAdminBootstrap;
 // Profile
 window.handleUpdateProfile = handleUpdateProfile;
+window.handleSaveSoulPreferences = handleSaveSoulPreferences;
 // UI Mode
 window.setUiMode = function setUiMode(mode) {
   const isSimple = mode === "simple";
@@ -1403,6 +1426,12 @@ window.unarchiveProject = unarchiveProject;
 // Home workspace
 window.openHomeProject = openHomeProject;
 window.openHomeTileList = openHomeTileList;
+window.startSmallerForTodo = startSmallerForTodo;
+window.moveTodoLater = moveTodoLater;
+window.markTodoNotNow = markTodoNotNow;
+window.dropTodoFromList = dropTodoFromList;
+window.startRescueMode = startRescueMode;
+window.setNormalDayMode = setNormalDayMode;
 window.retryTodaysPlan = retryTodaysPlan;
 window.setUpcomingTab = setUpcomingTab;
 window.refreshPrioritiesTile = refreshPrioritiesTile;
@@ -1431,8 +1460,18 @@ window.isOnboardingActive = isOnboardingActive;
 window.advanceOnboarding = advanceOnboarding;
 window.dismissOnboarding = dismissOnboarding;
 window.toggleOnboardingArea = toggleOnboardingArea;
+window.setOnboardingTone = setOnboardingTone;
 window.onboardingStep1Next = onboardingStep1Next;
+window.toggleOnboardingFailureMode = toggleOnboardingFailureMode;
+window.toggleOnboardingGoodDayTheme = toggleOnboardingGoodDayTheme;
+window.setOnboardingPlanningStyle = setOnboardingPlanningStyle;
+window.setOnboardingEnergyPattern = setOnboardingEnergyPattern;
+window.setOnboardingDailyRitual = setOnboardingDailyRitual;
+window.backOnboardingStep = backOnboardingStep;
+window.finishOnboardingStep2 = finishOnboardingStep2;
 window.onboardingAddTask = onboardingAddTask;
+window.finishOnboardingExamples = finishOnboardingExamples;
+window.skipOnboardingExamples = skipOnboardingExamples;
 window.onboardingSetDueDate = onboardingSetDueDate;
 // Admin
 window.changeUserRole = changeUserRole;

--- a/client/index.html
+++ b/client/index.html
@@ -1915,6 +1915,226 @@
                         </div>
 
                         <div class="profile-section">
+                          <h3>How this app supports you</h3>
+                          <p class="settings-support-copy">
+                            Tune the planning style, energy assumptions, and
+                            tone so the workspace feels more like support than
+                            supervision.
+                          </p>
+                          <form
+                            data-onsubmit="handleSaveSoulPreferences(event)"
+                          >
+                            <div class="form-group">
+                              <label>What kind of life are you managing?</label>
+                              <div class="settings-check-grid">
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulLifeAreas"
+                                    value="work"
+                                  />
+                                  Work</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulLifeAreas"
+                                    value="personal"
+                                  />
+                                  Personal</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulLifeAreas"
+                                    value="family"
+                                  />
+                                  Family / caregiving</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulLifeAreas"
+                                    value="health"
+                                  />
+                                  Health</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulLifeAreas"
+                                    value="side_projects"
+                                  />
+                                  Side projects</label
+                                >
+                              </div>
+                            </div>
+                            <div class="form-group">
+                              <label
+                                >When systems fail, what usually goes
+                                wrong?</label
+                              >
+                              <div class="settings-check-grid">
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulFailureModes"
+                                    value="overwhelmed"
+                                  />
+                                  Overwhelmed</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulFailureModes"
+                                    value="forgetful"
+                                  />
+                                  Forgetful</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulFailureModes"
+                                    value="perfectionist"
+                                  />
+                                  Perfectionist</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulFailureModes"
+                                    value="overcommitted"
+                                  />
+                                  Overcommitted</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulFailureModes"
+                                    value="inconsistent"
+                                  />
+                                  Inconsistent</label
+                                >
+                              </div>
+                            </div>
+                            <div class="settings-support-grid">
+                              <div class="form-group">
+                                <label for="soulPlanningStyle"
+                                  >Planning style</label
+                                >
+                                <select id="soulPlanningStyle">
+                                  <option value="structure">
+                                    I like structure
+                                  </option>
+                                  <option value="flexibility">
+                                    I like flexibility
+                                  </option>
+                                  <option value="both">I need both</option>
+                                </select>
+                              </div>
+                              <div class="form-group">
+                                <label for="soulEnergyPattern"
+                                  >Energy pattern</label
+                                >
+                                <select id="soulEnergyPattern">
+                                  <option value="morning">
+                                    Best in mornings
+                                  </option>
+                                  <option value="afternoon">
+                                    Best in afternoons
+                                  </option>
+                                  <option value="evening">
+                                    Best in evenings
+                                  </option>
+                                  <option value="variable">Varies a lot</option>
+                                </select>
+                              </div>
+                              <div class="form-group">
+                                <label for="soulTone">Tone</label>
+                                <select id="soulTone">
+                                  <option value="calm">Calm</option>
+                                  <option value="focused">Focused</option>
+                                  <option value="encouraging">
+                                    Encouraging
+                                  </option>
+                                  <option value="direct">Direct</option>
+                                </select>
+                              </div>
+                              <div class="form-group">
+                                <label for="soulDailyRitual"
+                                  >Daily ritual</label
+                                >
+                                <select id="soulDailyRitual">
+                                  <option value="morning_plan">
+                                    Morning plan
+                                  </option>
+                                  <option value="evening_reset">
+                                    Evening reset
+                                  </option>
+                                  <option value="both">Both</option>
+                                  <option value="neither">Neither</option>
+                                </select>
+                              </div>
+                            </div>
+                            <div class="form-group">
+                              <label>What makes a good day feel good?</label>
+                              <div class="settings-check-grid">
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulGoodDayThemes"
+                                    value="important_work"
+                                  />
+                                  Finish important work</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulGoodDayThemes"
+                                    value="life_admin"
+                                  />
+                                  Stay on top of life admin</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulGoodDayThemes"
+                                    value="avoid_overload"
+                                  />
+                                  Avoid overload</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulGoodDayThemes"
+                                    value="visible_progress"
+                                  />
+                                  Make visible progress</label
+                                >
+                                <label
+                                  ><input
+                                    type="checkbox"
+                                    name="soulGoodDayThemes"
+                                    value="protect_rest"
+                                  />
+                                  Protect time for family / rest</label
+                                >
+                              </div>
+                            </div>
+                            <p
+                              id="soulSupportPreview"
+                              class="settings-support-preview"
+                            >
+                              You’ll get calmer copy and gentler recovery
+                              language.
+                            </p>
+                            <button type="submit" class="btn">
+                              Save support preferences
+                            </button>
+                          </form>
+                        </div>
+
+                        <div class="profile-section">
                           <h3>Interface</h3>
                           <div class="info-row">
                             <span class="info-label">UI Mode</span>
@@ -1946,7 +2166,7 @@
                               class="mini-btn"
                               data-onclick="restartOnboarding()"
                             >
-                              Restart setup tour
+                              Restart soul setup
                             </button>
                             <span
                               style="
@@ -1954,7 +2174,7 @@
                                 font-size: 0.82em;
                                 color: var(--text-muted);
                               "
-                              >Re-run the 4-step onboarding guide</span
+                              >Re-run the 4-step guided setup</span
                             >
                           </div>
                         </div>
@@ -2415,7 +2635,7 @@
                           <input
                             type="text"
                             id="todoInput"
-                            placeholder="What needs to be done?"
+                            placeholder="What needs your attention?"
                             data-onkeypress="handleTodoKeyPress(event)"
                           />
                           <div
@@ -2645,6 +2865,19 @@
                                 </label>
                                 <label
                                   class="task-composer-inline-field"
+                                  for="todoEffortSelect"
+                                >
+                                  <span>Effort</span>
+                                  <select id="todoEffortSelect">
+                                    <option value="" selected>None</option>
+                                    <option value="1">Tiny</option>
+                                    <option value="2">Small</option>
+                                    <option value="3">Medium</option>
+                                    <option value="4">Deep</option>
+                                  </select>
+                                </label>
+                                <label
+                                  class="task-composer-inline-field"
                                   for="todoEnergySelect"
                                 >
                                   <span>Energy</span>
@@ -2666,6 +2899,34 @@
                                     min="0"
                                     step="1"
                                     placeholder="Minutes"
+                                  />
+                                </label>
+                              </div>
+                              <div class="field-row task-composer-fields">
+                                <label
+                                  class="task-composer-inline-field"
+                                  for="todoEmotionalStateSelect"
+                                >
+                                  <span>Emotional state</span>
+                                  <select id="todoEmotionalStateSelect">
+                                    <option value="" selected>None</option>
+                                    <option value="avoiding">Avoiding</option>
+                                    <option value="unclear">Unclear</option>
+                                    <option value="heavy">Heavy</option>
+                                    <option value="exciting">Exciting</option>
+                                    <option value="draining">Draining</option>
+                                  </select>
+                                </label>
+                                <label
+                                  class="task-composer-inline-field task-composer-inline-field--wide"
+                                  for="todoFirstStepInput"
+                                >
+                                  <span>First step</span>
+                                  <input
+                                    type="text"
+                                    id="todoFirstStepInput"
+                                    maxlength="255"
+                                    placeholder="Open the doc. Text Raj. Find last year's form."
                                   />
                                 </label>
                               </div>

--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -19,6 +19,11 @@ import {
 import { loadTodos } from "./todosService.js";
 import { closeTodoDrawer } from "./drawerUi.js";
 import { initOnboarding } from "./onboardingFlow.js";
+import {
+  SOUL_PROFILE_DEFAULTS,
+  normalizeSoulProfile,
+  SOUL_COPY,
+} from "./soulConfig.js";
 
 const { showMessage, hideMessage } = window.Utils || {};
 
@@ -417,6 +422,7 @@ export async function loadUserProfile() {
         });
       }
       updateUserDisplay();
+      await loadUserPlanningPreferences();
       await loadAdminBootstrapStatus();
 
       // Check if admin and show admin tab
@@ -428,6 +434,157 @@ export async function loadUserProfile() {
     }
   } catch (error) {
     console.error("Load profile error:", error);
+  }
+}
+
+export function populateSoulPreferencesForm() {
+  const prefs = normalizeSoulProfile(
+    state.userPlanningPreferences?.soulProfile,
+  );
+
+  const toggleCheckboxGroup = (name, selectedValues = []) => {
+    document
+      .querySelectorAll(`input[name="${name}"]`)
+      .forEach((inputElement) => {
+        if (!(inputElement instanceof HTMLInputElement)) return;
+        inputElement.checked = selectedValues.includes(inputElement.value);
+      });
+  };
+
+  toggleCheckboxGroup("soulLifeAreas", prefs.lifeAreas);
+  toggleCheckboxGroup("soulFailureModes", prefs.failureModes);
+  toggleCheckboxGroup("soulGoodDayThemes", prefs.goodDayThemes);
+
+  const planningStyle = document.getElementById("soulPlanningStyle");
+  if (planningStyle instanceof HTMLSelectElement) {
+    planningStyle.value = prefs.planningStyle;
+  }
+
+  const energyPattern = document.getElementById("soulEnergyPattern");
+  if (energyPattern instanceof HTMLSelectElement) {
+    energyPattern.value = prefs.energyPattern;
+  }
+
+  const tone = document.getElementById("soulTone");
+  if (tone instanceof HTMLSelectElement) {
+    tone.value = prefs.tone;
+  }
+
+  const dailyRitual = document.getElementById("soulDailyRitual");
+  if (dailyRitual instanceof HTMLSelectElement) {
+    dailyRitual.value = prefs.dailyRitual;
+  }
+
+  const preview = document.getElementById("soulSupportPreview");
+  if (preview instanceof HTMLElement) {
+    preview.textContent =
+      prefs.tone === "direct"
+        ? "You’ll get short, clear prompts and lighter review copy."
+        : prefs.tone === "encouraging"
+          ? "You’ll get warmer copy when plans drift and when work moves."
+          : prefs.tone === "focused"
+            ? "You’ll get steadier prompts aimed at clearer next actions."
+            : "You’ll get calmer copy and gentler recovery language.";
+  }
+}
+
+export async function loadUserPlanningPreferences() {
+  const apiCall = hooks.apiCall;
+  const API_URL = hooks.API_URL;
+
+  try {
+    const response = await apiCall(`${API_URL}/preferences`);
+    if (!response || !response.ok) return;
+    const preferences = await response.json();
+    state.userPlanningPreferences = {
+      ...(preferences || {}),
+      soulProfile: normalizeSoulProfile(preferences?.soulProfile),
+    };
+    populateSoulPreferencesForm();
+  } catch (error) {
+    console.error("Load planning preferences error:", error);
+    state.userPlanningPreferences = {
+      soulProfile: { ...SOUL_PROFILE_DEFAULTS },
+    };
+    populateSoulPreferencesForm();
+  }
+}
+
+function readSoulCheckboxValues(name) {
+  return Array.from(document.querySelectorAll(`input[name="${name}"]:checked`))
+    .map((inputElement) =>
+      inputElement instanceof HTMLInputElement ? inputElement.value : "",
+    )
+    .filter(Boolean);
+}
+
+function buildSoulProfilePayloadFromForm() {
+  const planningStyle = document.getElementById("soulPlanningStyle");
+  const energyPattern = document.getElementById("soulEnergyPattern");
+  const tone = document.getElementById("soulTone");
+  const dailyRitual = document.getElementById("soulDailyRitual");
+
+  return normalizeSoulProfile({
+    lifeAreas: readSoulCheckboxValues("soulLifeAreas"),
+    failureModes: readSoulCheckboxValues("soulFailureModes"),
+    goodDayThemes: readSoulCheckboxValues("soulGoodDayThemes"),
+    planningStyle:
+      planningStyle instanceof HTMLSelectElement
+        ? planningStyle.value
+        : SOUL_PROFILE_DEFAULTS.planningStyle,
+    energyPattern:
+      energyPattern instanceof HTMLSelectElement
+        ? energyPattern.value
+        : SOUL_PROFILE_DEFAULTS.energyPattern,
+    tone:
+      tone instanceof HTMLSelectElement
+        ? tone.value
+        : SOUL_PROFILE_DEFAULTS.tone,
+    dailyRitual:
+      dailyRitual instanceof HTMLSelectElement
+        ? dailyRitual.value
+        : SOUL_PROFILE_DEFAULTS.dailyRitual,
+  });
+}
+
+export async function handleSaveSoulPreferences(event) {
+  event.preventDefault();
+  hideMessage("profileMessage");
+  const apiCall = hooks.apiCall;
+  const parseApiBody = hooks.parseApiBody;
+  const API_URL = hooks.API_URL;
+
+  const payload = {
+    soulProfile: buildSoulProfilePayloadFromForm(),
+  };
+
+  try {
+    const response = await apiCall(`${API_URL}/preferences`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (response && response.ok) {
+      const updated = await response.json();
+      state.userPlanningPreferences = {
+        ...(updated || {}),
+        soulProfile: normalizeSoulProfile(updated?.soulProfile),
+      };
+      populateSoulPreferencesForm();
+      showMessage("profileMessage", SOUL_COPY.saved, "success");
+      return;
+    }
+
+    const data = response ? await parseApiBody(response) : {};
+    showMessage(
+      "profileMessage",
+      data.error || "Could not save support preferences.",
+      "error",
+    );
+  } catch (error) {
+    console.error("Save planning preferences error:", error);
+    showMessage("profileMessage", "Network error. Please try again.", "error");
   }
 }
 
@@ -690,7 +847,7 @@ export async function handleUpdateProfile(event) {
         });
       }
       updateUserDisplay();
-      showMessage("profileMessage", "Profile updated successfully!", "success");
+      showMessage("profileMessage", SOUL_COPY.saved, "success");
     } else {
       const data = response ? await parseApiBody(response) : {};
       showMessage(
@@ -732,6 +889,13 @@ export async function logout() {
   state.authToken = null;
   state.refreshToken = null;
   state.currentUser = null;
+  state.userPlanningPreferences = null;
+  state.currentDayContext = {
+    mode: "normal",
+    energy: "",
+    notes: "",
+    contextDate: "",
+  };
   setAuthState(AUTH_STATE.UNAUTHENTICATED);
   if (persistSession) {
     persistSession({

--- a/client/modules/drawerUi.js
+++ b/client/modules/drawerUi.js
@@ -11,6 +11,7 @@ import { TODO_UPDATED, UNDO_APPLIED } from "../platform/events/eventReasons.js";
 import { runAsyncLifecycle } from "./asyncLifecycle.js";
 import { applyAsyncAction, applyUiAction } from "./stateActions.js";
 import { callAgentAction } from "./agentApiClient.js";
+import { getEffortScoreLabel, getEffortScoreValue } from "./soulConfig.js";
 import { STORAGE_KEYS } from "../utils/storageKeys.js";
 import {
   hasTodoRow,
@@ -376,7 +377,11 @@ export function initializeDrawerDraft(todo) {
     categoryDetail: String(todo.category || ""),
     tagsText: Array.isArray(todo.tags) ? todo.tags.join(", ") : "",
     context: String(todo.context || ""),
+    effortScore:
+      typeof todo.effortScore === "number" ? String(todo.effortScore) : "",
     energy: String(todo.energy || ""),
+    emotionalState: String(todo.emotionalState || ""),
+    firstStep: String(todo.firstStep || ""),
     estimateMinutes:
       typeof todo.estimateMinutes === "number"
         ? String(todo.estimateMinutes)
@@ -455,8 +460,20 @@ function syncDrawerDraftFromPatch(updatedTodo, patchKeys) {
       case "context":
         d.context = String(updatedTodo.context || "");
         break;
+      case "effortScore":
+        d.effortScore =
+          typeof updatedTodo.effortScore === "number"
+            ? String(updatedTodo.effortScore)
+            : "";
+        break;
       case "energy":
         d.energy = String(updatedTodo.energy || "");
+        break;
+      case "emotionalState":
+        d.emotionalState = String(updatedTodo.emotionalState || "");
+        break;
+      case "firstStep":
+        d.firstStep = String(updatedTodo.firstStep || "");
         break;
       case "estimateMinutes":
         d.estimateMinutes =
@@ -799,6 +816,28 @@ export function onDrawerEnergyChange(event) {
   const energy = String(event?.target?.value || "");
   updateDrawerDraftField("energy", energy);
   saveDrawerPatch({ energy: energy || null });
+}
+
+export function onDrawerEffortChange(event) {
+  const effortScore = String(event?.target?.value || "");
+  updateDrawerDraftField("effortScore", effortScore);
+  saveDrawerPatch({ effortScore: getEffortScoreValue(effortScore) });
+}
+
+export function onDrawerEmotionalStateChange(event) {
+  const emotionalState = String(event?.target?.value || "");
+  updateDrawerDraftField("emotionalState", emotionalState);
+  saveDrawerPatch({ emotionalState: emotionalState || null });
+}
+
+export function onDrawerFirstStepInput(event) {
+  updateDrawerDraftField("firstStep", String(event?.target?.value || ""));
+}
+
+export function onDrawerFirstStepBlur() {
+  if (!state.drawerDraft) return;
+  const firstStep = String(state.drawerDraft.firstStep || "").trim();
+  saveDrawerPatch({ firstStep: firstStep || null });
 }
 
 export function onDrawerEstimateChange(event) {
@@ -1277,6 +1316,16 @@ export function renderTodoDrawerContent() {
         <span>Context</span>
         <input id="drawerContextInput" type="text" maxlength="100" value="${escapeHtml(draft.context)}" />
       </label>
+      <label class="todo-drawer__field" for="drawerEffortSelect">
+        <span>Effort</span>
+        <select id="drawerEffortSelect">
+          <option value="" ${!draft.effortScore ? "selected" : ""}>None</option>
+          <option value="1" ${draft.effortScore === "1" ? "selected" : ""}>Tiny</option>
+          <option value="2" ${draft.effortScore === "2" ? "selected" : ""}>Small</option>
+          <option value="3" ${draft.effortScore === "3" ? "selected" : ""}>Medium</option>
+          <option value="4" ${draft.effortScore === "4" ? "selected" : ""}>Deep</option>
+        </select>
+      </label>
       <label class="todo-drawer__field" for="drawerEnergySelect">
         <span>Energy</span>
         <select id="drawerEnergySelect">
@@ -1309,6 +1358,21 @@ export function renderTodoDrawerContent() {
           <span>Notes</span>
           <textarea id="drawerNotesTextarea" maxlength="2000">${escapeHtml(draft.notes)}</textarea>
         </label>
+        <label class="todo-drawer__field" for="drawerFirstStepInput">
+          <span>First step</span>
+          <input id="drawerFirstStepInput" type="text" maxlength="255" value="${escapeHtml(draft.firstStep)}" placeholder="Open the doc. Text Raj. Find last year's form." />
+        </label>
+        <label class="todo-drawer__field" for="drawerEmotionalStateSelect">
+          <span>Emotional state</span>
+          <select id="drawerEmotionalStateSelect">
+            <option value="" ${!draft.emotionalState ? "selected" : ""}>None</option>
+            <option value="avoiding" ${draft.emotionalState === "avoiding" ? "selected" : ""}>Avoiding</option>
+            <option value="unclear" ${draft.emotionalState === "unclear" ? "selected" : ""}>Unclear</option>
+            <option value="heavy" ${draft.emotionalState === "heavy" ? "selected" : ""}>Heavy</option>
+            <option value="exciting" ${draft.emotionalState === "exciting" ? "selected" : ""}>Exciting</option>
+            <option value="draining" ${draft.emotionalState === "draining" ? "selected" : ""}>Draining</option>
+          </select>
+        </label>
         <label class="todo-drawer__field" for="drawerTagsInput">
           <span>Tags</span>
           <input id="drawerTagsInput" type="text" maxlength="512" value="${escapeHtml(draft.tagsText)}" placeholder="comma, separated, tags" />
@@ -1331,6 +1395,11 @@ export function renderTodoDrawerContent() {
         </label>
         <div class="todo-drawer__meta">
           <div><strong>Source:</strong> ${escapeHtml(draft.source || "manual")}</div>
+          ${
+            draft.effortScore
+              ? `<div><strong>Effort:</strong> ${escapeHtml(getEffortScoreLabel(draft.effortScore) || draft.effortScore)}</div>`
+              : ""
+          }
           ${
             draft.completedAt
               ? `<div><strong>Completed at:</strong> ${escapeHtml(new Date(draft.completedAt).toLocaleString())}</div>`
@@ -1984,6 +2053,10 @@ export function bindTodoDrawerHandlers() {
       onDrawerContextInput(event);
       return;
     }
+    if (target.id === "drawerFirstStepInput") {
+      onDrawerFirstStepInput(event);
+      return;
+    }
     if (target.id === "drawerWaitingOnInput") {
       onDrawerWaitingOnInput(event);
       return;
@@ -2036,8 +2109,16 @@ export function bindTodoDrawerHandlers() {
       onDrawerPriorityChange(event);
       return;
     }
+    if (target.id === "drawerEffortSelect") {
+      onDrawerEffortChange(event);
+      return;
+    }
     if (target.id === "drawerEnergySelect") {
       onDrawerEnergyChange(event);
+      return;
+    }
+    if (target.id === "drawerEmotionalStateSelect") {
+      onDrawerEmotionalStateChange(event);
       return;
     }
     if (target.id === "drawerEstimateInput") {
@@ -2084,6 +2165,10 @@ export function bindTodoDrawerHandlers() {
       }
       if (target.id === "drawerContextInput") {
         onDrawerContextBlur();
+        return;
+      }
+      if (target.id === "drawerFirstStepInput") {
+        onDrawerFirstStepBlur();
         return;
       }
       if (target.id === "drawerWaitingOnInput") {

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -15,6 +15,7 @@
 import { state, hooks } from "./store.js";
 import { applyDomainAction } from "./stateActions.js";
 import { renderTodoRowTemplate } from "./uiTemplates.js";
+import { SOUL_COPY } from "./soulConfig.js";
 import {
   buildVisibleTodosQueryParams,
   clearVisibleTodosState,
@@ -935,6 +936,22 @@ function renderTodos() {
 
   const filteredTodos = getVisibleTodos();
   updateHeaderFromVisibleTodos(filteredTodos);
+  const rolledOverTodos =
+    state.currentDateView === "today"
+      ? filteredTodos.filter((todo) => {
+          if (!todo.dueDate) return false;
+          const dueDate = new Date(todo.dueDate);
+          if (Number.isNaN(dueDate.getTime())) return false;
+          const now = new Date();
+          const todayStart = new Date(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate(),
+          );
+          return dueDate < todayStart;
+        })
+      : [];
+  const firstRolledOverTodo = rolledOverTodos[0] || null;
   if (
     state.openTodoKebabId &&
     !filteredTodos.some(
@@ -1053,14 +1070,15 @@ function renderTodos() {
             if (isOverdue && !todaySectionState.injectedOverdue) {
               todaySectionState.injectedOverdue = true;
               sectionLabel =
-                '<li class="todo-section-label todo-section-label--overdue">Overdue</li>';
+                '<li class="todo-section-label todo-section-label--overdue">Still waiting</li>';
             } else if (
               !isOverdue &&
               !todaySectionState.injectedToday &&
               todaySectionState.hasBoth
             ) {
               todaySectionState.injectedToday = true;
-              sectionLabel = '<li class="todo-section-label">Due today</li>';
+              sectionLabel =
+                '<li class="todo-section-label">Worth your energy today</li>';
             }
           }
           return `${dateHeader}${sectionLabel}${categoryHeader}${renderTodoRowHtml(todo)}`;
@@ -1072,8 +1090,8 @@ function renderTodos() {
   if (filteredTodos.length === 0 && state.todos.length > 0) {
     const viewMessages = {
       today: {
-        heading: "All clear for today",
-        sub: "No tasks due today or overdue. Enjoy the moment.",
+        heading: SOUL_COPY.todayEmptyHeading,
+        sub: SOUL_COPY.todayEmptySubheading,
       },
       upcoming: {
         heading: "Nothing coming up",
@@ -1099,7 +1117,23 @@ function renderTodos() {
       msg.sub +
       "</p></div>";
   } else {
-    container.innerHTML = '<ul class="todos-list">' + rows + "</ul>";
+    const recoveryBanner =
+      state.currentDateView === "today" && firstRolledOverTodo
+        ? `
+          <div class="today-recovery-banner" data-testid="today-recovery-banner">
+            <div class="today-recovery-banner__copy">
+              <h3>${hooks.escapeHtml?.(SOUL_COPY.rolledOverHeading) || SOUL_COPY.rolledOverHeading}</h3>
+              <p>${hooks.escapeHtml?.(SOUL_COPY.rolledOverSubheading) || SOUL_COPY.rolledOverSubheading}</p>
+            </div>
+            <div class="today-recovery-banner__actions">
+              <button type="button" class="mini-btn" data-onclick="startSmallerForTodo('${hooks.escapeHtml?.(String(firstRolledOverTodo.id)) || firstRolledOverTodo.id}')">Start smaller</button>
+              <button type="button" class="mini-btn" data-onclick="moveTodoLater('${hooks.escapeHtml?.(String(firstRolledOverTodo.id)) || firstRolledOverTodo.id}')">Move later</button>
+              <button type="button" class="mini-btn" data-onclick="markTodoNotNow('${hooks.escapeHtml?.(String(firstRolledOverTodo.id)) || firstRolledOverTodo.id}')">Not now</button>
+              <button type="button" class="mini-btn" data-onclick="dropTodoFromList('${hooks.escapeHtml?.(String(firstRolledOverTodo.id)) || firstRolledOverTodo.id}')">Drop from list</button>
+            </div>
+          </div>`
+        : "";
+    container.innerHTML = `${recoveryBanner}<ul class="todos-list">${rows}</ul>`;
   }
 
   if (state.selectedTodoId && !hooks.getTodoById?.(state.selectedTodoId)) {

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -3,6 +3,9 @@
 // =============================================================================
 import { state, hooks } from "./store.js";
 import { applyDomainAction } from "./stateActions.js";
+import { EventBus } from "./eventBus.js";
+import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
+import { TODO_UPDATED } from "../platform/events/eventReasons.js";
 import {
   isSameLocalDay,
   isTodoUnsorted,
@@ -18,6 +21,7 @@ import {
   loadPrioritiesBrief,
 } from "./homePrioritiesTile.js";
 import { loadHomeFocusSuggestions } from "./homeAiService.js";
+import { callAgentAction } from "./agentApiClient.js";
 import {
   getDayPlanState,
   generateDayPlan,
@@ -28,6 +32,7 @@ import {
   onboardingStep,
   maybeRenderOnboardingModal,
 } from "./onboardingFlow.js";
+import { SOUL_COPY, buildRescueSuggestion } from "./soulConfig.js";
 
 const { escapeHtml } = window.Utils || {};
 const { getProjectLeafName, normalizeProjectPath } =
@@ -73,7 +78,7 @@ export function formatHomeDueBadge(todo) {
   const tomorrow = new Date(today);
   tomorrow.setDate(today.getDate() + 1);
   const dueDay = getStartOfToday(dueDate);
-  if (dueDay < today && !todo.completed) return "Overdue";
+  if (dueDay < today && !todo.completed) return "Still waiting";
   if (isSameLocalDay(dueDate, now)) return "Today";
   if (isSameLocalDay(dueDate, tomorrow)) return "Tomorrow";
   return dueDate.toLocaleDateString(undefined, {
@@ -119,7 +124,7 @@ export function getHomeTopFocusDeterministicReason(todo) {
   if (dueDate) {
     const now = new Date();
     const today = getStartOfToday(now);
-    if (dueDate < today && !todo.completed) return "Overdue";
+    if (dueDate < today && !todo.completed) return "Still waiting";
     if (isSameLocalDay(dueDate, now)) return "Due today";
     const tomorrow = new Date(today);
     tomorrow.setDate(today.getDate() + 1);
@@ -177,7 +182,7 @@ export function buildHomeDueSoonGroups(items = []) {
     grouped[key].push(todo);
   }
   return [
-    { key: "overdue", label: "Overdue", items: grouped.overdue },
+    { key: "overdue", label: "Still waiting", items: grouped.overdue },
     { key: "today", label: "Today", items: grouped.today },
     { key: "tomorrow", label: "Tomorrow", items: grouped.tomorrow },
     { key: "next_3_days", label: "Next 3 days", items: grouped.next_3_days },
@@ -474,6 +479,70 @@ export function getHomeDashboardModel({ topFocusItems = [] } = {}) {
   };
 }
 
+function getRolledOverTodos() {
+  const today = getStartOfToday(new Date());
+  return getOpenTodos().filter((todo) => {
+    const dueDate = getTodoDueDate(todo);
+    return !!dueDate && dueDate < today;
+  });
+}
+
+function getPlannedEffortScoreTotal() {
+  return getOpenTodos()
+    .filter((todo) => {
+      const dueDate = getTodoDueDate(todo);
+      return (
+        String(todo.status || "") === "next" ||
+        (dueDate && dueDate <= getEndOfDay(new Date()))
+      );
+    })
+    .reduce((sum, todo) => sum + Number(todo.effortScore || 0), 0);
+}
+
+async function applyRecoveryPatch(todoId, patch, successMessage) {
+  try {
+    await hooks.applyTodoPatch?.(todoId, patch);
+    EventBus.dispatch(TODOS_CHANGED, { reason: TODO_UPDATED });
+    hooks.applyFiltersAndRender?.({ reason: "soul-recovery-action" });
+    hooks.showMessage?.("todosMessage", successMessage, "success");
+  } catch (error) {
+    console.error("Recovery action failed:", error);
+    hooks.showMessage?.(
+      "todosMessage",
+      error.message || "Could not update that task.",
+      "error",
+    );
+  }
+}
+
+async function setDayContextMode(mode) {
+  const contextDate = new Date().toISOString().slice(0, 10);
+  try {
+    await callAgentAction("/agent/write/set_day_context", {
+      contextDate,
+      mode,
+    });
+    state.currentDayContext = {
+      ...state.currentDayContext,
+      contextDate,
+      mode,
+    };
+    hooks.applyFiltersAndRender?.({ reason: `day-context-${mode}` });
+    hooks.showMessage?.(
+      "todosMessage",
+      mode === "rescue" ? SOUL_COPY.gotIt : SOUL_COPY.saved,
+      "success",
+    );
+  } catch (error) {
+    console.error("Set day context failed:", error);
+    hooks.showMessage?.(
+      "todosMessage",
+      error.message || "Could not change day mode.",
+      "error",
+    );
+  }
+}
+
 export function buildHomeTileListByKey(key) {
   const model = getHomeDashboardModel();
   if (key === "due_soon") return model.dueSoon;
@@ -576,7 +645,7 @@ export async function hydrateHomeTopFocusIfNeeded() {
 // ---------------------------------------------------------------------------
 
 const HOME_BADGE_ICONS = {
-  Overdue: `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>`,
+  "Still waiting": `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>`,
   Today: `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"/><line x1="16" x2="16" y1="2" y2="6"/><line x1="8" x2="8" y1="2" y2="6"/><line x1="3" x2="21" y1="10" y2="10"/><path d="M8 14h.01"/><path d="M12 14h.01"/></svg>`,
   Tomorrow: `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`,
 };
@@ -592,6 +661,7 @@ export function renderHomeTaskRow(todo, { reason = "" } = {}) {
   const dueBadge = formatHomeDueBadge(todo);
   const projectName = normalizeProjectPath(todo?.category || todo?.projectName);
   const projectLabel = projectName ? getProjectLeafName(projectName) : "";
+  const isRolledOver = dueBadge === "Still waiting";
   const badgeIcon =
     HOME_BADGE_ICONS[dueBadge] ??
     (dueBadge
@@ -614,7 +684,7 @@ export function renderHomeTaskRow(todo, { reason = "" } = {}) {
       >
         ${escapeHtml(String(todo.title || "Untitled task"))}
       </button>
-      ${dueBadge ? `<span class="home-task-row__badge ${dueBadge === "Overdue" ? "home-task-row__badge--overdue" : ""}">${badgeIcon}${escapeHtml(dueBadge)}</span>` : ""}
+      ${dueBadge ? `<span class="home-task-row__badge ${dueBadge === "Still waiting" ? "home-task-row__badge--overdue" : ""}">${badgeIcon}${escapeHtml(dueBadge)}</span>` : ""}
       ${
         projectName
           ? `<button
@@ -628,8 +698,39 @@ export function renderHomeTaskRow(todo, { reason = "" } = {}) {
       }
       ${reason ? `<div class="home-task-row__reason">${escapeHtml(reason)}</div>` : ""}
       ${
-        aiSuggestion
-          ? `<div class="home-task-row__actions">
+        isRolledOver
+          ? `<div class="home-task-row__actions home-task-row__actions--recovery">
+              <button
+                type="button"
+                class="mini-btn home-task-row__action"
+                data-onclick="startSmallerForTodo('${escapeHtml(String(todo.id))}')"
+              >
+                Start smaller
+              </button>
+              <button
+                type="button"
+                class="mini-btn home-task-row__action home-task-row__action--secondary"
+                data-onclick="moveTodoLater('${escapeHtml(String(todo.id))}')"
+              >
+                Move later
+              </button>
+              <button
+                type="button"
+                class="mini-btn home-task-row__action home-task-row__action--secondary"
+                data-onclick="markTodoNotNow('${escapeHtml(String(todo.id))}')"
+              >
+                Not now
+              </button>
+              <button
+                type="button"
+                class="mini-btn home-task-row__action home-task-row__action--secondary"
+                data-onclick="dropTodoFromList('${escapeHtml(String(todo.id))}')"
+              >
+                Drop from list
+              </button>
+            </div>`
+          : aiSuggestion
+            ? `<div class="home-task-row__actions">
               <button
                 type="button"
                 class="mini-btn home-task-row__action"
@@ -647,7 +748,7 @@ export function renderHomeTaskRow(todo, { reason = "" } = {}) {
                 ${isDismissing ? "Dismissing…" : "Dismiss"}
               </button>
             </div>`
-          : ""
+            : ""
       }
     </div>
   `;
@@ -807,6 +908,42 @@ function renderHomeBriefCard(model) {
   `;
 }
 
+function renderRescuePanel() {
+  const rolledOverCount = getRolledOverTodos().length;
+  const plannedEffortScoreTotal = getPlannedEffortScoreTotal();
+  const suggestion = buildRescueSuggestion({
+    rolledOverCount,
+    plannedEffortScoreTotal,
+    repeatedDeferrals: 0,
+  });
+  const rescueActive = state.currentDayContext?.mode === "rescue";
+
+  return `
+    <section class="home-rescue-panel" data-testid="home-rescue-panel">
+      <div>
+        <p class="home-rescue-panel__eyebrow">Rescue mode</p>
+        <h3 class="home-rescue-panel__title">${
+          rescueActive
+            ? escapeHtml(SOUL_COPY.rescueActive)
+            : "Keep the day workable."
+        }</h3>
+        <p class="home-rescue-panel__summary">${
+          suggestion
+            ? escapeHtml(suggestion)
+            : "Use rescue mode when you need a smaller plan, fewer anchors, and less pressure."
+        }</p>
+      </div>
+      <div class="home-rescue-panel__actions">
+        ${
+          rescueActive
+            ? `<button type="button" class="mini-btn" data-onclick="setNormalDayMode()">Back to normal</button>`
+            : `<button type="button" class="btn" data-onclick="startRescueMode()">Start rescue mode</button>`
+        }
+      </div>
+    </section>
+  `;
+}
+
 export function renderProjectsToNudgeTile(items = []) {
   const folderIcon = `<svg class="home-project-row__icon" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>`;
   return `
@@ -829,7 +966,7 @@ export function renderProjectsToNudgeTile(items = []) {
                     data-onclick="openHomeProject('${escapeHtml(project.projectName)}')"
                   >
                     <span class="home-project-row__header">${folderIcon}<span class="home-project-row__name">${escapeHtml(getProjectLeafName(project.projectName))}</span></span>
-                    <span class="home-project-row__meta">${project.openCount} open${project.overdueCount ? ` · ${project.overdueCount} overdue` : ""}${project.dueSoonCount ? ` · ${project.dueSoonCount} due soon` : ""}</span>
+                    <span class="home-project-row__meta">${project.openCount} open${project.overdueCount ? ` · ${project.overdueCount} still waiting` : ""}${project.dueSoonCount ? ` · ${project.dueSoonCount} due soon` : ""}</span>
                   </button>
                 `,
                 )
@@ -1054,9 +1191,10 @@ export function renderHomeDashboard() {
   // view — guarantees the overlay only appears when home workspace is active.
   maybeRenderOnboardingModal();
 
-  // During inline onboarding steps (2 = add tasks, 3 = set due dates), suppress
-  // the normal dashboard tiles so the onboarding banner has visual focus.
-  if (isOnboardingActive() && (onboardingStep === 2 || onboardingStep === 3)) {
+  // During the inline example-task step, suppress the normal tiles so the
+  // onboarding banner has visual focus. Modal steps can keep the dashboard
+  // underneath as context.
+  if (isOnboardingActive() && onboardingStep === 3) {
     return `<section class="home-dashboard" data-testid="home-dashboard"></section>`;
   }
   void loadPrioritiesBrief();
@@ -1075,6 +1213,7 @@ export function renderHomeDashboard() {
   return `
     <section class="home-dashboard" data-testid="home-dashboard">
       ${hasTasks ? renderHomeBriefCard(model) : ""}
+      ${hasTasks ? renderRescuePanel() : ""}
       ${
         hasTasks
           ? `<div class="home-dashboard__support-grid">
@@ -1125,6 +1264,58 @@ export function openHomeProject(projectName) {
 
 export function openTodoFromHomeTile(todoId) {
   openTodoDrawer(String(todoId || ""), document.activeElement);
+}
+
+export async function startSmallerForTodo(todoId) {
+  const todo = state.todos.find((item) => String(item.id) === String(todoId));
+  if (!todo) return;
+  const proposed = await hooks.showInputDialog?.(
+    "What is the smallest first step?",
+  );
+  const firstStep = String(proposed || "").trim();
+  if (!firstStep) return;
+  await applyRecoveryPatch(todoId, { firstStep }, SOUL_COPY.saved);
+}
+
+export async function moveTodoLater(todoId) {
+  const todo = state.todos.find((item) => String(item.id) === String(todoId));
+  if (!todo) return;
+  const sourceDate = getTodoDueDate(todo) || new Date();
+  const movedDate = new Date(sourceDate);
+  movedDate.setDate(movedDate.getDate() + 3);
+  movedDate.setHours(12, 0, 0, 0);
+  await applyRecoveryPatch(
+    todoId,
+    { dueDate: movedDate.toISOString() },
+    SOUL_COPY.movedLater,
+  );
+}
+
+export async function markTodoNotNow(todoId) {
+  await applyRecoveryPatch(todoId, { status: "someday" }, SOUL_COPY.movedLater);
+}
+
+export async function dropTodoFromList(todoId) {
+  const todo = state.todos.find((item) => String(item.id) === String(todoId));
+  if (!todo) return;
+  await applyRecoveryPatch(
+    todoId,
+    { archived: true },
+    SOUL_COPY.droppedFromList,
+  );
+  hooks.addUndoAction?.(
+    "archive",
+    { id: todoId },
+    "Task removed from the list",
+  );
+}
+
+export async function startRescueMode() {
+  await setDayContextMode("rescue");
+}
+
+export async function setNormalDayMode() {
+  await setDayContextMode("normal");
 }
 
 export function getHomeDrilldownLabel() {

--- a/client/modules/onboardingFlow.js
+++ b/client/modules/onboardingFlow.js
@@ -1,66 +1,101 @@
 // =============================================================================
-// onboardingFlow.js — First-time user onboarding: 4-step guided setup.
-// Step 1: area picker (modal)
-// Step 2: add first 3 tasks (inline on Home)
-// Step 3: set one due date (inline on Home)
-// Step 4: meet the daily brief (modal)
+// onboardingFlow.js — Soul MVP onboarding built on the existing step model.
+// Step 1: belief + life areas + tone (modal)
+// Step 2: planning patterns + rituals (modal)
+// Step 3: seed a few example tasks + one freeform capture (inline on Home)
+// Step 4: daily brief preview + rescue mode (modal)
 // =============================================================================
 
 import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
 import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
 import { ONBOARDING_COMPLETE } from "../platform/events/eventReasons.js";
+import {
+  SOUL_COPY,
+  SOUL_PROFILE_DEFAULTS,
+  SOUL_LIFE_AREAS,
+  SOUL_FAILURE_MODES,
+  SOUL_PLANNING_STYLES,
+  SOUL_ENERGY_PATTERNS,
+  SOUL_GOOD_DAY_THEMES,
+  SOUL_TONES,
+  SOUL_DAILY_RITUALS,
+  normalizeSoulProfile,
+  getExampleSeedTasks,
+  getTonePreview,
+} from "./soulConfig.js";
 
 const { escapeHtml } = window.Utils || {};
 
-// ---------------------------------------------------------------------------
-// State (module-level, not in shared store)
-// ---------------------------------------------------------------------------
-
-let _step = 0; // 0 = not started, 1-4 = active step, 5 = complete
-let _pendingTasks = []; // tasks created in step 2 — { id, title }
+let _step = 0;
 let _saving = false;
+let _createdSeedTitles = [];
+let _draftProfile = normalizeSoulProfile(SOUL_PROFILE_DEFAULTS);
 
-const AREA_OPTIONS = [
-  { key: "work", label: "Work" },
-  { key: "home", label: "Home" },
-  { key: "family", label: "Family" },
-  { key: "finance", label: "Finance" },
-  { key: "health", label: "Health" },
-  { key: "side-projects", label: "Side projects" },
-];
+function getCurrentSoulProfile() {
+  return normalizeSoulProfile(
+    state.userPlanningPreferences?.soulProfile || _draftProfile,
+  );
+}
 
-// ---------------------------------------------------------------------------
-// Initialisation — called after loadUserProfile() resolves
-// ---------------------------------------------------------------------------
+function setDraftProfile(patch = {}) {
+  _draftProfile = normalizeSoulProfile({
+    ...getCurrentSoulProfile(),
+    ...patch,
+  });
+}
+
+function toggleDraftListValue(key, value) {
+  const current = Array.isArray(_draftProfile?.[key]) ? _draftProfile[key] : [];
+  const next = current.includes(value)
+    ? current.filter((item) => item !== value)
+    : [...current, value];
+  setDraftProfile({ [key]: next });
+}
+
+async function saveSoulProfilePatch(patch = {}) {
+  const nextSoulProfile = normalizeSoulProfile({
+    ...getCurrentSoulProfile(),
+    ...patch,
+  });
+  setDraftProfile(nextSoulProfile);
+
+  try {
+    const response = await hooks.apiCall(`${hooks.API_URL}/preferences`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ soulProfile: nextSoulProfile }),
+    });
+    if (!response || !response.ok) return;
+    const preferences = await response.json();
+    state.userPlanningPreferences = {
+      ...(preferences || {}),
+      soulProfile: normalizeSoulProfile(preferences?.soulProfile),
+    };
+    _draftProfile = state.userPlanningPreferences.soulProfile;
+    hooks.populateSoulPreferencesForm?.();
+  } catch (error) {
+    console.warn("Onboarding preferences save failed:", error);
+  }
+}
 
 export function initOnboarding() {
-  if (_step > 0) return; // already initialized — guard against duplicate calls
+  if (_step > 0) return;
   const user = state.currentUser;
-  if (!user) return;
+  if (!user || user.onboardingCompletedAt) return;
 
-  // Already completed — never show again
-  if (user.onboardingCompletedAt) return;
-
-  // Resume from saved step, defaulting to step 1
+  _draftProfile = getCurrentSoulProfile();
   _step = Number(user.onboardingStep || 0);
   if (_step <= 0) _step = 1;
   if (_step >= 5) {
     _markComplete();
     return;
   }
-
-  // Modal steps (1 & 4) are shown as a side effect of renderHomeDashboard()
-  // to guarantee they only appear when the home view is active.
-  // Inline steps (2 & 3) are handled via the renderHomeDashboard() guard.
-  // No immediate _render() call here.
 }
 
-// Called by renderHomeDashboard() — shows modal overlay for steps 1 & 4 when
-// home view is active. Idempotent: no-op if overlay is already present.
 export function maybeRenderOnboardingModal() {
-  if (_step !== 1 && _step !== 4) return;
-  if (document.getElementById("onboardingOverlay")) return; // already shown
+  if (![1, 2, 4].includes(_step)) return;
+  if (document.getElementById("onboardingOverlay")) return;
   _render();
 }
 
@@ -68,27 +103,19 @@ export function isOnboardingActive() {
   return _step >= 1 && _step <= 4;
 }
 
-// ---------------------------------------------------------------------------
-// Navigation
-// ---------------------------------------------------------------------------
-
 export function advanceOnboarding() {
   if (_step >= 4) {
-    _markComplete();
+    void _markComplete();
     return;
   }
   _step += 1;
-  _saveStep(_step);
+  void _saveStep(_step);
   _render();
 }
 
 export function dismissOnboarding() {
-  _markComplete();
+  void _markComplete();
 }
-
-// ---------------------------------------------------------------------------
-// Server persistence
-// ---------------------------------------------------------------------------
 
 async function _saveStep(step) {
   if (_saving) return;
@@ -99,8 +126,11 @@ async function _saveStep(step) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ step }),
     });
-  } catch (err) {
-    console.warn("Onboarding step save failed:", err);
+    if (state.currentUser) {
+      state.currentUser.onboardingStep = step;
+    }
+  } catch (error) {
+    console.warn("Onboarding step save failed:", error);
   } finally {
     _saving = false;
   }
@@ -120,17 +150,12 @@ async function _markComplete() {
       const user = await response.json();
       state.currentUser = { ...state.currentUser, ...user };
     }
-  } catch (err) {
-    console.warn("Onboarding complete save failed:", err);
+  } catch (error) {
+    console.warn("Onboarding complete save failed:", error);
   }
 
-  // Refresh the home dashboard now that onboarding is done
   EventBus.dispatch(TODOS_CHANGED, { reason: ONBOARDING_COMPLETE });
 }
-
-// ---------------------------------------------------------------------------
-// Render dispatcher
-// ---------------------------------------------------------------------------
 
 function _render() {
   if (_step === 1) {
@@ -139,8 +164,8 @@ function _render() {
     return;
   }
   if (_step === 2) {
-    _removeOverlay();
-    _renderStep2Inline();
+    _removeInlineBanner();
+    _renderStep2Modal();
     return;
   }
   if (_step === 3) {
@@ -151,377 +176,401 @@ function _render() {
   if (_step === 4) {
     _removeInlineBanner();
     _renderStep4Modal();
-    return;
   }
 }
 
-// ---------------------------------------------------------------------------
-// Step 1 — Area picker modal
-// ---------------------------------------------------------------------------
+function renderSelectionButtons(
+  options,
+  selectedValues,
+  handlerName,
+  groupKey,
+) {
+  return options
+    .map((option) => {
+      const selected = selectedValues.includes(option.value);
+      return `
+        <button
+          type="button"
+          class="onb-choice-btn${selected ? " onb-choice-btn--selected" : ""}"
+          data-group="${escapeHtml(groupKey)}"
+          data-value="${escapeHtml(option.value)}"
+          data-onclick="${handlerName}('${escapeHtml(option.value)}')"
+        >
+          ${escapeHtml(option.label)}
+        </button>`;
+    })
+    .join("");
+}
+
+function renderChoiceCards(options, selectedValue, handlerName) {
+  return options
+    .map((option) => {
+      const selected = selectedValue === option.value;
+      return `
+        <button
+          type="button"
+          class="onb-card-btn${selected ? " onb-card-btn--selected" : ""}"
+          data-onclick="${handlerName}('${escapeHtml(option.value)}')"
+        >
+          <span class="onb-card-btn__label">${escapeHtml(option.label)}</span>
+        </button>`;
+    })
+    .join("");
+}
 
 function _renderStep1Modal() {
   _removeOverlay();
-
-  const selected = new Set(["work"]); // sensible default pre-selection
-
+  const profile = getCurrentSoulProfile();
   const overlay = document.createElement("div");
   overlay.id = "onboardingOverlay";
   overlay.className = "onboarding-overlay";
   overlay.setAttribute("role", "dialog");
   overlay.setAttribute("aria-modal", "true");
   overlay.setAttribute("aria-labelledby", "onboardingModalTitle");
-
-  const renderGrid = () =>
-    AREA_OPTIONS.map((area) => {
-      const isSelected = selected.has(area.key);
-      return `
-      <button type="button"
-              class="onb-area-btn${isSelected ? " onb-area-btn--selected" : ""}"
-              data-area="${escapeHtml(area.key)}"
-              data-onclick="toggleOnboardingArea('${escapeHtml(area.key)}')">
-        ${escapeHtml(area.label)}
-      </button>`;
-    }).join("");
-
   overlay.innerHTML = `
-    <div class="onb-modal">
+    <div class="onb-modal onb-modal--wide">
       <div class="onb-progress">
         <span class="onb-progress__dot onb-progress__dot--active"></span>
         <span class="onb-progress__dot"></span>
         <span class="onb-progress__dot"></span>
         <span class="onb-progress__dot"></span>
       </div>
+      <p class="onb-modal__eyebrow">A calmer start</p>
       <h2 class="onb-modal__title" id="onboardingModalTitle">
-        What areas of your life do you want to track?
+        ${escapeHtml(SOUL_COPY.onboardingBelief)}
       </h2>
       <p class="onb-modal__subtitle">
-        We'll create a project for each. You can change this any time.
+        Let’s set the tone first, then we’ll get you to a useful screen quickly.
       </p>
-      <div class="onb-area-grid" id="onbAreaGrid">
-        ${renderGrid()}
+      <div class="onb-section">
+        <div class="onb-section__label">What kind of life are you managing?</div>
+        <div class="onb-choice-grid">
+          ${renderSelectionButtons(
+            SOUL_LIFE_AREAS,
+            profile.lifeAreas,
+            "toggleOnboardingArea",
+            "lifeAreas",
+          )}
+        </div>
+      </div>
+      <div class="onb-section">
+        <div class="onb-section__label">Pick the tone you want to hear back</div>
+        <div class="onb-card-grid">
+          ${renderChoiceCards(SOUL_TONES, profile.tone, "setOnboardingTone")}
+        </div>
+        <p class="onb-modal__helper">${escapeHtml(getTonePreview(profile.tone))}</p>
       </div>
       <div class="onb-modal__actions">
-        <button type="button" class="onb-skip-btn"
-                data-onclick="dismissOnboarding()">Skip for now</button>
-        <button type="button" class="onb-primary-btn" id="onbStep1Next"
-                data-onclick="onboardingStep1Next()">
-          Create projects →
+        <button type="button" class="onb-skip-btn" data-onclick="dismissOnboarding()">Skip for now</button>
+        <button type="button" class="onb-primary-btn" data-onclick="onboardingStep1Next()">
+          Continue
         </button>
       </div>
     </div>`;
-
   document.body.appendChild(overlay);
+}
 
-  // Store selected set on overlay for use by toggle handler
-  overlay._selectedAreas = selected;
+function _renderStep2Modal() {
+  _removeOverlay();
+  const profile = getCurrentSoulProfile();
+  const overlay = document.createElement("div");
+  overlay.id = "onboardingOverlay";
+  overlay.className = "onboarding-overlay";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-labelledby", "onboardingModalTitle");
+  overlay.innerHTML = `
+    <div class="onb-modal onb-modal--wide">
+      <div class="onb-progress">
+        <span class="onb-progress__dot"></span>
+        <span class="onb-progress__dot onb-progress__dot--active"></span>
+        <span class="onb-progress__dot"></span>
+        <span class="onb-progress__dot"></span>
+      </div>
+      <h2 class="onb-modal__title" id="onboardingModalTitle">
+        Tell us how planning usually gets hard
+      </h2>
+      <div class="onb-section">
+        <div class="onb-section__label">When task systems fail, what usually happens?</div>
+        <div class="onb-choice-grid">
+          ${renderSelectionButtons(
+            SOUL_FAILURE_MODES,
+            profile.failureModes,
+            "toggleOnboardingFailureMode",
+            "failureModes",
+          )}
+        </div>
+      </div>
+      <div class="onb-section">
+        <div class="onb-section__label">Planning style</div>
+        <div class="onb-card-grid">
+          ${renderChoiceCards(
+            SOUL_PLANNING_STYLES,
+            profile.planningStyle,
+            "setOnboardingPlanningStyle",
+          )}
+        </div>
+      </div>
+      <div class="onb-inline-grid">
+        <div class="onb-section">
+          <div class="onb-section__label">Energy pattern</div>
+          <div class="onb-card-grid onb-card-grid--compact">
+            ${renderChoiceCards(
+              SOUL_ENERGY_PATTERNS,
+              profile.energyPattern,
+              "setOnboardingEnergyPattern",
+            )}
+          </div>
+        </div>
+        <div class="onb-section">
+          <div class="onb-section__label">Daily ritual</div>
+          <div class="onb-card-grid onb-card-grid--compact">
+            ${renderChoiceCards(
+              SOUL_DAILY_RITUALS,
+              profile.dailyRitual,
+              "setOnboardingDailyRitual",
+            )}
+          </div>
+        </div>
+      </div>
+      <div class="onb-section">
+        <div class="onb-section__label">What does a good day look like?</div>
+        <div class="onb-choice-grid">
+          ${renderSelectionButtons(
+            SOUL_GOOD_DAY_THEMES,
+            profile.goodDayThemes,
+            "toggleOnboardingGoodDayTheme",
+            "goodDayThemes",
+          )}
+        </div>
+      </div>
+      <div class="onb-modal__actions">
+        <button type="button" class="onb-skip-btn" data-onclick="backOnboardingStep()">Back</button>
+        <button type="button" class="onb-primary-btn" data-onclick="finishOnboardingStep2()">
+          Keep going
+        </button>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+}
+
+function _renderStep3Inline() {
+  _removeInlineBanner();
+  const banner = document.createElement("section");
+  banner.id = "onboardingInlineBanner";
+  banner.className = "onboarding-inline-banner onboarding-inline-banner--soul";
+  const seedTitles = getExampleSeedTasks(getCurrentSoulProfile());
+  const pendingSet = new Set(_createdSeedTitles);
+  banner.innerHTML = `
+    <div class="onboarding-inline-banner__header">
+      <div>
+        <p class="onboarding-inline-banner__eyebrow">Step 3 of 4</p>
+        <h3>Start with a few gentle examples</h3>
+        <p>${escapeHtml(SOUL_COPY.taskPromptSecondary)}</p>
+      </div>
+      <button type="button" class="mini-btn" data-onclick="skipOnboardingExamples()">
+        Skip examples
+      </button>
+    </div>
+    <div class="onboarding-inline-banner__examples">
+      ${seedTitles
+        .map(
+          (title) => `
+            <button
+              type="button"
+              class="onb-example-btn${pendingSet.has(title) ? " onb-example-btn--added" : ""}"
+              data-onclick="onboardingAddTask('${escapeHtml(title)}')"
+              ${pendingSet.has(title) ? "disabled" : ""}
+            >
+              ${pendingSet.has(title) ? "Added" : "Add"} ${escapeHtml(title)}
+            </button>`,
+        )
+        .join("")}
+    </div>
+    <div class="onboarding-inline-banner__capture">
+      <input
+        id="onboardingCustomTaskInput"
+        type="text"
+        maxlength="200"
+        placeholder="${escapeHtml(SOUL_COPY.taskPromptPrimary)}"
+      />
+      <button type="button" class="btn" data-onclick="onboardingAddTask()">
+        Add task
+      </button>
+      <button type="button" class="mini-btn" data-onclick="finishOnboardingExamples()">
+        Continue
+      </button>
+    </div>
+    ${
+      _createdSeedTitles.length > 0
+        ? `<p class="onboarding-inline-banner__helper">You can keep going now, or add one more example first.</p>`
+        : `<p class="onboarding-inline-banner__helper">Nothing here gets a forced due date. You can keep this light.</p>`
+    }
+  `;
+  const host = document.getElementById("todosContent");
+  if (host instanceof HTMLElement) {
+    host.prepend(banner);
+  }
+}
+
+function _renderStep4Modal() {
+  _removeOverlay();
+  const profile = getCurrentSoulProfile();
+  const overlay = document.createElement("div");
+  overlay.id = "onboardingOverlay";
+  overlay.className = "onboarding-overlay";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-labelledby", "onboardingModalTitle");
+  overlay.innerHTML = `
+    <div class="onb-modal">
+      <div class="onb-progress">
+        <span class="onb-progress__dot"></span>
+        <span class="onb-progress__dot"></span>
+        <span class="onb-progress__dot"></span>
+        <span class="onb-progress__dot onb-progress__dot--active"></span>
+      </div>
+      <p class="onb-modal__eyebrow">Daily brief preview</p>
+      <h2 class="onb-modal__title" id="onboardingModalTitle">
+        Your Home view will stay small on purpose
+      </h2>
+      <p class="onb-modal__subtitle">
+        You’ll see one clear focus, a few things due soon, and a short cleanup list when it helps.
+      </p>
+      <div class="onb-preview-card">
+        <div class="onb-preview-card__title">Today’s focus</div>
+        <p class="onb-preview-card__text">
+          ${escapeHtml(getTonePreview(profile.tone))}
+        </p>
+      </div>
+      <div class="onb-preview-card onb-preview-card--muted">
+        <div class="onb-preview-card__title">Rescue mode</div>
+        <p class="onb-preview-card__text">
+          ${escapeHtml(SOUL_COPY.rescueIntro)}
+        </p>
+      </div>
+      <div class="onb-modal__actions">
+        <button type="button" class="onb-skip-btn" data-onclick="backOnboardingStep()">Back</button>
+        <button type="button" class="onb-primary-btn" data-onclick="advanceOnboarding()">
+          Open my workspace
+        </button>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
 }
 
 export function toggleOnboardingArea(areaKey) {
-  const overlay = document.getElementById("onboardingOverlay");
-  if (!overlay || !overlay._selectedAreas) return;
-  const selected = overlay._selectedAreas;
-  if (selected.has(areaKey)) {
-    selected.delete(areaKey);
-  } else {
-    selected.add(areaKey);
-  }
-  // Re-render the grid
-  const grid = document.getElementById("onbAreaGrid");
-  if (grid) {
-    grid.innerHTML = AREA_OPTIONS.map((area) => {
-      const isSelected = selected.has(area.key);
-      return `
-        <button type="button"
-                class="onb-area-btn${isSelected ? " onb-area-btn--selected" : ""}"
-                data-area="${escapeHtml(area.key)}"
-                data-onclick="toggleOnboardingArea('${escapeHtml(area.key)}')">
-          ${escapeHtml(area.label)}
-        </button>`;
-    }).join("");
-  }
+  toggleDraftListValue("lifeAreas", areaKey);
+  _renderStep1Modal();
+}
+
+export function setOnboardingTone(tone) {
+  setDraftProfile({ tone });
+  _renderStep1Modal();
 }
 
 export async function onboardingStep1Next() {
-  const overlay = document.getElementById("onboardingOverlay");
-  const selected = overlay?._selectedAreas;
-  const btn = document.getElementById("onbStep1Next");
-
-  if (btn) {
-    btn.disabled = true;
-    btn.textContent = "Creating\u2026";
-  }
-
-  // Create a project for each selected area in parallel
-  if (selected && selected.size > 0) {
-    const creates = Array.from(selected).map((areaKey) => {
-      const label =
-        AREA_OPTIONS.find((a) => a.key === areaKey)?.label || areaKey;
-      return hooks
-        .apiCall(`${hooks.API_URL}/projects`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: label, area: areaKey }),
-        })
-        .catch(() => null);
-    });
-    await Promise.all(creates);
-    // Reload projects so rail reflects new state
-    await hooks.loadProjects?.();
-  }
-
-  advanceOnboarding();
-}
-
-// ---------------------------------------------------------------------------
-// Step 2 — Add first tasks (inline on Home)
-// ---------------------------------------------------------------------------
-
-function _renderStep2Inline() {
-  _ensureInlineBannerMounted();
-  const banner = document.getElementById("onboardingInlineBanner");
-  if (!banner) return;
-
-  const taskCount = _pendingTasks.length;
-
-  banner.innerHTML = `
-    <div class="onb-inline">
-      <div class="onb-inline__header">
-        <div class="onb-inline__progress">
-          <div class="onb-inline__bar">
-            <div class="onb-inline__fill" style="width:50%"></div>
-          </div>
-          <span class="onb-inline__step-label">Step 2 of 4</span>
-        </div>
-        <button type="button" class="onb-dismiss-x"
-                data-onclick="dismissOnboarding()" aria-label="Dismiss setup">\xd7</button>
-      </div>
-      <h3 class="onb-inline__title">Add your first tasks</h3>
-      <p class="onb-inline__sub">
-        What's on your mind right now? Add at least one to continue.
-      </p>
-      <div class="onb-task-entry">
-        <input type="text"
-               id="onbTaskInput"
-               class="onb-task-input"
-               placeholder="e.g. Finish AWS study plan"
-               maxlength="200"
-               autocomplete="off" />
-        <button type="button" class="onb-add-task-btn"
-                data-onclick="onboardingAddTask()">Add</button>
-      </div>
-      ${
-        taskCount > 0
-          ? `
-        <div class="onb-task-list">
-          ${_pendingTasks
-            .map(
-              (t) => `
-            <div class="onb-task-row">
-              <span class="onb-task-row__check">\u2713</span>
-              <span class="onb-task-row__title">${escapeHtml(t.title)}</span>
-            </div>`,
-            )
-            .join("")}
-        </div>`
-          : ""
-      }
-      <div class="onb-inline__footer">
-        <span class="onb-inline__count">
-          ${
-            taskCount === 0
-              ? "No tasks yet"
-              : taskCount === 1
-                ? "1 task added"
-                : `${taskCount} tasks added`
-          }
-        </span>
-        <button type="button"
-                class="onb-primary-btn${taskCount === 0 ? " onb-primary-btn--disabled" : ""}"
-                ${taskCount === 0 ? "disabled" : ""}
-                data-onclick="advanceOnboarding()">Next \u2192</button>
-      </div>
-    </div>`;
-
-  // Auto-focus the input
-  window.requestAnimationFrame(() => {
-    document.getElementById("onbTaskInput")?.focus();
+  await saveSoulProfilePatch({
+    lifeAreas: getCurrentSoulProfile().lifeAreas,
+    tone: getCurrentSoulProfile().tone,
   });
+  _step = 2;
+  await _saveStep(_step);
+  _render();
 }
 
-export async function onboardingAddTask() {
-  const input = document.getElementById("onbTaskInput");
-  if (!(input instanceof HTMLInputElement)) return;
-  const title = input.value.trim();
-  if (!title) return;
+export function toggleOnboardingFailureMode(value) {
+  toggleDraftListValue("failureModes", value);
+  _renderStep2Modal();
+}
 
-  input.value = "";
-  input.disabled = true;
+export function toggleOnboardingGoodDayTheme(value) {
+  toggleDraftListValue("goodDayThemes", value);
+  _renderStep2Modal();
+}
+
+export function setOnboardingPlanningStyle(value) {
+  setDraftProfile({ planningStyle: value });
+  _renderStep2Modal();
+}
+
+export function setOnboardingEnergyPattern(value) {
+  setDraftProfile({ energyPattern: value });
+  _renderStep2Modal();
+}
+
+export function setOnboardingDailyRitual(value) {
+  setDraftProfile({ dailyRitual: value });
+  _renderStep2Modal();
+}
+
+export function backOnboardingStep() {
+  if (_step <= 1) return;
+  _step -= 1;
+  void _saveStep(_step);
+  _render();
+}
+
+export async function finishOnboardingStep2() {
+  await saveSoulProfilePatch({
+    failureModes: getCurrentSoulProfile().failureModes,
+    planningStyle: getCurrentSoulProfile().planningStyle,
+    energyPattern: getCurrentSoulProfile().energyPattern,
+    goodDayThemes: getCurrentSoulProfile().goodDayThemes,
+    dailyRitual: getCurrentSoulProfile().dailyRitual,
+  });
+  _step = 3;
+  await _saveStep(_step);
+  _render();
+}
+
+export async function onboardingAddTask(seedTitle = "") {
+  const input = document.getElementById("onboardingCustomTaskInput");
+  const title = String(
+    seedTitle || (input instanceof HTMLInputElement ? input.value : "") || "",
+  ).trim();
+  if (!title) return;
 
   try {
     const response = await hooks.apiCall(`${hooks.API_URL}/todos`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title, status: "next", source: "manual" }),
+      body: JSON.stringify({
+        title,
+        status: "next",
+        priority: "medium",
+        source: "system_seed",
+      }),
     });
-    if (response && response.ok) {
-      const task = await response.json();
-      _pendingTasks.push({ id: task.id, title: task.title });
-      // Reload todos so the main list stays in sync
-      await hooks.loadTodos?.();
+    if (!response || !response.ok) return;
+    const todo = await response.json();
+    _createdSeedTitles.push(title);
+    state.todos.unshift(todo);
+    EventBus.dispatch(TODOS_CHANGED, { reason: "onboarding-seed-created" });
+    hooks.updateCategoryFilter?.();
+    hooks.populateSoulPreferencesForm?.();
+    if (input instanceof HTMLInputElement && !seedTitle) {
+      input.value = "";
     }
-  } catch (err) {
-    console.warn("Onboarding task create failed:", err);
-  } finally {
-    if (input) input.disabled = false;
-  }
-
-  _renderStep2Inline();
-
-  // Limit to 5 tasks in onboarding
-  if (_pendingTasks.length >= 5) {
-    advanceOnboarding();
+    _renderStep3Inline();
+  } catch (error) {
+    console.warn("Onboarding example task creation failed:", error);
   }
 }
 
-// ---------------------------------------------------------------------------
-// Step 3 — Set one due date (inline on Home)
-// ---------------------------------------------------------------------------
-
-function _renderStep3Inline() {
-  _ensureInlineBannerMounted();
-  const banner = document.getElementById("onboardingInlineBanner");
-  if (!banner) return;
-
-  banner.innerHTML = `
-    <div class="onb-inline">
-      <div class="onb-inline__header">
-        <div class="onb-inline__progress">
-          <div class="onb-inline__bar">
-            <div class="onb-inline__fill" style="width:75%"></div>
-          </div>
-          <span class="onb-inline__step-label">Step 3 of 4</span>
-        </div>
-        <button type="button" class="onb-dismiss-x"
-                data-onclick="dismissOnboarding()" aria-label="Dismiss setup">\xd7</button>
-      </div>
-      <h3 class="onb-inline__title">Which one has a deadline?</h3>
-      <p class="onb-inline__sub">
-        Setting a due date helps the planner rank your work. You can skip this.
-      </p>
-      <div class="onb-due-list">
-        ${_pendingTasks
-          .map(
-            (t) => `
-          <div class="onb-due-row" id="onb-due-${escapeHtml(t.id)}">
-            <span class="onb-due-row__title">${escapeHtml(t.title)}</span>
-            <input type="date"
-                   class="onb-due-input"
-                   data-task-id="${escapeHtml(t.id)}"
-                   data-onchange="onboardingSetDueDate('${escapeHtml(t.id)}', this.value)" />
-          </div>`,
-          )
-          .join("")}
-      </div>
-      <div class="onb-inline__footer">
-        <button type="button" class="onb-skip-btn"
-                data-onclick="advanceOnboarding()">Skip</button>
-        <button type="button" class="onb-primary-btn"
-                data-onclick="advanceOnboarding()">Done \u2192</button>
-      </div>
-    </div>`;
+export async function finishOnboardingExamples() {
+  _step = 4;
+  await _saveStep(_step);
+  _render();
 }
 
-export async function onboardingSetDueDate(taskId, dateValue) {
-  if (!taskId || !dateValue) return;
-  const dueDate = new Date(`${dateValue}T09:00:00`).toISOString();
-  try {
-    await hooks.apiCall(
-      `${hooks.API_URL}/todos/${encodeURIComponent(taskId)}`,
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dueDate }),
-      },
-    );
-  } catch (err) {
-    console.warn("Onboarding due date save failed:", err);
-  }
+export async function skipOnboardingExamples() {
+  await finishOnboardingExamples();
 }
 
-// ---------------------------------------------------------------------------
-// Step 4 — Meet the daily brief (modal)
-// ---------------------------------------------------------------------------
-
-function _renderStep4Modal() {
-  _removeOverlay();
-
-  const overlay = document.createElement("div");
-  overlay.id = "onboardingOverlay";
-  overlay.className = "onboarding-overlay";
-  overlay.setAttribute("role", "dialog");
-  overlay.setAttribute("aria-modal", "true");
-  overlay.setAttribute("aria-labelledby", "onboardingModalTitle");
-
-  overlay.innerHTML = `
-    <div class="onb-modal onb-modal--wide">
-      <div class="onb-progress">
-        <span class="onb-progress__dot onb-progress__dot--done"></span>
-        <span class="onb-progress__dot onb-progress__dot--done"></span>
-        <span class="onb-progress__dot onb-progress__dot--done"></span>
-        <span class="onb-progress__dot onb-progress__dot--active"></span>
-      </div>
-      <h2 class="onb-modal__title" id="onboardingModalTitle">
-        You're set up. Here's your daily brief.
-      </h2>
-      <p class="onb-modal__subtitle">
-        Every time you open the app, this tile synthesises what matters most
-        right now \u2014 deadlines, blockers, and the one thing to do today.
-      </p>
-      <div class="onb-brief-preview" id="onbBriefPreview">
-        <div class="onb-brief-loading">Generating your first brief\u2026</div>
-      </div>
-      <div class="onb-modal__actions onb-modal__actions--right">
-        <button type="button" class="onb-primary-btn"
-                data-onclick="dismissOnboarding()">
-          Let's go \u2192
-        </button>
-      </div>
-    </div>`;
-
-  document.body.appendChild(overlay);
-
-  // Kick off the priorities brief in the background
-  _loadBriefPreview();
+export async function onboardingSetDueDate() {
+  return Promise.resolve();
 }
-
-async function _loadBriefPreview() {
-  const container = document.getElementById("onbBriefPreview");
-  if (!container) return;
-
-  try {
-    const response = await hooks.apiCall(
-      `${hooks.API_URL}/ai/priorities-brief`,
-    );
-    if (response && response.ok) {
-      const data = await response.json();
-      container.innerHTML = `<div class="onb-brief-content">${data.html || ""}</div>`;
-    } else {
-      container.innerHTML = `
-        <div class="onb-brief-fallback">
-          Your priorities will appear here based on your tasks and deadlines.
-        </div>`;
-    }
-  } catch {
-    container.innerHTML = `
-      <div class="onb-brief-fallback">
-        Your priorities will appear here based on your tasks and deadlines.
-      </div>`;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// DOM helpers
-// ---------------------------------------------------------------------------
 
 function _removeOverlay() {
   document.getElementById("onboardingOverlay")?.remove();
@@ -531,23 +580,4 @@ function _removeInlineBanner() {
   document.getElementById("onboardingInlineBanner")?.remove();
 }
 
-function _ensureInlineBannerMounted() {
-  if (document.getElementById("onboardingInlineBanner")) return;
-
-  const banner = document.createElement("section");
-  banner.id = "onboardingInlineBanner";
-  banner.className = "onboarding-inline-banner";
-
-  // Insert before #homeFocusDashboard (the home dashboard section)
-  const dashboard = document.getElementById("homeFocusDashboard");
-  if (dashboard && dashboard.parentElement) {
-    dashboard.parentElement.insertBefore(banner, dashboard);
-  } else {
-    // Fallback: prepend to todosScrollRegion
-    const scroll = document.getElementById("todosScrollRegion");
-    if (scroll) scroll.prepend(banner);
-  }
-}
-
-// Export step value for render guard in homeDashboard.js
 export { _step as onboardingStep };

--- a/client/modules/overlayManager.js
+++ b/client/modules/overlayManager.js
@@ -9,6 +9,7 @@ import { state, hooks } from "./store.js";
 import { EventBus } from "./eventBus.js";
 import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
 import { TODO_UPDATED } from "../platform/events/eventReasons.js";
+import { SOUL_COPY } from "./soulConfig.js";
 
 const DomSelectors = window.DomSelectors || {};
 
@@ -414,7 +415,7 @@ export async function saveEditedTodo() {
     EventBus.dispatch(TODOS_CHANGED, { reason: TODO_UPDATED });
     hooks.syncTodoDrawerStateWithRender?.();
     closeEditTodoModal({ restoreFocus: false });
-    showMessage("todosMessage", "Task updated", "success");
+    showMessage("todosMessage", SOUL_COPY.saved, "success");
   } catch (error) {
     console.error("Save edited todo failed:", error);
     showMessage(

--- a/client/modules/quickEntry.js
+++ b/client/modules/quickEntry.js
@@ -703,7 +703,12 @@ export function resetTaskComposerFields() {
   const scheduledDateInput = document.getElementById("todoScheduledDateInput");
   const reviewDateInput = document.getElementById("todoReviewDateInput");
   const contextInput = document.getElementById("todoContextInput");
+  const effortSelect = document.getElementById("todoEffortSelect");
   const energySelect = document.getElementById("todoEnergySelect");
+  const emotionalStateSelect = document.getElementById(
+    "todoEmotionalStateSelect",
+  );
+  const firstStepInput = document.getElementById("todoFirstStepInput");
   const estimateInput = document.getElementById("todoEstimateInput");
   const tagsInput = document.getElementById("todoTagsInput");
   const waitingOnInput = document.getElementById("todoWaitingOnInput");
@@ -719,7 +724,11 @@ export function resetTaskComposerFields() {
     scheduledDateInput.value = "";
   if (reviewDateInput instanceof HTMLInputElement) reviewDateInput.value = "";
   if (contextInput instanceof HTMLInputElement) contextInput.value = "";
+  if (effortSelect instanceof HTMLSelectElement) effortSelect.value = "";
   if (energySelect instanceof HTMLSelectElement) energySelect.value = "";
+  if (emotionalStateSelect instanceof HTMLSelectElement)
+    emotionalStateSelect.value = "";
+  if (firstStepInput instanceof HTMLInputElement) firstStepInput.value = "";
   if (estimateInput instanceof HTMLInputElement) estimateInput.value = "";
   if (tagsInput instanceof HTMLInputElement) tagsInput.value = "";
   if (waitingOnInput instanceof HTMLInputElement) waitingOnInput.value = "";

--- a/client/modules/soulConfig.js
+++ b/client/modules/soulConfig.js
@@ -1,0 +1,196 @@
+// =============================================================================
+// soulConfig.js — Shared Soul MVP defaults, option catalogs, copy, and helpers
+// =============================================================================
+
+export const SOUL_PROFILE_DEFAULTS = {
+  lifeAreas: [],
+  failureModes: [],
+  planningStyle: "both",
+  energyPattern: "variable",
+  goodDayThemes: [],
+  tone: "calm",
+  dailyRitual: "neither",
+};
+
+export const SOUL_LIFE_AREAS = [
+  { value: "work", label: "Work" },
+  { value: "personal", label: "Personal" },
+  { value: "family", label: "Family / caregiving" },
+  { value: "health", label: "Health" },
+  { value: "side_projects", label: "Side projects" },
+];
+
+export const SOUL_FAILURE_MODES = [
+  { value: "overwhelmed", label: "Overwhelmed" },
+  { value: "forgetful", label: "Forgetful" },
+  { value: "perfectionist", label: "Perfectionist" },
+  { value: "overcommitted", label: "Overcommitted" },
+  { value: "inconsistent", label: "Inconsistent" },
+];
+
+export const SOUL_PLANNING_STYLES = [
+  { value: "structure", label: "I like structure" },
+  { value: "flexibility", label: "I like flexibility" },
+  { value: "both", label: "I need both" },
+];
+
+export const SOUL_ENERGY_PATTERNS = [
+  { value: "morning", label: "Best in mornings" },
+  { value: "afternoon", label: "Best in afternoons" },
+  { value: "evening", label: "Best in evenings" },
+  { value: "variable", label: "Varies a lot" },
+];
+
+export const SOUL_GOOD_DAY_THEMES = [
+  { value: "important_work", label: "Finish important work" },
+  { value: "life_admin", label: "Stay on top of life admin" },
+  { value: "avoid_overload", label: "Avoid overload" },
+  { value: "visible_progress", label: "Make visible progress" },
+  { value: "protect_rest", label: "Protect time for family / rest" },
+];
+
+export const SOUL_TONES = [
+  { value: "calm", label: "Calm" },
+  { value: "focused", label: "Focused" },
+  { value: "encouraging", label: "Encouraging" },
+  { value: "direct", label: "Direct" },
+];
+
+export const SOUL_DAILY_RITUALS = [
+  { value: "morning_plan", label: "Morning plan" },
+  { value: "evening_reset", label: "Evening reset" },
+  { value: "both", label: "Both" },
+  { value: "neither", label: "Neither" },
+];
+
+export const TODO_EMOTIONAL_STATES = [
+  { value: "", label: "None" },
+  { value: "avoiding", label: "Avoiding" },
+  { value: "unclear", label: "Unclear" },
+  { value: "heavy", label: "Heavy" },
+  { value: "exciting", label: "Exciting" },
+  { value: "draining", label: "Draining" },
+];
+
+export const TODO_EFFORT_OPTIONS = [
+  { value: "", label: "None" },
+  { value: "1", label: "Tiny" },
+  { value: "2", label: "Small" },
+  { value: "3", label: "Medium" },
+  { value: "4", label: "Deep" },
+];
+
+export const SOUL_COPY = {
+  onboardingBelief: "This app helps you make steady progress without guilt.",
+  rescueIntro:
+    "When your day blows up, rescue mode helps you replan without shame.",
+  taskPromptPrimary: "What needs your attention?",
+  taskPromptSecondary: "What would help today feel lighter?",
+  saved: "Saved.",
+  updated: "Updated.",
+  gotIt: "Got it.",
+  rolledOverHeading: "A few things rolled over.",
+  rolledOverSubheading: "Let’s make the day smaller before it gets louder.",
+  todayHeading: "A few things worth your energy.",
+  todayEmptyHeading: "Your list is clear.",
+  todayEmptySubheading: "Nothing is pressing right now.",
+  listEmptyHeading: "Nothing here yet.",
+  listEmptySubheading: "Add what matters next.",
+  movedLater: "Moved. You can pick this up later.",
+  droppedFromList: "Dropped from the list. You can bring it back if needed.",
+  rescueActive: "Rescue mode is on. Keep today intentionally small.",
+  rescuePrompt: "Heavy day? Switch to rescue mode and keep only what matters.",
+  reviewIntro:
+    "Run a gentle weekly review to see what moved, what got stuck, and what to carry forward.",
+};
+
+export function normalizeSoulProfile(profile) {
+  const value = profile && typeof profile === "object" ? profile : {};
+  const dedupeList = (items) =>
+    Array.isArray(items)
+      ? Array.from(
+          new Set(
+            items.map((item) => String(item || "").trim()).filter(Boolean),
+          ),
+        )
+      : [];
+
+  return {
+    ...SOUL_PROFILE_DEFAULTS,
+    ...value,
+    lifeAreas: dedupeList(value.lifeAreas),
+    failureModes: dedupeList(value.failureModes),
+    goodDayThemes: dedupeList(value.goodDayThemes),
+  };
+}
+
+export function getEffortScoreLabel(score) {
+  const numeric = Number.parseInt(String(score ?? ""), 10);
+  if (numeric === 1) return "Tiny";
+  if (numeric === 2) return "Small";
+  if (numeric === 3) return "Medium";
+  if (numeric === 4) return "Deep";
+  return "";
+}
+
+export function getEffortScoreValue(rawValue) {
+  const value = Number.parseInt(String(rawValue ?? ""), 10);
+  if (value >= 1 && value <= 4) return value;
+  return null;
+}
+
+export function getExampleSeedTasks(profile = SOUL_PROFILE_DEFAULTS) {
+  const soulProfile = normalizeSoulProfile(profile);
+  const examples = [];
+  const pushExample = (title) => {
+    if (!title || examples.includes(title) || examples.length >= 3) return;
+    examples.push(title);
+  };
+
+  if (soulProfile.lifeAreas.includes("work")) {
+    pushExample("Email Sarah about the design review");
+  }
+  if (soulProfile.lifeAreas.includes("personal")) {
+    pushExample("Take the first step on taxes");
+  }
+  if (soulProfile.lifeAreas.includes("family")) {
+    pushExample("Check in about the family schedule");
+  }
+  if (soulProfile.lifeAreas.includes("health")) {
+    pushExample("Rest for 20 minutes");
+  }
+  if (soulProfile.lifeAreas.includes("side_projects")) {
+    pushExample("Open the notes for the next side-project step");
+  }
+
+  pushExample("Clear one small piece of life admin");
+  pushExample("Write down the next action for something you keep postponing");
+
+  return examples.slice(0, 3);
+}
+
+export function getTonePreview(tone) {
+  if (tone === "direct") return "Clear, quiet nudges. No guilt.";
+  if (tone === "encouraging") return "Warm support that still stays grounded.";
+  if (tone === "focused") return "A steadier, sharper plan with less noise.";
+  return "Calm guidance that helps you start without pressure.";
+}
+
+export function buildRescueSuggestion({
+  rolledOverCount = 0,
+  plannedEffortScoreTotal = 0,
+  repeatedDeferrals = 0,
+} = {}) {
+  const reasons = [];
+  if (rolledOverCount >= 5) {
+    reasons.push(`${rolledOverCount} items are still waiting`);
+  }
+  if (plannedEffortScoreTotal >= 10) {
+    reasons.push("today already looks heavy");
+  }
+  if (repeatedDeferrals >= 3) {
+    reasons.push("a few tasks keep slipping");
+  }
+  if (reasons.length === 0) return "";
+  return `${SOUL_COPY.rescuePrompt} ${reasons.join(", ")}.`;
+}

--- a/client/modules/stateActions.js
+++ b/client/modules/stateActions.js
@@ -552,6 +552,22 @@ export function applyAsyncAction(type, payload = {}) {
       state.weeklyReviewState.actions = Array.isArray(payload.actions)
         ? payload.actions
         : [];
+      state.weeklyReviewState.rolloverGroups = Array.isArray(
+        payload.rolloverGroups,
+      )
+        ? payload.rolloverGroups
+        : [];
+      state.weeklyReviewState.anchorSuggestions = Array.isArray(
+        payload.anchorSuggestions,
+      )
+        ? payload.anchorSuggestions
+        : [];
+      state.weeklyReviewState.behaviorAdjustment = String(
+        payload.behaviorAdjustment || "",
+      );
+      state.weeklyReviewState.reflectionSummary = String(
+        payload.reflectionSummary || "",
+      );
       return state.weeklyReviewState;
     case "weeklyReview/failure":
       state.weeklyReviewState.loading = false;

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -117,6 +117,10 @@ export function createInitialWeeklyReviewState() {
     summary: null,
     findings: [],
     actions: [],
+    rolloverGroups: [],
+    anchorSuggestions: [],
+    behaviorAdjustment: "",
+    reflectionSummary: "",
     mode: "suggest",
   };
 }
@@ -142,6 +146,13 @@ export const state = {
   authToken: null,
   refreshToken: null,
   authState: null, // set after AUTH_STATE is loaded from AppState
+  userPlanningPreferences: null,
+  currentDayContext: {
+    mode: "normal",
+    energy: "",
+    notes: "",
+    contextDate: "",
+  },
 
   // Todos
   todos: [],

--- a/client/modules/todosService.js
+++ b/client/modules/todosService.js
@@ -14,6 +14,7 @@ import {
   patchVisibleCategoryGroupStats,
 } from "./todosViewPatches.js";
 import { EventBus } from "./eventBus.js";
+import { getEffortScoreValue } from "./soulConfig.js";
 import { TODOS_CHANGED } from "../platform/events/eventTypes.js";
 import {
   TODO_ADDED,
@@ -283,7 +284,12 @@ async function addTodo() {
   const scheduledDateInput = document.getElementById("todoScheduledDateInput");
   const reviewDateInput = document.getElementById("todoReviewDateInput");
   const contextInput = document.getElementById("todoContextInput");
+  const effortSelect = document.getElementById("todoEffortSelect");
   const energySelect = document.getElementById("todoEnergySelect");
+  const emotionalStateSelect = document.getElementById(
+    "todoEmotionalStateSelect",
+  );
+  const firstStepInput = document.getElementById("todoFirstStepInput");
   const estimateInput = document.getElementById("todoEstimateInput");
   const tagsInput = document.getElementById("todoTagsInput");
   const waitingOnInput = document.getElementById("todoWaitingOnInput");
@@ -347,11 +353,29 @@ async function addTodo() {
   if (contextInput instanceof HTMLInputElement && contextInput.value.trim()) {
     payload.context = contextInput.value.trim();
   }
+  if (effortSelect instanceof HTMLSelectElement) {
+    const effortScore = getEffortScoreValue(effortSelect.value);
+    if (effortScore !== null) {
+      payload.effortScore = effortScore;
+    }
+  }
   if (
     energySelect instanceof HTMLSelectElement &&
     String(energySelect.value || "").trim()
   ) {
     payload.energy = energySelect.value;
+  }
+  if (
+    emotionalStateSelect instanceof HTMLSelectElement &&
+    String(emotionalStateSelect.value || "").trim()
+  ) {
+    payload.emotionalState = emotionalStateSelect.value;
+  }
+  if (
+    firstStepInput instanceof HTMLInputElement &&
+    firstStepInput.value.trim()
+  ) {
+    payload.firstStep = firstStepInput.value.trim();
   }
   if (
     estimateInput instanceof HTMLInputElement &&
@@ -412,8 +436,17 @@ async function addTodo() {
       if (contextInput instanceof HTMLInputElement) {
         contextInput.value = "";
       }
+      if (effortSelect instanceof HTMLSelectElement) {
+        effortSelect.value = "";
+      }
       if (energySelect instanceof HTMLSelectElement) {
         energySelect.value = "";
+      }
+      if (emotionalStateSelect instanceof HTMLSelectElement) {
+        emotionalStateSelect.value = "";
+      }
+      if (firstStepInput instanceof HTMLInputElement) {
+        firstStepInput.value = "";
       }
       if (estimateInput instanceof HTMLInputElement) {
         estimateInput.value = "";
@@ -914,6 +947,15 @@ function performUndo() {
       break;
     case "bulk-complete":
       lastAction.data.forEach((todoId) => toggleTodo(todoId, false));
+      break;
+    case "archive":
+      applyTodoPatch(lastAction.data.id, { archived: false })
+        .then(() => {
+          EventBus.dispatch(TODOS_CHANGED, { reason: UNDO_APPLIED });
+        })
+        .catch((error) => {
+          console.error("Failed to undo archive:", error);
+        });
       break;
   }
 }

--- a/client/modules/weeklyReviewUi.js
+++ b/client/modules/weeklyReviewUi.js
@@ -9,6 +9,7 @@
 import { state, hooks } from "./store.js";
 import { applyAsyncAction } from "./stateActions.js";
 import { callAgentAction } from "./agentApiClient.js";
+import { SOUL_COPY } from "./soulConfig.js";
 
 // ---------------------------------------------------------------------------
 // Render
@@ -34,6 +35,44 @@ function renderActionRow(a) {
       <span class="wr-action__type">${escapeHtml(label)}</span>
       ${a.title ? `<span class="wr-action__title">${escapeHtml(a.title)}</span>` : ""}
       ${a.reason ? `<p class="wr-action__reason">${escapeHtml(a.reason)}</p>` : ""}
+    </div>`;
+}
+
+function renderRolloverGroup(group) {
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+  const items = Array.isArray(group?.items) ? group.items : [];
+  return `
+    <div class="wr-rollover-group">
+      <div class="wr-rollover-group__header">
+        <span class="wr-finding__type">${escapeHtml(String(group?.label || group?.key || "Group"))}</span>
+        <span class="wr-finding__subject">${escapeHtml(String(items.length))}</span>
+      </div>
+      ${
+        items.length > 0
+          ? `<ul class="wr-rollover-group__list">
+              ${items
+                .map(
+                  (item) =>
+                    `<li>${escapeHtml(String(item?.title || "Untitled task"))}</li>`,
+                )
+                .join("")}
+            </ul>`
+          : `<p class="wr-empty">Nothing here.</p>`
+      }
+    </div>`;
+}
+
+function renderAnchorSuggestion(item) {
+  const escapeHtml = hooks.escapeHtml || ((s) => String(s));
+  return `
+    <div class="wr-action">
+      <span class="wr-action__type">anchor</span>
+      <span class="wr-action__title">${escapeHtml(String(item?.title || "Untitled task"))}</span>
+      ${
+        item?.reason
+          ? `<p class="wr-action__reason">${escapeHtml(String(item.reason))}</p>`
+          : ""
+      }
     </div>`;
 }
 
@@ -75,18 +114,48 @@ export function renderWeeklyReviewView() {
       <div class="wr-error">${escapeHtml(s.error)}</div>
       <button type="button" class="wr-btn" data-wr-action="suggest">Retry</button>`;
   } else if (s.hasRun) {
+    const reflectionHtml = s.reflectionSummary
+      ? `<section class="wr-section">
+           <h3 class="wr-section__title">Reflection</h3>
+           <p class="wr-intro">${escapeHtml(s.reflectionSummary)}</p>
+         </section>`
+      : "";
+
     const findingsHtml =
       s.findings.length > 0
         ? `<section class="wr-section">
-            <h3 class="wr-section__title">Findings (${s.findings.length})</h3>
+            <h3 class="wr-section__title">What got stuck (${s.findings.length})</h3>
             ${s.findings.map(renderFindingRow).join("")}
           </section>`
         : "";
 
+    const rolloverHtml =
+      s.rolloverGroups.length > 0
+        ? `<section class="wr-section">
+             <h3 class="wr-section__title">Rollover review</h3>
+             ${s.rolloverGroups.map(renderRolloverGroup).join("")}
+           </section>`
+        : "";
+
+    const anchorsHtml =
+      s.anchorSuggestions.length > 0
+        ? `<section class="wr-section">
+             <h3 class="wr-section__title">Next week focus</h3>
+             ${s.anchorSuggestions.map(renderAnchorSuggestion).join("")}
+           </section>`
+        : "";
+
+    const adjustmentHtml = s.behaviorAdjustment
+      ? `<section class="wr-section">
+           <h3 class="wr-section__title">One adjustment</h3>
+           <p class="wr-intro">${escapeHtml(s.behaviorAdjustment)}</p>
+         </section>`
+      : "";
+
     const actionsHtml =
       s.actions.length > 0
         ? `<section class="wr-section">
-            <h3 class="wr-section__title">Recommended actions (${s.actions.length})</h3>
+            <h3 class="wr-section__title">Suggested cleanup (${s.actions.length})</h3>
             ${s.actions.map(renderActionRow).join("")}
             ${
               s.mode === "suggest"
@@ -98,11 +167,11 @@ export function renderWeeklyReviewView() {
                 : `<p class="wr-applied-msg">Actions applied.</p>`
             }
           </section>`
-        : `<p class="wr-empty">No recommended actions this week.</p>`;
+        : `<p class="wr-empty">Nothing urgent to clean up this week.</p>`;
 
-    bodyHtml = `${renderSummaryBadges(s.summary)}${findingsHtml}${actionsHtml}`;
+    bodyHtml = `${renderSummaryBadges(s.summary)}${reflectionHtml}${rolloverHtml}${findingsHtml}${anchorsHtml}${adjustmentHtml}${actionsHtml}`;
   } else {
-    bodyHtml = `<p class="wr-intro">Run the weekly review to surface stale tasks, projects without a next action, and get recommendations.</p>`;
+    bodyHtml = `<p class="wr-intro">${escapeHtml(SOUL_COPY.reviewIntro)}</p>`;
   }
 
   // All dynamic values are passed through escapeHtml before innerHTML assignment.
@@ -146,6 +215,14 @@ async function runWeeklyReview(mode = "suggest") {
         : Array.isArray(review?.appliedActions)
           ? review.appliedActions
           : [],
+      rolloverGroups: Array.isArray(review?.rolloverGroups)
+        ? review.rolloverGroups
+        : [],
+      anchorSuggestions: Array.isArray(review?.anchorSuggestions)
+        ? review.anchorSuggestions
+        : [],
+      behaviorAdjustment: String(review?.behaviorAdjustment || ""),
+      reflectionSummary: String(review?.reflectionSummary || ""),
     });
     if (mode === "apply") {
       applyAsyncAction("weeklyReview/mode:set", { mode: "apply" });

--- a/client/styles.css
+++ b/client/styles.css
@@ -3861,6 +3861,7 @@ body.is-todos-view .floating-new-task-cta {
   justify-self: end;
   align-self: start;
   position: relative;
+  z-index: 60;
   width: 34px;
   min-width: 34px;
   max-width: 34px;
@@ -3910,7 +3911,7 @@ body.is-todos-view .floating-new-task-cta {
   display: none;
   flex-direction: column;
   gap: 6px;
-  z-index: 10;
+  z-index: 70;
 }
 
 .todo-kebab-menu--open {
@@ -5842,6 +5843,7 @@ body.is-drawer-open {
     transform var(--dur-fast) var(--ease-out);
   min-width: 0;
   min-height: var(--row-height);
+  isolation: isolate;
 }
 
 /* Hide secondary affordances by default; reveal on hover/mode */
@@ -6494,7 +6496,8 @@ textarea:disabled {
   }
 
   .floating-new-task-cta {
-    right: 12px;
+    left: 12px;
+    right: auto;
     bottom: 12px;
   }
 
@@ -8649,6 +8652,11 @@ body.dark-mode .dock-icon--sun {
   padding-bottom: 72px;
 }
 
+body:has(.todo-kebab-menu--open) .floating-new-task-cta,
+body:has(.todo-kebab-menu--open) .bottom-action-dock {
+  pointer-events: none;
+}
+
 #projectsRail {
   padding-bottom: 72px;
 }
@@ -8825,7 +8833,8 @@ body.is-admin-user .projects-rail__footer--admin-only {
 
   /* 9. Fix floating CTA — anchor to bottom-right of viewport */
   .floating-new-task-cta {
-    right: 20px;
+    left: 20px;
+    right: auto;
     bottom: 24px;
   }
 
@@ -9689,6 +9698,289 @@ body.is-admin-user .projects-rail__footer--admin-only {
 
 .onboarding-progress__dot.is-active {
   background: var(--primary-color);
+}
+
+.onb-modal--wide {
+  width: min(760px, 94vw);
+}
+
+.onb-modal__eyebrow,
+.onboarding-inline-banner__eyebrow,
+.home-rescue-panel__eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.onb-section + .onb-section,
+.onb-inline-grid + .onb-section {
+  margin-top: 18px;
+}
+
+.onb-section__label {
+  margin-bottom: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.onb-choice-grid,
+.settings-check-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.onb-choice-btn,
+.onb-card-btn {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--card-bg, var(--panel-bg, var(--sidebar-bg)));
+  color: var(--text-primary);
+  padding: 12px 14px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease,
+    transform 0.16s ease;
+}
+
+.onb-choice-btn:hover,
+.onb-card-btn:hover {
+  border-color: rgba(61, 115, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.onb-choice-btn--selected,
+.onb-card-btn--selected {
+  border-color: rgba(61, 115, 255, 0.55);
+  background: color-mix(in srgb, var(--accent-color, #3d73ff) 8%, white);
+}
+
+.onb-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.onb-card-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.onb-inline-grid,
+.settings-support-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.onb-card-btn__label {
+  display: block;
+  font-weight: 600;
+}
+
+.onb-modal__helper {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.onb-modal__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.onb-skip-btn,
+.onb-primary-btn {
+  border-radius: 999px;
+  padding: 10px 16px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.onb-primary-btn {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.onb-preview-card {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--accent-color, #3d73ff) 4%, white);
+}
+
+.onb-preview-card + .onb-preview-card {
+  margin-top: 10px;
+}
+
+.onb-preview-card--muted {
+  background: color-mix(in srgb, var(--border-color) 24%, white);
+}
+
+.onb-preview-card__title {
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.onb-preview-card__text {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.onboarding-inline-banner--soul {
+  display: grid;
+  gap: 14px;
+  margin: 4px 0 18px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border-color);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent-color, #3d73ff) 6%, white),
+    color-mix(in srgb, var(--accent-color, #3d73ff) 2%, white)
+  );
+}
+
+.onboarding-inline-banner__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+}
+
+.onboarding-inline-banner__header h3,
+.onboarding-inline-banner__header p,
+.onboarding-inline-banner__helper {
+  margin: 0;
+}
+
+.onboarding-inline-banner__examples,
+.onboarding-inline-banner__capture {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.onb-example-btn {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--text-primary);
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.onb-example-btn--added {
+  opacity: 0.7;
+  cursor: default;
+}
+
+#onboardingCustomTaskInput {
+  flex: 1 1 260px;
+}
+
+.settings-support-copy,
+.settings-support-preview {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.settings-check-grid label {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--input-bg);
+}
+
+.home-rescue-panel {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  margin: 18px 0 0;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border-color);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 250, 245, 0.92),
+    rgba(248, 247, 244, 0.92)
+  );
+}
+
+.home-rescue-panel__title,
+.home-rescue-panel__summary {
+  margin: 0;
+}
+
+.home-rescue-panel__summary {
+  margin-top: 6px;
+  color: var(--text-secondary);
+}
+
+.home-task-row__actions--recovery {
+  grid-column: 2 / -1;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.today-recovery-banner {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 14px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: rgba(255, 252, 248, 0.94);
+}
+
+.today-recovery-banner__copy h3,
+.today-recovery-banner__copy p {
+  margin: 0;
+}
+
+.today-recovery-banner__copy p {
+  margin-top: 4px;
+  color: var(--text-secondary);
+}
+
+.today-recovery-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 720px) {
+  .onb-inline-grid,
+  .settings-support-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-rescue-panel,
+  .today-recovery-banner,
+  .onboarding-inline-banner__header {
+    display: grid;
+  }
+
+  .home-rescue-panel__actions,
+  .today-recovery-banner__actions {
+    justify-content: start;
+  }
 }
 
 /* ── Simple mode — hides advanced features for a clean task list ── */

--- a/prisma/migrations/20260324030000_soul_mvp/migration.sql
+++ b/prisma/migrations/20260324030000_soul_mvp/migration.sql
@@ -1,0 +1,8 @@
+ALTER TYPE "TodoSource" ADD VALUE IF NOT EXISTS 'system_seed';
+
+ALTER TABLE "todos"
+ADD COLUMN "first_step" VARCHAR(255),
+ADD COLUMN "emotional_state" VARCHAR(20);
+
+ALTER TABLE "user_planning_preferences"
+ADD COLUMN "soul_profile" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ enum ProjectReviewCadence {
 
 enum TodoSource {
   manual
+  system_seed
   chat
   email
   import
@@ -387,6 +388,8 @@ model Todo {
   blockedReason            String?            @map("blocked_reason") @db.VarChar(500)
   effortScore              Int?               @map("effort_score")
   confidenceScore          Int?               @map("confidence_score")
+  firstStep                String?            @map("first_step") @db.VarChar(255)
+  emotionalState           String?            @map("emotional_state") @db.VarChar(20)
   sourceText               String?            @map("source_text") @db.Text
   createdByPrompt          String?            @map("created_by_prompt") @db.Text
   notes                    String?            @db.Text
@@ -718,6 +721,7 @@ model UserPlanningPreferences {
   preferredContexts     String[] @default([]) @map("preferred_contexts")
   waitingFollowUpDays   Int      @default(7) @map("waiting_follow_up_days")
   workWindowsJson       Json?    @map("work_windows_json")
+  soulProfile           Json?    @map("soul_profile")
   createdAt             DateTime @default(now()) @map("created_at")
   updatedAt             DateTime @updatedAt @map("updated_at")
 

--- a/src/agent/agent-manifest.json
+++ b/src/agent/agent-manifest.json
@@ -97,7 +97,7 @@
     },
     "taskSource": {
       "type": "string",
-      "enum": ["manual", "chat", "email", "import", "automation"]
+      "enum": ["manual", "system_seed", "chat", "email", "import", "automation"]
     },
     "todoRecurrence": {
       "type": "object",
@@ -244,7 +244,22 @@
         },
         "source": {
           "type": ["string", "null"],
-          "enum": ["manual", "chat", "email", "import", "automation", null]
+          "enum": [
+            "manual",
+            "system_seed",
+            "chat",
+            "email",
+            "import",
+            "automation",
+            null
+          ]
+        },
+        "firstStep": {
+          "type": ["string", "null"]
+        },
+        "emotionalState": {
+          "type": ["string", "null"],
+          "enum": ["avoiding", "unclear", "heavy", "exciting", "draining", null]
         },
         "createdByPrompt": {
           "type": ["string", "null"]
@@ -3633,6 +3648,7 @@
               "office",
               "home",
               "overloaded",
+              "rescue",
               "sprint",
               "catch_up"
             ],

--- a/src/preferences.api.integration.test.ts
+++ b/src/preferences.api.integration.test.ts
@@ -40,6 +40,15 @@ describe("Preferences API Integration", () => {
     expect(response.body.preferredContexts).toEqual([]);
     expect(response.body.maxDailyTasks).toBeNull();
     expect(response.body.preferredChunkMinutes).toBeNull();
+    expect(response.body.soulProfile).toEqual({
+      lifeAreas: [],
+      failureModes: [],
+      planningStyle: "both",
+      energyPattern: "variable",
+      goodDayThemes: [],
+      tone: "calm",
+      dailyRitual: "neither",
+    });
   });
 
   it("PATCH /preferences updates and returns updated prefs", async () => {
@@ -68,5 +77,38 @@ describe("Preferences API Integration", () => {
 
     expect(response.body.maxDailyTasks).toBe(10);
     expect(response.body.preferredContexts).toEqual(["home", "office"]);
+  });
+
+  it("PATCH /preferences merges soul profile updates", async () => {
+    await request(app)
+      .patch("/preferences")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        soulProfile: {
+          tone: "focused",
+          lifeAreas: ["work", "personal"],
+        },
+      })
+      .expect(200);
+
+    const response = await request(app)
+      .patch("/preferences")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        soulProfile: {
+          planningStyle: "structure",
+        },
+      })
+      .expect(200);
+
+    expect(response.body.soulProfile).toEqual({
+      lifeAreas: ["work", "personal"],
+      failureModes: [],
+      planningStyle: "structure",
+      energyPattern: "variable",
+      goodDayThemes: [],
+      tone: "focused",
+      dailyRitual: "neither",
+    });
   });
 });

--- a/src/routes/preferencesRouter.ts
+++ b/src/routes/preferencesRouter.ts
@@ -1,6 +1,52 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 
+const VALID_LIFE_AREAS = [
+  "work",
+  "personal",
+  "family",
+  "health",
+  "side_projects",
+] as const;
+const VALID_FAILURE_MODES = [
+  "overwhelmed",
+  "forgetful",
+  "perfectionist",
+  "overcommitted",
+  "inconsistent",
+] as const;
+const VALID_PLANNING_STYLES = ["structure", "flexibility", "both"] as const;
+const VALID_ENERGY_PATTERNS = [
+  "morning",
+  "afternoon",
+  "evening",
+  "variable",
+] as const;
+const VALID_GOOD_DAY_THEMES = [
+  "important_work",
+  "life_admin",
+  "avoid_overload",
+  "visible_progress",
+  "protect_rest",
+] as const;
+const VALID_TONES = ["calm", "focused", "encouraging", "direct"] as const;
+const VALID_DAILY_RITUALS = [
+  "morning_plan",
+  "evening_reset",
+  "both",
+  "neither",
+] as const;
+
+const soulDefaults = {
+  lifeAreas: [] as string[],
+  failureModes: [] as string[],
+  planningStyle: "both",
+  energyPattern: "variable",
+  goodDayThemes: [] as string[],
+  tone: "calm",
+  dailyRitual: "neither",
+};
+
 export function createPreferencesRouter(prisma: PrismaClient): Router {
   const router = Router();
 
@@ -12,6 +58,7 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
     preferredContexts: [] as string[],
     waitingFollowUpDays: 7,
     workWindowsJson: null,
+    soulProfile: { ...soulDefaults },
   };
 
   router.get("/", async (req: Request, res: Response, next: NextFunction) => {
@@ -37,10 +84,15 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
         res.status(401).json({ error: "Unauthorized" });
         return;
       }
+
+      const existing = await prisma.userPlanningPreferences.findUnique({
+        where: { userId },
+      });
+      const update = buildUpdate(req.body, existing?.soulProfile ?? null);
       const prefs = await prisma.userPlanningPreferences.upsert({
         where: { userId },
-        create: { userId, ...buildUpdate(req.body) },
-        update: buildUpdate(req.body),
+        create: { userId, ...update },
+        update,
       });
       res.json(toDto(prefs));
     } catch (error) {
@@ -48,23 +100,127 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
     }
   });
 
-  function buildUpdate(body: Record<string, unknown>) {
+  function buildUpdate(
+    body: Record<string, unknown>,
+    currentSoulProfile: unknown,
+  ) {
     const update: Record<string, unknown> = {};
-    if (body.maxDailyTasks !== undefined)
+    if (body.maxDailyTasks !== undefined) {
       update.maxDailyTasks = body.maxDailyTasks;
-    if (body.preferredChunkMinutes !== undefined)
+    }
+    if (body.preferredChunkMinutes !== undefined) {
       update.preferredChunkMinutes = body.preferredChunkMinutes;
-    if (body.deepWorkPreference !== undefined)
+    }
+    if (body.deepWorkPreference !== undefined) {
       update.deepWorkPreference = body.deepWorkPreference;
-    if (body.weekendsActive !== undefined)
+    }
+    if (body.weekendsActive !== undefined) {
       update.weekendsActive = body.weekendsActive;
-    if (body.preferredContexts !== undefined)
+    }
+    if (body.preferredContexts !== undefined) {
       update.preferredContexts = body.preferredContexts;
-    if (body.waitingFollowUpDays !== undefined)
+    }
+    if (body.waitingFollowUpDays !== undefined) {
       update.waitingFollowUpDays = body.waitingFollowUpDays;
-    if (body.workWindowsJson !== undefined)
+    }
+    if (body.workWindowsJson !== undefined) {
       update.workWindowsJson = body.workWindowsJson;
+    }
+    if (body.soulProfile !== undefined) {
+      update.soulProfile = mergeSoulProfile(
+        currentSoulProfile,
+        body.soulProfile,
+      );
+    }
     return update;
+  }
+
+  function toStringList<T extends string>(
+    value: unknown,
+    valid: readonly T[],
+    maxItems: number,
+  ): T[] {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map(
+        (item) =>
+          String(item || "")
+            .trim()
+            .toLowerCase() as T,
+      )
+      .filter(
+        (item, index, items) =>
+          !!item && valid.includes(item) && items.indexOf(item) === index,
+      )
+      .slice(0, maxItems);
+  }
+
+  function toEnumValue<T extends string>(
+    value: unknown,
+    valid: readonly T[],
+    fallback: T,
+  ): T {
+    const normalized = String(value || "")
+      .trim()
+      .toLowerCase() as T;
+    return valid.includes(normalized) ? normalized : fallback;
+  }
+
+  function mergeSoulProfile(current: unknown, incoming: unknown) {
+    const currentValue =
+      current && typeof current === "object"
+        ? (current as Record<string, unknown>)
+        : {};
+    const nextValue =
+      incoming && typeof incoming === "object"
+        ? (incoming as Record<string, unknown>)
+        : {};
+    return {
+      lifeAreas:
+        nextValue.lifeAreas !== undefined
+          ? toStringList(nextValue.lifeAreas, VALID_LIFE_AREAS, 6)
+          : toStringList(currentValue.lifeAreas, VALID_LIFE_AREAS, 6),
+      failureModes:
+        nextValue.failureModes !== undefined
+          ? toStringList(nextValue.failureModes, VALID_FAILURE_MODES, 6)
+          : toStringList(currentValue.failureModes, VALID_FAILURE_MODES, 6),
+      planningStyle:
+        nextValue.planningStyle !== undefined
+          ? toEnumValue(nextValue.planningStyle, VALID_PLANNING_STYLES, "both")
+          : toEnumValue(
+              currentValue.planningStyle,
+              VALID_PLANNING_STYLES,
+              soulDefaults.planningStyle,
+            ),
+      energyPattern:
+        nextValue.energyPattern !== undefined
+          ? toEnumValue(
+              nextValue.energyPattern,
+              VALID_ENERGY_PATTERNS,
+              "variable",
+            )
+          : toEnumValue(
+              currentValue.energyPattern,
+              VALID_ENERGY_PATTERNS,
+              soulDefaults.energyPattern,
+            ),
+      goodDayThemes:
+        nextValue.goodDayThemes !== undefined
+          ? toStringList(nextValue.goodDayThemes, VALID_GOOD_DAY_THEMES, 6)
+          : toStringList(currentValue.goodDayThemes, VALID_GOOD_DAY_THEMES, 6),
+      tone:
+        nextValue.tone !== undefined
+          ? toEnumValue(nextValue.tone, VALID_TONES, "calm")
+          : toEnumValue(currentValue.tone, VALID_TONES, soulDefaults.tone),
+      dailyRitual:
+        nextValue.dailyRitual !== undefined
+          ? toEnumValue(nextValue.dailyRitual, VALID_DAILY_RITUALS, "neither")
+          : toEnumValue(
+              currentValue.dailyRitual,
+              VALID_DAILY_RITUALS,
+              soulDefaults.dailyRitual,
+            ),
+    };
   }
 
   function toDto(p: {
@@ -75,6 +231,7 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
     preferredContexts: string[];
     waitingFollowUpDays: number;
     workWindowsJson: unknown;
+    soulProfile: unknown;
   }) {
     return {
       maxDailyTasks: p.maxDailyTasks,
@@ -84,6 +241,10 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
       preferredContexts: p.preferredContexts,
       waitingFollowUpDays: p.waitingFollowUpDays,
       workWindowsJson: p.workWindowsJson,
+      soulProfile: {
+        ...soulDefaults,
+        ...mergeSoulProfile(null, p.soulProfile),
+      },
     };
   }
 

--- a/src/services/dayContextService.ts
+++ b/src/services/dayContextService.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from "@prisma/client";
 
 export type DayMode =
   | "normal"
+  | "rescue"
   | "travel"
   | "office"
   | "home"
@@ -33,6 +34,11 @@ export interface ModeModifiers {
 
 export const MODE_MODIFIERS: Record<DayMode, ModeModifiers> = {
   normal: { scoreBoosts: {} },
+  rescue: {
+    maxTaskCount: 3,
+    budgetMultiplier: 0.6,
+    scoreBoosts: { shortTask: 20, adminTask: 5, projectTask: -10 },
+  },
   travel: {
     budgetMultiplier: 0.7,
     scoreBoosts: { shortTask: 10, adminTask: -10 },

--- a/src/services/planner/reviewEngine.test.ts
+++ b/src/services/planner/reviewEngine.test.ts
@@ -84,6 +84,9 @@ describe("ReviewEngine", () => {
         "upcoming_deadline",
       ]),
     );
+    expect(result.rolloverGroups).toHaveLength(4);
+    expect(result.anchorSuggestions.length).toBeLessThanOrEqual(5);
+    expect(result.behaviorAdjustment).toBeTruthy();
   });
 
   it("calculates project health risks and interventions", () => {

--- a/src/services/planner/reviewEngine.ts
+++ b/src/services/planner/reviewEngine.ts
@@ -3,7 +3,9 @@ import type {
   AnalyzeProjectHealthIntervention,
   AnalyzeProjectHealthResult,
   PlannerFinding,
+  WeeklyReviewAnchorSuggestion,
   WeeklyReviewAction,
+  WeeklyReviewRolloverGroup,
   WeeklyReviewResult,
 } from "../../types/plannerTypes";
 import { ProjectPlanningEngine } from "./projectPlanningEngine";
@@ -163,6 +165,19 @@ export class ReviewEngine {
       });
     });
 
+    const rolloverGroups = this.buildRolloverGroups(openTasks, input.now);
+    const anchorSuggestions = this.buildAnchorSuggestions(openTasks, input.now);
+    const behaviorAdjustment = this.buildBehaviorAdjustment(
+      rolloverGroups,
+      openTasks,
+    );
+    const reflectionSummary = this.buildReflectionSummary(
+      openTasks,
+      waitingTasks.length,
+      staleTasks.length,
+      anchorSuggestions,
+    );
+
     return {
       summary: {
         projectsWithoutNextAction,
@@ -172,7 +187,149 @@ export class ReviewEngine {
       },
       findings,
       recommendedActions,
+      rolloverGroups,
+      anchorSuggestions,
+      behaviorAdjustment,
+      reflectionSummary,
     };
+  }
+
+  private buildRolloverGroups(
+    openTasks: Todo[],
+    now: Date,
+  ): WeeklyReviewRolloverGroup[] {
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const staleCutoff = new Date(now);
+    staleCutoff.setDate(staleCutoff.getDate() - 30);
+    const overdueTasks = openTasks.filter(
+      (task) => task.dueDate && task.dueDate < today,
+    );
+    const staleTasks = openTasks.filter(
+      (task) => task.updatedAt <= staleCutoff,
+    );
+
+    return [
+      {
+        key: "do",
+        title: "Do this week",
+        items: overdueTasks
+          .filter((task) => (task.priority ?? "medium") !== "low")
+          .slice(0, 4)
+          .map((task) => ({
+            taskId: task.id,
+            title: task.title,
+            reason: "It is still waiting and may need a clear restart.",
+          })),
+      },
+      {
+        key: "defer",
+        title: "Move later",
+        items: openTasks
+          .filter(
+            (task) => task.status === "waiting" || task.status === "scheduled",
+          )
+          .slice(0, 4)
+          .map((task) => ({
+            taskId: task.id,
+            title: task.title,
+            reason: "It looks like a candidate to move with intention.",
+          })),
+      },
+      {
+        key: "shrink",
+        title: "Make smaller",
+        items: openTasks
+          .filter(
+            (task) =>
+              (task.effortScore ?? 0) >= 3 ||
+              Boolean(String(task.blockedReason || "").trim()),
+          )
+          .slice(0, 4)
+          .map((task) => ({
+            taskId: task.id,
+            title: task.title,
+            reason: "This may move faster with a smaller first step.",
+          })),
+      },
+      {
+        key: "drop",
+        title: "Let go",
+        items: staleTasks
+          .filter((task) => (task.priority ?? "medium") === "low")
+          .slice(0, 4)
+          .map((task) => ({
+            taskId: task.id,
+            title: task.title,
+            reason:
+              "If it no longer matters, it may be okay to let this leave the list.",
+          })),
+      },
+    ];
+  }
+
+  private buildAnchorSuggestions(
+    openTasks: Todo[],
+    now: Date,
+  ): WeeklyReviewAnchorSuggestion[] {
+    return [...openTasks]
+      .sort((a, b) => {
+        const aDue = a.dueDate?.getTime() ?? Number.POSITIVE_INFINITY;
+        const bDue = b.dueDate?.getTime() ?? Number.POSITIVE_INFINITY;
+        if (aDue !== bDue) return aDue - bDue;
+        const aPriority =
+          a.priority === "high" || a.priority === "urgent" ? 1 : 0;
+        const bPriority =
+          b.priority === "high" || b.priority === "urgent" ? 1 : 0;
+        return bPriority - aPriority;
+      })
+      .slice(0, 5)
+      .map((task) => ({
+        taskId: task.id,
+        title: task.title,
+        reason:
+          task.dueDate && task.dueDate < now
+            ? "A rolled-over item that needs a clean decision."
+            : task.status === "in_progress"
+              ? "Already moving, so it can anchor momentum."
+              : "A good candidate for a smaller focus list next week.",
+      }));
+  }
+
+  private buildBehaviorAdjustment(
+    rolloverGroups: WeeklyReviewRolloverGroup[],
+    openTasks: Todo[],
+  ): string {
+    const shrinkCount =
+      rolloverGroups.find((group) => group.key === "shrink")?.items.length ?? 0;
+    const waitingCount = openTasks.filter(
+      (task) =>
+        task.status === "waiting" || String(task.waitingOn || "").trim(),
+    ).length;
+    if (shrinkCount >= 3) {
+      return "Keep next week’s focus list smaller and start the heavier work with a tiny first step.";
+    }
+    if (waitingCount >= 3) {
+      return "Clear the waiting items early so they stop dragging across the week.";
+    }
+    return "A smaller focus list will probably feel steadier than trying to carry everything forward.";
+  }
+
+  private buildReflectionSummary(
+    openTasks: Todo[],
+    waitingCount: number,
+    staleCount: number,
+    anchorSuggestions: WeeklyReviewAnchorSuggestion[],
+  ): string | null {
+    if (openTasks.length === 0) {
+      return "Your list looks light right now. Keep next week simple.";
+    }
+    if (staleCount > 0 && waitingCount > 0) {
+      return "The week carried some drag, but you still have a clear chance to reset by shrinking stale work and following up on what is blocked.";
+    }
+    if (anchorSuggestions.length > 0) {
+      return "You kept enough signal in the system to choose a smaller, steadier focus for next week.";
+    }
+    return null;
   }
 
   analyzeProjectHealth(input: {

--- a/src/services/plannerService.ts
+++ b/src/services/plannerService.ts
@@ -249,6 +249,10 @@ export class PlannerService implements IPlannerService {
         findings: base.findings,
         recommendedActions: base.recommendedActions,
         appliedActions: [],
+        rolloverGroups: base.rolloverGroups,
+        anchorSuggestions: base.anchorSuggestions,
+        behaviorAdjustment: base.behaviorAdjustment,
+        reflectionSummary: base.reflectionSummary,
       };
     }
 
@@ -276,6 +280,10 @@ export class PlannerService implements IPlannerService {
       findings: base.findings,
       recommendedActions: base.recommendedActions,
       appliedActions,
+      rolloverGroups: base.rolloverGroups,
+      anchorSuggestions: base.anchorSuggestions,
+      behaviorAdjustment: base.behaviorAdjustment,
+      reflectionSummary: base.reflectionSummary,
     };
   }
 

--- a/src/services/prismaTodoService.ts
+++ b/src/services/prismaTodoService.ts
@@ -437,6 +437,8 @@ export class PrismaTodoService implements ITodoService {
           blockedReason: dto.blockedReason ?? null,
           effortScore: dto.effortScore ?? null,
           confidenceScore: dto.confidenceScore ?? null,
+          firstStep: dto.firstStep ?? null,
+          emotionalState: dto.emotionalState ?? null,
           sourceText: dto.sourceText ?? null,
           areaId: dto.areaId ?? null,
           goalId: dto.goalId ?? null,
@@ -545,6 +547,9 @@ export class PrismaTodoService implements ITodoService {
         updateData.effortScore = dto.effortScore;
       if (dto.confidenceScore !== undefined)
         updateData.confidenceScore = dto.confidenceScore;
+      if (dto.firstStep !== undefined) updateData.firstStep = dto.firstStep;
+      if (dto.emotionalState !== undefined)
+        updateData.emotionalState = dto.emotionalState;
       if (dto.sourceText !== undefined) updateData.sourceText = dto.sourceText;
       if (dto.areaId !== undefined) updateData.areaId = dto.areaId;
       if (dto.goalId !== undefined) updateData.goalId = dto.goalId;
@@ -1064,6 +1069,9 @@ export class PrismaTodoService implements ITodoService {
       blockedReason: prismaTodo.blockedReason ?? null,
       effortScore: prismaTodo.effortScore ?? null,
       confidenceScore: prismaTodo.confidenceScore ?? null,
+      firstStep: prismaTodo.firstStep ?? null,
+      emotionalState:
+        (prismaTodo.emotionalState as Todo["emotionalState"]) ?? null,
       sourceText: prismaTodo.sourceText ?? null,
       areaId: prismaTodo.areaId ?? null,
       goalId: prismaTodo.goalId ?? null,

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -186,6 +186,14 @@ export class TodoService implements ITodoService {
         nextOccurrence: dto.recurrence?.nextOccurrence ?? undefined,
       },
       source: dto.source ?? undefined,
+      blockedReason: dto.blockedReason ?? undefined,
+      effortScore: dto.effortScore ?? undefined,
+      confidenceScore: dto.confidenceScore ?? undefined,
+      firstStep: dto.firstStep ?? undefined,
+      emotionalState: dto.emotionalState ?? undefined,
+      sourceText: dto.sourceText ?? undefined,
+      areaId: dto.areaId ?? undefined,
+      goalId: dto.goalId ?? undefined,
       createdByPrompt: dto.createdByPrompt ?? undefined,
       notes: dto.notes ?? undefined,
       userId,
@@ -425,6 +433,33 @@ export class TodoService implements ITodoService {
       }),
       ...(dto.source !== undefined && {
         source: dto.source === null ? undefined : dto.source,
+      }),
+      ...(dto.blockedReason !== undefined && {
+        blockedReason:
+          dto.blockedReason === null ? undefined : dto.blockedReason,
+      }),
+      ...(dto.effortScore !== undefined && {
+        effortScore: dto.effortScore === null ? undefined : dto.effortScore,
+      }),
+      ...(dto.confidenceScore !== undefined && {
+        confidenceScore:
+          dto.confidenceScore === null ? undefined : dto.confidenceScore,
+      }),
+      ...(dto.firstStep !== undefined && {
+        firstStep: dto.firstStep === null ? undefined : dto.firstStep,
+      }),
+      ...(dto.emotionalState !== undefined && {
+        emotionalState:
+          dto.emotionalState === null ? undefined : dto.emotionalState,
+      }),
+      ...(dto.sourceText !== undefined && {
+        sourceText: dto.sourceText === null ? undefined : dto.sourceText,
+      }),
+      ...(dto.areaId !== undefined && {
+        areaId: dto.areaId === null ? undefined : dto.areaId,
+      }),
+      ...(dto.goalId !== undefined && {
+        goalId: dto.goalId === null ? undefined : dto.goalId,
       }),
       ...(dto.createdByPrompt !== undefined && {
         createdByPrompt:

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,11 +18,39 @@ export type Energy = "low" | "medium" | "high";
 export type ReviewCadence = "weekly" | "biweekly" | "monthly" | "quarterly";
 export type TaskSource =
   | "manual"
+  | "system_seed"
   | "chat"
   | "email"
   | "import"
   | "automation"
   | "api";
+export type TodoEmotionalState =
+  | "avoiding"
+  | "unclear"
+  | "heavy"
+  | "exciting"
+  | "draining";
+export type SoulPlanningStyle = "structure" | "flexibility" | "both";
+export type SoulEnergyPattern =
+  | "morning"
+  | "afternoon"
+  | "evening"
+  | "variable";
+export type SoulTone = "calm" | "focused" | "encouraging" | "direct";
+export type SoulDailyRitual =
+  | "morning_plan"
+  | "evening_reset"
+  | "both"
+  | "neither";
+export interface SoulProfileDto {
+  lifeAreas: string[];
+  failureModes: string[];
+  planningStyle: SoulPlanningStyle;
+  energyPattern: SoulEnergyPattern;
+  goodDayThemes: string[];
+  tone: SoulTone;
+  dailyRitual: SoulDailyRitual;
+}
 export type RecurrenceType =
   | "none"
   | "daily"
@@ -120,6 +148,8 @@ export interface Todo {
   blockedReason?: string | null;
   effortScore?: number | null;
   confidenceScore?: number | null;
+  firstStep?: string | null;
+  emotionalState?: TodoEmotionalState | null;
   sourceText?: string | null;
   areaId?: string | null;
   goalId?: string | null;
@@ -189,6 +219,8 @@ export interface CreateTodoDto {
   blockedReason?: string | null;
   effortScore?: number | null;
   confidenceScore?: number | null;
+  firstStep?: string | null;
+  emotionalState?: TodoEmotionalState | null;
   sourceText?: string | null;
   areaId?: string | null;
   goalId?: string | null;
@@ -223,6 +255,8 @@ export interface UpdateTodoDto {
   blockedReason?: string | null;
   effortScore?: number | null;
   confidenceScore?: number | null;
+  firstStep?: string | null;
+  emotionalState?: TodoEmotionalState | null;
   sourceText?: string | null;
   areaId?: string | null;
   goalId?: string | null;
@@ -333,6 +367,7 @@ export interface UserPlanningPreferencesDto {
   preferredContexts: string[];
   waitingFollowUpDays: number;
   workWindowsJson?: unknown;
+  soulProfile?: SoulProfileDto;
 }
 
 export interface CreateCaptureItemDto {

--- a/src/types/plannerTypes.ts
+++ b/src/types/plannerTypes.ts
@@ -105,6 +105,22 @@ export interface WeeklyReviewAction extends PlannerRecommendation {
   createdTaskId?: string;
 }
 
+export interface WeeklyReviewRolloverGroup {
+  key: "do" | "defer" | "shrink" | "drop";
+  title: string;
+  items: Array<{
+    taskId: string;
+    title: string;
+    reason: string;
+  }>;
+}
+
+export interface WeeklyReviewAnchorSuggestion {
+  taskId: string;
+  title: string;
+  reason: string;
+}
+
 export type WeeklyReviewFinding = PlannerFinding;
 
 export interface WeeklyReviewResult {
@@ -112,6 +128,10 @@ export interface WeeklyReviewResult {
   findings: WeeklyReviewFinding[];
   recommendedActions: WeeklyReviewAction[];
   appliedActions: WeeklyReviewAction[];
+  rolloverGroups: WeeklyReviewRolloverGroup[];
+  anchorSuggestions: WeeklyReviewAnchorSuggestion[];
+  behaviorAdjustment: string;
+  reflectionSummary?: string | null;
 }
 
 export interface DecideNextWorkInput {

--- a/src/validation/agentValidation.ts
+++ b/src/validation/agentValidation.ts
@@ -66,6 +66,8 @@ const TASK_FIELD_KEYS = [
   "blockedReason",
   "effortScore",
   "confidenceScore",
+  "firstStep",
+  "emotionalState",
 ];
 const LIST_TASK_KEYS = [
   "completed",
@@ -1885,6 +1887,7 @@ const VALID_DAY_MODES = [
   "office",
   "home",
   "overloaded",
+  "rescue",
   "sprint",
   "catch_up",
 ];

--- a/src/validation/constants.ts
+++ b/src/validation/constants.ts
@@ -7,6 +7,7 @@ import {
   SortOrder,
   TaskSource,
   TaskStatus,
+  TodoEmotionalState,
   TodoSortBy,
 } from "../types";
 
@@ -56,11 +57,20 @@ export const VALID_REVIEW_CADENCES: ReviewCadence[] = [
 
 export const VALID_TASK_SOURCES: TaskSource[] = [
   "manual",
+  "system_seed",
   "chat",
   "email",
   "import",
   "automation",
   "api",
+];
+
+export const VALID_TODO_EMOTIONAL_STATES: TodoEmotionalState[] = [
+  "avoiding",
+  "unclear",
+  "heavy",
+  "exciting",
+  "draining",
 ];
 
 export const VALID_RECURRENCE_TYPES: RecurrenceType[] = [

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -26,6 +26,7 @@ import {
   RunFeedbackAutomationRequestDto,
   TaskSource,
   TaskStatus,
+  TodoEmotionalState,
   TodoSortBy,
   SortOrder,
   UpdateFeedbackAutomationConfigDto,
@@ -44,6 +45,7 @@ import {
   VALID_SORT_ORDERS,
   VALID_TASK_SOURCES,
   VALID_TASK_STATUSES,
+  VALID_TODO_EMOTIONAL_STATES,
 } from "./constants";
 
 export class ValidationError extends Error {
@@ -251,6 +253,30 @@ function normalizeTaskSourceValue(
     throw new ValidationError(`${field} is invalid`);
   }
   return source;
+}
+
+function normalizeEmotionalStateValue(
+  value: unknown,
+  field: string,
+  allowNull: boolean,
+): TodoEmotionalState | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    if (!allowNull) {
+      throw new ValidationError(`${field} is required`);
+    }
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new ValidationError(`${field} is invalid`);
+  }
+  const emotionalState = value.toLowerCase() as TodoEmotionalState;
+  if (!VALID_TODO_EMOTIONAL_STATES.includes(emotionalState)) {
+    throw new ValidationError(`${field} is invalid`);
+  }
+  return emotionalState;
 }
 
 function normalizeStringList(
@@ -986,9 +1012,9 @@ export function validateCreateTodo(data: unknown): CreateTodoDto {
     true,
   );
   if (effortScore !== undefined && effortScore !== null) {
-    if (effortScore < 1 || effortScore > 5) {
+    if (effortScore < 1 || effortScore > 4) {
       throw new ValidationError(
-        "effortScore must be an integer between 1 and 5",
+        "effortScore must be an integer between 1 and 4",
       );
     }
   }
@@ -1070,6 +1096,12 @@ export function validateCreateTodo(data: unknown): CreateTodoDto {
     ),
     effortScore,
     confidenceScore,
+    firstStep: normalizeNullableString(body.firstStep, "firstStep", 255),
+    emotionalState: normalizeEmotionalStateValue(
+      body.emotionalState,
+      "emotionalState",
+      true,
+    ),
     sourceText: normalizeNullableString(body.sourceText, "sourceText", 100000),
     areaId,
     goalId,
@@ -1264,9 +1296,9 @@ export function validateUpdateTodo(data: unknown): UpdateTodoDto {
       true,
     );
     if (effortScore !== undefined && effortScore !== null) {
-      if (effortScore < 1 || effortScore > 5) {
+      if (effortScore < 1 || effortScore > 4) {
         throw new ValidationError(
-          "effortScore must be an integer between 1 and 5",
+          "effortScore must be an integer between 1 and 4",
         );
       }
     }
@@ -1294,6 +1326,22 @@ export function validateUpdateTodo(data: unknown): UpdateTodoDto {
       body.sourceText,
       "sourceText",
       100000,
+    );
+  }
+
+  if (body.firstStep !== undefined) {
+    update.firstStep = normalizeNullableString(
+      body.firstStep,
+      "firstStep",
+      255,
+    );
+  }
+
+  if (body.emotionalState !== undefined) {
+    update.emotionalState = normalizeEmotionalStateValue(
+      body.emotionalState,
+      "emotionalState",
+      true,
     );
   }
 

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -272,6 +272,41 @@ async function installHomeFocusMockApi(
       });
     }
 
+    if (pathname === "/preferences" && method === "GET") {
+      return json(route, 200, {
+        maxDailyTasks: null,
+        preferredChunkMinutes: null,
+        deepWorkPreference: null,
+        weekendsActive: true,
+        preferredContexts: [],
+        waitingFollowUpDays: 7,
+        workWindowsJson: null,
+        soulProfile: {
+          lifeAreas: ["work"],
+          failureModes: ["overwhelmed"],
+          planningStyle: "both",
+          energyPattern: "variable",
+          goodDayThemes: ["visible_progress"],
+          tone: "calm",
+          dailyRitual: "neither",
+        },
+      });
+    }
+
+    if (pathname === "/agent/write/set_day_context" && method === "POST") {
+      const body = await parseBody(route);
+      return json(route, 200, {
+        ok: true,
+        action: "set_day_context",
+        dayContext: {
+          contextDate: body.contextDate || nowIso().slice(0, 10),
+          mode: body.mode || "normal",
+          energy: body.energy || null,
+          notes: body.notes || null,
+        },
+      });
+    }
+
     if (pathname === "/projects" && method === "GET") {
       return json(route, 200, []);
     }
@@ -298,6 +333,10 @@ async function installHomeFocusMockApi(
         order: list.length,
         priority: (body.priority as string) || "medium",
         notes: body.notes ?? null,
+        firstStep: body.firstStep ?? null,
+        emotionalState: body.emotionalState ?? null,
+        effortScore:
+          typeof body.effortScore === "number" ? body.effortScore : null,
         userId,
         createdAt: nowIso(),
         updatedAt: nowIso(),
@@ -788,6 +827,29 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await expect(page.locator("#inlineQuickAdd")).toBeVisible();
     await expect(page.locator('[data-testid="home-dashboard"]')).toHaveCount(0);
     await expect(page.locator("#aiWorkspace")).toBeHidden();
+  });
+
+  test("Home shows rescue mode affordance and can switch the day into rescue mode", async ({
+    page,
+  }) => {
+    await clickWorkspaceView(page, "home");
+    await expect(
+      page.locator('[data-testid="home-rescue-panel"]'),
+    ).toBeVisible();
+
+    const requestPromise = page.waitForRequest(
+      (request) =>
+        request.url().endsWith("/agent/write/set_day_context") &&
+        request.method() === "POST",
+    );
+    await page.getByRole("button", { name: "Start rescue mode" }).click();
+    const request = await requestPromise;
+    const payload = JSON.parse(request.postData() || "{}");
+
+    expect(payload.mode).toBe("rescue");
+    await expect(
+      page.locator('[data-testid="home-rescue-panel"]'),
+    ).toContainText("Rescue mode is on");
   });
 
   test("Today and Upcoming still navigate on the planner surface", async ({

--- a/tests/ui/project-crud.spec.ts
+++ b/tests/ui/project-crud.spec.ts
@@ -534,7 +534,7 @@ test.describe("Project actions drawer", () => {
       .click();
 
     await selectWorkspaceView(page, "all", isMobile);
-    await expect(page.locator(".todo-item")).not.toContainText("Home task");
+    await expect(page.getByText("Home task")).toHaveCount(0);
   });
 
   test("mobile uses the same project edit surface as a bottom sheet", async ({

--- a/tests/ui/todo-drawer-edit.spec.ts
+++ b/tests/ui/todo-drawer-edit.spec.ts
@@ -18,6 +18,9 @@ type TodoSeed = {
   tags?: string[];
   context?: string | null;
   energy?: string | null;
+  effortScore?: number | null;
+  emotionalState?: string | null;
+  firstStep?: string | null;
   estimateMinutes?: number | null;
   waitingOn?: string | null;
   dependsOnTaskIds?: string[];
@@ -170,6 +173,10 @@ async function installDrawerEditMockApi(
         tags: Array.isArray(body.tags) ? body.tags : [],
         context: body.context ?? null,
         energy: body.energy ?? null,
+        effortScore:
+          typeof body.effortScore === "number" ? body.effortScore : null,
+        emotionalState: body.emotionalState ?? null,
+        firstStep: body.firstStep ?? null,
         estimateMinutes:
           typeof body.estimateMinutes === "number"
             ? body.estimateMinutes
@@ -421,6 +428,9 @@ test.describe("Todo drawer essentials editing", () => {
         tags: [],
         context: null,
         energy: null,
+        effortScore: null,
+        emotionalState: null,
+        firstStep: null,
         estimateMinutes: null,
         waitingOn: null,
         dependsOnTaskIds: [],
@@ -437,10 +447,14 @@ test.describe("Todo drawer essentials editing", () => {
     await page.locator("#drawerReviewDateInput").fill("2026-05-04T08:00");
     await page.locator("#drawerContextInput").fill("@computer");
     await page.locator("#drawerContextInput").blur();
+    await page.locator("#drawerEffortSelect").selectOption("3");
     await page.locator("#drawerEnergySelect").selectOption("medium");
     await page.locator("#drawerEstimateInput").fill("45");
     await page.locator("#drawerDetailsToggle").click();
     await expect(page.locator("#drawerDetailsPanel")).toBeVisible();
+    await page.locator("#drawerFirstStepInput").fill("Email the vendor");
+    await page.locator("#drawerFirstStepInput").blur();
+    await page.locator("#drawerEmotionalStateSelect").selectOption("heavy");
     await page.locator("#drawerTagsInput").fill("travel, planning");
     await page.locator("#drawerTagsInput").blur();
     await page.locator("#drawerWaitingOnInput").fill("Vendor quote");
@@ -464,6 +478,25 @@ test.describe("Todo drawer essentials editing", () => {
           (entry) =>
             entry.patch.startDate ===
             toIsoFromLocalDateTime("2026-05-01T09:00"),
+        ),
+      )
+      .toBeTruthy();
+    await expect
+      .poll(() =>
+        state.updatePatches.some((entry) => entry.patch.effortScore === 3),
+      )
+      .toBeTruthy();
+    await expect
+      .poll(() =>
+        state.updatePatches.some(
+          (entry) => entry.patch.firstStep === "Email the vendor",
+        ),
+      )
+      .toBeTruthy();
+    await expect
+      .poll(() =>
+        state.updatePatches.some(
+          (entry) => entry.patch.emotionalState === "heavy",
         ),
       )
       .toBeTruthy();
@@ -549,7 +582,12 @@ test.describe("Todo drawer essentials editing", () => {
     await page.locator("#todoScheduledDateInput").fill("2026-05-31T10:00");
     await page.locator("#todoReviewDateInput").fill("2026-06-02T08:30");
     await page.locator("#todoContextInput").fill("@computer");
+    await page.locator("#todoEffortSelect").selectOption("2");
     await page.locator("#todoEnergySelect").selectOption("low");
+    await page.locator("#todoEmotionalStateSelect").selectOption("exciting");
+    await page
+      .locator("#todoFirstStepInput")
+      .fill("Price three flight options");
     await page.locator("#todoEstimateInput").fill("30");
     await page.locator("#todoTagsInput").fill("travel, planning");
     await page.locator("#todoWaitingOnInput").fill("Budget approval");
@@ -572,7 +610,10 @@ test.describe("Todo drawer essentials editing", () => {
       status: "scheduled",
       category: "Work",
       context: "@computer",
+      effortScore: 2,
       energy: "low",
+      emotionalState: "exciting",
+      firstStep: "Price three flight options",
       estimateMinutes: 30,
       waitingOn: "Budget approval",
       notes: "Need options ready",


### PR DESCRIPTION
## Summary

This PR ships a constrained Soul MVP for the todos app. The goal is to make the product feel calmer, more humane, and more recovery-oriented without rewriting the underlying task engine or introducing a broad new planning system.

For users, this changes the tone and behavior of the app in a few specific places that matter most: onboarding now asks how they work and what kind of support they need, task creation and editing can capture a small amount of felt complexity, Home and Today now offer gentler recovery flows for rolled-over work, Rescue mode can shrink a heavy day, and weekly review becomes more reflective instead of sounding like cleanup drudgery.

## Problem

The app had already moved toward a calmer workspace shell, but the experience still behaved like a productivity system that mostly understood tasks as rows, dates, and filters. It was missing a lightweight layer that could reflect real working patterns such as overwhelm, unclear tasks, energy limits, and the need to recover after plans drift.

That gap showed up in three places for users:

1. Onboarding configured the app but did not help users feel understood.
2. Task and planning surfaces did not have enough language or metadata to support recovery-oriented recommendations.
3. Review and rollover moments could still feel mechanical or punitive even when the UI was visually calmer.

## Root cause

The main issue was not one broken screen. The product lacked a shared soul-oriented model and copy layer that could be reused across onboarding, task flows, Home, Today, settings, and weekly review. Without that shared layer, the app could look calmer while still sounding and behaving like a standard task tool.

## What changed

On the backend, this PR adds the smallest viable set of new persisted data and response shape changes:

- `UserPlanningPreferences` now supports additive `soulProfile` JSON with defaults and partial patch merging.
- `Todo` now supports `firstStep` and `emotionalState`.
- `system_seed` is supported for onboarding-seeded tasks.
- `UserDayContext.mode` now supports `rescue`.
- Weekly review responses now include additive soul-review outputs such as `rolloverGroups`, `anchorSuggestions`, `behaviorAdjustment`, and optional `reflectionSummary`.
- Validation, planner services, agent validation, and the MCP/agent manifest were updated so the new fields are first-class and backward-compatible.

On the frontend, the PR introduces a shared soul configuration and copy layer, then wires it through the key user journeys:

- onboarding was rebuilt into a 4-step soul-aware flow
- settings gained a persistent "How this app supports you" preferences editor
- quick entry and drawer editing now support `Effort`, `Energy`, `Emotional state`, and `First step` in the disclosed metadata path
- Home and Today now use gentler copy and provide recovery actions for rolled-over work
- Rescue mode can be entered manually or suggested heuristically from heavy-day signals
- weekly review now renders a reflective summary, rollover groups, anchor suggestions, and one behavior adjustment

The styling work supports those behaviors and also fixes a mobile interaction issue discovered during validation: the floating New Task CTA was colliding with row kebab actions near the bottom of the list. The final fix moved the mobile CTA out of the row-action lane and raised the row action stack so drawer and destructive flows remain reachable.

## User impact

After this change, the app should feel more understanding without becoming heavier:

- new users are asked about life areas, failure modes, planning style, tone, rituals, and what a good day means
- they can land with seeded example tasks that reflect their context, without forced due dates
- existing users can add nuance to tasks when it helps, but can still capture tasks quickly with the compact default flow
- rolled-over work is framed as something to recover from, not something to feel punished by
- overloaded days can be intentionally shrunk through Rescue mode
- weekly review ends with a smaller focus set and one concrete adjustment instead of just more backlog pressure

## Scope boundaries kept intact

This stays within the MVP boundaries:

- no new core task status taxonomy
- no AI coaching requirement
- no new dashboard surface
- no `whyItMatters`, `timeConfidence`, or `recoveryState` schema yet
- no separate Rescue workspace
- no new recommendation engine beyond lightweight heuristics layered on existing planning behavior

## Validation

The change was validated with the required checks:

- `npx tsc --noEmit`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit -- --runInBand`
- `CI=1 npm run test:ui:fast`

The UI tests were also extended to cover the new Soul MVP behavior, including onboarding/preferences persistence, richer task metadata flows, rescue-mode affordances, and the calmer Home/Today treatment.
