### PR TITLE
feat(ui): remove bottom dock — floating FAB + sidebar profile hub

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -880,6 +880,31 @@
                           <path d="M9 3v18" />
                         </svg>
                       </button>
+                      <button
+                        id="dockProfileBtn"
+                        type="button"
+                        class="rail-profile-btn"
+                        data-onclick="toggleProfilePanel()"
+                        aria-label="Profile menu"
+                        aria-haspopup="true"
+                        title="Profile menu"
+                      >
+                        <svg
+                          class="app-icon"
+                          width="16"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <circle cx="12" cy="8" r="4" />
+                          <path d="M6 20a6 6 0 0 1 12 0" />
+                        </svg>
+                      </button>
                     </div>
                     <div class="rail-search-container" id="railSearchContainer">
                       <div class="search-bar">
@@ -1241,6 +1266,30 @@
                         <span class="projects-rail__section-label"
                           >Projects</span
                         >
+                        <button
+                          id="railNewProjectBtn"
+                          type="button"
+                          class="projects-rail__add-btn"
+                          data-onclick="createProject()"
+                          aria-label="New project"
+                          title="New project"
+                        >
+                          <svg
+                            class="app-icon"
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <line x1="12" y1="5" x2="12" y2="19" />
+                            <line x1="5" y1="12" x2="19" y2="12" />
+                          </svg>
+                        </button>
                       </div>
                       <div id="projectsRailList" class="projects-rail__list">
                         <!-- Populated by JS — no placeholder needed -->
@@ -3566,98 +3615,7 @@
       </main>
     </div>
 
-    <!-- Bottom Action Dock -->
-    <div
-      id="bottomActionDock"
-      class="bottom-action-dock"
-      role="toolbar"
-      aria-label="Global actions"
-    >
-      <div class="dock__group dock__group--left">
-        <button
-          id="dockProfileBtn"
-          type="button"
-          class="dock-icon-btn"
-          data-onclick="toggleProfilePanel()"
-          aria-label="Profile menu"
-          aria-haspopup="true"
-          title="Profile menu"
-        >
-          <svg
-            class="dock-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <circle cx="12" cy="10" r="3" />
-            <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662" />
-          </svg>
-        </button>
-      </div>
-      <div class="dock__group dock__group--right">
-        <button
-          id="dockNewProjectBtn"
-          type="button"
-          class="dock-action-btn dock-action-btn--secondary"
-          data-onclick="createProject()"
-          aria-label="New project"
-        >
-          <svg
-            class="dock-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <path
-              d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
-            />
-            <line x1="12" y1="11" x2="12" y2="17" />
-            <line x1="9" y1="14" x2="15" y2="14" />
-          </svg>
-          New Project
-        </button>
-        <button
-          type="button"
-          class="dock-action-btn dock-action-btn--primary"
-          data-onclick="openTaskComposer()"
-          aria-label="New task"
-        >
-          <svg
-            class="dock-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="8" x2="12" y2="16" />
-            <line x1="8" y1="12" x2="16" y2="12" />
-          </svg>
-          New Task
-        </button>
-      </div>
-    </div>
+    <!-- Bottom dock removed — profile hub lives in sidebar, New Task is a floating FAB -->
 
     <!-- Profile hub menu (anchored above dock Profile button) -->
     <div

--- a/client/modules/projectsState.js
+++ b/client/modules/projectsState.js
@@ -761,7 +761,7 @@ function closeProjectCrudModal({ restoreFocus = true } = {}) {
     if (lastProjectCrudOpener?.isConnected) {
       lastProjectCrudOpener.focus({ preventScroll: true });
     } else {
-      const fallback = document.getElementById("dockNewProjectBtn");
+      const fallback = document.getElementById("railNewProjectBtn");
       if (fallback instanceof HTMLElement) {
         fallback.focus({ preventScroll: true });
       }

--- a/client/styles.css
+++ b/client/styles.css
@@ -2883,8 +2883,37 @@ body.dark-mode .delete-btn {
 .projects-rail__header {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: var(--s-2);
+}
+
+.rail-profile-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.rail-profile-btn:hover {
+  background: var(--card-hover);
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.rail-profile-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .projects-rail__primary,
@@ -2945,6 +2974,33 @@ body.is-admin-user .dock-admin-btn {
   color: var(--text-secondary);
   font-size: var(--fs-sm);
   font-weight: var(--fw-medium);
+}
+
+.projects-rail__add-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.projects-rail__add-btn:hover {
+  background: var(--card-hover);
+  color: var(--text);
+}
+
+.projects-rail__add-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .projects-rail-create-btn {
@@ -3336,10 +3392,11 @@ button.projects-rail-item {
   }
 }
 
-/* Floating New Task CTA hidden on desktop — the dashboard hero button serves that role */
+/* Floating New Task CTA — visible on all viewports in todos view */
 @media (min-width: 769px) {
   .floating-new-task-cta {
-    display: none !important;
+    right: 24px;
+    bottom: 24px;
   }
 }
 
@@ -6721,9 +6778,8 @@ textarea:disabled {
   }
 
   .floating-new-task-cta {
-    left: 12px;
-    right: auto;
-    bottom: 12px;
+    right: 16px;
+    bottom: 72px;
   }
 
   .todos-top-bar {
@@ -8888,16 +8944,15 @@ body.dark-mode .dock-icon--sun {
 }
 
 #todosScrollRegion {
-  padding-bottom: 88px;
+  padding-bottom: 72px;
 }
 
-body:has(.todo-kebab-menu--open) .floating-new-task-cta,
-body:has(.todo-kebab-menu--open) .bottom-action-dock {
+body:has(.todo-kebab-menu--open) .floating-new-task-cta {
   pointer-events: none;
 }
 
 #projectsRail {
-  padding-bottom: 88px;
+  padding-bottom: var(--s-5);
 }
 
 .projects-rail__footer--admin-only {
@@ -8912,8 +8967,8 @@ body.is-admin-user .projects-rail__footer--admin-only {
 
 .dock-profile-panel {
   position: fixed;
-  bottom: 76px;
-  left: var(--s-5);
+  top: 48px;
+  left: var(--s-3);
   z-index: 55;
   width: 220px;
   background: var(--surface);
@@ -9093,11 +9148,10 @@ body.is-admin-user .projects-rail__footer--admin-only {
     padding-top: 16px;
   }
 
-  /* 9. Fix floating CTA — anchor to bottom-right of viewport */
+  /* 9. Floating CTA — bottom-right on mobile */
   .floating-new-task-cta {
-    left: 20px;
-    right: auto;
-    bottom: 24px;
+    right: 16px;
+    bottom: 72px;
   }
 
   /* 10. Reduce card padding on mobile */

--- a/tests/ui/app-smoke.spec.ts
+++ b/tests/ui/app-smoke.spec.ts
@@ -11,14 +11,15 @@ import {
  */
 async function clickLogout(page: Page) {
   const profileBtn = page.locator("#dockProfileBtn");
-  if (await profileBtn.isVisible()) {
+  if (await profileBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+    await profileBtn.scrollIntoViewIfNeeded();
     await profileBtn.click();
+    // Logout is a menuitem in the profile hub dropdown.
+    await page.getByRole("menuitem", { name: "Logout" }).click();
+  } else {
+    // Mobile: direct logout button in header bar.
+    await page.getByRole("button", { name: "Logout" }).click();
   }
-  // Logout is a menuitem in the profile hub on desktop, a button on mobile.
-  await page
-    .getByRole("menuitem", { name: "Logout" })
-    .or(page.getByRole("button", { name: "Logout" }))
-    .click();
 }
 
 type UserRecord = {

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -874,11 +874,12 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await expect(page.locator("#todosListHeaderDateBadge")).toBeHidden();
   });
 
-  test("Desktop dock profile hub contains nav items", async ({ page }) => {
-    test.skip(isMobileViewport(page), "Dock is desktop-only.");
+  test("Sidebar profile hub contains nav items", async ({ page }) => {
+    test.skip(isMobileViewport(page), "Sidebar is desktop-only.");
 
-    // Open profile hub dropdown
+    // Profile button is in the sidebar utility section — scroll into view
     const profileBtn = page.locator("#dockProfileBtn");
+    await profileBtn.scrollIntoViewIfNeeded();
     await expect(profileBtn).toBeVisible();
     await profileBtn.click();
 

--- a/tests/ui/layout-invariants.spec.ts
+++ b/tests/ui/layout-invariants.spec.ts
@@ -197,10 +197,10 @@ test.describe("Todos layout invariants", () => {
       await expect(rail).not.toHaveClass(/projects-rail--collapsed/);
     }
 
-    // Topbar hidden on desktop; floating CTA and shortcuts btn removed.
+    // Topbar hidden on desktop; shortcuts btn removed; floating CTA visible.
     await expect(page.locator(".todos-top-bar")).toBeHidden();
     await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
-    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
+    await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
     await expect(page.locator(".keyboard-shortcuts-btn")).toHaveCount(0);
 
     // Sidebar search must be accessible on desktop.

--- a/tests/ui/project-crud.spec.ts
+++ b/tests/ui/project-crud.spec.ts
@@ -445,7 +445,7 @@ test.describe("Project actions drawer", () => {
   }) => {
     test.skip(isMobile, "Desktop-focused CRUD rail interactions");
 
-    await page.locator("#dockNewProjectBtn").click();
+    await page.locator("#railNewProjectBtn").click();
     await expect(page.locator("#projectCrudModal")).toBeVisible();
     await page.locator("#projectCrudNameInput").fill("Errands");
     await page.locator("#projectCrudSubmitButton").click();
@@ -565,12 +565,12 @@ test.describe("Project actions drawer", () => {
   }) => {
     test.skip(isMobile, "Desktop-focused CRUD rail interactions");
 
-    await page.locator("#dockNewProjectBtn").click();
+    await page.locator("#railNewProjectBtn").click();
     await page.locator("#projectCrudNameInput").fill("Chores");
     await page.locator("#projectCrudSubmitButton").click();
     await expect(page.locator("#projectCrudModal")).toBeHidden();
 
-    await page.locator("#dockNewProjectBtn").click();
+    await page.locator("#railNewProjectBtn").click();
     await page.locator("#projectCrudNameInput").fill("Chores");
     await page.locator("#projectCrudSubmitButton").click();
 

--- a/tests/ui/topbar-no-cta-clipping.spec.ts
+++ b/tests/ui/topbar-no-cta-clipping.spec.ts
@@ -193,8 +193,8 @@ test.describe("Top bar and rail ellipsis hardening", () => {
       await expect(rail).not.toHaveClass(/projects-rail--collapsed/);
     }
 
-    // Floating CTA removed on desktop; search is now in the sidebar rail.
-    await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
+    // Floating CTA visible on desktop; search is in the sidebar rail.
+    await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
     await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
     const searchArea = page.locator("#railSearchContainer .search-bar");
     await expect(searchArea).toBeVisible();


### PR DESCRIPTION
## Summary

- Remove the fixed bottom action dock bar entirely
- **New Task:** floating pill FAB in bottom-right corner (now visible on all viewports)
- **Profile hub:** avatar button in sidebar rail header, opens dropdown with Settings/Feedback/Admin/Theme/Logout
- **New Project:** `+` button in the Projects section header of the sidebar rail
- Mobile FAB positioned at `bottom: 72px` to avoid overlapping row kebab buttons

## What changed

| Before | After |
|--------|-------|
| 68px fixed dock bar at bottom | No dock — clean layout edge-to-edge |
| New Task in dock button | Floating FAB pill (accent gradient) |
| Profile hub in dock | Avatar in sidebar header (always visible) |
| New Project in dock | `+` in Projects section header |
| Scroll padding 88px | 72px (just FAB clearance) |

## Test plan

- [x] `npm run format:check` — pass
- [x] `npm run lint:html` — pass
- [x] `npm run lint:css` — pass
- [x] `npx tsc --noEmit` — pass
- [x] `npm run test:unit` — 301/304 pass (3 pre-existing MCP OAuth failures)
- [x] `CI=1 npm run test:ui:fast` — 220/220 pass
- [ ] Visual QA: verify FAB position on desktop + mobile, profile dropdown opens from sidebar header, New Project + button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)