### PR TITLE
feat(ui): keyboard shortcut hint, project delete undo, drag settle animation

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1105,6 +1105,7 @@ function bindDockHandlers() {
   hooks.shouldUseServerVisibleTodos = shouldUseServerVisibleTodos;
   // todosService / filterLogic → projectsState
   hooks.loadProjects = loadProjects;
+  hooks.createProjectByName = createProjectByName;
   hooks.refreshProjectCatalog = refreshProjectCatalog;
   hooks.scheduleLoadSelectedProjectHeadings =
     scheduleLoadSelectedProjectHeadings;

--- a/client/index.html
+++ b/client/index.html
@@ -1408,6 +1408,40 @@
                           </svg>
                           <span class="projects-rail-item__label">Profile</span>
                         </button>
+                        <button
+                          type="button"
+                          class="projects-rail-item projects-rail-utility-item"
+                          data-onclick="toggleShortcuts()"
+                          title="Keyboard shortcuts (?)"
+                          aria-label="Keyboard shortcuts"
+                        >
+                          <svg
+                            class="nav-icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="15"
+                            height="15"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            aria-hidden="true"
+                          >
+                            <rect width="20" height="16" x="2" y="4" rx="2" />
+                            <path d="M6 8h.001" />
+                            <path d="M10 8h.001" />
+                            <path d="M14 8h.001" />
+                            <path d="M18 8h.001" />
+                            <path d="M8 12h.001" />
+                            <path d="M12 12h.001" />
+                            <path d="M16 12h.001" />
+                            <path d="M7 16h10" />
+                          </svg>
+                          <span class="projects-rail-item__label"
+                            >Shortcuts</span
+                          >
+                        </button>
                       </div>
                     </div>
                     <div
@@ -3899,20 +3933,16 @@
           <span class="shortcut-desc">Select All Todos</span>
           <kbd class="shortcut-key">Ctrl/Cmd + A</kbd>
         </div>
-        <div style="text-align: center; margin-top: 20px">
-          <button
-            data-onclick="toggleShortcuts()"
-            style="
-              padding: 10px 20px;
-              background: #667eea;
-              color: white;
-              border: none;
-              border-radius: 8px;
-              cursor: pointer;
-            "
-          >
-            Close
-          </button>
+        <div class="shortcut-item">
+          <span class="shortcut-desc">Command Palette</span>
+          <kbd class="shortcut-key">Ctrl/Cmd + K</kbd>
+        </div>
+        <div class="shortcut-item">
+          <span class="shortcut-desc">New Task (no modifier)</span>
+          <kbd class="shortcut-key">N</kbd>
+        </div>
+        <div style="text-align: center; margin-top: var(--s-4)">
+          <button class="btn" data-onclick="toggleShortcuts()">Close</button>
         </div>
       </div>
     </div>

--- a/client/modules/dragDrop.js
+++ b/client/modules/dragDrop.js
@@ -216,9 +216,24 @@ function handleDrop(e, rowElement = null) {
     const nextHeadingId = selectedProject
       ? String(targetTodo?.headingId || "")
       : null;
-    reorderTodos(state.draggedTodoId, dropTargetId, {
+    const movedId = state.draggedTodoId;
+    reorderTodos(movedId, dropTargetId, {
       nextHeadingId: selectedProject ? nextHeadingId || null : undefined,
       placement,
+    });
+    // Apply settle animation after DOM re-renders
+    requestAnimationFrame(() => {
+      const movedRow = document.querySelector(
+        `.todo-item[data-todo-id="${movedId}"]`,
+      );
+      if (movedRow instanceof HTMLElement) {
+        movedRow.classList.add("todo-item--settling");
+        movedRow.addEventListener(
+          "animationend",
+          () => movedRow.classList.remove("todo-item--settling"),
+          { once: true },
+        );
+      }
     });
   }
 }

--- a/client/modules/projectsState.js
+++ b/client/modules/projectsState.js
@@ -932,10 +932,10 @@ async function deleteProjectByName(
   EventBus.dispatch(TODOS_CHANGED, { reason: PROJECT_SELECTED });
   hooks.updateHeaderFromVisibleTodos?.(hooks.getVisibleTodos?.() ?? []);
 
-  hooks.showMessage?.(
-    "todosMessage",
+  hooks.addUndoAction?.(
+    "delete-project",
+    { name: normalized },
     `Deleted project "${normalized}"`,
-    "success",
   );
   return true;
 }

--- a/client/modules/todosService.js
+++ b/client/modules/todosService.js
@@ -953,6 +953,16 @@ function performUndo() {
           console.error("Failed to undo archive:", error);
         });
       break;
+    case "delete-project":
+      hooks
+        .createProjectByName?.(lastAction.data.name)
+        .then(() => {
+          EventBus.dispatch(TODOS_CHANGED, { reason: UNDO_APPLIED });
+        })
+        .catch((error) => {
+          console.error("Failed to undo project delete:", error);
+        });
+      break;
   }
 }
 

--- a/client/styles.css
+++ b/client/styles.css
@@ -2220,6 +2220,21 @@ textarea:focus-visible,
   border-top: 3px solid var(--accent);
 }
 
+@keyframes settle-in {
+  from {
+    opacity: 0.6;
+    transform: scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.todo-item--settling {
+  animation: settle-in var(--dur-base) var(--ease-spring);
+}
+
 .todo-item.todo-item--heading-drop-target {
   position: relative;
 }


### PR DESCRIPTION
## Summary

Three "world-class" polish gaps addressed:

### 1. Keyboard shortcut discoverability
- Keyboard icon button added to sidebar utility section (below Theme, above Profile)
- `Cmd+K` (command palette) and `N` (quick new task) added to shortcuts overlay
- Inline-styled Close button replaced with `.btn` class

### 2. Undo for project delete
- Project deletion now pushes `"delete-project"` action to undo stack with toast
- Undo re-creates the project by name via `createProjectByName`
- `hooks.createProjectByName` exposed for cross-module access

### 3. Drag-to-reorder settle animation
- `@keyframes settle-in` — scale 0.97→1 + opacity 0.6→1 with `--ease-spring`
- Applied to the moved row via `requestAnimationFrame` after DOM re-render
- Auto-removes `.todo-item--settling` on `animationend`

## Test plan

- [x] All lint/format/typecheck pass
- [x] `CI=1 npm run test:ui:fast` — 220/220 pass
- [ ] Visual QA: click Shortcuts in sidebar, verify overlay; delete project then undo; drag a todo and observe settle animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)