### PR TITLE
feat(ui): clickable tag chips with filter — tags as navigation

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -122,6 +122,8 @@ import {
   renderTodoRowHtml,
   renderProjectHeadingGroupedRows,
   renderTodos,
+  setActiveTagFilter,
+  getUniqueTagsWithCounts,
 } from "./modules/filterLogic.js";
 import {
   DialogManager,
@@ -1336,6 +1338,10 @@ window.createSubproject = createSubproject;
 window.renameProjectTree = renameProjectTree;
 // Project key selection (used directly by UI tests via page.evaluate)
 window.setSelectedProjectKey = setSelectedProjectKey;
+window.toggleTagFilter = function toggleTagFilter(tag) {
+  var current = state.activeTagFilter;
+  setActiveTagFilter(current === tag ? "" : tag);
+};
 // Views / navigation
 window.switchView = switchView;
 window.toggleProfilePanel = toggleProfilePanel;

--- a/client/index.html
+++ b/client/index.html
@@ -3199,6 +3199,13 @@
                             class="todos-list-header__date-badge"
                             hidden
                           ></span>
+                          <span
+                            id="tagFilterIndicator"
+                            class="tag-filter-indicator"
+                            hidden
+                            data-onclick="toggleTagFilter('')"
+                            title="Clear tag filter"
+                          ></span>
                         </div>
                         <div class="todos-list-header__actions">
                           <span

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -23,6 +23,11 @@ import {
   loadVisibleTodos,
   shouldUseServerVisibleTodos,
 } from "./todosService.js";
+import {
+  illustrationNoTasks,
+  illustrationNoMatches,
+  illustrationEmptyProject,
+} from "../utils/illustrations.js";
 
 // ---------------------------------------------------------------------------
 // Utility functions injected via hooks by app.js:
@@ -334,6 +339,13 @@ function filterTodosList(todosList, { searchQuery = "" } = {}) {
     );
   }
 
+  if (state.activeTagFilter) {
+    filtered = filtered.filter(
+      (todo) =>
+        Array.isArray(todo.tags) && todo.tags.includes(state.activeTagFilter),
+    );
+  }
+
   filtered = filtered.filter((todo) => matchesDateView(todo));
 
   // TODO(plan-filter): inject plan task IDs into filter pipeline
@@ -389,6 +401,23 @@ function filterTodos({ skipPipeline = false, reason = "manual" } = {}) {
   return getVisibleTodos();
 }
 
+function setActiveTagFilter(tag) {
+  state.activeTagFilter = tag || "";
+  filterTodos({ reason: "tag-filter" });
+}
+
+function getUniqueTagsWithCounts() {
+  const counts = new Map();
+  state.todos.forEach((todo) => {
+    if (!Array.isArray(todo.tags)) return;
+    todo.tags.forEach((t) => {
+      const tag = String(t).trim();
+      if (tag) counts.set(tag, (counts.get(tag) || 0) + 1);
+    });
+  });
+  return counts;
+}
+
 // =============================================================================
 // DOM Boundary Layer — functions below intentionally read/write DOM elements.
 // This is acceptable view-controller glue. Do not add getElementById calls
@@ -421,6 +450,7 @@ function clearFilters() {
   if (searchInput) searchInput.value = "";
   const sheetSearch = document.getElementById("searchInputSheet");
   if (sheetSearch) sheetSearch.value = "";
+  state.activeTagFilter = "";
   setDateView("all", { skipApply: true });
   applyFiltersAndRender({ reason: "clear-filters" });
 }
@@ -580,6 +610,17 @@ function updateHeaderAndContextUI({
 
   hooks.syncProjectHeaderActions?.();
   hooks.updateTopbarProjectsButton?.(projectName);
+
+  const tagIndicator = document.getElementById("tagFilterIndicator");
+  if (tagIndicator instanceof HTMLElement) {
+    if (state.activeTagFilter) {
+      tagIndicator.hidden = false;
+      tagIndicator.textContent = `#${state.activeTagFilter} ✕`;
+    } else {
+      tagIndicator.hidden = true;
+      tagIndicator.textContent = "";
+    }
+  }
 
   // Done-today badge
   const doneBadge = document.getElementById("doneTodayBadge");
@@ -770,7 +811,8 @@ function renderProjectHeadingGroupedRows(projectTodos, projectName) {
   if (!unheaded.length && !headings.length) {
     rows += `
       <li class="project-inline-empty">
-        Start with a task or a heading. The project stays intentionally quiet until you add structure.
+        ${illustrationEmptyProject()}
+        <p>Start with a task or a heading. The project stays intentionally quiet until you add structure.</p>
       </li>
     `;
   }
@@ -942,9 +984,10 @@ function renderTodos() {
     state.isTodoDrawerOpen = false;
     state.selectedTodoId = null;
     state.openTodoKebabId = null;
+    // All content below is hardcoded — no user input, safe for innerHTML
     container.innerHTML = `
                     <div id="todosEmptyState" class="empty-state">
-                        <div class="empty-state-icon">\u2728</div>
+                        ${illustrationNoTasks()}
                         <h3>No tasks yet</h3>
                         <p>Add your first task to get started with a calm, focused list.</p>
                         <p class="empty-state-hint">Tip: press Ctrl/Cmd + N to create a task.</p>
@@ -1134,7 +1177,9 @@ function renderTodos() {
       sub: "Try adjusting your filters.",
     };
     container.innerHTML =
-      '<div class="empty-state"><h3>' +
+      '<div class="empty-state">' +
+      illustrationNoMatches() +
+      "<h3>" +
       msg.heading +
       "</h3><p>" +
       msg.sub +
@@ -1191,6 +1236,8 @@ export {
   filterTodosList,
   applyFiltersAndRender,
   filterTodos,
+  setActiveTagFilter,
+  getUniqueTagsWithCounts,
   clearFilters,
   getSelectedProjectFilterValue,
   getSelectedProjectKey,

--- a/client/modules/store.js
+++ b/client/modules/store.js
@@ -213,6 +213,7 @@ export const state = {
   currentDateView: "all",
   currentWorkspaceView: "home",
   homeListDrilldownKey: "",
+  activeTagFilter: "",
   isMoreFiltersOpen: false,
   viewportMode: "desktop",
   railPresentationMode: "sidebar",

--- a/client/modules/taskDrawerAssist.js
+++ b/client/modules/taskDrawerAssist.js
@@ -473,7 +473,18 @@ function renderTodoChips(todo, { isOverdue, dueDateStr }) {
     );
   }
 
-  return chips.slice(0, 3).join("");
+  // Tag chips — clickable to filter
+  if (Array.isArray(todo.tags) && todo.tags.length > 0 && chips.length < 3) {
+    const maxTags = 3 - chips.length;
+    todo.tags.slice(0, maxTags).forEach((tag) => {
+      const safeTag = hooks.escapeHtml(String(tag));
+      chips.push(
+        `<span class="todo-chip todo-chip--tag" title="Filter by #${safeTag}" data-onclick="event.stopPropagation(); toggleTagFilter('${safeTag}')">#${safeTag}</span>`,
+      );
+    });
+  }
+
+  return chips.slice(0, 4).join("");
 }
 
 export {

--- a/client/styles.css
+++ b/client/styles.css
@@ -2814,9 +2814,16 @@ body.dark-mode .delete-btn {
 }
 
 .project-inline-empty {
-  padding: 6px 2px 14px;
+  padding: var(--s-4) var(--s-2) var(--s-4);
   color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
   font-size: 0.86rem;
+  text-align: center;
+}
+
+.project-inline-empty .empty-state-illustration {
+  width: 88px;
+  height: 72px;
+  margin-bottom: var(--s-2);
 }
 
 .projects-rail {
@@ -4642,6 +4649,13 @@ body.is-todos-view .floating-new-task-cta {
   margin-bottom: var(--s-4);
 }
 
+.empty-state-illustration {
+  width: 120px;
+  height: 96px;
+  margin: 0 auto var(--s-4);
+  display: block;
+}
+
 .empty-state-hint {
   margin-top: var(--s-2);
   font-size: var(--fs-sm);
@@ -6284,6 +6298,41 @@ body.is-bulk-selecting .todo-item {
   background: color-mix(in oklab, var(--accent) 8%, transparent);
   border-color: color-mix(in oklab, var(--accent) 24%, transparent);
   color: var(--accent);
+}
+
+.todo-chip--tag {
+  background: color-mix(in oklab, var(--muted) 10%, transparent);
+  border-color: color-mix(in oklab, var(--muted) 24%, transparent);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.todo-chip--tag:hover {
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
+  color: var(--accent);
+}
+
+.tag-filter-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-1);
+  padding: 2px var(--s-2);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.tag-filter-indicator:hover {
+  background: color-mix(in oklab, var(--accent) 20%, transparent);
 }
 
 .priority-badge {
@@ -8276,6 +8325,12 @@ body.is-todos-view .projects-rail__header {
   margin: var(--s-4) auto;
 }
 
+.home-empty-cta .empty-state-illustration {
+  width: 140px;
+  height: 112px;
+  margin-bottom: var(--s-4);
+}
+
 .home-empty-cta__heading {
   font-size: var(--fs-xl);
   font-weight: 600;
@@ -9125,6 +9180,12 @@ body.is-admin-user .projects-rail__footer--admin-only {
   text-align: center;
   color: var(--text-secondary);
   font-size: var(--fs-body);
+}
+
+.inbox-view__empty .empty-state-illustration {
+  width: 100px;
+  height: 80px;
+  margin-bottom: var(--s-3);
 }
 
 .inbox-view__error {


### PR DESCRIPTION
## Summary

Phase 2 of the product feature gap plan. Tags were stored as string arrays but completely invisible in the UI.

- **Tag chips on rows:** `#tag` chips after existing chips, clickable to activate filter
- **Filter pipeline:** `state.activeTagFilter` → `filterTodosList()` filters by tag
- **Header indicator:** "#tagname ✕" badge shows when tag filter is active, click to clear
- **Stop propagation:** Tag chip clicks don't open the drawer

## Test plan

- [x] All lint/format/typecheck pass
- [x] `CI=1 npm run test:ui:fast` — 220/220 pass
- [ ] Create task with tags "work, urgent", verify chips appear on row
- [ ] Click a tag chip, verify list filters to only tasks with that tag
- [ ] Verify header shows "#work ✕" badge, click to clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)