### PR TITLE
fix(ui): landing page login — anchor targets auth form directly

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -116,7 +116,10 @@
                           data-onclick="switchAuthTab('login')"
                           >Log in</a
                         >
-                        <a href="#authFormSection" class="landing-nav__cta"
+                        <a
+                          href="#authFormSection"
+                          class="landing-nav__cta"
+                          data-onclick="switchAuthTab('register')"
                           >Get started free</a
                         >
                       </div>
@@ -139,6 +142,7 @@
                         <a
                           href="#authFormSection"
                           class="landing-btn landing-btn--primary"
+                          data-onclick="switchAuthTab('register')"
                           >Get started free</a
                         >
                         <a
@@ -464,7 +468,7 @@
                   </section>
 
                   <!-- Final CTA -->
-                  <section id="authFormSection" class="landing-cta-section">
+                  <section class="landing-cta-section">
                     <div class="landing-section__inner">
                       <h2 class="landing-section__heading">
                         Get started — it's&nbsp;free
@@ -477,7 +481,7 @@
                   </section>
                 </div>
 
-                <div class="auth-container">
+                <div id="authFormSection" class="auth-container">
                   <div class="auth-tabs">
                     <button
                       id="loginTabButton"

--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -77,6 +77,13 @@ export function switchAuthTab(tab, triggerEl) {
   if (triggerEl) {
     triggerEl.classList.add("active");
     triggerEl.setAttribute("aria-selected", "true");
+  } else {
+    // Activate the matching tab button when called without a trigger (e.g., from landing page)
+    const tabBtn = document.getElementById(tab + "TabButton");
+    if (tabBtn) {
+      tabBtn.classList.add("active");
+      tabBtn.setAttribute("aria-selected", "true");
+    }
   }
   const targetForm = document.getElementById(tab + "Form");
   if (targetForm) {


### PR DESCRIPTION
## Summary

- Move `id="authFormSection"` from landing CTA heading to `.auth-container` so anchor scroll lands on the actual form
- Fix `switchAuthTab()` to activate tab button when called without `triggerEl` (from landing links)
- "Get started free" CTAs now call `switchAuthTab('register')` to show register form

## Test plan

- [ ] Click "Get started free" on landing → should scroll to register form with Register tab active
- [ ] Click "Log in" in nav → should scroll to form with Login tab active

🤖 Generated with [Claude Code](https://claude.com/claude-code)