### PR TITLE
feat(oauth): add Google sign-in to MCP OAuth authorization pages

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -295,6 +295,8 @@ export function createApp(
       authService,
       mcpOAuthService,
       mcpClientService,
+      googleAuthService,
+      socialAuthService,
     }),
   );
 

--- a/src/mcp/mcpOAuthPages.ts
+++ b/src/mcp/mcpOAuthPages.ts
@@ -19,6 +19,17 @@ function renderHiddenFields(fields: Record<string, string | undefined>) {
     .join("");
 }
 
+function renderGoogleButton(url: string, label: string) {
+  return `<a href="${escapeHtml(url)}" style="display:flex;align-items:center;justify-content:center;gap:10px;padding:12px 18px;border:1px solid #cbd5e1;border-radius:999px;text-decoration:none;color:#111827;font-weight:600;background:white;">
+  <svg width="18" height="18" viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59a14.5 14.5 0 0 1 0-9.18l-7.98-6.19a24.0 24.0 0 0 0 0 21.56l7.98-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/></svg>
+  ${escapeHtml(label)}
+</a>`;
+}
+
+function renderDivider() {
+  return `<div style="display:flex;align-items:center;gap:12px;margin:16px 0;"><hr style="flex:1;border:none;border-top:1px solid #e5e7eb;"><span style="color:#6b7280;font-size:0.875rem;">or</span><hr style="flex:1;border:none;border-top:1px solid #e5e7eb;"></div>`;
+}
+
 function renderPageShell(title: string, body: string, headExtra?: string) {
   return `<!doctype html>
 <html lang="en">
@@ -146,6 +157,7 @@ export function renderOAuthLoginPage(input: {
   hiddenFields: Record<string, string | undefined>;
   clientName?: string;
   registerUrl?: string;
+  googleUrl?: string;
 }) {
   const clientCopy = input.clientName
     ? `Sign in to connect <strong>${escapeHtml(input.clientName)}</strong> to your Todos account.`
@@ -155,6 +167,8 @@ export function renderOAuthLoginPage(input: {
     `<h1>Connect Assistant</h1>
      <p>${clientCopy}</p>
      ${input.error ? `<div class="error">${escapeHtml(input.error)}</div>` : ""}
+     ${input.googleUrl ? renderGoogleButton(input.googleUrl, "Sign in with Google") : ""}
+     ${input.googleUrl ? renderDivider() : ""}
      <form method="post" action="${escapeHtml(input.formAction)}">
        ${renderHiddenFields(input.hiddenFields)}
        <label>
@@ -179,6 +193,7 @@ export function renderOAuthRegisterPage(input: {
   hiddenFields: Record<string, string | undefined>;
   clientName?: string;
   loginUrl?: string;
+  googleUrl?: string;
 }) {
   const clientCopy = input.clientName
     ? `Create an account to connect <strong>${escapeHtml(input.clientName)}</strong> to Todos.`
@@ -188,6 +203,8 @@ export function renderOAuthRegisterPage(input: {
     `<h1>Create Account</h1>
      <p>${clientCopy}</p>
      ${input.error ? `<div class="error">${escapeHtml(input.error)}</div>` : ""}
+     ${input.googleUrl ? renderGoogleButton(input.googleUrl, "Sign up with Google") : ""}
+     ${input.googleUrl ? renderDivider() : ""}
      <form method="post" action="${escapeHtml(input.formAction)}">
        ${renderHiddenFields(input.hiddenFields)}
        <label>

--- a/src/mcpPublicRouter.test.ts
+++ b/src/mcpPublicRouter.test.ts
@@ -589,4 +589,99 @@ describe("Public MCP OAuth and discovery routes", () => {
 
     expect(response.headers["content-type"]).toContain("text/event-stream");
   });
+
+  describe("MCP OAuth Google sign-in", () => {
+    it("returns 501 for google/start when Google login is not configured", async () => {
+      const register = await request(app)
+        .post("/oauth/register")
+        .send({
+          redirect_uris: ["https://chat.openai.com/aip/callback"],
+          client_name: "ChatGPT",
+        })
+        .expect(201);
+
+      const pkce = createPkcePair(
+        "oauth-verifier-google-start-1111111111111111111111111111",
+      );
+      const response = await request(app)
+        .get(
+          `/oauth/authorize/google/start?client_id=${encodeURIComponent(
+            register.body.client_id,
+          )}&redirect_uri=${encodeURIComponent(
+            "https://chat.openai.com/aip/callback",
+          )}&response_type=code&scope=tasks.read&state=s1&code_challenge=${encodeURIComponent(
+            pkce.challenge,
+          )}&code_challenge_method=S256`,
+        )
+        .expect(501);
+
+      expect(response.text).toContain("Google Login Not Available");
+    });
+
+    it("returns 501 for google/callback when Google login is not configured", async () => {
+      const response = await request(app)
+        .get("/oauth/authorize/google/callback?code=abc&state=xyz")
+        .expect(501);
+
+      expect(response.text).toContain("Google Login Not Available");
+    });
+
+    it("does not show Google button on login page when Google is disabled", async () => {
+      const register = await request(app)
+        .post("/oauth/register")
+        .send({
+          redirect_uris: ["https://chat.openai.com/aip/callback"],
+          client_name: "ChatGPT",
+        })
+        .expect(201);
+
+      const pkce = createPkcePair(
+        "oauth-verifier-no-google-btn-1111111111111111111111111111",
+      );
+      const response = await request(app)
+        .get(
+          `/oauth/authorize?client_id=${encodeURIComponent(
+            register.body.client_id,
+          )}&redirect_uri=${encodeURIComponent(
+            "https://chat.openai.com/aip/callback",
+          )}&response_type=code&scope=tasks.read&state=s2&code_challenge=${encodeURIComponent(
+            pkce.challenge,
+          )}&code_challenge_method=S256`,
+        )
+        .expect(200);
+
+      expect(response.text).toContain("Connect Assistant");
+      expect(response.text).not.toContain("Sign in with Google");
+      expect(response.text).not.toContain("google/start");
+    });
+
+    it("does not show Google button on register page when Google is disabled", async () => {
+      const register = await request(app)
+        .post("/oauth/register")
+        .send({
+          redirect_uris: ["https://chat.openai.com/aip/callback"],
+          client_name: "ChatGPT",
+        })
+        .expect(201);
+
+      const pkce = createPkcePair(
+        "oauth-verifier-no-google-reg-1111111111111111111111111111",
+      );
+      const response = await request(app)
+        .get(
+          `/oauth/authorize/register?client_id=${encodeURIComponent(
+            register.body.client_id,
+          )}&redirect_uri=${encodeURIComponent(
+            "https://chat.openai.com/aip/callback",
+          )}&response_type=code&scope=tasks.read&state=s3&code_challenge=${encodeURIComponent(
+            pkce.challenge,
+          )}&code_challenge_method=S256`,
+        )
+        .expect(200);
+
+      expect(response.text).toContain("Create Account");
+      expect(response.text).not.toContain("Sign up with Google");
+      expect(response.text).not.toContain("google/start");
+    });
+  });
 });

--- a/src/routes/mcpPublicRouter.ts
+++ b/src/routes/mcpPublicRouter.ts
@@ -19,11 +19,15 @@ import {
 } from "../validation/mcpValidation";
 import { config } from "../config";
 import { validateRegister } from "../validation/authValidation";
+import { GoogleAuthService } from "../services/googleAuthService";
+import { SocialAuthService } from "../services/socialAuthService";
 
 interface McpPublicRouterDeps {
   authService?: AuthService;
   mcpOAuthService: McpOAuthService;
   mcpClientService: McpClientService;
+  googleAuthService?: GoogleAuthService;
+  socialAuthService?: SocialAuthService;
 }
 
 interface LinkSession {
@@ -184,6 +188,9 @@ function logMcpOauthEvent(input: {
     | "signup_view"
     | "signup_success"
     | "signup_error"
+    | "google_start"
+    | "google_callback_success"
+    | "google_callback_error"
     | "approve_success"
     | "approve_error"
     | "deny"
@@ -416,10 +423,19 @@ function mapAuthorizeError(message: string): {
   }
 }
 
+const MCP_GOOGLE_STATE_COOKIE = "mcp_google_state";
+const MCP_GOOGLE_PARAMS_COOKIE = "mcp_google_params";
+
+function buildMcpGoogleRedirectUri(): string {
+  return `${config.baseUrl}/oauth/authorize/google/callback`;
+}
+
 export function createMcpPublicRouter({
   authService,
   mcpOAuthService,
   mcpClientService,
+  googleAuthService,
+  socialAuthService,
 }: McpPublicRouterDeps): Router {
   const router = Router();
 
@@ -557,23 +573,26 @@ export function createMcpPublicRouter({
           clientName: client.clientName,
           scopes: authorize.scopes,
         });
-        const registerUrl = `/oauth/authorize/register?${buildAuthorizeSearchParams(
-          {
-            clientId: authorize.clientId,
-            redirectUri: authorize.redirectUri,
-            responseType: authorize.responseType,
-            scope: describeMcpScopes(authorize.scopes),
-            state: authorize.state,
-            codeChallenge: authorize.codeChallenge,
-            codeChallengeMethod: authorize.codeChallengeMethod,
-          },
-        )}`;
+        const authorizeSearchParams = buildAuthorizeSearchParams({
+          clientId: authorize.clientId,
+          redirectUri: authorize.redirectUri,
+          responseType: authorize.responseType,
+          scope: describeMcpScopes(authorize.scopes),
+          state: authorize.state,
+          codeChallenge: authorize.codeChallenge,
+          codeChallengeMethod: authorize.codeChallengeMethod,
+        });
+        const registerUrl = `/oauth/authorize/register?${authorizeSearchParams}`;
+        const googleUrl = googleAuthService
+          ? `/oauth/authorize/google/start?${authorizeSearchParams}`
+          : undefined;
         return res.status(200).send(
           renderOAuthLoginPage({
             formAction: "/oauth/authorize/login",
             hiddenFields,
             clientName: client.clientName,
             registerUrl,
+            googleUrl,
           }),
         );
       }
@@ -760,7 +779,7 @@ export function createMcpPublicRouter({
         code_challenge_method: authorize.codeChallengeMethod,
       };
 
-      const loginUrl = `/oauth/authorize?${buildAuthorizeSearchParams({
+      const regAuthorizeSearchParams = buildAuthorizeSearchParams({
         clientId: authorize.clientId,
         redirectUri: authorize.redirectUri,
         responseType: authorize.responseType,
@@ -768,7 +787,11 @@ export function createMcpPublicRouter({
         state: authorize.state,
         codeChallenge: authorize.codeChallenge,
         codeChallengeMethod: authorize.codeChallengeMethod,
-      })}`;
+      });
+      const loginUrl = `/oauth/authorize?${regAuthorizeSearchParams}`;
+      const googleRegUrl = googleAuthService
+        ? `/oauth/authorize/google/start?${regAuthorizeSearchParams}`
+        : undefined;
 
       logMcpOauthEvent({
         requestId,
@@ -784,6 +807,7 @@ export function createMcpPublicRouter({
           hiddenFields,
           clientName: client.clientName,
           loginUrl,
+          googleUrl: googleRegUrl,
         }),
       );
     } catch (error) {
@@ -900,6 +924,262 @@ export function createMcpPublicRouter({
       logMcpOauthEvent({
         requestId,
         event: "signup_error",
+        errorCode: mapped.code,
+      });
+      res.status(400).send(
+        renderOAuthErrorPage({
+          title: mapped.title,
+          message: mapped.description,
+        }),
+      );
+    }
+  });
+
+  // ── Google OAuth flow for MCP authorize ─────────────────────────────
+
+  router.get("/oauth/authorize/google/start", async (req, res) => {
+    const requestId = buildRequestId(req);
+    setRequestId(res, requestId);
+    setNoStoreHeaders(res);
+
+    try {
+      if (!googleAuthService || !authService) {
+        return res.status(501).send(
+          renderOAuthErrorPage({
+            title: "Google Login Not Available",
+            message: "Google login is not configured on this server.",
+          }),
+        );
+      }
+
+      const authorize = validateOAuthAuthorizeRequest(req.query);
+      mcpClientService.assertRedirectUri(
+        authorize.clientId,
+        authorize.redirectUri,
+      );
+
+      const mcpGoogleRedirectUri = buildMcpGoogleRedirectUri();
+      const { url, state } =
+        googleAuthService.generateAuthUrl(mcpGoogleRedirectUri);
+
+      // Store the Google CSRF state in a cookie
+      const cookies: string[] = [];
+      cookies.push(
+        serializeCookie(MCP_GOOGLE_STATE_COOKIE, state, {
+          maxAgeSeconds: 600,
+        }),
+      );
+
+      // Store the MCP OAuth params so we can resume after Google callback
+      const oauthParams = JSON.stringify({
+        client_id: authorize.clientId,
+        redirect_uri: authorize.redirectUri,
+        response_type: authorize.responseType,
+        scope: describeMcpScopes(authorize.scopes),
+        state: authorize.state,
+        code_challenge: authorize.codeChallenge,
+        code_challenge_method: authorize.codeChallengeMethod,
+      });
+      cookies.push(
+        serializeCookie(MCP_GOOGLE_PARAMS_COOKIE, oauthParams, {
+          maxAgeSeconds: 600,
+        }),
+      );
+
+      res.setHeader("Set-Cookie", cookies);
+
+      logMcpOauthEvent({
+        requestId,
+        event: "google_start",
+        clientId: authorize.clientId,
+      });
+
+      res.redirect(url);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      const mapped = mapAuthorizeError(message);
+      logMcpOauthEvent({
+        requestId,
+        event: "google_callback_error",
+        errorCode: mapped.code,
+      });
+      res.status(400).send(
+        renderOAuthErrorPage({
+          title: mapped.title,
+          message: mapped.description,
+        }),
+      );
+    }
+  });
+
+  router.get("/oauth/authorize/google/callback", async (req, res) => {
+    const requestId = buildRequestId(req);
+    setRequestId(res, requestId);
+    setNoStoreHeaders(res);
+
+    try {
+      if (!googleAuthService || !socialAuthService || !authService) {
+        return res.status(501).send(
+          renderOAuthErrorPage({
+            title: "Google Login Not Available",
+            message: "Google login is not configured on this server.",
+          }),
+        );
+      }
+
+      const cookies = readCookies(req);
+
+      // Validate CSRF state
+      const queryState = req.query.state as string | undefined;
+      const storedState = cookies[MCP_GOOGLE_STATE_COOKIE];
+      if (!queryState || !storedState || queryState !== storedState) {
+        return res.status(400).send(
+          renderOAuthErrorPage({
+            title: "Invalid State",
+            message: "OAuth state mismatch. Please try again.",
+            hint: "Return to the assistant and restart the connection flow.",
+          }),
+        );
+      }
+
+      // Recover MCP OAuth params
+      const rawParams = cookies[MCP_GOOGLE_PARAMS_COOKIE];
+      if (!rawParams) {
+        return res.status(400).send(
+          renderOAuthErrorPage({
+            title: "Session Expired",
+            message:
+              "The authorization session could not be recovered. Please try again.",
+            hint: "Return to the assistant and restart the connection flow.",
+          }),
+        );
+      }
+
+      let oauthParams: Record<string, string>;
+      try {
+        oauthParams = JSON.parse(rawParams);
+      } catch {
+        return res.status(400).send(
+          renderOAuthErrorPage({
+            title: "Invalid Session",
+            message: "The authorization session data is corrupted.",
+            hint: "Return to the assistant and restart the connection flow.",
+          }),
+        );
+      }
+
+      // Clear Google cookies
+      const clearCookies: string[] = [
+        serializeCookie(MCP_GOOGLE_STATE_COOKIE, "", {
+          expires: new Date(0).toUTCString(),
+          maxAgeSeconds: 0,
+        }),
+        serializeCookie(MCP_GOOGLE_PARAMS_COOKIE, "", {
+          expires: new Date(0).toUTCString(),
+          maxAgeSeconds: 0,
+        }),
+      ];
+
+      // Check for Google error
+      if (req.query.error) {
+        res.setHeader("Set-Cookie", clearCookies);
+        return res.status(400).send(
+          renderOAuthErrorPage({
+            title: "Google Login Failed",
+            message: "Google sign-in was cancelled or failed.",
+            hint: "Return to the assistant and try again.",
+          }),
+        );
+      }
+
+      const code = req.query.code as string | undefined;
+      if (!code) {
+        res.setHeader("Set-Cookie", clearCookies);
+        return res.status(400).send(
+          renderOAuthErrorPage({
+            title: "Missing Code",
+            message: "Google did not return an authorization code.",
+            hint: "Return to the assistant and try again.",
+          }),
+        );
+      }
+
+      // Validate MCP OAuth params
+      const authorize = validateOAuthAuthorizeRequest(oauthParams);
+      const client = mcpClientService.assertRedirectUri(
+        authorize.clientId,
+        authorize.redirectUri,
+      );
+
+      // Exchange Google code for user profile
+      const mcpGoogleRedirectUri = buildMcpGoogleRedirectUri();
+      const profile = await googleAuthService.handleCallback(
+        code,
+        mcpGoogleRedirectUri,
+      );
+
+      // Find or create user via social auth service
+      const socialResult = await socialAuthService.findOrCreateSocialUser(
+        profile,
+        (userId, email) => authService!.issueTokens(userId, email),
+      );
+
+      // Issue MCP authorization code directly (implicit consent for Google sign-in)
+      const authCode = await mcpOAuthService.createAuthorizationCode({
+        userId: socialResult.user.id,
+        email: socialResult.user.email || profile.email || "",
+        clientId: authorize.clientId,
+        redirectUri: authorize.redirectUri,
+        scopes: authorize.scopes,
+        assistantName: client.clientName,
+        state: authorize.state,
+        codeChallenge: authorize.codeChallenge,
+        codeChallengeMethod: authorize.codeChallengeMethod,
+      });
+
+      logMcpOauthEvent({
+        requestId,
+        event: "google_callback_success",
+        userId: socialResult.user.id,
+        clientId: authorize.clientId,
+        clientName: client.clientName,
+        scopes: authorize.scopes,
+      });
+
+      const finalRedirectUri = appendQuery(authorize.redirectUri, {
+        code: authCode.code,
+        state: authorize.state,
+      });
+      const nonce = randomBytes(16).toString("base64");
+      res
+        .status(303)
+        .setHeader("Location", finalRedirectUri)
+        .setHeader(
+          "Content-Security-Policy",
+          `default-src 'self'; script-src 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`,
+        );
+
+      // Append clear cookies to any existing Set-Cookie headers
+      const existingCookies = res.getHeader("Set-Cookie");
+      const allCookies = [
+        ...(Array.isArray(existingCookies)
+          ? existingCookies
+          : existingCookies
+            ? [String(existingCookies)]
+            : []),
+        ...clearCookies,
+      ];
+      res.setHeader("Set-Cookie", allCookies);
+
+      res.send(
+        renderOAuthRedirectPage({ redirectUri: finalRedirectUri, nonce }),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      const mapped = mapAuthorizeError(message);
+      logMcpOauthEvent({
+        requestId,
+        event: "google_callback_error",
         errorCode: mapped.code,
       });
       res.status(400).send(

--- a/src/services/googleAuthService.ts
+++ b/src/services/googleAuthService.ts
@@ -17,14 +17,16 @@ export class GoogleAuthService {
   /**
    * Generate the Google OAuth consent URL with a cryptographic state param.
    * Returns { url, state } so the caller can persist state for CSRF validation.
+   * An optional redirectUri overrides the default callback URL (e.g. for MCP OAuth).
    */
-  generateAuthUrl(): { url: string; state: string } {
+  generateAuthUrl(redirectUri?: string): { url: string; state: string } {
     const state = randomBytes(32).toString("hex");
     const url = this.client.generateAuthUrl({
       access_type: "offline",
       scope: ["openid", "email", "profile"],
       state,
       prompt: "select_account",
+      ...(redirectUri ? { redirect_uri: redirectUri } : {}),
     });
     return { url, state };
   }
@@ -32,15 +34,26 @@ export class GoogleAuthService {
   /**
    * Exchange the authorization code for tokens, verify the ID token,
    * and return a normalized SocialUserProfile.
+   * An optional redirectUri must match the one used in generateAuthUrl.
    */
-  async handleCallback(code: string): Promise<SocialUserProfile> {
-    const { tokens } = await this.client.getToken(code);
+  async handleCallback(
+    code: string,
+    redirectUri?: string,
+  ): Promise<SocialUserProfile> {
+    const client = redirectUri
+      ? new OAuth2Client(
+          config.googleClientId,
+          config.googleClientSecret,
+          redirectUri,
+        )
+      : this.client;
+    const { tokens } = await client.getToken(code);
 
     if (!tokens.id_token) {
       throw new Error("Google did not return an ID token");
     }
 
-    const ticket = await this.client.verifyIdToken({
+    const ticket = await client.verifyIdToken({
       idToken: tokens.id_token,
       audience: config.googleClientId,
     });


### PR DESCRIPTION
## Summary

- Add Google sign-in/sign-up buttons to MCP OAuth login and register pages (shown only when `GOOGLE_LOGIN_ENABLED=true`)
- Add `GET /oauth/authorize/google/start` endpoint that stores MCP OAuth params in cookies and redirects to Google consent screen
- Add `GET /oauth/authorize/google/callback` endpoint that exchanges Google auth code, finds/creates user via SocialAuthService, issues MCP authorization code, and redirects to the client
- Extend `GoogleAuthService` to accept optional `redirectUri` for MCP's distinct callback URL
- Add 4 unit tests covering disabled-state guards and page rendering

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Prettier formatting passes
- [x] HTML and CSS linting passes
- [x] All 304 unit tests pass (including 4 new Google OAuth tests)
- [ ] Manual: enable `GOOGLE_LOGIN_ENABLED=true` and verify Google button appears on `/oauth/authorize` login page
- [ ] Manual: complete Google sign-in flow through MCP OAuth and verify authorization code is issued

https://claude.ai/code/session_0161CCtqkk9V4zSXDebvYUwm