### PR TITLE
fix(ui): landing page auth buttons broken — chained data-onclick not supported

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -110,18 +110,20 @@
                         <a href="#landing-features" class="landing-nav__link"
                           >Features</a
                         >
-                        <a
-                          href="#"
+                        <button
+                          type="button"
                           class="landing-nav__link"
-                          data-onclick="event.preventDefault(); showAuthPage('login')"
-                          >Log in</a
+                          data-onclick="showAuthPage('login')"
                         >
-                        <a
-                          href="#"
+                          Log in
+                        </button>
+                        <button
+                          type="button"
                           class="landing-nav__cta"
-                          data-onclick="event.preventDefault(); showAuthPage('register')"
-                          >Get started free</a
+                          data-onclick="showAuthPage('register')"
                         >
+                          Get started free
+                        </button>
                       </div>
                     </div>
                   </nav>
@@ -139,12 +141,13 @@
                         dashboard to manage.
                       </p>
                       <div class="landing-hero__ctas">
-                        <a
-                          href="#"
+                        <button
+                          type="button"
                           class="landing-btn landing-btn--primary"
-                          data-onclick="event.preventDefault(); showAuthPage('register')"
-                          >Get started free</a
+                          data-onclick="showAuthPage('register')"
                         >
+                          Get started free
+                        </button>
                         <a
                           href="#landing-features"
                           class="landing-btn landing-btn--secondary"
@@ -477,24 +480,26 @@
                         No credit card required. Start organizing your tasks in
                         seconds.
                       </p>
-                      <a
-                        href="#"
+                      <button
+                        type="button"
                         class="landing-btn landing-btn--primary"
-                        data-onclick="event.preventDefault(); showAuthPage('register')"
-                        >Create free account</a
+                        data-onclick="showAuthPage('register')"
                       >
+                        Create free account
+                      </button>
                     </div>
                   </section>
                 </div>
 
                 <div id="authFormSection" class="auth-container auth-page">
                   <div class="auth-page__header">
-                    <a
-                      href="#"
+                    <button
+                      type="button"
                       class="auth-page__back"
-                      data-onclick="event.preventDefault(); showLandingPage()"
-                      >← Back</a
+                      data-onclick="showLandingPage()"
                     >
+                      ← Back
+                    </button>
                     <span class="auth-page__logo">Todo App</span>
                   </div>
                   <div class="auth-tabs">

--- a/client/styles.css
+++ b/client/styles.css
@@ -634,6 +634,10 @@ body:not(.is-todos-view) .container {
   text-decoration: none;
   font-size: var(--fs-sm);
   font-weight: 500;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
   transition: color 0.15s;
 }
 
@@ -651,6 +655,8 @@ body:not(.is-todos-view) .container {
   font-size: var(--fs-sm);
   font-weight: 600;
   text-decoration: none;
+  border: none;
+  cursor: pointer;
   transition:
     transform 0.15s,
     box-shadow 0.15s;
@@ -714,6 +720,8 @@ body:not(.is-todos-view) .container {
   font-size: var(--fs-body);
   font-weight: 600;
   text-decoration: none;
+  border: none;
+  cursor: pointer;
   transition:
     transform 0.15s,
     box-shadow 0.15s;
@@ -1052,6 +1060,10 @@ body:not(.is-todos-view) .container {
   color: var(--text-secondary);
   font-size: var(--fs-meta);
   text-decoration: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
   transition: color var(--dur-fast) var(--ease-out);
 }
 


### PR DESCRIPTION
## Summary

**Root cause:** The `data-onclick` event dispatcher uses a regex that only matches a single function call. Expressions like `event.preventDefault(); showAuthPage('login')` silently failed — the second statement never executed.

**Fix:** Replace all `<a href="#" data-onclick="event.preventDefault(); fn()">` with `<button type="button" data-onclick="fn()">`. Buttons don't trigger navigation, so no `preventDefault` needed.

Affected elements:
- Landing nav "Log in" and "Get started free"
- Hero "Get started free" CTA
- Bottom "Create free account" CTA
- Auth page "← Back" link

## Test plan

- [x] `app-smoke.spec.ts` — 4/4 pass (register, logout, re-register)
- [ ] Visual QA: click all landing CTAs → verify auth page opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)