### PR TITLE
feat(ui): dead CSS removal + color token sweep — Final Mile PR 4+5

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -16,6 +16,7 @@ html {
   --danger: #e05260;
   --danger-2: #c94855;
   --success: #2f9e6a;
+  --warning: #d97706;
   --overlay: rgb(15 23 42 / 55%);
   --scrim: rgb(15 23 42 / 35%);
 
@@ -129,6 +130,7 @@ body.dark-mode {
   --danger: #ff7f8a;
   --danger-2: #ef6f7b;
   --success: #5ecf9f;
+  --warning: #fbbf24;
   --overlay: rgb(2 6 23 / 72%);
   --scrim: rgb(2 6 23 / 50%);
   --ring-color: color-mix(in oklab, var(--accent) 50%, transparent);
@@ -1240,19 +1242,6 @@ textarea:focus-visible,
   box-shadow: var(--focus-ring);
 }
 
-.btn {
-  width: 100%;
-  padding: var(--s-3) var(--s-5);
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
-  color: white;
-  border: none;
-  border-radius: var(--r-sm);
-  font-size: var(--fs-md);
-  font-weight: var(--fw-semibold);
-  cursor: pointer;
-  transition: transform var(--dur-fast);
-}
-
 .btn:hover {
   transform: translateY(-2px);
 }
@@ -1327,9 +1316,9 @@ textarea:focus-visible,
 }
 
 .message.warning {
-  background: rgb(201 137 0 / 12%);
-  color: #c98900;
-  border: 1px solid rgb(201 137 0 / 24%);
+  background: color-mix(in oklab, var(--warning) 12%, transparent);
+  color: var(--warning);
+  border: 1px solid color-mix(in oklab, var(--warning) 24%, transparent);
 }
 
 .add-todo {
@@ -1527,8 +1516,8 @@ textarea:focus-visible,
 }
 
 .ai-badge--med {
-  color: #9a6b00;
-  border-color: rgb(214 143 0 / 40%);
+  color: var(--warning);
+  border-color: color-mix(in oklab, var(--warning) 40%, transparent);
   background: rgb(214 143 0 / 10%);
 }
 
@@ -2046,7 +2035,7 @@ textarea:focus-visible,
   margin-top: 6px;
   margin-bottom: 4px;
   font-size: var(--fs-body);
-  color: #b45309;
+  color: var(--warning);
 }
 
 .plan-draft-actions-top,
@@ -2215,7 +2204,7 @@ textarea:focus-visible,
 }
 
 .todo-item.todo-item--active {
-  border: 2px solid #667eea;
+  border: 2px solid var(--accent);
 }
 
 .todo-item.dragging {
@@ -4762,13 +4751,13 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .admin-feedback-pill--bug {
-  background: rgb(203 72 57 / 12%);
-  color: #9c2f20;
+  background: color-mix(in oklab, var(--danger) 12%, transparent);
+  color: var(--danger);
 }
 
 .admin-feedback-pill--feature {
-  background: rgb(44 136 104 / 12%);
-  color: #15654b;
+  background: color-mix(in oklab, var(--success) 12%, transparent);
+  color: var(--success);
 }
 
 .admin-feedback-pill--general,
@@ -4981,8 +4970,8 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .role-badge.admin {
-  background: rgb(201 137 0 / 14%);
-  color: #8f6300;
+  background: color-mix(in oklab, var(--warning) 14%, transparent);
+  color: var(--warning);
 }
 
 .role-badge.user {
@@ -5004,7 +4993,7 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .action-btn.promote {
-  background: #ffc107;
+  background: var(--warning);
   color: #000;
 }
 
@@ -5119,12 +5108,12 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .priority-btn.medium {
-  border-color: #c98900;
-  color: #c98900;
+  border-color: var(--warning);
+  color: var(--warning);
 }
 
 .priority-btn.medium.active {
-  background: #c98900;
+  background: var(--warning);
   color: white;
 }
 
@@ -5154,7 +5143,7 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .priority-badge.medium {
-  background: #c98900;
+  background: var(--warning);
   color: white;
 }
 
@@ -5283,21 +5272,6 @@ body.is-todos-view .floating-new-task-cta {
   border-radius: var(--r-sm);
   background: var(--input-bg);
   color: var(--text-primary);
-}
-
-.mini-btn {
-  padding: 6px 10px;
-  border: none;
-  border-radius: var(--r-sm);
-  background: var(--surface-3);
-  color: #fff;
-  cursor: pointer;
-  font-size: var(--fs-meta);
-  font-weight: 600;
-}
-
-.mini-btn:hover {
-  opacity: 0.9;
 }
 
 .modal-overlay {
@@ -5469,11 +5443,11 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .todo-drawer__save-status[data-state="saving"] {
-  color: #0369a1;
+  color: var(--accent);
 }
 
 .todo-drawer__save-status[data-state="saved"] {
-  color: #15803d;
+  color: var(--success);
 }
 
 .todo-drawer__save-status[data-state="error"] {
@@ -5510,7 +5484,7 @@ body.is-todos-view .floating-new-task-cta {
 .todo-drawer__field textarea:focus,
 .todo-drawer__field select:focus {
   outline: none;
-  border-color: #667eea;
+  border-color: var(--accent);
 }
 
 .todo-drawer__field--inline {
@@ -5670,7 +5644,7 @@ body.is-todos-view .floating-new-task-cta {
 
 .todo-drawer__agent-error {
   font-size: var(--fs-meta);
-  color: var(--danger-color, #dc2626);
+  color: var(--danger);
   margin-bottom: 6px;
 }
 
@@ -5847,7 +5821,7 @@ body.is-drawer-open {
 }
 
 .add-subtask-btn:hover {
-  background: #5568d3;
+  background: var(--accent-2);
 }
 
 .expand-section {
@@ -5866,7 +5840,7 @@ body.is-drawer-open {
 }
 
 .expand-section:hover {
-  color: #5568d3;
+  color: var(--accent);
 }
 
 .expand-icon {
@@ -5949,7 +5923,7 @@ body.is-bulk-selecting .todo-item {
 
 .todo-item:hover {
   background: var(--surface);
-  border-color: #c7d4e4;
+  border-color: var(--border);
   box-shadow: var(--shadow-1);
 }
 
@@ -6024,39 +5998,39 @@ body.is-bulk-selecting .todo-item {
 }
 
 .todo-chip--project {
-  background: rgba(79, 110, 247, 0.08);
-  border-color: rgba(79, 110, 247, 0.28);
-  color: #2f4db7;
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 28%, transparent);
+  color: var(--accent);
 }
 
 .todo-chip--priority.low {
-  background: rgba(47, 158, 106, 0.12);
-  border-color: rgba(47, 158, 106, 0.34);
-  color: #256f4d;
+  background: color-mix(in oklab, var(--success) 12%, transparent);
+  border-color: color-mix(in oklab, var(--success) 34%, transparent);
+  color: var(--success);
 }
 
 .todo-chip--priority.medium {
-  background: rgba(220, 156, 15, 0.12);
-  border-color: rgba(220, 156, 15, 0.34);
-  color: #855f03;
+  background: color-mix(in oklab, var(--warning) 12%, transparent);
+  border-color: color-mix(in oklab, var(--warning) 34%, transparent);
+  color: var(--warning);
 }
 
 .todo-chip--priority.high {
-  background: rgba(224, 82, 96, 0.12);
-  border-color: rgba(224, 82, 96, 0.34);
-  color: #a5303f;
+  background: color-mix(in oklab, var(--danger) 12%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 34%, transparent);
+  color: var(--danger);
 }
 
 .todo-chip--due {
-  background: rgba(73, 119, 232, 0.07);
-  border-color: rgba(73, 119, 232, 0.24);
-  color: #355ec4;
+  background: color-mix(in oklab, var(--accent) 7%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 24%, transparent);
+  color: var(--accent);
 }
 
 .todo-chip--due-overdue {
-  background: rgba(224, 82, 96, 0.14);
-  border-color: rgba(224, 82, 96, 0.36);
-  color: #9f2534;
+  background: color-mix(in oklab, var(--danger) 14%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 36%, transparent);
+  color: var(--danger);
 }
 
 .priority-badge {
@@ -6086,49 +6060,43 @@ body.is-bulk-selecting .todo-item {
 }
 
 body.dark-mode .todo-item:hover {
-  border-color: #3d516f;
+  border-color: var(--border);
 }
 
 body.dark-mode .todo-chip {
-  background: #1d2a3c;
-  border-color: #33465f;
+  background: var(--surface-2);
+  border-color: var(--border);
   color: var(--text-secondary);
 }
 
 body.dark-mode .todo-chip--project {
-  background: rgba(137, 164, 255, 0.13);
-  border-color: rgba(137, 164, 255, 0.34);
-  color: #c3d2ff;
+  background: color-mix(in oklab, var(--accent) 13%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 34%, transparent);
 }
 
 body.dark-mode .todo-chip--priority.low {
-  background: rgba(94, 207, 159, 0.18);
-  border-color: rgba(94, 207, 159, 0.38);
-  color: #b8f0d9;
+  background: color-mix(in oklab, var(--success) 18%, transparent);
+  border-color: color-mix(in oklab, var(--success) 38%, transparent);
 }
 
 body.dark-mode .todo-chip--priority.medium {
-  background: rgba(244, 186, 54, 0.18);
-  border-color: rgba(244, 186, 54, 0.36);
-  color: #ffe1a3;
+  background: color-mix(in oklab, var(--warning) 18%, transparent);
+  border-color: color-mix(in oklab, var(--warning) 36%, transparent);
 }
 
 body.dark-mode .todo-chip--priority.high {
-  background: rgba(255, 127, 138, 0.2);
-  border-color: rgba(255, 127, 138, 0.4);
-  color: #ffd0d6;
+  background: color-mix(in oklab, var(--danger) 20%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 40%, transparent);
 }
 
 body.dark-mode .todo-chip--due {
-  background: rgba(137, 164, 255, 0.14);
-  border-color: rgba(137, 164, 255, 0.34);
-  color: #ccd8ff;
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 34%, transparent);
 }
 
 body.dark-mode .todo-chip--due-overdue {
-  background: rgba(255, 127, 138, 0.2);
-  border-color: rgba(255, 127, 138, 0.42);
-  color: #ffd6dc;
+  background: color-mix(in oklab, var(--danger) 20%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 42%, transparent);
 }
 
 .todo-item.completed .todo-chip {
@@ -7220,24 +7188,24 @@ body.is-todos-view .projects-rail-item__count {
   display: block;
 }
 .urgent {
-  background: #fcebeb;
-  border: 0.5px solid #f09595;
+  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  border: 0.5px solid color-mix(in oklab, var(--danger) 40%, transparent);
   border-radius: var(--border-radius-md);
   padding: 0.6rem 1rem;
   font-size: 13px;
-  color: #791f1f;
+  color: var(--danger);
   margin-bottom: 0.75rem;
   display: flex;
   gap: 10px;
   align-items: flex-start;
 }
 .warn {
-  background: #faeeda;
-  border: 0.5px solid #ef9f27;
+  background: color-mix(in oklab, var(--warning) 14%, var(--surface));
+  border: 0.5px solid var(--warning);
   border-radius: var(--border-radius-md);
   padding: 0.6rem 1rem;
   font-size: 13px;
-  color: #854f0b;
+  color: var(--warning);
   margin-bottom: 0.6rem;
   display: flex;
   gap: 10px;
@@ -7251,10 +7219,10 @@ body.is-todos-view .projects-rail-item__count {
   margin-top: 4px;
 }
 .dot-lg.r {
-  background: #a32d2d;
+  background: var(--danger);
 }
 .dot-lg.a {
-  background: #ba7517;
+  background: var(--warning);
 }
 .track {
   display: grid;
@@ -7270,16 +7238,16 @@ body.is-todos-view .projects-rail-item__count {
   text-align: center;
 }
 .col-head.now {
-  background: #faeeda;
-  color: #7a4e00;
+  background: color-mix(in oklab, var(--warning) 14%, var(--surface));
+  color: var(--warning);
 }
 .col-head.soon {
-  background: #e6f1fb;
-  color: #1246a0;
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface));
+  color: var(--accent);
 }
 .col-head.after {
-  background: #f1efe8;
-  color: #5f5e5a;
+  background: var(--surface-2);
+  color: var(--muted);
 }
 .col-body {
   background: var(--color-background-primary);
@@ -7309,19 +7277,19 @@ body.is-todos-view .projects-rail-item__count {
   margin-top: 5px;
 }
 .dot.r {
-  background: #a32d2d;
+  background: var(--danger);
 }
 .dot.a {
-  background: #ba7517;
+  background: var(--warning);
 }
 .dot.g {
-  background: #1d9e75;
+  background: var(--success);
 }
 .dot.b {
-  background: #185fa5;
+  background: var(--accent);
 }
 .dot.p {
-  background: #534ab7;
+  background: var(--accent-2);
 }
 .card {
   background: var(--color-background-primary);
@@ -7504,9 +7472,9 @@ body.is-todos-view .projects-rail-item__count {
 }
 
 .home-task-row__badge--overdue {
-  color: #b91c1c;
-  background: color-mix(in oklab, #ef4444 10%, var(--surface));
-  border-color: color-mix(in oklab, #ef4444 30%, var(--border-color));
+  color: var(--danger);
+  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  border-color: color-mix(in oklab, var(--danger) 30%, var(--border-color));
 }
 
 .home-task-row__project {
@@ -7925,8 +7893,8 @@ body.is-todos-view .priority-btn.low.active {
 }
 
 body.is-todos-view .priority-btn.medium.active {
-  border-color: #c98900;
-  background: color-mix(in oklab, #c98900 90%, black 8%);
+  border-color: var(--warning);
+  background: color-mix(in oklab, var(--warning) 90%, black 8%);
 }
 
 body.is-todos-view .priority-btn.high.active {
@@ -9039,7 +9007,7 @@ body.is-admin-user .projects-rail__footer--admin-only {
 }
 
 .inbox-view__error {
-  color: var(--danger-color, #dc2626);
+  color: var(--danger);
 }
 
 /* ── Day Plan Agent panel ───────────────────────────────────────────────── */
@@ -9109,7 +9077,7 @@ body.is-admin-user .projects-rail__footer--admin-only {
 }
 
 .day-plan-agent__error {
-  color: var(--danger-color, #dc2626);
+  color: var(--danger);
 }
 
 .day-plan-agent__totals {
@@ -9303,7 +9271,7 @@ body.is-admin-user .projects-rail__footer--admin-only {
 
 .wr-error {
   font-size: var(--fs-meta);
-  color: var(--danger-color, #dc2626);
+  color: var(--danger);
   margin-bottom: 8px;
 }
 
@@ -9406,7 +9374,7 @@ body.is-admin-user .projects-rail__footer--admin-only {
 
 .cleanup-error {
   font-size: var(--fs-meta);
-  color: var(--danger-color, #dc2626);
+  color: var(--danger);
   margin-bottom: 8px;
 }
 


### PR DESCRIPTION
## Summary

- Remove duplicate `.btn` and `.mini-btn` definitions (superseded by M7 design system)
- Add `--warning` token (`#d97706` light / `#fbbf24` dark)
- Replace 62 hardcoded hex colors with semantic tokens (`--accent`, `--success`, `--danger`, `--warning`)
- Convert chip, badge, banner, and dot components to use `color-mix()` with tokens
- Dark-mode chip overrides now derive from tokens instead of hardcoded pastels
- Hardcoded color count: 113 → 51 (remaining are brand colors, contrast whites, and fallbacks)

## Test plan

- [x] `npx tsc --noEmit` — pass
- [x] `npm run format:check` — pass
- [x] `npm run lint:html` — pass
- [x] `npm run lint:css` — pass
- [x] `npm run test:unit` — 300/300 pass
- [x] `CI=1 npm run test:ui:fast` — 217/217 pass
- [ ] Visual QA: verify chip colors, priority badges, warning messages, banners in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)