### PR TITLE
feat(ui): recurring tasks — drawer fields, completion advance, row badge

### DIFF
--- a/client/modules/drawerUi.js
+++ b/client/modules/drawerUi.js
@@ -398,6 +398,10 @@ export function initializeDrawerDraft(todo) {
     archived: !!todo.archived,
     source: String(todo.source || ""),
     completedAt: todo.completedAt ? String(todo.completedAt) : "",
+    recurrenceType: String(todo.recurrenceType || "none"),
+    recurrenceInterval: todo.recurrenceInterval
+      ? String(todo.recurrenceInterval)
+      : "1",
   };
 }
 
@@ -496,6 +500,12 @@ function syncDrawerDraftFromPatch(updatedTodo, patchKeys) {
         break;
       case "archived":
         d.archived = !!updatedTodo.archived;
+        break;
+      case "recurrence":
+        d.recurrenceType = String(updatedTodo.recurrenceType || "none");
+        d.recurrenceInterval = updatedTodo.recurrenceInterval
+          ? String(updatedTodo.recurrenceInterval)
+          : "1";
         break;
       default:
         break;
@@ -785,6 +795,29 @@ export function onDrawerReviewDateChange(event) {
   const value = String(event?.target?.value || "");
   updateDrawerDraftField("reviewDate", value);
   saveDrawerPatch({ reviewDate: toIsoFromDateTimeInput(value) });
+}
+
+export function onDrawerRecurrenceTypeChange(event) {
+  const value = String(event?.target?.value || "none");
+  updateDrawerDraftField("recurrenceType", value);
+  const recurrence =
+    value === "none"
+      ? null
+      : {
+          type: value,
+          interval: parseInt(state.drawerDraft?.recurrenceInterval || "1", 10),
+        };
+  saveDrawerPatch({ recurrence });
+}
+
+export function onDrawerRecurrenceIntervalChange(event) {
+  const value = String(event?.target?.value || "1");
+  updateDrawerDraftField("recurrenceInterval", value);
+  const recurrence = {
+    type: state.drawerDraft?.recurrenceType || "daily",
+    interval: parseInt(value, 10) || 1,
+  };
+  saveDrawerPatch({ recurrence });
 }
 
 export function onDrawerProjectChange(event) {
@@ -1309,6 +1342,26 @@ export function renderTodoDrawerContent() {
         <span>Review date</span>
         <input id="drawerReviewDateInput" type="datetime-local" value="${escapeHtml(draft.reviewDate)}" />
       </label>
+      <label class="todo-drawer__field" for="drawerRecurrenceType">
+        <span>Repeat</span>
+        <select id="drawerRecurrenceType">
+          <option value="none" ${draft.recurrenceType === "none" ? "selected" : ""}>None</option>
+          <option value="daily" ${draft.recurrenceType === "daily" ? "selected" : ""}>Daily</option>
+          <option value="weekly" ${draft.recurrenceType === "weekly" ? "selected" : ""}>Weekly</option>
+          <option value="monthly" ${draft.recurrenceType === "monthly" ? "selected" : ""}>Monthly</option>
+          <option value="yearly" ${draft.recurrenceType === "yearly" ? "selected" : ""}>Yearly</option>
+        </select>
+      </label>
+      ${
+        draft.recurrenceType !== "none"
+          ? `
+      <label class="todo-drawer__field" for="drawerRecurrenceInterval">
+        <span>Every</span>
+        <input id="drawerRecurrenceInterval" type="number" min="1" max="365" value="${escapeHtml(draft.recurrenceInterval)}" />
+      </label>
+      `
+          : ""
+      }
       <label class="todo-drawer__field" for="drawerProjectSelect">
         <span>Project</span>
         <select id="drawerProjectSelect">
@@ -2124,6 +2177,14 @@ export function bindTodoDrawerHandlers() {
     }
     if (target.id === "drawerReviewDateInput") {
       onDrawerReviewDateChange(event);
+      return;
+    }
+    if (target.id === "drawerRecurrenceType") {
+      onDrawerRecurrenceTypeChange(event);
+      return;
+    }
+    if (target.id === "drawerRecurrenceInterval") {
+      onDrawerRecurrenceIntervalChange(event);
       return;
     }
     if (target.id === "drawerProjectSelect") {

--- a/client/modules/taskDrawerAssist.js
+++ b/client/modules/taskDrawerAssist.js
@@ -454,7 +454,26 @@ function renderTodoChips(todo, { isOverdue, dueDateStr }) {
     );
   }
 
-  return chips.slice(0, 2).join("");
+  if (
+    todo.recurrenceType &&
+    todo.recurrenceType !== "none" &&
+    chips.length < 3
+  ) {
+    const units = {
+      daily: "day",
+      weekly: "week",
+      monthly: "month",
+      yearly: "year",
+    };
+    const n = todo.recurrenceInterval || 1;
+    const unit = units[todo.recurrenceType] || todo.recurrenceType;
+    const label = n === 1 ? `Every ${unit}` : `Every ${n} ${unit}s`;
+    chips.push(
+      `<span class="todo-chip todo-chip--recurrence" title="${hooks.escapeHtml(label)}"><svg class="app-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg> ${hooks.escapeHtml(label)}</span>`,
+    );
+  }
+
+  return chips.slice(0, 3).join("");
 }
 
 export {

--- a/client/modules/todosService.js
+++ b/client/modules/todosService.js
@@ -3,6 +3,7 @@
 // Imports state from store.js. Cross-module calls go through hooks.
 // =============================================================================
 import { state, hooks, createInitialHomeAiState } from "./store.js";
+import { computeNextOccurrence } from "../utils/recurrence.js";
 import { planTodayTaskIds } from "./planTodayAgent.js";
 import {
   hasTodoRow,
@@ -508,11 +509,35 @@ async function toggleTodo(id, forceValue = null) {
 
   const newCompletedValue = forceValue !== null ? forceValue : !todo.completed;
 
+  // Recurring task completion: advance to next occurrence instead of marking done
+  const isRecurring =
+    newCompletedValue && todo.recurrenceType && todo.recurrenceType !== "none";
+
+  let body;
+  if (isRecurring) {
+    const nextDate = computeNextOccurrence(
+      todo.recurrenceType,
+      todo.recurrenceInterval || 1,
+      todo.dueDate,
+    );
+    body = {
+      completed: false,
+      dueDate: nextDate ? nextDate.toISOString() : null,
+      recurrence: {
+        type: todo.recurrenceType,
+        interval: todo.recurrenceInterval || 1,
+        nextOccurrence: nextDate ? nextDate.toISOString() : null,
+      },
+    };
+  } else {
+    body = { completed: newCompletedValue };
+  }
+
   try {
     const response = await hooks.apiCall(`${hooks.API_URL}/todos/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ completed: newCompletedValue }),
+      body: JSON.stringify(body),
     });
 
     if (response && response.ok) {
@@ -535,7 +560,12 @@ async function toggleTodo(id, forceValue = null) {
         EventBus.dispatch(TODOS_CHANGED, { reason: TODO_TOGGLED });
       }
 
-      if (forceValue === null && newCompletedValue) {
+      if (isRecurring) {
+        const nextLabel = body.dueDate
+          ? new Date(body.dueDate).toLocaleDateString()
+          : "soon";
+        showUndoToast(`Done — next: ${nextLabel}`);
+      } else if (forceValue === null && newCompletedValue) {
         addUndoAction("complete", { id }, "Todo marked as complete");
       }
     }

--- a/client/styles.css
+++ b/client/styles.css
@@ -6280,6 +6280,12 @@ body.is-bulk-selecting .todo-item {
   color: var(--danger);
 }
 
+.todo-chip--recurrence {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 24%, transparent);
+  color: var(--accent);
+}
+
 .priority-badge {
   font-size: var(--fs-meta);
   font-weight: var(--fw-medium);

--- a/client/utils/recurrence.js
+++ b/client/utils/recurrence.js
@@ -1,0 +1,88 @@
+// =============================================================================
+// recurrence.js — Next-occurrence calculator for recurring tasks.
+// Pure date math, no side effects. Used by todosService and drawerUi.
+// =============================================================================
+
+/**
+ * Compute the next occurrence date for a recurring task.
+ *
+ * Anchors to the task's current due date (or today if none). For "every N
+ * weeks" this means the interval is measured from the due date, not from when
+ * the user clicks complete. This avoids drift and matches Things 3 behavior.
+ *
+ * Monthly edge case: if the day doesn't exist in the target month (e.g.,
+ * Jan 31 + 1 month = Feb 28/29), we clamp to the last day of the month.
+ *
+ * @param {string} recurrenceType  "daily" | "weekly" | "monthly" | "yearly"
+ * @param {number} interval        How many units between occurrences (default 1)
+ * @param {string|Date|null} currentDueDate  The task's current due date
+ * @returns {Date|null}  The next occurrence, or null if no recurrence
+ */
+export function computeNextOccurrence(
+  recurrenceType,
+  interval = 1,
+  currentDueDate = null,
+) {
+  if (
+    !recurrenceType ||
+    recurrenceType === "none" ||
+    recurrenceType === "rrule"
+  )
+    return null;
+
+  const n = Math.max(1, Math.round(interval) || 1);
+  const anchor = currentDueDate ? new Date(currentDueDate) : new Date();
+
+  if (Number.isNaN(anchor.getTime())) return null;
+
+  switch (recurrenceType) {
+    case "daily":
+      anchor.setDate(anchor.getDate() + n);
+      break;
+    case "weekly":
+      anchor.setDate(anchor.getDate() + n * 7);
+      break;
+    case "monthly": {
+      const origDay = anchor.getDate();
+      anchor.setMonth(anchor.getMonth() + n);
+      // Clamp: if the month rolled over (e.g. Jan 31 → Mar 3), go to last day
+      if (anchor.getDate() < origDay) {
+        anchor.setDate(0); // last day of previous month
+      }
+      break;
+    }
+    case "yearly": {
+      const origDay = anchor.getDate();
+      anchor.setFullYear(anchor.getFullYear() + n);
+      if (anchor.getDate() < origDay) {
+        anchor.setDate(0);
+      }
+      break;
+    }
+    default:
+      return null;
+  }
+
+  return anchor;
+}
+
+/**
+ * Build recurrence label for display.
+ * @param {string} type
+ * @param {number} interval
+ * @returns {string}  e.g. "Every day", "Every 2 weeks", "Monthly"
+ */
+export function recurrenceLabel(type, interval = 1) {
+  if (!type || type === "none") return "";
+  const n = interval || 1;
+  const units = {
+    daily: "day",
+    weekly: "week",
+    monthly: "month",
+    yearly: "year",
+  };
+  const unit = units[type];
+  if (!unit) return type;
+  if (n === 1) return `Every ${unit}`;
+  return `Every ${n} ${unit}s`;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the product feature gap plan. Backend has full recurrence support but had zero UI.

- **Drawer fields:** Repeat select (None/Daily/Weekly/Monthly/Yearly) + interval input
- **Smart completion:** Recurring tasks advance to next occurrence instead of marking done
- **Row badge:** Refresh icon + "Every day/week/month" chip on recurring task rows
- **Date math:** `computeNextOccurrence()` handles monthly clamping (Jan 31 → Feb 28)

## Test plan

- [x] All lint/format/typecheck pass
- [x] `CI=1 npm run test:ui:fast` — 220/220 pass
- [ ] Create task with "Weekly" recurrence + due date, complete it, verify due date advances 7 days
- [ ] Verify "Every week" chip shows on recurring tasks
- [ ] Change recurrence type in drawer, verify API payload includes recurrence object

🤖 Generated with [Claude Code](https://claude.com/claude-code)