### PR TITLE
feat(ui): profile hub dropdown — consolidate dock icons into one menu

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1032,6 +1032,11 @@ function toggleProfilePanel() {
     if (emailEl instanceof HTMLElement) {
       emailEl.textContent = state.currentUser?.email ?? "";
     }
+    // Sync theme label
+    var isDark = document.body.classList.contains("dark-mode");
+    var themeLabel = panel.querySelector(".dock-theme-label");
+    if (themeLabel)
+      themeLabel.textContent = isDark ? "Light mode" : "Dark mode";
     panel.hidden = false;
     state.isProfilePanelOpen = true;
     DialogManager.open("profilePanel", panel, {
@@ -1333,6 +1338,17 @@ window.setSelectedProjectKey = setSelectedProjectKey;
 // Views / navigation
 window.switchView = switchView;
 window.toggleProfilePanel = toggleProfilePanel;
+window.profileNavTo = function profileNavTo(view) {
+  closeProfilePanel({ restoreFocus: false });
+  switchView(view);
+};
+window.profileToggleTheme = function profileToggleTheme() {
+  ThemeModule.toggleTheme();
+  // Update the label inside the panel
+  var isDark = document.body.classList.contains("dark-mode");
+  var label = document.querySelector(".dock-theme-label");
+  if (label) label.textContent = isDark ? "Light mode" : "Dark mode";
+};
 window.logout = logout;
 window.handleFeedbackTypeChange = handleFeedbackTypeChange;
 window.handleFeedbackAttachmentChange = handleFeedbackAttachmentChange;

--- a/client/index.html
+++ b/client/index.html
@@ -3575,138 +3575,19 @@
     >
       <div class="dock__group dock__group--left">
         <button
-          type="button"
-          class="dock-icon-btn"
-          data-onclick="switchView('settings', this)"
-          aria-label="Settings"
-          title="Settings"
-        >
-          <svg
-            class="dock-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path
-              d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
-            />
-            <circle cx="12" cy="12" r="3" />
-          </svg>
-          <span class="dock-icon-btn__label">Settings</span>
-        </button>
-        <button
-          type="button"
-          class="dock-icon-btn"
-          data-onclick="switchView('feedback', this)"
-          aria-label="Feedback"
-          title="Feedback"
-        >
-          <svg
-            class="dock-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path
-              d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-            />
-          </svg>
-          <span class="dock-icon-btn__label">Feedback</span>
-        </button>
-        <button
-          type="button"
-          class="dock-icon-btn dock-admin-btn"
-          data-onclick="switchView('admin', this)"
-          aria-label="Admin"
-          title="Admin"
-        >
-          <svg
-            class="dock-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-          </svg>
-          <span class="dock-icon-btn__label">Admin</span>
-        </button>
-        <button
-          type="button"
-          class="dock-icon-btn"
-          data-onclick="toggleTheme()"
-          aria-label="Toggle dark mode"
-          title="Toggle dark mode"
-        >
-          <svg
-            class="dock-icon dock-icon--moon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
-          </svg>
-          <svg
-            class="dock-icon dock-icon--sun"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="12" cy="12" r="4" />
-            <path
-              d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
-            />
-          </svg>
-          <span class="dock-icon-btn__label">Theme</span>
-        </button>
-        <button
           id="dockProfileBtn"
           type="button"
           class="dock-icon-btn"
           data-onclick="toggleProfilePanel()"
-          aria-label="Profile"
+          aria-label="Profile menu"
           aria-haspopup="true"
-          title="Profile"
+          title="Profile menu"
         >
           <svg
             class="dock-icon"
             xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
+            width="18"
+            height="18"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -3719,7 +3600,6 @@
             <circle cx="12" cy="10" r="3" />
             <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662" />
           </svg>
-          <span class="dock-icon-btn__label">Profile</span>
         </button>
       </div>
       <div class="dock__group dock__group--right">
@@ -3779,21 +3659,150 @@
       </div>
     </div>
 
-    <!-- Profile panel (anchored above dock Profile button) -->
+    <!-- Profile hub menu (anchored above dock Profile button) -->
     <div
       id="dockProfilePanel"
       class="dock-profile-panel"
       hidden
-      role="dialog"
-      aria-label="Profile"
+      role="menu"
+      aria-label="Profile menu"
     >
       <span id="dockProfileEmail" class="dock-profile-panel__email"></span>
+      <div class="dock-profile-panel__divider"></div>
       <button
         type="button"
-        class="dock-profile-panel__logout"
-        data-onclick="logout()"
-        aria-label="Logout"
+        class="dock-profile-panel__item"
+        role="menuitem"
+        data-onclick="profileNavTo('settings')"
       >
+        <svg
+          class="app-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path
+            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+          />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        Settings
+      </button>
+      <button
+        type="button"
+        class="dock-profile-panel__item"
+        role="menuitem"
+        data-onclick="profileNavTo('feedback')"
+      >
+        <svg
+          class="app-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path
+            d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+          />
+        </svg>
+        Feedback
+      </button>
+      <button
+        type="button"
+        class="dock-profile-panel__item dock-admin-btn"
+        role="menuitem"
+        data-onclick="profileNavTo('admin')"
+      >
+        <svg
+          class="app-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+        Admin
+      </button>
+      <div class="dock-profile-panel__divider"></div>
+      <button
+        type="button"
+        class="dock-profile-panel__item"
+        role="menuitem"
+        data-onclick="profileToggleTheme()"
+      >
+        <svg
+          class="app-icon dock-icon--moon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+        </svg>
+        <svg
+          class="app-icon dock-icon--sun"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path
+            d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"
+          />
+        </svg>
+        <span class="dock-theme-label">Dark mode</span>
+      </button>
+      <div class="dock-profile-panel__divider"></div>
+      <button
+        type="button"
+        class="dock-profile-panel__item dock-profile-panel__item--danger"
+        role="menuitem"
+        data-onclick="logout()"
+      >
+        <svg
+          class="app-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+          <polyline points="16 17 21 12 16 7" />
+          <line x1="21" y1="12" x2="9" y2="12" />
+        </svg>
         Logout
       </button>
     </div>

--- a/client/styles.css
+++ b/client/styles.css
@@ -8919,53 +8919,69 @@ body.is-admin-user .projects-rail__footer--admin-only {
   background: var(--surface);
   border: 1px solid var(--border-color);
   border-radius: var(--r-md);
-  box-shadow:
-    0 4px 12px rgb(0 0 0 / 8%),
-    0 1px 4px rgb(0 0 0 / 5%);
-  padding: var(--s-3);
+  box-shadow: var(--shadow-elevated);
+  padding: var(--s-2);
   display: flex;
   flex-direction: column;
-  gap: var(--s-2);
+  gap: 0;
 }
 
-/* Author CSS overrides UA [hidden]{display:none} — restore it explicitly. */
 .dock-profile-panel[hidden] {
   display: none;
 }
 
 .dock-profile-panel__email {
   display: block;
-  padding: 2px var(--s-2);
-  font-size: var(--fs-sm);
-  color: var(--muted);
+  padding: var(--s-2) var(--s-2);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.dock-profile-panel__logout {
+.dock-profile-panel__divider {
+  height: 1px;
+  background: var(--border-color);
+  margin: var(--s-1) 0;
+}
+
+.dock-profile-panel__item {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
   width: 100%;
-  padding: 6px var(--s-2);
+  padding: var(--s-2);
   text-align: left;
   background: transparent;
   border: none;
   border-radius: var(--r-sm);
   color: var(--text-secondary);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-body);
   cursor: pointer;
   transition:
-    background 0.12s ease,
-    color 0.12s ease;
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
 }
 
-.dock-profile-panel__logout:hover {
+.dock-profile-panel__item:hover {
   background: var(--card-hover);
   color: var(--text);
 }
 
-.dock-profile-panel__logout:focus-visible {
+.dock-profile-panel__item:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
+}
+
+.dock-profile-panel__item--danger {
+  color: var(--danger);
+}
+
+.dock-profile-panel__item--danger:hover {
+  background: color-mix(in oklab, var(--danger) 8%, var(--surface));
+  color: var(--danger);
 }
 
 .todo-drawer__agent-hint {

--- a/tests/ui/app-smoke.spec.ts
+++ b/tests/ui/app-smoke.spec.ts
@@ -14,7 +14,11 @@ async function clickLogout(page: Page) {
   if (await profileBtn.isVisible()) {
     await profileBtn.click();
   }
-  await page.getByRole("button", { name: "Logout" }).click();
+  // Logout is a menuitem in the profile hub on desktop, a button on mobile.
+  await page
+    .getByRole("menuitem", { name: "Logout" })
+    .or(page.getByRole("button", { name: "Logout" }))
+    .click();
 }
 
 type UserRecord = {

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -874,14 +874,19 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await expect(page.locator("#todosListHeaderDateBadge")).toBeHidden();
   });
 
-  test("Desktop dock shows visible utility labels", async ({ page }) => {
-    test.skip(isMobileViewport(page), "Dock labels are desktop-only.");
+  test("Desktop dock profile hub contains nav items", async ({ page }) => {
+    test.skip(isMobileViewport(page), "Dock is desktop-only.");
 
-    const dock = page.locator("#bottomActionDock .dock__group--left");
-    await expect(dock).toContainText("Settings");
-    await expect(dock).toContainText("Feedback");
-    await expect(dock).toContainText("Theme");
-    await expect(dock).toContainText("Profile");
+    // Open profile hub dropdown
+    const profileBtn = page.locator("#dockProfileBtn");
+    await expect(profileBtn).toBeVisible();
+    await profileBtn.click();
+
+    const panel = page.locator("#dockProfilePanel");
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Settings");
+    await expect(panel).toContainText("Feedback");
+    await expect(panel).toContainText("Logout");
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace 5 dock icon buttons (Settings, Feedback, Admin, Theme, Profile) with a single Profile avatar button
- Profile dropdown becomes the hub: email, nav links (Settings/Feedback/Admin), theme toggle, logout
- Fixes dock overflow: 5 labeled buttons (322px min) exceeded sidebar width (272px)
- Admin link only visible to admin users (same `dock-admin-btn` CSS rule)
- Theme toggle shows dynamic label ("Dark mode" / "Light mode")
- Logout styled as danger item with log-out icon

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint:html` — pass
- [x] `npm run lint:css` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npm run test:unit` — 301/304 pass (3 pre-existing MCP OAuth failures on master)
- [x] `CI=1 npm run test:ui:fast` — 220/220 pass
- [ ] Visual QA: click profile button, verify all menu items work, verify theme toggle updates label

🤖 Generated with [Claude Code](https://claude.com/claude-code)