### PR TITLE
feat(pwa): add web app manifest for home screen installability

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,6 +6,12 @@
     <meta name="app-version" content="1.6.0" />
     <title>Todo App</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#4F46E5" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Todos" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>

--- a/client/manifest.json
+++ b/client/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Todos — Calm Task Management",
+  "short_name": "Todos",
+  "description": "A calm, AI-native workspace for managing your tasks, projects, and daily focus.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f4f7fb",
+  "theme_color": "#4F46E5",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `manifest.json` with app name, standalone display mode, theme color (#4F46E5)
- SVG favicon as PWA icon (scalable, works at all sizes)
- Apple mobile web app meta tags for iOS
- Theme color meta for browser chrome

## Test plan

- [x] Format/lint pass
- [ ] Open app in Chrome → verify install prompt appears in address bar
- [ ] Add to home screen on iOS/Android → verify standalone mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)