### PR TITLE
refactor(ui): split styles.css into base/landing/auth/app CSS files

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,7 +12,10 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Todos" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
-    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="/styles/base.css" />
+    <link rel="stylesheet" href="/styles/landing.css" />
+    <link rel="stylesheet" href="/styles/auth.css" />
+    <link rel="stylesheet" href="/styles/app.css" />
   </head>
   <body>
     <div id="appShell">

--- a/client/styles/app.css
+++ b/client/styles/app.css
@@ -1,0 +1,9336 @@
+.add-todo {
+  display: flex;
+  gap: var(--s-3);
+  margin-bottom: 0;
+}
+
+.add-todo input {
+  flex: 1;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  font-size: 1em;
+}
+
+.quick-entry {
+  flex-direction: column;
+  gap: var(--s-3);
+}
+
+.quick-entry > input {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  font-size: 1em;
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.quick-entry-toolbar {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.quick-entry-natural-due {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.quick-entry-natural-due-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+}
+
+.quick-entry-natural-due-chip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.quick-entry-natural-due-chip--applied {
+  border-color: rgb(34 197 94 / 35%);
+  background: rgb(34 197 94 / 10%);
+  color: var(--text-primary);
+}
+
+.quick-entry-natural-due-chip--suggested {
+  border-color: rgb(59 130 246 / 35%);
+  background: rgb(59 130 246 / 10%);
+}
+
+.natural-date-chip--muted {
+  display: inline-block;
+  font-size: var(--fs-meta);
+  color: var(--text-muted);
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: color-mix(in oklab, var(--border-color) 40%, transparent);
+  opacity: 0.8;
+}
+
+.quick-entry-natural-due-chip__action {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: var(--fs-meta);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.quick-entry-natural-due-chip__action:hover {
+  color: var(--text-primary);
+}
+
+.quick-entry-properties-toggle--active {
+  background: color-mix(in oklab, var(--accent) 14%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 35%, var(--border-color));
+}
+
+.quick-entry-properties-panel {
+  display: grid;
+  gap: var(--s-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  padding: var(--s-3);
+  background: var(--surface-2);
+}
+
+.field-row {
+  display: flex;
+  gap: var(--s-3);
+  width: 100%;
+  flex-wrap: wrap;
+}
+
+.field-row input {
+  flex: 1;
+  min-width: 200px;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.field-row select {
+  flex: 1;
+  min-width: 180px;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.action-row {
+  display: flex;
+  gap: var(--s-3);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.action-label {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.ai-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.ai-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.ai-action-btn {
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  border-radius: var(--r-sm);
+  font: inherit;
+  font-size: 11px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.ai-action-btn:focus-visible,
+.ai-undo:focus-visible,
+.ai-confirm button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ai-badge {
+  font-size: 11px;
+  font-weight: var(--fw-semibold);
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  padding: 1px 7px;
+}
+
+.ai-badge--high {
+  color: var(--danger);
+  border-color: rgb(217 83 79 / 40%);
+  background: rgb(217 83 79 / 10%);
+}
+
+.ai-badge--med {
+  color: var(--warning);
+  border-color: color-mix(in oklab, var(--warning) 40%, transparent);
+  background: rgb(214 143 0 / 10%);
+}
+
+.ai-badge--low {
+  color: var(--text-secondary);
+}
+
+.ai-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-undo {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ai-empty {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+
+.ai-tooltip {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.ai-debug-meta,
+.ai-debug-suggestion-id {
+  font-family: ui-monospace, sfmono-regular, menlo, monospace;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.ai-debug-meta {
+  margin-bottom: 6px;
+}
+
+.ai-debug-suggestion-id {
+  margin-top: 2px;
+}
+
+.ai-on-create-assist {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+  padding: var(--s-2) var(--s-3);
+}
+
+@media (max-width: 768px) {
+  .ai-on-create-assist {
+    padding: var(--s-1) var(--s-2);
+    font-size: var(--fs-body);
+  }
+
+  .ai-create-chip {
+    min-width: 140px;
+    max-width: 100%;
+    padding: 6px 8px;
+  }
+}
+
+.ai-create-assist__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+  margin-bottom: var(--s-2);
+}
+
+.ai-create-assist__title {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.ai-create-assist__expand {
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--fs-xs);
+  cursor: pointer;
+}
+
+.ai-create-assist__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2);
+}
+
+.ai-create-chip {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 180px;
+  max-width: 260px;
+  padding: 8px 10px;
+}
+
+.ai-create-chip--applied {
+  border-color: rgb(47 158 106 / 40%);
+  background: rgb(47 158 106 / 8%);
+}
+
+.ai-create-chip__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+}
+
+.ai-create-chip__label {
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.ai-create-chip__confidence {
+  color: var(--text-secondary);
+}
+
+.ai-create-chip__summary {
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-create-chip__actions {
+  justify-content: flex-start;
+}
+
+.ai-create-chip__action,
+.ai-create-chip__dismiss,
+.ai-create-chip__undo,
+.ai-create-chip__confirm,
+.ai-create-chip__choice {
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  border-radius: var(--r-sm);
+  font: inherit;
+  font-size: 11px;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.ai-create-chip__dismiss {
+  width: 24px;
+  padding: 4px 0;
+}
+
+.ai-create-chip__confirm {
+  background: rgb(47 158 106 / 12%);
+  border-color: rgb(47 158 106 / 36%);
+  color: var(--success);
+}
+
+.ai-create-chip__undo {
+  color: var(--accent);
+  background: transparent;
+  border: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.ai-create-chip__applied {
+  font-size: 11px;
+  color: var(--success);
+  font-weight: var(--fw-semibold);
+}
+
+.ai-create-chip__helper {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.ai-create-chip__choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ai-create-assist__empty {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+
+/* Lint-first chip — shown in place of the full AI assist row until user
+   clicks Fix or Review to reveal server-backed suggestions. */
+.ai-lint-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-1) var(--s-2);
+  border-radius: var(--r-sm);
+  background: var(--color-warning-bg, #fffbe6);
+  border: 1px solid var(--color-warning-border, #ffe58f);
+  font-size: var(--fs-sm);
+  color: var(--text-secondary, var(--text-muted));
+}
+
+.ai-lint-chip__icon {
+  flex-shrink: 0;
+}
+
+.ai-lint-chip__message {
+  flex: 1;
+  min-width: 0;
+}
+
+.ai-lint-chip__action {
+  flex-shrink: 0;
+  padding: 2px var(--s-2);
+  border-radius: var(--r-sm);
+  border: 1px solid currentColor;
+  background: transparent;
+  cursor: pointer;
+  font-size: var(--fs-xs, 0.72rem);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.ai-lint-chip__action--secondary {
+  opacity: 0.65;
+}
+
+.ai-workspace {
+  margin-top: var(--s-3);
+  padding: var(--s-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+}
+
+.ai-workspace-header {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--s-2);
+}
+
+.ai-workspace-toggle {
+  flex: 1 1 auto;
+  min-width: 180px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text-primary);
+  padding: var(--s-2) var(--s-3);
+  font: inherit;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+}
+
+.ai-workspace-toggle__title {
+  min-width: 0;
+}
+
+.ai-workspace-status-chip {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: var(--fs-small);
+  padding: 0 var(--s-2);
+  height: 28px;
+}
+
+.ai-workspace-header-actions {
+  display: inline-flex;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+}
+
+.ai-workspace-body {
+  display: block;
+}
+
+.ai-workspace.ai-workspace--collapsed .ai-workspace-body {
+  display: none;
+}
+
+.ai-workspace.ai-workspace--collapsed .ai-workspace-header {
+  margin-bottom: 0;
+}
+
+.ai-workspace-inputs {
+  display: flex;
+  gap: var(--s-3);
+  flex-wrap: wrap;
+}
+
+.ai-workspace-inputs input {
+  flex: 1;
+  min-width: 220px;
+  padding: var(--s-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.ai-workspace-inputs input:first-of-type {
+  flex: 2;
+  min-width: 260px;
+}
+
+.ai-brain-dump {
+  margin-top: var(--s-3);
+}
+
+.ai-brain-dump label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.ai-brain-dump-input {
+  width: 100%;
+  min-height: 96px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  resize: vertical;
+  font-family: var(--font-sans);
+}
+
+.ai-brain-dump-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.ai-brain-dump-helper {
+  margin-top: 8px;
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.ai-meta {
+  margin-top: var(--s-3);
+  padding-top: var(--s-2);
+  border-top: 1px dashed var(--border-color);
+}
+
+.ai-meta summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+  font-weight: 600;
+  user-select: none;
+}
+
+.ai-meta summary:hover {
+  color: var(--text-primary);
+}
+
+.ai-meta > div {
+  margin-top: 10px;
+}
+
+.critic-panel-enhanced {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  padding: 12px;
+  background: var(--input-bg);
+}
+
+.critic-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.critic-panel-title {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.critic-panel-score {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.critic-section {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+  padding: 10px;
+  margin-top: 10px;
+}
+
+.critic-section-title {
+  display: block;
+  font-size: var(--fs-body);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.critic-improvement-line {
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.critic-suggestion-list {
+  margin: 8px 0 0 18px;
+  color: var(--text-secondary);
+}
+
+.critic-feedback-input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.critic-feedback-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2);
+  margin-top: var(--s-2);
+}
+
+.critic-feedback-chip {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  padding: 4px 10px;
+  font-size: var(--fs-small);
+  cursor: pointer;
+}
+
+.critic-feedback-chip:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+}
+
+.critic-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
+.critic-future-insights {
+  margin-top: 12px;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.critic-future-insights summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.critic-future-insights p {
+  margin-top: 8px;
+}
+
+.plan-draft-panel {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  padding: 12px;
+  background: var(--input-bg);
+}
+
+.plan-draft-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.plan-draft-title {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.plan-draft-count {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.plan-draft-warning {
+  margin-top: 6px;
+  margin-bottom: 4px;
+  font-size: var(--fs-body);
+  color: var(--warning);
+}
+
+.plan-draft-actions-top,
+.plan-draft-actions-bottom {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.plan-draft-actions-top {
+  margin-bottom: 10px;
+}
+
+.plan-draft-actions-bottom {
+  margin-top: 10px;
+}
+
+.plan-draft-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.plan-draft-task-row {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+  padding: 10px;
+}
+
+.plan-draft-task-row.dimmed {
+  opacity: 0.7;
+}
+
+.plan-draft-task-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.plan-draft-title-input,
+.plan-draft-description-input,
+.plan-draft-date-input,
+.plan-draft-project-select,
+.plan-draft-project-input,
+.plan-draft-priority-select,
+.plan-feedback-input {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.plan-draft-title-input {
+  flex: 1;
+  min-width: 220px;
+  padding: 8px 10px;
+}
+
+.plan-draft-description-input {
+  width: 100%;
+  margin-top: 8px;
+  padding: 8px 10px;
+  min-height: 64px;
+  resize: vertical;
+}
+
+.plan-draft-meta-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.plan-draft-date-input,
+.plan-draft-project-select,
+.plan-draft-project-input,
+.plan-draft-priority-select {
+  padding: 8px 10px;
+}
+
+.plan-draft-project-select,
+.plan-draft-project-input {
+  min-width: 160px;
+  flex: 1;
+}
+
+.plan-draft-subtasks {
+  margin-top: 8px;
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+}
+
+.plan-draft-subtasks ul {
+  margin: 6px 0 0 16px;
+}
+
+.plan-feedback-input {
+  width: 100%;
+  margin-top: 10px;
+  padding: 8px 10px;
+}
+
+.add-btn {
+  padding: 12px 24px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: white;
+  border: none;
+  border-radius: var(--r-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--dur-fast);
+}
+
+.todos-list {
+  list-style: none;
+}
+
+.todo-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 16px 0 6px;
+  padding: 6px 10px;
+  font-size: var(--fs-meta);
+  font-weight: 600;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-color);
+}
+
+.todos-list .todo-group-header:first-child {
+  margin-top: 0;
+  border-top: none;
+  padding-top: 0;
+}
+
+.todo-section-label {
+  list-style: none;
+  padding: var(--s-1) var(--s-2);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: var(--s-2);
+}
+
+.todo-section-label:first-child {
+  margin-top: 0;
+}
+
+.todo-section-label--overdue {
+  color: var(--danger);
+}
+
+/* Legacy .todo-item block removed — superseded by M7 normalized
+   definition at line ~5843 with design tokens and 3-column grid */
+
+.todo-item:hover {
+  background: var(--card-hover);
+  border-color: var(--text-muted);
+}
+
+.todo-item.completed {
+  opacity: 0.6;
+}
+
+.todo-item.todo-item--active {
+  border: 2px solid var(--accent);
+}
+
+.todo-item.dragging {
+  opacity: 0.5;
+  transform: rotate(2deg);
+}
+
+.todo-item.drag-over {
+  border-top: 3px solid var(--accent);
+}
+
+@keyframes settle-in {
+  from {
+    opacity: 0.6;
+    transform: scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.todo-item--settling {
+  animation: settle-in var(--dur-base) var(--ease-spring);
+}
+
+.todo-item.todo-item--heading-drop-target {
+  position: relative;
+}
+
+.todo-item.todo-item--heading-drop-before {
+  border-top: 3px solid var(--accent);
+}
+
+.todo-item.todo-item--heading-drop-after {
+  border-bottom: 3px solid var(--accent);
+}
+
+.drag-handle {
+  cursor: grab;
+  font-size: 1.2em;
+  color: var(--text-muted);
+  user-select: none;
+  border-radius: 4px;
+  padding: 2px 4px;
+  transition: background 0.15s;
+}
+
+.drag-handle:hover {
+  background: var(--card-hover, rgba(0, 0, 0, 0.05));
+  color: var(--text-secondary);
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.bulk-checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  margin-right: 4px;
+  accent-color: var(--accent, #667eea);
+  border-radius: 3px;
+  opacity: 0.7;
+}
+
+.bulk-checkbox:checked {
+  opacity: 1;
+}
+
+.todo-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border-color);
+  border-radius: var(--r-circle);
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition:
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.todo-checkbox:hover {
+  border-color: var(--success);
+}
+
+.todo-checkbox:checked {
+  background: var(--success);
+  border-color: var(--success);
+  animation: check-pulse 300ms var(--ease-spring);
+}
+
+.todo-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 6px;
+  width: 5px;
+  height: 10px;
+  border: solid #fff;
+  border-width: 0 2px 2px 0;
+  animation: checkmark-in 200ms var(--ease-spring) both;
+}
+
+@keyframes checkmark-in {
+  from {
+    opacity: 0;
+    transform: rotate(45deg) scale(0);
+  }
+  to {
+    opacity: 1;
+    transform: rotate(45deg) scale(1);
+  }
+}
+
+@keyframes check-pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.todo-checkbox:focus-visible {
+  box-shadow: var(--focus-ring);
+}
+
+/* Mobile sheet drag handle — visible affordance for dismissal */
+.sheet-drag-handle {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border-color);
+  margin: var(--s-2) auto var(--s-3);
+}
+
+@media (min-width: 769px) {
+  .sheet-drag-handle {
+    display: none;
+  }
+}
+
+.todo-content {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.todo-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.todo-title:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--text-muted);
+  text-underline-offset: 2px;
+}
+
+.todo-description {
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.todo-item.completed .todo-title {
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+
+.delete-btn {
+  padding: 8px 16px;
+  background: rgba(255, 71, 87, 0.12);
+  color: var(--danger);
+  border: 1px solid rgba(255, 71, 87, 0.32);
+  border-radius: 10px;
+  cursor: pointer;
+  font-size: var(--fs-body);
+  font-weight: 600;
+  transition:
+    background var(--dur-fast),
+    border-color var(--dur-fast);
+  justify-self: end;
+  align-self: start;
+}
+
+.delete-btn:hover {
+  background: rgba(255, 71, 87, 0.2);
+  border-color: rgba(255, 71, 87, 0.45);
+}
+
+body.dark-mode .delete-btn {
+  background: rgb(255 71 87 / 18%);
+  border-color: rgb(255 71 87 / 40%);
+}
+
+.todos-layout {
+  display: grid;
+  grid-template-columns: minmax(208px, 240px) minmax(0, 1fr);
+  gap: var(--s-3);
+  align-items: stretch;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+}
+
+.todos-layout--rail-collapsed {
+  grid-template-columns: 64px minmax(0, 1fr);
+}
+
+.todos-layout--sidebar-mounted {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.todos-main-zone {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.settings-pane {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.settings-pane::-webkit-scrollbar {
+  width: 6px;
+}
+
+.settings-pane::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.settings-pane::-webkit-scrollbar-thumb:hover {
+  background: var(--muted);
+}
+
+/* --- Settings cards --- */
+
+.settings-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  padding: var(--s-5);
+  margin-bottom: var(--s-4);
+}
+
+.settings-card__title {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--s-3);
+}
+
+.settings-card__subtitle {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--s-2);
+}
+
+.settings-card__divider {
+  border-top: 1px solid var(--border-color);
+  margin: var(--s-4) 0;
+}
+
+.settings-card__group {
+  margin-bottom: var(--s-2);
+}
+
+.settings-card__inline-action {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  margin-top: var(--s-3);
+}
+
+/* --- Settings banner (verification, etc.) --- */
+
+.settings-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-3);
+  border-radius: var(--r-sm);
+  margin-bottom: var(--s-4);
+}
+
+.settings-banner--warning {
+  background: color-mix(in oklab, var(--warning) 14%, var(--surface));
+  border: 1px solid var(--warning);
+  color: var(--warning);
+}
+
+.settings-banner__body strong {
+  font-weight: var(--fw-semibold);
+}
+
+/* --- Settings hint (secondary text) --- */
+
+.settings-hint {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  margin-top: var(--s-1);
+}
+
+.settings-pane__section {
+  margin-top: var(--s-3);
+  padding-top: var(--s-3);
+  border-top: 1px solid var(--border-color);
+}
+
+#todosView.todos-view--settings-active .settings-pane {
+  display: block;
+}
+
+/* --- Shared pane shell (settings, feedback, admin) --- */
+
+.pane-shell {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.pane-shell__header {
+  margin-bottom: var(--s-4);
+}
+
+.pane-shell__header h2 {
+  margin: 0;
+}
+
+.pane-shell__actions {
+  margin-bottom: var(--s-2);
+}
+
+.pane-shell__lede {
+  margin-top: var(--s-1);
+  color: var(--text-secondary);
+}
+
+.pane-back-btn {
+  font-size: var(--fs-meta);
+}
+
+.pane-back-btn::before {
+  content: "\2190\00a0";
+}
+
+/* --- Per-pane base styles (consistent layout, flat background) --- */
+
+.feedback-pane {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+}
+
+#todosView.todos-view--feedback-active .feedback-pane {
+  display: block;
+}
+
+.admin-pane {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+}
+
+#todosView.todos-view--admin-active .admin-pane {
+  display: block;
+}
+
+#todosView.todos-view--settings-active .todos-top-bar,
+#todosView.todos-view--settings-active #todosScrollRegion,
+#todosView.todos-view--feedback-active .todos-top-bar,
+#todosView.todos-view--feedback-active #todosScrollRegion,
+#todosView.todos-view--feedback-active #aiWorkspace,
+#todosView.todos-view--admin-active .todos-top-bar,
+#todosView.todos-view--admin-active #todosScrollRegion,
+#todosView.todos-view--admin-active #aiWorkspace {
+  display: none;
+}
+
+.todos-list-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  margin-bottom: 0;
+  padding: 6px 2px 12px;
+  border: 0;
+  border-radius: 0;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--surface) 96%, transparent) 0%,
+    color-mix(in oklab, var(--surface) 96%, transparent) 78%,
+    transparent 100%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.todos-list-header__context {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.todos-list-header__breadcrumb {
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-medium);
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+.todos-list-header__title {
+  margin: 0;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: var(--lh-tight);
+  letter-spacing: 0.01em;
+}
+
+.todos-list-header__count {
+  margin: 0;
+  font-size: var(--fs-meta);
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+  white-space: nowrap;
+}
+
+.done-today-badge {
+  font-size: var(--fs-label);
+  font-weight: 600;
+  color: var(--success);
+  white-space: nowrap;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--success) 10%, transparent);
+}
+
+.todos-list-header__actions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--s-2);
+  min-width: 0;
+}
+
+.todos-list-header__project-actions[hidden] {
+  display: none !important;
+}
+
+.todos-list-header__project-actions {
+  flex: 0 0 auto;
+}
+
+.todos-list-header__date-badge {
+  font-size: 0.72rem;
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+  white-space: nowrap;
+}
+
+.todo-heading-divider {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 24px 0 8px;
+  padding: 4px 2px 4px 10px;
+  border: 0;
+  border-left: 3px solid var(--accent, #667eea);
+  background: transparent;
+  cursor: grab;
+}
+
+.todo-heading-divider__title {
+  font-size: var(--fs-meta);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+}
+
+.todo-heading-divider__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.todo-heading-divider__drag-handle {
+  color: color-mix(in oklab, var(--text-secondary) 76%, var(--surface));
+  font-size: 0.74rem;
+  letter-spacing: -0.1em;
+  user-select: none;
+}
+
+.todo-heading-divider__count {
+  font-size: 0.72rem;
+  color: color-mix(in oklab, var(--text-secondary) 84%, var(--surface));
+}
+
+.todo-heading-divider__menu {
+  border: 0;
+  background: transparent;
+  color: color-mix(in oklab, var(--text-secondary) 78%, var(--surface));
+  border-radius: 999px;
+  min-width: 28px;
+  height: 28px;
+  line-height: 1;
+  cursor: default;
+}
+
+.todo-heading-divider__move-btn {
+  border: 1px solid color-mix(in oklab, var(--border-color) 74%, transparent);
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+  color: color-mix(in oklab, var(--text-secondary) 82%, var(--surface));
+  border-radius: 999px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.todo-heading-divider__move-btn:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: color-mix(in oklab, var(--border-color) 56%, transparent);
+}
+
+.todo-heading-divider__move-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.todo-heading-divider--dragging {
+  opacity: 0.55;
+}
+
+.todo-heading-divider--drag-over-before {
+  border-top: 2px solid color-mix(in oklab, var(--accent) 55%, transparent);
+  margin-top: 18px;
+  padding-top: 2px;
+}
+
+.todo-heading-divider--drag-over-after {
+  border-bottom: 2px solid color-mix(in oklab, var(--accent) 55%, transparent);
+  margin-bottom: 18px;
+  padding-bottom: 2px;
+}
+.project-inline-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 2px 0 10px;
+  padding: 0;
+}
+
+.project-inline-actions__task {
+  width: auto;
+  min-width: 108px;
+}
+
+.project-inline-empty {
+  padding: var(--s-4) var(--s-2) var(--s-4);
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+  font-size: 0.86rem;
+  text-align: center;
+}
+
+.project-inline-empty .empty-state-illustration {
+  width: 88px;
+  height: 72px;
+  margin-bottom: var(--s-2);
+}
+
+.projects-rail {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  padding: var(--s-3);
+  display: grid;
+  gap: var(--s-3);
+  position: sticky;
+  top: var(--s-4);
+  min-height: 0;
+  height: 100%;
+  max-height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.projects-rail.projects-rail--collapsed {
+  width: 64px;
+  padding-left: var(--s-1);
+  padding-right: var(--s-1);
+}
+
+.projects-rail.projects-rail--collapsed .projects-rail__header {
+  justify-content: center;
+}
+
+.projects-rail.projects-rail--collapsed .projects-rail__section-header,
+.projects-rail.projects-rail--collapsed .projects-rail__footer,
+.projects-rail.projects-rail--collapsed #railSearchContainer {
+  display: none;
+}
+
+.projects-rail.projects-rail--collapsed .nav-label,
+.projects-rail.projects-rail--collapsed .projects-rail-item__label,
+.projects-rail.projects-rail--collapsed .projects-rail-item__count {
+  display: none;
+}
+
+.projects-rail.projects-rail--collapsed #projectsRailList,
+.projects-rail.projects-rail--collapsed
+  .projects-rail__section:not(.projects-rail__section--workspace) {
+  display: none;
+}
+
+.projects-rail.projects-rail--collapsed .workspace-view-item {
+  justify-content: center;
+  align-items: center;
+  min-height: 46px;
+  height: 46px;
+  padding: 0;
+}
+
+.projects-rail.projects-rail--collapsed .workspace-view-item .nav-icon {
+  width: 18px;
+  height: 18px;
+  opacity: 0.72;
+}
+
+.projects-rail.projects-rail--collapsed .workspace-view-item:hover .nav-icon,
+.projects-rail.projects-rail--collapsed
+  .workspace-view-item.projects-rail-item--active
+  .nav-icon {
+  opacity: 0.92;
+}
+
+.projects-rail.projects-rail--collapsed
+  .workspace-view-item.projects-rail-item--active {
+  border-radius: 10px;
+}
+
+.projects-rail__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+}
+
+.rail-profile-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.rail-profile-btn:hover {
+  background: var(--card-hover);
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.rail-profile-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.projects-rail__primary,
+.projects-rail__list {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.projects-rail__section {
+  border-top: 1px solid var(--border-color);
+  padding-top: var(--s-3);
+}
+
+.projects-rail__footer {
+  margin-top: auto;
+  border-top: 1px solid var(--border-color);
+  padding: 8px 0 4px;
+}
+
+/* Admin rail button – hidden by default, revealed for admin users via body class.
+   Use button.admin-rail-btn (type+class specificity 0,1,1) so it beats
+   .projects-rail-item { display: flex } (class-only specificity 0,1,0). */
+button.admin-rail-btn {
+  display: none;
+}
+
+body.is-admin-user button.admin-rail-btn {
+  display: flex;
+}
+
+.dock-admin-btn {
+  display: none;
+}
+
+body.is-admin-user .dock-admin-btn {
+  display: inline-flex;
+}
+
+.rail-search-container {
+  padding: 4px 8px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 2px;
+}
+
+.projects-rail__section--workspace {
+  border-top: none;
+}
+
+.projects-rail__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--s-2);
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+}
+
+.projects-rail__add-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.projects-rail__add-btn:hover {
+  background: var(--card-hover);
+  color: var(--text);
+}
+
+.projects-rail__add-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.projects-rail-create-btn {
+  width: auto;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0 8px;
+  font-size: var(--fs-body);
+  line-height: 1;
+}
+
+.workspace-view-item {
+  justify-content: flex-start;
+  font-weight: var(--fw-medium);
+}
+
+.projects-rail-area-group {
+  margin-bottom: 4px;
+}
+
+.projects-rail-area-header {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary, #888);
+  padding: 10px 12px 2px;
+  user-select: none;
+  pointer-events: none;
+}
+
+.projects-rail--collapsed .projects-rail-area-header {
+  display: none;
+}
+
+.projects-rail-row {
+  position: relative;
+  min-width: 0;
+}
+
+.projects-rail-item {
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-primary);
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+  font: inherit;
+  line-height: var(--lh-tight);
+  text-align: left;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.projects-rail-item > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.projects-rail-item__label {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+button.projects-rail-item {
+  width: 100%;
+  cursor: pointer;
+}
+
+.sidebar-nav-item {
+  justify-content: flex-start;
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+}
+
+.projects-rail-kebab {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: var(--card-bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.projects-rail-row:hover .projects-rail-kebab,
+.projects-rail-row:focus-within .projects-rail-kebab,
+.projects-rail-row--menu-open .projects-rail-kebab {
+  opacity: 1;
+}
+
+.projects-rail-kebab:hover {
+  background: var(--surface);
+  border-color: var(--border-color);
+}
+
+.projects-rail-kebab:focus-visible {
+  opacity: 1;
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.projects-rail-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 140px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-1);
+  padding: 4px;
+  display: none;
+  z-index: 80;
+}
+
+.projects-rail-menu--open {
+  display: grid;
+  gap: 2px;
+}
+
+.projects-rail-menu-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  padding: 7px 8px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.projects-rail-menu-item:hover {
+  background: var(--surface);
+  border-color: var(--border-color);
+}
+
+.projects-rail-menu-item--danger {
+  color: var(--danger);
+}
+
+.projects-rail-item:hover {
+  background: var(--surface);
+  border-color: var(--border-color);
+}
+
+.projects-rail-item--active {
+  background: color-mix(in oklab, var(--accent) 8%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--accent) 28%, transparent);
+  font-weight: var(--fw-medium);
+}
+
+@media (hover: hover) {
+  .projects-rail-item:hover {
+    background: color-mix(in oklab, var(--accent) 5%, var(--surface-2));
+  }
+}
+
+.projects-rail-item[role="option"][aria-selected="true"] {
+  background: rgb(79 110 247 / 8%);
+  border-color: rgb(79 110 247 / 28%);
+}
+
+.projects-rail-item[role="option"]:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-color: rgb(79 110 247 / 40%);
+}
+
+.projects-rail-item__count {
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 2px 8px;
+  min-width: 24px;
+  text-align: center;
+}
+
+.projects-rail__footer {
+  border-top: 1px solid var(--border-color);
+  padding-top: var(--s-3);
+}
+
+.projects-rail__footer .mini-btn {
+  width: 100%;
+}
+
+.project-crud-modal-card {
+  max-width: 420px;
+}
+
+.project-edit-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--scrim);
+  display: none;
+  z-index: 2440;
+}
+
+.project-edit-drawer-backdrop--open {
+  display: block;
+}
+
+.project-edit-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(400px, 100%);
+  height: 100vh;
+  display: none;
+  flex-direction: column;
+  background: var(--container-bg);
+  border-left: 1px solid var(--border-color);
+  box-shadow: -14px 0 28px rgba(15, 23, 42, 0.14);
+  z-index: 2450;
+}
+
+.project-edit-drawer--open {
+  display: flex;
+}
+
+.project-edit-drawer__handle {
+  display: none;
+}
+
+.project-edit-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.project-edit-drawer__header h2 {
+  margin: 0;
+  font-size: var(--fs-section);
+  color: var(--text-primary);
+}
+
+.project-edit-drawer__content {
+  flex: 1;
+  min-height: 0;
+  padding: 16px;
+  overflow-y: auto;
+  display: grid;
+  gap: 16px;
+}
+
+.project-edit-drawer__meta {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  line-height: 1.45;
+}
+
+.project-edit-drawer__footer {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.project-edit-drawer__delete-btn {
+  width: 100%;
+}
+
+.project-delete-dialog {
+  max-width: 460px;
+  display: grid;
+  gap: 12px;
+}
+
+.project-delete-dialog h3,
+.project-delete-dialog p {
+  margin: 0;
+}
+
+.project-delete-dialog p {
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.project-delete-dialog__actions {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.project-delete-dialog__actions .add-btn,
+.project-delete-dialog__actions .mini-btn,
+.project-delete-dialog__actions .delete-btn {
+  width: auto;
+}
+
+.projects-rail-mobile-open {
+  display: none;
+}
+
+.projects-rail-mobile-open.projects-rail-mobile-open--show {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.projects-rail-mobile-open .projects-active-label {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+}
+
+#projectsRailTopbarLabel {
+  display: block;
+  max-width: 220px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.2;
+  padding-block: 0;
+  font-size: var(--fs-sm);
+}
+
+#todosScrollRegion {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+  padding-bottom: var(--s-3);
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+#todosContent {
+  min-width: 0;
+}
+
+.projects-rail-backdrop,
+.projects-rail-sheet {
+  display: none;
+}
+
+.projects-rail-backdrop--open {
+  display: block;
+}
+
+.projects-rail-sheet--open {
+  display: grid;
+}
+
+/* Nav tabs permanently hidden — elements stay in DOM for JS switchView() */
+#navTabs {
+  display: none !important;
+}
+
+/* Top bar hidden on desktop (body.is-todos-view raises specificity to 0,2,0
+   so it beats the base .todos-top-bar{display:grid} rule at 0,1,0). */
+@media (min-width: 769px) {
+  body.is-todos-view .todos-top-bar {
+    display: none;
+  }
+  /* Header is redundant on desktop todos view — sidebar handles all navigation
+     and account actions. It remains visible on mobile and auth view. */
+  body.is-todos-view .header {
+    display: none;
+  }
+}
+
+/* Floating New Task CTA — visible on all viewports in todos view */
+@media (min-width: 769px) {
+  .floating-new-task-cta {
+    right: 24px;
+    bottom: 24px;
+  }
+}
+
+/* Hide context list-header when the home dashboard is rendered in #todosContent */
+#todosScrollRegion:has(#todosContent > .home-dashboard) #todosListHeader {
+  display: none;
+}
+
+#todosView[data-surface-mode="home"] #todosListHeader,
+#todosView[data-surface-mode="list"] #homeFocusDashboard {
+  display: none;
+}
+
+.todos-top-bar {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
+  gap: var(--s-3);
+  align-items: center;
+  margin-bottom: var(--s-3);
+  padding: var(--s-3) var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--card-bg);
+  min-width: 0;
+}
+
+.todos-top-bar > * {
+  min-width: 0;
+}
+
+.todos-top-bar-left {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.todos-top-bar-left h2 {
+  margin: 0;
+  font-size: var(--fs-section);
+  color: var(--text-primary);
+}
+
+.todos-count-summary {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.todos-top-bar-search {
+  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.search-bar {
+  margin-bottom: 0;
+  position: relative;
+  min-width: 0;
+}
+
+.search-input {
+  min-width: 0;
+  width: 100%;
+  padding: 12px 40px 12px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  font-size: 1em;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  transition: border-color var(--dur-base);
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.search-icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.todos-top-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  min-width: max-content;
+  overflow: visible;
+}
+
+.top-add-btn {
+  width: auto;
+  flex: 0 0 auto;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.more-filters-toggle {
+  white-space: nowrap;
+}
+
+.floating-new-task-cta {
+  display: none;
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 45;
+  min-height: 44px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  box-shadow: var(--shadow-1);
+}
+
+body.is-todos-view .floating-new-task-cta {
+  display: inline-flex;
+  align-items: center;
+}
+
+.home-focus-dashboard {
+  margin-bottom: 8px;
+}
+
+.home-focus-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.home-focus-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  padding: 10px;
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+}
+
+.home-focus-card > h3 {
+  font-size: var(--fs-sm);
+  margin-bottom: 8px;
+}
+
+.home-focus-list {
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.home-focus-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.home-focus-row__main {
+  min-width: 0;
+}
+
+.home-focus-row__title {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.home-focus-row__reason {
+  margin-top: 2px;
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+}
+
+.home-focus-due-chip {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: var(--fs-xs);
+  color: var(--text-secondary);
+  background: var(--surface-2);
+}
+
+.home-focus-due-chip--overdue {
+  color: var(--danger);
+  border-color: color-mix(in oklab, var(--danger) 45%, var(--border-color));
+}
+
+.home-focus-group {
+  margin-bottom: 6px;
+}
+
+.home-focus-group__label {
+  margin-bottom: 4px;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.home-focus-empty {
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+}
+
+.todos-minimal-filters {
+  margin-bottom: 0;
+  display: flex;
+  gap: var(--s-2);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.project-filter-label {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.todos-minimal-filters select {
+  padding: 8px 12px;
+  border: 2px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.todos-minimal-filters--legacy {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.more-filters-panel {
+  display: none;
+  margin-bottom: 0;
+  padding: var(--s-3);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--card-bg);
+}
+
+.more-filters-panel.more-filters--open {
+  display: block;
+}
+
+.more-filters-actions {
+  margin-top: var(--s-2);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.clear-filters-btn {
+  padding: 8px 16px;
+  background: var(--input-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+
+.ics-export-helper {
+  margin-top: var(--s-2);
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.date-view-tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.date-view-tab {
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: var(--fs-meta);
+  font-weight: 600;
+}
+
+.date-view-tab:hover {
+  color: var(--text-primary);
+}
+
+.date-view-tab.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.bulk-actions-toolbar {
+  background: var(--accent);
+  color: white;
+  padding: var(--s-3) var(--s-4);
+  border-radius: var(--r-sm);
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+}
+
+.bulk-actions-toolbar button {
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: var(--fs-body);
+  transition: background var(--dur-base);
+}
+
+.bulk-actions-toolbar button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.bulk-count {
+  margin-left: auto;
+  font-size: var(--fs-body);
+}
+
+.shortcuts-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--overlay);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.shortcuts-overlay.active {
+  display: flex;
+}
+
+.shortcuts-content {
+  background: var(--container-bg);
+  border-radius: var(--r-lg);
+  padding: 30px;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.shortcuts-content h2 {
+  color: var(--text-primary);
+  margin-bottom: var(--s-4);
+}
+
+.shortcuts-section-title {
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: var(--s-3) 0 var(--s-1);
+}
+
+.shortcut-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.shortcut-key {
+  background: var(--card-bg);
+  padding: 6px 12px;
+  border-radius: var(--r-sm);
+  font-family: monospace;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.shortcut-desc {
+  color: var(--text-secondary);
+  flex: 1;
+  margin-right: 20px;
+}
+
+.command-palette-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 12vh;
+  background: var(--overlay);
+  z-index: 2550;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity var(--dur-fast) var(--ease-out),
+    visibility 0s var(--dur-fast);
+}
+
+.command-palette-overlay--open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity var(--dur-fast) var(--ease-out),
+    visibility 0s 0s;
+}
+
+.command-palette-panel {
+  width: min(560px, 92vw);
+  max-height: 72vh;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  transform: scale(0.96) translateY(-8px);
+  transition: transform var(--dur-base) var(--ease-spring);
+  background: var(--container-bg);
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.command-palette-overlay--open .command-palette-panel {
+  transform: scale(1) translateY(0);
+}
+
+.command-palette-input {
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--fs-md);
+  line-height: var(--lh-base);
+  padding: var(--s-4);
+  width: 100%;
+}
+
+.command-palette-input:focus {
+  outline: none;
+  box-shadow: inset 0 -1px 0 0 var(--accent);
+}
+
+.command-palette-list {
+  display: grid;
+  gap: 6px;
+  padding: var(--s-3);
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.command-palette-section {
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+}
+
+.command-palette-option {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.command-palette-option:hover,
+.command-palette-option--active {
+  border-color: var(--border-color);
+  background: var(--surface-2);
+}
+
+.command-palette-option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.command-palette-option--task {
+  display: grid;
+  gap: 2px;
+}
+
+.command-palette-option__title {
+  color: var(--text-primary);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-tight);
+}
+
+.command-palette-option__meta {
+  color: var(--text-secondary);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-base);
+}
+
+.command-palette-option--completed .command-palette-option__title,
+.command-palette-option--completed .command-palette-option__meta {
+  color: var(--text-muted);
+}
+
+.command-palette-inline-empty {
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  padding: 8px 10px;
+}
+
+.command-palette-empty {
+  color: var(--text-secondary);
+  padding: var(--s-4);
+  border-top: 1px solid var(--border-color);
+}
+
+/* ========== PHASE E: ANIMATIONS & TRANSITIONS ========== */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+.todo-item {
+  animation: slideIn var(--dur-base) var(--ease-out)-out;
+}
+
+.todo-item.removing {
+  animation: fadeOut var(--dur-base) var(--ease-out)-out forwards;
+}
+
+.todo-item .bulk-checkbox,
+.todo-item .drag-handle,
+.todo-item .todo-checkbox {
+  align-self: center;
+}
+
+.todo-content > div[style*="display: flex"][style*="flex-wrap: wrap"] {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 8px !important;
+  margin-top: 0 !important;
+}
+
+.todo-content > div[style*="display: flex"][style*="flex-wrap: wrap"] span {
+  background: var(--container-bg) !important;
+  color: var(--text-secondary) !important;
+  border: 1px solid var(--border-color) !important;
+  border-radius: 999px !important;
+  padding: 4px 10px !important;
+  font-size: 0.78em !important;
+  font-weight: 600;
+}
+
+.todo-content
+  > div[style*="display: flex"][style*="flex-wrap: wrap"]
+  span.priority-badge {
+  color: var(--text-primary) !important;
+}
+
+.todo-content > div[style*="margin-top: 8px;"] {
+  margin-top: 0 !important;
+}
+
+.todo-inline-actions {
+  margin-top: 4px;
+}
+
+.todo-inline-actions .mini-btn {
+  background: var(--card-hover);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.todo-inline-actions .mini-btn:hover {
+  background: var(--container-bg);
+}
+
+.todo-row-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  justify-self: end;
+  align-self: start;
+  position: relative;
+  z-index: 60;
+  width: 34px;
+  min-width: 34px;
+  max-width: 34px;
+}
+
+.todo-kebab {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-section);
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background var(--dur-fast),
+    opacity var(--dur-fast) var(--ease-out);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.todo-kebab:hover {
+  background: var(--card-bg);
+}
+
+.todo-item:hover .todo-kebab,
+.todo-item:focus-within .todo-kebab,
+.todo-item--active .todo-kebab,
+.todo-kebab[aria-expanded="true"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.todo-kebab-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 220px;
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--container-bg);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  z-index: 70;
+}
+
+.todo-kebab-menu--open {
+  display: flex;
+}
+
+.todo-kebab-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 7px 10px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.todo-kebab-item:hover {
+  background: var(--card-bg);
+  border-color: var(--border-color);
+}
+
+.todo-kebab-item--danger {
+  color: var(--danger);
+}
+
+.todo-kebab-project-label {
+  display: grid;
+  gap: 6px;
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  padding: 4px 2px;
+}
+
+.todo-kebab-project-label select {
+  width: 100%;
+  padding: 7px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.todo-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--scrim);
+  z-index: 2390;
+  display: none;
+}
+
+.todo-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(420px, 100%);
+  border-left: 1px solid var(--border-color);
+  background: var(--container-bg);
+  box-shadow: -14px 0 28px rgba(15, 23, 42, 0.14);
+  z-index: 2400;
+  display: none;
+  flex-direction: column;
+}
+
+.todo-drawer--open {
+  display: flex;
+}
+
+.todo-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.todo-drawer__header h2 {
+  margin: 0;
+  font-size: var(--fs-section);
+  color: var(--text-primary);
+}
+
+.todo-drawer__content {
+  padding: 16px;
+  overflow-y: auto;
+  display: grid;
+  gap: 16px;
+}
+
+.todo-drawer__section {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--card-bg);
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.todo-drawer__section-title {
+  font-size: var(--fs-meta);
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.skeleton-line {
+  height: 12px;
+  border-radius: 999px;
+  background: var(--card-hover);
+}
+
+.skeleton-line--short {
+  width: 62%;
+}
+
+.btn-icon {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--container-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-section);
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.btn-icon:hover {
+  background: var(--card-bg);
+}
+
+.add-btn:active {
+  animation: pulse var(--dur-base) var(--ease-out)-out;
+}
+
+.delete-btn:active {
+  animation: pulse var(--dur-base) var(--ease-out)-out;
+}
+
+/* Undo/Redo Toast Notification */
+.undo-toast {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  background: var(--surface-3);
+  color: white;
+  padding: 12px 20px;
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-1);
+  display: none;
+  align-items: center;
+  gap: 12px;
+  z-index: 1500;
+  animation: slideIn var(--dur-base) var(--ease-out)-out;
+}
+
+.undo-toast.active {
+  display: flex;
+}
+
+.undo-toast button {
+  background: var(--accent);
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+/* ========== PHASE E: RESPONSIVE MOBILE VIEW ========== */
+@media (max-width: 768px) {
+  .todos-layout {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .projects-rail {
+    display: none;
+  }
+
+  .projects-rail-mobile-open {
+    white-space: nowrap;
+  }
+
+  .projects-rail-kebab {
+    opacity: 1;
+  }
+
+  .projects-rail-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay);
+    z-index: 69;
+  }
+
+  .projects-rail-sheet {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(320px, 88vw);
+    z-index: 70;
+    border-right: 1px solid var(--border-color);
+    background: var(--container-bg);
+    padding: var(--s-4);
+    overflow-y: auto;
+    align-content: start;
+    gap: var(--s-3);
+    box-shadow: var(--shadow-2);
+  }
+
+  body.is-projects-rail-open {
+    overflow: hidden;
+  }
+
+  body {
+    padding: 0;
+  }
+
+  #appShell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  #appSidebar,
+  body.is-todos-view #appSidebar {
+    display: none;
+  }
+
+  body.is-todos-view .nav-tabs {
+    display: flex !important;
+  }
+
+  #appMainScroll {
+    min-height: 100dvh;
+    max-height: 100dvh;
+    padding: 10px;
+  }
+
+  body.is-todos-view {
+    padding: 10px;
+    overflow: auto;
+  }
+
+  .container {
+    border-radius: var(--r-md);
+    max-width: 100%;
+  }
+
+  .header {
+    padding: 20px;
+  }
+
+  .header h1 {
+    font-size: 1.5em;
+  }
+
+  .user-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .theme-toggle {
+    align-self: flex-end;
+  }
+
+  .content {
+    padding: 15px;
+  }
+
+  body.is-todos-view .container {
+    height: calc(100dvh - 20px);
+    max-height: calc(100dvh - 20px);
+    border-radius: var(--r-md);
+  }
+
+  .todos-top-bar {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .todos-list-header {
+    top: var(--s-1);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .todos-top-bar-left {
+    justify-content: flex-start;
+    gap: var(--s-2);
+  }
+
+  .todos-top-bar-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .todos-top-bar-actions .add-btn,
+  .todos-top-bar-actions .mini-btn {
+    width: auto;
+  }
+
+  .todos-minimal-filters {
+    align-items: stretch;
+  }
+
+  .todos-minimal-filters select {
+    width: 100%;
+  }
+
+  .add-todo {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .add-todo input {
+    width: 100%;
+  }
+
+  .add-btn {
+    width: 100%;
+  }
+
+  .todos-top-bar-actions .add-btn,
+  .todos-top-bar-actions .mini-btn {
+    width: auto;
+  }
+
+  .action-row {
+    align-items: stretch;
+  }
+
+  .action-row .add-btn {
+    margin-left: 0 !important;
+  }
+
+  .ai-workspace-inputs input:first-of-type,
+  .ai-workspace-inputs input {
+    min-width: 100%;
+  }
+
+  .todo-item {
+    grid-template-columns: auto auto minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .todo-item .bulk-checkbox {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .todo-item .drag-handle {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .todo-item .todo-checkbox {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .todo-content {
+    grid-column: 2 / span 3;
+    grid-row: 2;
+    margin-top: 0;
+  }
+
+  .todo-row-actions {
+    grid-column: 4;
+    grid-row: 1;
+  }
+
+  .todo-kebab {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .drag-handle {
+    font-size: 1.5em;
+  }
+
+  .bulk-actions-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .bulk-actions-toolbar button {
+    width: 100%;
+  }
+
+  .bulk-count {
+    margin-left: 0;
+    margin-top: 8px;
+  }
+
+  .shortcuts-content {
+    padding: 20px;
+    max-width: 90%;
+    margin: 20px;
+  }
+
+  .undo-toast {
+    bottom: 70px;
+    right: 15px;
+    left: 15px;
+  }
+
+  .todo-drawer {
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 92vh;
+    max-height: 92vh;
+    border-left: none;
+    border-top: 1px solid var(--border-color);
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
+    box-shadow: 0 -12px 28px rgba(15, 23, 42, 0.18);
+  }
+}
+
+@media (max-width: 480px) {
+  .header h1 {
+    font-size: 1.3em;
+  }
+
+  .nav-tabs {
+    gap: 5px;
+  }
+
+  .nav-tab {
+    padding: 8px 12px;
+    font-size: 0.85em;
+  }
+
+  .todo-title {
+    font-size: 0.95em;
+  }
+
+  .search-input {
+    font-size: var(--fs-body);
+  }
+
+  .todos-top-bar-actions .add-btn,
+  .todos-top-bar-actions .mini-btn {
+    flex: 1 1 auto;
+  }
+}
+
+.empty-state {
+  text-align: center;
+  padding: calc(var(--s-6) + var(--s-5)) var(--s-5);
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.todo-list-state {
+  text-align: center;
+  padding: var(--s-6) var(--s-5);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.todo-list-state h3 {
+  margin-bottom: 8px;
+  font-size: var(--fs-lg);
+  color: var(--text-primary);
+}
+
+.todo-list-state p {
+  margin: 0;
+}
+
+.todo-list-state--error .mini-btn {
+  margin-top: var(--s-3);
+}
+
+.todos-list--skeleton {
+  margin-top: 0;
+}
+
+.todo-skeleton-row {
+  pointer-events: none;
+  cursor: default;
+}
+
+.todo-skeleton-row .todo-content {
+  gap: var(--s-2);
+}
+
+.skeleton-block {
+  display: inline-flex;
+  border-radius: 999px;
+  background: var(--card-hover);
+}
+
+.skeleton-block--checkbox {
+  width: 18px;
+  height: 18px;
+}
+
+.skeleton-block--drag {
+  width: 14px;
+  height: 18px;
+}
+
+.skeleton-block--kebab {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border-color);
+}
+
+.skeleton-chip {
+  width: 84px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--card-hover);
+}
+
+.empty-state-icon {
+  font-size: 4em;
+  margin-bottom: var(--s-4);
+}
+
+.empty-state-illustration {
+  width: 120px;
+  height: 96px;
+  margin: 0 auto var(--s-4);
+  display: block;
+}
+
+.empty-state-hint {
+  margin-top: var(--s-2);
+  font-size: var(--fs-sm);
+}
+
+.profile-section {
+  margin-bottom: var(--s-5);
+}
+
+.feedback-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
+  gap: var(--s-4);
+  align-items: start;
+}
+
+.feedback-card {
+  padding: var(--s-4);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  background: var(--card-bg);
+  box-shadow: var(--shadow-sm);
+}
+
+.feedback-card--context {
+  position: sticky;
+  top: var(--s-4);
+}
+
+.feedback-helper {
+  margin: var(--s-2) 0 0;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.feedback-context-list {
+  margin: 0 0 var(--s-5);
+}
+
+.feedback-context-row {
+  display: grid;
+  grid-template-columns: minmax(0, 110px) minmax(0, 1fr);
+  gap: var(--s-2);
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.feedback-context-row dt {
+  color: var(--text-secondary);
+  font-weight: var(--fw-medium);
+}
+
+.feedback-context-row dd {
+  margin: 0;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.feedback-submit-btn {
+  margin-top: var(--s-4);
+}
+
+.feedback-confirmation {
+  margin-bottom: var(--s-4);
+  padding: var(--s-4);
+  border: 1px solid color-mix(in oklab, var(--accent) 28%, var(--border-color));
+  border-radius: var(--r-lg);
+  background: color-mix(in oklab, var(--accent) 8%, var(--card-bg));
+}
+
+.feedback-confirmation__meta {
+  color: var(--text-secondary);
+}
+
+.feedback-confirmation__actions {
+  display: flex;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+  margin-top: var(--s-3);
+}
+
+.profile-section h3 {
+  margin-bottom: var(--s-3);
+  color: var(--text-primary);
+}
+
+@media (max-width: 960px) {
+  .feedback-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feedback-card--context {
+    position: static;
+  }
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--s-2) var(--s-3);
+  background: var(--surface-2);
+  border-radius: var(--r-sm);
+  margin-bottom: var(--s-1);
+  font-size: var(--fs-body);
+}
+
+.info-label {
+  font-weight: var(--fw-medium);
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+}
+
+.info-value {
+  color: var(--text-primary);
+  font-size: var(--fs-body);
+}
+
+.admin-layout {
+  display: grid;
+  gap: 24px;
+}
+
+.admin-section {
+  background: var(--surface-elevated, var(--card-bg));
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  padding: 20px;
+}
+
+.admin-section__header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.admin-section__title {
+  margin: 0;
+  font-size: var(--fs-section);
+}
+
+.admin-section__subtitle {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+}
+
+.admin-filter-groups {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.admin-filter-group {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-filter-label {
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+  color: var(--text-secondary);
+}
+
+.admin-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-filter-chip {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 999px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.admin-filter-chip.is-active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.admin-feedback-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 18px;
+}
+
+.admin-feedback-list,
+.admin-feedback-detail {
+  min-height: 220px;
+}
+
+.admin-feedback-row {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  border-radius: var(--r-md);
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+  display: grid;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.admin-feedback-row.is-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.admin-feedback-row__top,
+.admin-feedback-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  align-items: center;
+}
+
+.admin-feedback-row__meta {
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+}
+
+.admin-feedback-row__title {
+  color: var(--text-primary);
+}
+
+.admin-feedback-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 4px 8px;
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+  background: var(--card-bg);
+  color: var(--text-secondary);
+}
+
+.admin-feedback-pill--bug {
+  background: color-mix(in oklab, var(--danger) 12%, transparent);
+  color: var(--danger);
+}
+
+.admin-feedback-pill--feature {
+  background: color-mix(in oklab, var(--success) 12%, transparent);
+  color: var(--success);
+}
+
+.admin-feedback-pill--general,
+.admin-feedback-pill--status {
+  background: rgb(79 110 247 / 13%);
+  color: var(--accent);
+}
+
+.admin-detail-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  padding: 18px;
+  display: grid;
+  gap: 18px;
+}
+
+.admin-detail-card__header h3,
+.admin-detail-block h4 {
+  margin: 0;
+}
+
+.admin-detail-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.admin-detail-panel {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.admin-detail-block {
+  display: grid;
+  gap: 10px;
+}
+
+.admin-detail-block__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.admin-detail-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 14px;
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  font: inherit;
+}
+
+.admin-detail-meta {
+  display: grid;
+  gap: 10px;
+}
+
+.admin-detail-meta--card {
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+}
+
+.admin-detail-meta__row {
+  display: grid;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.admin-detail-meta__label {
+  font-size: var(--fs-meta);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.admin-detail-meta__value {
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.admin-detail-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: var(--text-primary);
+}
+
+.admin-detail-empty-copy {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.admin-detail-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.admin-detail-link:hover {
+  text-decoration: underline;
+}
+
+.admin-detail-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.admin-detail-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-feedback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.admin-feedback-empty {
+  border: 1px dashed var(--border-color);
+  border-radius: var(--r-md);
+  padding: 24px;
+  color: var(--text-secondary);
+}
+
+.admin-feedback-rejection {
+  min-height: 100px;
+}
+
+.admin-automation-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 18px;
+}
+
+.admin-automation-form {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-automation-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-primary);
+}
+
+.admin-automation-toggle input {
+  inline-size: 16px;
+  block-size: 16px;
+}
+
+.admin-automation-decision-list {
+  display: grid;
+  gap: 10px;
+}
+
+.admin-automation-decision {
+  width: 100%;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  border-radius: var(--r-md);
+  padding: 14px;
+  text-align: left;
+  cursor: pointer;
+  display: grid;
+  gap: 10px;
+}
+
+.admin-automation-decision:hover {
+  border-color: var(--accent);
+}
+
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+.users-table th,
+.users-table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.users-table th {
+  background: var(--card-bg);
+  font-weight: var(--fw-semibold);
+  color: var(--text-secondary);
+}
+
+.users-table tr:hover {
+  background: var(--card-bg);
+}
+
+.role-badge {
+  padding: 4px 8px;
+  border-radius: var(--r-sm);
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.role-badge.admin {
+  background: color-mix(in oklab, var(--warning) 14%, transparent);
+  color: var(--warning);
+}
+
+.role-badge.user {
+  background: rgb(79 110 247 / 13%);
+  color: var(--accent);
+}
+
+.action-btn {
+  padding: 6px 12px;
+  margin: 0 4px;
+  border: none;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: 0.85em;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.action-btn.promote {
+  background: var(--warning);
+  color: #000;
+}
+
+.action-btn.demote {
+  background: var(--muted);
+  color: white;
+}
+
+.action-btn.delete {
+  background: var(--danger);
+  color: white;
+}
+
+.action-btn:hover {
+  opacity: 0.8;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: var(--text-muted);
+}
+
+.spinner {
+  border: 3px solid var(--border-color);
+  border-top: 3px solid var(--accent);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 20px;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 600px) {
+  .container {
+    border-radius: 0;
+  }
+
+  .add-todo {
+    flex-direction: column;
+  }
+
+  .users-table {
+    font-size: 0.85em;
+  }
+
+  .action-btn {
+    padding: 4px 8px;
+    font-size: 0.75em;
+  }
+
+  .admin-feedback-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-automation-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-detail-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ========== PHASE B: PRIORITY, NOTES, SUBTASKS ========== */
+.priority-selector {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.priority-btn {
+  padding: 8px 16px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: var(--fs-body);
+  font-weight: 600;
+  transition:
+    background var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+}
+
+.priority-btn:hover {
+  transform: translateY(-2px);
+}
+
+.priority-btn.active {
+  border-width: 2px;
+}
+
+.priority-btn.low {
+  border-color: var(--accent-2);
+  color: var(--accent-2);
+}
+
+.priority-btn.low.active {
+  background: var(--accent-2);
+  color: white;
+}
+
+.priority-btn.medium {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.priority-btn.medium.active {
+  background: var(--warning);
+  color: white;
+}
+
+.priority-btn.high {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.priority-btn.high.active {
+  background: var(--danger);
+  color: white;
+}
+
+.priority-badge {
+  padding: 4px 10px;
+  border-radius: var(--r-sm);
+  font-size: 0.85em;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.priority-badge.low {
+  background: var(--accent-2);
+  color: white;
+}
+
+.priority-badge.medium {
+  background: var(--warning);
+  color: white;
+}
+
+.priority-badge.high {
+  background: var(--danger);
+  color: white;
+}
+
+.notes-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-color);
+}
+
+.notes-toggle {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: var(--fs-body);
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.notes-toggle:hover {
+  text-decoration: underline;
+}
+
+.notes-content {
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--card-bg);
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.notes-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: var(--fs-body);
+  resize: vertical;
+}
+
+.notes-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+.subtasks-section {
+  margin-top: 12px;
+}
+
+.subtask-list {
+  list-style: none;
+  margin-top: 8px;
+}
+
+.subtask-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--card-bg);
+  border-radius: var(--r-sm);
+  margin-bottom: 4px;
+  transition: background var(--dur-fast);
+}
+
+.subtask-item:hover {
+  background: var(--card-hover);
+}
+
+.subtask-item.completed {
+  opacity: 0.6;
+}
+
+.subtask-item.completed .subtask-title {
+  text-decoration: line-through;
+  color: var(--text-muted);
+}
+
+.subtask-title {
+  flex: 1;
+  color: var(--text-primary);
+  font-size: var(--fs-body);
+}
+
+.subtask-delete {
+  background: none;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  font-size: 1.1em;
+  padding: 2px 6px;
+  opacity: 0.6;
+}
+
+.subtask-delete:hover {
+  opacity: 1;
+}
+
+.todo-inline-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.todo-inline-actions select {
+  min-width: 160px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2500;
+  padding: 16px;
+}
+
+.modal-card {
+  width: min(760px, 100%);
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  background: var(--container-bg);
+  border-radius: var(--r-md);
+  padding: 18px;
+  box-shadow: var(--shadow-2);
+}
+
+.modal-card h3 {
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.confirm-dialog,
+.input-dialog {
+  max-width: 420px;
+  display: grid;
+  gap: 12px;
+}
+
+.confirm-dialog p,
+.input-dialog .input-dialog__label {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.confirm-dialog p {
+  font-size: var(--fs-body);
+}
+
+.confirm-dialog__actions .add-btn,
+.confirm-dialog__actions .mini-btn,
+.input-dialog__actions .add-btn,
+.input-dialog__actions .mini-btn {
+  width: auto;
+}
+
+.input-dialog__label {
+  display: block;
+  font-size: var(--fs-meta);
+  font-weight: 500;
+}
+
+.input-dialog__field {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--input-bg, var(--surface));
+  color: var(--text-primary);
+  font-size: var(--fs-body);
+  box-sizing: border-box;
+}
+
+.input-dialog__field:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted, rgb(99 102 241 / 20%));
+}
+
+.todo-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--scrim);
+  display: none;
+  z-index: 2390;
+}
+
+.todo-drawer-backdrop--open {
+  display: block;
+}
+
+.todo-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(420px, 100%);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--container-bg);
+  border-left: 1px solid var(--border-color);
+  z-index: 2400;
+  transform: translateX(100%);
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    transform var(--dur-slow) var(--ease-spring),
+    visibility 0s var(--dur-slow);
+}
+
+.todo-drawer--open {
+  transform: translateX(0);
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    transform var(--dur-slow) var(--ease-spring),
+    visibility 0s 0s;
+}
+
+.todo-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.todo-drawer__header h2 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.todo-drawer__content {
+  padding: 14px 16px;
+  overflow-y: auto;
+}
+
+.todo-drawer__section {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 10px;
+  background: var(--card-bg);
+  margin-bottom: 10px;
+}
+
+.todo-drawer__section-title {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.todo-drawer__section p {
+  color: var(--text-primary);
+  margin-bottom: 6px;
+  font-size: var(--fs-body);
+}
+
+.todo-drawer__save-status {
+  font-size: var(--fs-meta);
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.todo-drawer__save-status[data-state="saving"] {
+  color: var(--accent);
+}
+
+.todo-drawer__save-status[data-state="saved"] {
+  color: var(--success);
+}
+
+.todo-drawer__save-status[data-state="error"] {
+  color: var(--danger);
+}
+
+.todo-drawer__field {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.todo-drawer__field span {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  font-weight: 600;
+}
+
+.todo-drawer__field-hint {
+  color: var(--muted);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+
+/* ── Task picker (depends-on) ─────────────────────────────── */
+
+.task-picker {
+  position: relative;
+}
+
+.task-picker__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.task-picker__chips:empty {
+  margin-bottom: 0;
+}
+
+.task-picker__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--r-sm);
+  background: var(--card-hover);
+  color: var(--text);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-picker__chip-remove {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  flex-shrink: 0;
+}
+
+.task-picker__chip-remove:hover {
+  color: var(--danger);
+}
+
+.task-picker__search {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+  color: var(--text);
+  font-size: var(--fs-sm);
+}
+
+.task-picker__search::placeholder {
+  color: var(--muted);
+}
+
+.task-picker__dropdown {
+  display: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--card-bg);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+  margin-top: 2px;
+}
+
+.task-picker__dropdown--open {
+  display: block;
+}
+
+.task-picker__option {
+  padding: 6px 10px;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-picker__option:hover,
+.task-picker__option--active {
+  background: var(--card-hover);
+}
+
+.task-picker__option--done {
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+
+.task-picker__empty {
+  padding: 8px 10px;
+  font-size: var(--fs-sm);
+  color: var(--muted);
+}
+
+.todo-drawer__field input[type="text"],
+.todo-drawer__field input[type="date"],
+.todo-drawer__field textarea,
+.todo-drawer__field select {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.todo-drawer__field input[type="text"]:focus,
+.todo-drawer__field input[type="date"]:focus,
+.todo-drawer__field textarea:focus,
+.todo-drawer__field select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.todo-drawer__field--inline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.todo-drawer__accordion-toggle {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-weight: 600;
+  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.todo-drawer__accordion-toggle:hover {
+  background: var(--input-bg);
+  border-color: var(--border-color);
+}
+
+.todo-drawer__accordion-chevron {
+  color: var(--text-secondary);
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
+.todo-drawer__accordion-chevron--open {
+  transform: rotate(90deg);
+}
+
+.todo-drawer__accordion-panel {
+  margin-top: 8px;
+  display: grid;
+  gap: 10px;
+}
+
+.todo-drawer__accordion-panel[hidden] {
+  display: none !important;
+}
+
+.todo-drawer__subtasks-title {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  font-weight: 600;
+}
+
+.todo-drawer__subtasks-list {
+  list-style: none;
+  margin: 8px 0 0;
+  display: grid;
+  gap: 6px;
+}
+
+.todo-drawer__subtasks-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  font-size: var(--fs-body);
+}
+
+.todo-drawer__subtasks-item.completed {
+  color: var(--text-muted);
+}
+
+.todo-drawer__subtasks-empty {
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.todo-drawer-ai-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+}
+
+.todo-drawer-ai-card {
+  padding: 10px;
+}
+
+.todo-drawer-ai-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+}
+
+.todo-drawer-ai-card__label {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.todo-drawer-ai-card__summary {
+  margin-top: 4px;
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+}
+
+.todo-drawer-ai-card__rationale {
+  margin-top: 4px;
+}
+
+.todo-drawer-ai-card__actions {
+  margin-top: var(--s-2);
+}
+
+.todo-drawer__section--danger {
+  border-color: rgba(220, 38, 38, 0.35);
+}
+
+/* ── Agent action sections (Break Down / Follow Up) ── */
+.todo-drawer__agent-btn {
+  padding: 6px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.todo-drawer__agent-btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.todo-drawer__agent-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.todo-drawer__agent-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.todo-drawer__agent-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+  background: var(--primary-color);
+}
+
+.todo-drawer__agent-loading {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
+.todo-drawer__agent-error {
+  font-size: var(--fs-meta);
+  color: var(--danger);
+  margin-bottom: 6px;
+}
+
+.todo-drawer__agent-success {
+  font-size: var(--fs-meta);
+  color: var(--success-color, #16a34a);
+  padding: 4px 0;
+}
+
+.todo-drawer__break-down-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.todo-drawer__break-down-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: var(--fs-meta);
+  cursor: pointer;
+}
+
+.todo-drawer__break-down-item input[type="checkbox"] {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.todo-drawer__agent-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.todo-drawer__follow-up-preview {
+  font-size: var(--fs-meta);
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  margin-bottom: 10px;
+  color: var(--text-primary);
+}
+
+.todo-drawer__delete-btn {
+  width: 100%;
+  justify-self: stretch;
+}
+
+body.is-drawer-open {
+  overflow: hidden;
+}
+
+.todo-drawer {
+  overflow: hidden;
+}
+
+.todo-drawer__header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--container-bg);
+}
+
+.todo-drawer__content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 768px) {
+  .project-edit-drawer {
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: auto;
+    max-height: min(88dvh, 720px);
+    border-left: none;
+    border-top: 1px solid var(--border-color);
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    box-shadow: 0 -18px 36px rgba(15, 23, 42, 0.18);
+  }
+
+  .project-edit-drawer__handle {
+    display: block;
+    width: 44px;
+    height: 5px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--border-color) 76%, white);
+    margin: 10px auto 0;
+  }
+
+  .project-edit-drawer__header {
+    padding-top: 8px;
+  }
+
+  .project-edit-drawer__footer {
+    grid-template-columns: 1fr 1fr;
+    display: grid;
+  }
+
+  .project-edit-drawer__footer .add-btn,
+  .project-edit-drawer__footer .mini-btn {
+    width: 100%;
+  }
+
+  .todo-drawer {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100dvh;
+    max-height: 100dvh;
+    border-left: none;
+    border-top: none;
+    border-radius: 0;
+  }
+}
+
+.btn-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: var(--fs-section);
+}
+
+@media (max-width: 768px) {
+  .btn-icon {
+    width: 44px;
+    height: 44px;
+    font-size: var(--fs-section);
+  }
+}
+
+.btn-icon:hover {
+  background: var(--card-bg);
+}
+
+.add-subtask-form {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.add-subtask-input {
+  flex: 1;
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: 0.85em;
+}
+
+.add-subtask-btn {
+  padding: 6px 12px;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: 0.85em;
+}
+
+.add-subtask-btn:hover {
+  background: var(--accent-2);
+}
+
+.expand-section {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 6px 8px;
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.85em;
+  transition: color var(--dur-fast);
+  width: fit-content;
+}
+
+.expand-section:hover {
+  color: var(--accent);
+}
+
+.expand-icon {
+  font-size: 0.8em;
+  transition: transform var(--dur-base);
+}
+
+.expand-icon.expanded {
+  transform: rotate(90deg);
+}
+
+/* M3 PR1: calm list row visual refinement (presentation only) */
+.todo-item {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-3) var(--s-4);
+  border-radius: var(--r-md);
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  position: relative;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out),
+    transform var(--dur-fast) var(--ease-out);
+  min-width: 0;
+  min-height: var(--row-height);
+  isolation: isolate;
+}
+
+/* Hide secondary affordances by default; reveal on hover/mode */
+.todo-item .bulk-checkbox {
+  display: none;
+}
+
+.todo-item .drag-handle {
+  display: none;
+  position: absolute;
+  left: calc(-1 * var(--s-3));
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.5;
+}
+
+@media (hover: hover) {
+  .todo-item:hover .drag-handle {
+    display: flex;
+  }
+}
+
+/* Bulk selection mode: show checkboxes, expand grid */
+body.is-bulk-selecting .todo-item .bulk-checkbox {
+  display: block;
+}
+
+body.is-bulk-selecting .todo-item {
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+}
+
+/* Hover elevation (pointer devices only) */
+@media (hover: hover) {
+  .todo-item:hover {
+    border-color: color-mix(in oklab, var(--border-color) 70%, var(--accent));
+    box-shadow: var(--shadow-hover);
+    transform: translateY(-1px);
+  }
+
+  .todo-item:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-0);
+  }
+}
+
+/* Selected task (open in drawer) */
+.todo-item--selected {
+  border-left: 3px solid var(--accent);
+  background: color-mix(in oklab, var(--accent) 4%, var(--card-bg));
+}
+
+.todo-item:hover {
+  background: var(--surface);
+  border-color: var(--border);
+  box-shadow: var(--shadow-1);
+}
+
+.todo-item .bulk-checkbox,
+.todo-item .drag-handle,
+.todo-item .todo-checkbox {
+  align-self: start;
+  margin-top: 2px;
+}
+
+.todo-content {
+  min-width: 0;
+  display: grid;
+  gap: var(--s-2);
+}
+
+.todo-title {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-tight);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.todo-description {
+  font-size: var(--fs-meta);
+  line-height: 1.35;
+  color: var(--text-secondary);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.todo-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--s-2);
+  min-height: 24px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.todo-meta > :not(.todo-chip) {
+  font-size: var(--fs-meta);
+  line-height: 1;
+}
+
+.todo-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  line-height: 1.25;
+  white-space: nowrap;
+  max-width: min(100%, 220px);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+}
+
+.todo-chip--project {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 28%, transparent);
+  color: var(--accent);
+}
+
+.todo-chip--priority.low {
+  background: color-mix(in oklab, var(--success) 12%, transparent);
+  border-color: color-mix(in oklab, var(--success) 34%, transparent);
+  color: var(--success);
+}
+
+.todo-chip--priority.medium {
+  background: color-mix(in oklab, var(--warning) 12%, transparent);
+  border-color: color-mix(in oklab, var(--warning) 34%, transparent);
+  color: var(--warning);
+}
+
+.todo-chip--priority.high {
+  background: color-mix(in oklab, var(--danger) 12%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 34%, transparent);
+  color: var(--danger);
+}
+
+.todo-chip--due {
+  background: color-mix(in oklab, var(--accent) 7%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 24%, transparent);
+  color: var(--accent);
+}
+
+.todo-chip--due-overdue {
+  background: color-mix(in oklab, var(--danger) 14%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 36%, transparent);
+  color: var(--danger);
+}
+
+.todo-chip--recurrence {
+  background: color-mix(in oklab, var(--accent) 8%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 24%, transparent);
+  color: var(--accent);
+}
+
+.todo-chip--tag {
+  background: color-mix(in oklab, var(--muted) 10%, transparent);
+  border-color: color-mix(in oklab, var(--muted) 24%, transparent);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.todo-chip--tag:hover {
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
+  color: var(--accent);
+}
+
+.tag-filter-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-1);
+  padding: 2px var(--s-2);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.tag-filter-indicator:hover {
+  background: color-mix(in oklab, var(--accent) 20%, transparent);
+}
+
+.priority-badge {
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+}
+
+.todo-item.todo-item--active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.16);
+}
+
+.todo-item.todo-item--active:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.16);
+}
+
+.todo-item.completed {
+  opacity: 0.92;
+  background: color-mix(in oklab, var(--card-bg) 88%, var(--surface) 12%);
+}
+
+.todo-item.completed .todo-title,
+.todo-item.completed .todo-description,
+.todo-item.completed .todo-chip {
+  color: var(--text-secondary);
+}
+
+body.dark-mode .todo-item:hover {
+  border-color: var(--border);
+}
+
+body.dark-mode .todo-chip {
+  background: var(--surface-2);
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+body.dark-mode .todo-chip--project {
+  background: color-mix(in oklab, var(--accent) 13%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 34%, transparent);
+}
+
+body.dark-mode .todo-chip--priority.low {
+  background: color-mix(in oklab, var(--success) 18%, transparent);
+  border-color: color-mix(in oklab, var(--success) 38%, transparent);
+}
+
+body.dark-mode .todo-chip--priority.medium {
+  background: color-mix(in oklab, var(--warning) 18%, transparent);
+  border-color: color-mix(in oklab, var(--warning) 36%, transparent);
+}
+
+body.dark-mode .todo-chip--priority.high {
+  background: color-mix(in oklab, var(--danger) 20%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 40%, transparent);
+}
+
+body.dark-mode .todo-chip--due {
+  background: color-mix(in oklab, var(--accent) 14%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 34%, transparent);
+}
+
+body.dark-mode .todo-chip--due-overdue {
+  background: color-mix(in oklab, var(--danger) 20%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 42%, transparent);
+}
+
+.todo-item.completed .todo-chip {
+  opacity: 0.88;
+}
+
+@media (max-width: 768px) {
+  .todo-item {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-rows: auto auto;
+    row-gap: var(--s-2);
+    column-gap: var(--s-2);
+    padding: var(--s-3);
+  }
+
+  .todo-item .bulk-checkbox {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .todo-item .drag-handle {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .todo-item .todo-checkbox {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .todo-row-actions {
+    grid-column: 5;
+    grid-row: 1;
+    justify-self: end;
+    width: 34px;
+    min-width: 34px;
+    max-width: 34px;
+  }
+
+  .todo-content {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    gap: 6px;
+  }
+
+  .todo-chip {
+    font-size: var(--fs-label);
+  }
+
+  .todo-kebab {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .todo-title {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+/* M7 PR77: inputs + buttons calm-system normalization (CSS only) */
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: 1px solid transparent;
+}
+
+.btn-secondary {
+  background: var(--surface-2);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid transparent;
+}
+
+.add-btn,
+.btn {
+  min-height: 40px;
+  padding: 0 var(--s-3);
+  border-radius: var(--r-sm);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: 1px solid transparent;
+  font-weight: var(--fw-semibold);
+}
+
+.mini-btn {
+  min-height: 40px;
+  padding: 0 var(--s-3);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  font-weight: var(--fw-medium);
+}
+
+.mini-btn:hover {
+  background: color-mix(in oklab, var(--surface-2) 70%, var(--surface));
+  border-color: color-mix(in oklab, var(--border-color) 72%, var(--text-muted));
+  opacity: 1;
+}
+
+.top-add-btn,
+.more-filters-toggle,
+#projectsRailMobileOpen {
+  min-height: 40px;
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+#projectsRailToggle,
+.projects-rail-kebab,
+.todo-kebab {
+  min-width: 36px;
+  min-height: 36px;
+}
+
+.search-input,
+.quick-entry > input,
+.field-row input,
+.field-row select,
+.ai-workspace-inputs input,
+.add-subtask-input,
+.todo-inline-actions select,
+.todo-kebab-project-label select,
+.todo-drawer__field input[type="text"],
+.todo-drawer__field input[type="date"],
+.todo-drawer__field select {
+  min-height: 40px;
+  padding-left: var(--s-3);
+  padding-right: var(--s-3);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.todo-drawer__field textarea,
+.notes-textarea,
+.ai-brain-dump-input {
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.search-input:hover,
+.quick-entry > input:hover,
+.field-row input:hover,
+.field-row select:hover,
+.ai-workspace-inputs input:hover,
+.todo-drawer__field input[type="text"]:hover,
+.todo-drawer__field input[type="date"]:hover,
+.todo-drawer__field select:hover,
+.todo-drawer__field textarea:hover,
+.notes-textarea:hover,
+.ai-brain-dump-input:hover,
+.mini-btn:hover {
+  border-color: color-mix(in oklab, var(--border-color) 72%, var(--text-muted));
+}
+
+.search-input:focus,
+.quick-entry > input:focus,
+.field-row input:focus,
+.field-row select:focus,
+.ai-workspace-inputs input:focus,
+.todo-drawer__field input[type="text"]:focus,
+.todo-drawer__field input[type="date"]:focus,
+.todo-drawer__field select:focus,
+.todo-drawer__field textarea:focus,
+.notes-textarea:focus,
+.ai-brain-dump-input:focus,
+.mini-btn:focus,
+.add-btn:focus,
+.btn:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[role="button"]:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+
+.todos-top-bar {
+  min-width: 0;
+}
+
+.todos-top-bar-left,
+.todos-top-bar-search,
+.todos-top-bar-actions {
+  min-width: 0;
+}
+
+.todos-top-bar-actions {
+  flex-wrap: nowrap;
+}
+
+#projectsRailTopbarLabel {
+  line-height: var(--lh-tight);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.todo-chip {
+  min-height: 24px;
+  line-height: 1.2;
+  background: var(--surface-2);
+  border-color: color-mix(in oklab, var(--border-color) 88%, var(--surface));
+}
+
+.todo-chip--project {
+  background: color-mix(in oklab, var(--surface-2) 84%, var(--accent));
+  border-color: color-mix(in oklab, var(--border-color) 74%, var(--accent));
+}
+
+.todo-chip--priority.low,
+.todo-chip--priority.medium,
+.todo-chip--priority.high {
+  filter: saturate(0.82);
+}
+
+/* Post-M7 combined polish: low-risk containment + calm density hardening */
+#todosView .todos-top-bar,
+#todosView .todos-top-bar-left,
+#todosView .todos-top-bar-search,
+#todosView .todos-top-bar-actions,
+#todosView .todos-list-header,
+#todosView .todos-list-header__context,
+#todosView .todo-item,
+#todosView .todo-content,
+#todosView .todo-meta,
+#todosView .todo-row-actions,
+#todosView .projects-rail-row,
+#todosView .projects-rail-item,
+#todosView .projects-rail-item__label,
+#todosView #todosContent {
+  min-width: 0;
+}
+
+#todosView #todosScrollRegion {
+  overflow-x: hidden;
+}
+
+#todosView #todosScrollRegion > * {
+  min-width: 0;
+}
+
+#todosView .todos-top-bar-actions {
+  flex-wrap: nowrap;
+}
+
+#todosView .todos-top-bar-actions .top-add-btn,
+#todosView .todos-top-bar-actions .more-filters-toggle {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+#todosView .projects-rail-item__label,
+#todosView #projectsRailTopbarLabel,
+#todosView .todos-list-header__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#todosView .projects-rail.projects-rail--collapsed .projects-rail-item {
+  overflow: hidden;
+}
+
+#todosView .todo-item {
+  grid-template-columns: auto minmax(0, 1fr) 34px;
+}
+
+#todosView .todo-row-actions {
+  width: 34px;
+  min-width: 34px;
+  max-width: 34px;
+}
+
+#todosView .todo-title,
+#todosView .todo-description {
+  min-width: 0;
+}
+
+#todosView .todo-chip {
+  max-width: min(100%, 180px);
+  min-height: 24px;
+  line-height: 1.2;
+  padding: 3px 9px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Post-M7 combined hardening: topbar/rail/header/row overflow + truncation invariants */
+.todos-layout,
+.todos-main-zone,
+.todos-top-bar,
+.todos-top-bar-left,
+.todos-top-bar-search,
+.todos-top-bar-actions,
+#todosScrollRegion,
+#todosContent,
+.todos-list-header,
+.todos-list-header__context,
+.todo-item,
+.todo-content,
+.todo-meta,
+.todo-row-actions,
+.projects-rail-row,
+.projects-rail-item,
+.projects-rail-item__label {
+  min-width: 0;
+}
+
+.todos-top-bar {
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
+}
+
+.projects-rail-mobile-open {
+  max-width: min(42vw, 320px);
+}
+
+#projectsRailTopbarLabel {
+  max-width: 100%;
+}
+
+.todos-top-bar-actions {
+  flex-wrap: nowrap;
+}
+
+.todos-top-bar-actions .top-add-btn,
+.todos-top-bar-actions .more-filters-toggle {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+
+.todos-list-header {
+  overflow: hidden;
+  flex-wrap: nowrap;
+}
+
+.todos-list-header__context {
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.todos-list-header__title {
+  max-width: 100%;
+}
+
+#todosScrollRegion > * {
+  min-width: 0;
+}
+
+.projects-rail.projects-rail--collapsed .projects-rail-item {
+  overflow: hidden;
+}
+
+.projects-rail.projects-rail--collapsed .projects-rail-item__label {
+  max-width: 100%;
+}
+
+.todo-item {
+  grid-template-columns: auto minmax(0, 1fr) 34px;
+}
+
+.todo-row-actions {
+  width: 34px;
+  min-width: 34px;
+  max-width: 34px;
+  overflow: visible;
+}
+
+.todo-title,
+.todo-description {
+  min-width: 0;
+}
+
+.todo-meta {
+  overflow: hidden;
+}
+
+.todo-chip {
+  max-width: min(100%, 180px);
+}
+
+@media (max-width: 768px) {
+  .home-focus-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .floating-new-task-cta {
+    right: 16px;
+    bottom: 72px;
+  }
+
+  .todos-top-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .todos-top-bar-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .todos-list-header {
+    flex-wrap: wrap;
+  }
+
+  .projects-rail-mobile-open {
+    max-width: 100%;
+  }
+}
+
+/* M8: Notion-like calm density (single strong CTA in Todos) */
+body.is-todos-view .add-btn,
+body.is-todos-view .btn,
+body.is-todos-view .mini-btn {
+  background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
+  color: var(--text-secondary);
+  border: 1px solid color-mix(in oklab, var(--border-color) 80%, var(--surface));
+  font-weight: var(--fw-medium);
+  box-shadow: none;
+}
+
+body.is-todos-view .add-btn:hover,
+body.is-todos-view .btn:hover,
+body.is-todos-view .mini-btn:hover {
+  background: color-mix(in oklab, var(--surface) 78%, var(--surface-2));
+  color: var(--text-primary);
+  border-color: color-mix(in oklab, var(--border-color) 66%, var(--text-muted));
+}
+
+body.is-todos-view .top-add-btn {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border-color: transparent;
+  font-weight: var(--fw-semibold);
+}
+
+body.is-todos-view .top-add-btn:hover {
+  filter: saturate(1.05) brightness(1.02);
+}
+
+body.is-todos-view .todos-top-bar,
+body.is-todos-view .more-filters-panel,
+body.is-todos-view .todos-list-header,
+body.is-todos-view .quick-entry-properties-panel {
+  border-color: color-mix(in oklab, var(--border-color) 72%, var(--surface));
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+}
+
+body.is-todos-view .todos-top-bar {
+  padding: 14px;
+}
+
+body.is-todos-view .todos-list-header {
+  padding: 14px;
+}
+
+body.is-todos-view .projects-rail {
+  background: transparent;
+  border-color: color-mix(in oklab, var(--border-color) 72%, transparent);
+  box-shadow: none;
+}
+
+body.is-todos-view .projects-rail-item,
+body.is-todos-view .todo-item {
+  border-color: color-mix(in oklab, var(--border-color) 74%, var(--surface));
+}
+
+/* M9: Sidebar hierarchy + density polish */
+body.is-todos-view #appSidebar {
+  padding: 12px 10px;
+  background: color-mix(in oklab, var(--surface-2) 90%, var(--surface));
+}
+
+body.is-todos-view .app-sidebar__top {
+  gap: 10px;
+}
+
+body.is-todos-view #projectsRailHost > #projectsRail {
+  padding: 0 2px;
+}
+
+body.is-todos-view .projects-rail {
+  gap: 10px;
+}
+
+body.is-todos-view .projects-rail__header {
+  padding: 0 6px 6px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--border-color) 70%, transparent);
+}
+
+body.is-todos-view .projects-rail__section {
+  padding-top: 10px;
+  margin-top: 2px;
+  border-top-color: color-mix(in oklab, var(--border-color) 70%, transparent);
+}
+
+body.is-todos-view .projects-rail__section--workspace {
+  margin-top: 0;
+}
+
+body.is-todos-view .projects-rail__section-header {
+  margin-bottom: 6px;
+  padding: 0 6px;
+  font-size: 12px;
+  text-transform: none;
+  color: color-mix(in oklab, var(--text-secondary) 84%, var(--text-muted));
+}
+
+body.is-todos-view .projects-rail__primary,
+body.is-todos-view .projects-rail__list,
+body.is-todos-view .app-sidebar__settings {
+  gap: 4px;
+}
+
+body.is-todos-view .projects-rail-row {
+  padding-right: 30px;
+}
+
+body.is-todos-view .projects-rail-item,
+body.is-todos-view .sidebar-nav-item {
+  border-radius: 8px;
+  padding: 6px 8px;
+  min-height: 34px;
+  background: transparent;
+  border-color: transparent;
+}
+
+body.is-todos-view .workspace-view-item,
+body.is-todos-view .sidebar-nav-item {
+  font-weight: var(--fw-medium);
+}
+
+body.is-todos-view .projects-rail-item:hover {
+  background: color-mix(in oklab, var(--surface) 86%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
+}
+
+body.is-todos-view .projects-rail-item--active,
+body.is-todos-view .projects-rail-item[role="option"][aria-selected="true"] {
+  background: color-mix(in oklab, var(--accent) 7%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 22%, var(--border-color));
+}
+
+body.is-todos-view .projects-rail-item__count {
+  font-size: 11px;
+  color: color-mix(in oklab, var(--text-secondary) 82%, var(--text-muted));
+  background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 58%, transparent);
+  padding: 1px 6px;
+  min-width: 20px;
+}
+
+body.is-todos-view .projects-rail-kebab {
+  width: 22px;
+  height: 22px;
+  right: 2px;
+  background: transparent;
+}
+
+body.is-todos-view .app-sidebar__settings .projects-rail-item {
+  justify-content: flex-start;
+}
+
+/* M9: Main panel compaction (keep behavior unchanged) */
+body.is-todos-view #appMainScroll {
+  padding: 12px;
+}
+
+body.is-todos-view .content {
+  padding: 0;
+}
+
+body.is-todos-view .header {
+  padding: 8px 12px;
+}
+
+body.is-todos-view .user-bar {
+  margin-top: 6px;
+}
+
+body.is-todos-view .nav-tabs {
+  padding: 4px 10px;
+  gap: 6px;
+}
+
+body.is-todos-view .nav-tab {
+  padding: 4px 9px;
+  font-size: 11px;
+  color: color-mix(in oklab, var(--text-secondary) 90%, var(--text-muted));
+  background: color-mix(in oklab, var(--surface) 96%, transparent);
+}
+
+body.is-todos-view .nav-tab.active {
+  color: color-mix(in oklab, var(--accent) 70%, var(--text-primary));
+  border-color: color-mix(in oklab, var(--accent) 28%, var(--border-color));
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface));
+}
+
+body.is-todos-view .todos-top-bar {
+  gap: 10px;
+  margin-bottom: 8px;
+  padding: 10px 12px;
+}
+
+body.is-todos-view .search-input {
+  padding: 10px 38px 10px 12px;
+}
+
+body.is-todos-view #todosScrollRegion {
+  gap: 8px;
+  padding-bottom: 8px;
+}
+
+body.is-todos-view .more-filters-panel {
+  padding: 10px 12px;
+}
+
+body.is-todos-view .add-todo.quick-entry {
+  gap: 8px;
+}
+
+body.is-todos-view .quick-entry > input,
+body.is-todos-view .field-row input,
+body.is-todos-view .field-row select {
+  padding: 10px 12px;
+}
+
+body.is-todos-view .quick-entry-toolbar {
+  margin-top: -2px;
+}
+
+body.is-todos-view .quick-entry-properties-panel {
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+body.is-todos-view .field-row {
+  gap: 10px;
+}
+
+body.is-todos-view .action-row {
+  gap: 10px;
+}
+
+body.is-todos-view .todos-list-header {
+  align-items: center;
+  padding: 10px 12px;
+}
+
+/* M9a: keep legacy top tabs available (less dominant) for Todos<->Settings switching */
+body.is-todos-view .nav-tabs {
+  display: flex !important;
+}
+
+/* M9a: preserve topbar/quick-entry/AI goal input height parity for CTA invariants */
+body.is-todos-view .ai-workspace-inputs input {
+  padding: 10px 12px;
+}
+
+/* M10: Density tighten follow-up (reduce pre-list vertical stack) */
+body.is-todos-view #appSidebar {
+  padding: 10px 8px;
+}
+
+body.is-todos-view #appMainScroll {
+  padding: 10px;
+}
+
+body.is-todos-view .projects-rail__header {
+  padding: 0 4px 5px;
+}
+
+body.is-todos-view .projects-rail__section-header {
+  margin-bottom: 4px;
+  padding: 0 4px;
+}
+
+body.is-todos-view .projects-rail-item,
+body.is-todos-view .sidebar-nav-item {
+  padding: 5px 7px;
+  min-height: 32px;
+}
+
+body.is-todos-view .projects-rail-item__count {
+  padding: 1px 5px;
+}
+
+body.is-todos-view .todos-top-bar {
+  gap: 8px;
+  margin-bottom: 6px;
+  padding: 8px 10px;
+}
+
+body.is-todos-view .todos-top-bar-actions {
+  gap: 6px;
+}
+
+body.is-todos-view #todosScrollRegion {
+  gap: 6px;
+  padding-bottom: 6px;
+}
+
+body.is-todos-view .more-filters-panel,
+body.is-todos-view .todos-list-header {
+  padding: 8px 10px;
+}
+
+body.is-todos-view .add-todo.quick-entry {
+  gap: 6px;
+}
+
+body.is-todos-view .quick-entry > input {
+  padding-top: 9px;
+  padding-bottom: 9px;
+}
+
+body.is-todos-view .quick-entry-toolbar {
+  margin-top: -4px;
+}
+
+body.is-todos-view .quick-entry-properties-panel {
+  gap: 8px;
+  padding: 8px 10px;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row {
+  gap: 8px;
+  align-items: center;
+}
+
+body.is-todos-view .quick-entry-properties-panel .action-row {
+  gap: 8px;
+  align-items: center;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row select {
+  min-width: 150px;
+}
+
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"] {
+  min-width: 170px;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+  padding: 8px 10px !important;
+  font-size: 12px;
+  min-height: 36px;
+}
+
+body.is-todos-view .action-label {
+  font-size: 12px;
+}
+
+body.is-todos-view .priority-selector {
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+body.is-todos-view .priority-btn {
+  padding: 6px 10px;
+  font-size: 0.8em;
+  line-height: 1.1;
+}
+
+body.is-todos-view .priority-btn:hover {
+  transform: none;
+}
+
+@media (min-width: 1180px) {
+  body.is-todos-view .quick-entry-properties-panel {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  body.is-todos-view .quick-entry-properties-panel > .field-row {
+    grid-column: 1;
+  }
+
+  body.is-todos-view .quick-entry-properties-panel > .action-row {
+    grid-column: 2;
+    justify-self: end;
+    margin: 0;
+  }
+
+  body.is-todos-view
+    .quick-entry-properties-panel
+    > .action-row
+    #critiqueDraftButton {
+    max-width: 170px;
+  }
+}
+
+@media (max-width: 1179px) {
+  body.is-todos-view .quick-entry-properties-panel {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* M11: Quick-entry accordion density pass (reduce pre-list stack height) */
+body.is-todos-view .add-todo.quick-entry {
+  gap: 4px;
+}
+
+body.is-todos-view .quick-entry > input {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+body.is-todos-view .quick-entry-toolbar {
+  margin-top: -6px;
+  min-height: 28px;
+}
+
+body.is-todos-view .quick-entry-properties-toggle {
+  padding: 4px 8px;
+  font-size: 12px;
+  min-height: 28px;
+}
+
+body.is-todos-view .quick-entry-properties-panel {
+  gap: 6px;
+  padding: 6px 8px;
+  margin-top: 0;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row,
+body.is-todos-view .quick-entry-properties-panel .action-row {
+  gap: 6px;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row input,
+body.is-todos-view .quick-entry-properties-panel .field-row select,
+body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+  min-height: 34px;
+}
+
+body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+  padding: 6px 9px !important;
+  font-size: 11px;
+}
+
+body.is-todos-view .action-label {
+  font-size: 11px;
+}
+
+body.is-todos-view .priority-selector {
+  gap: 4px;
+}
+
+body.is-todos-view .priority-btn {
+  padding: 4px 8px;
+  font-size: 0.76em;
+}
+
+body.is-todos-view .expand-section {
+  margin-top: 4px;
+  padding: 4px 6px;
+  font-size: 0.8em;
+}
+
+body.is-todos-view .notes-textarea {
+  margin-top: 4px !important;
+}
+
+/* M12: secondary top tabs + unified rail row polish */
+body.is-todos-view .nav-tabs {
+  gap: 4px;
+  padding: 3px 8px;
+  background: color-mix(in oklab, var(--card-bg) 96%, var(--surface));
+  border-bottom-color: color-mix(
+    in oklab,
+    var(--border-color) 55%,
+    transparent
+  );
+}
+
+body.is-todos-view .nav-tab {
+  padding: 3px 8px;
+  font-size: 10px;
+  line-height: 1.15;
+  border-radius: 999px;
+  border-color: color-mix(in oklab, var(--border-color) 50%, transparent);
+  background: color-mix(in oklab, var(--surface) 98%, transparent);
+  color: color-mix(in oklab, var(--text-secondary) 78%, var(--text-muted));
+}
+
+body.is-todos-view .nav-tab:hover {
+  background: color-mix(in oklab, var(--surface) 88%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 68%, transparent);
+  color: var(--text-secondary);
+}
+
+body.is-todos-view .nav-tab.active {
+  color: color-mix(in oklab, var(--accent) 62%, var(--text-primary));
+  border-color: color-mix(in oklab, var(--accent) 20%, var(--border-color));
+  background: color-mix(in oklab, var(--accent) 4%, var(--surface));
+  box-shadow: none;
+}
+
+body.is-todos-view .projects-rail {
+  gap: 8px;
+}
+
+body.is-todos-view .projects-rail__section {
+  padding-top: 8px;
+  margin-top: 0;
+}
+
+body.is-todos-view .projects-rail__section-header {
+  margin-bottom: 3px;
+  padding: 0 3px;
+  font-size: 11px;
+  letter-spacing: 0.01em;
+}
+
+body.is-todos-view .projects-rail__primary,
+body.is-todos-view .projects-rail__list,
+body.is-todos-view .app-sidebar__settings {
+  gap: 2px;
+}
+
+body.is-todos-view .projects-rail-row {
+  padding-right: 28px;
+}
+
+body.is-todos-view .projects-rail-item,
+body.is-todos-view .sidebar-nav-item {
+  min-height: 30px;
+  padding: 4px 7px;
+  border-radius: 7px;
+  border-color: transparent;
+}
+
+body.is-todos-view .projects-rail-item:hover,
+body.is-todos-view .sidebar-nav-item:hover {
+  background: color-mix(in oklab, var(--surface) 84%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 60%, transparent);
+}
+
+body.is-todos-view .projects-rail-item--active,
+body.is-todos-view .projects-rail-item[role="option"][aria-selected="true"] {
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface));
+  border-color: color-mix(in oklab, var(--accent) 18%, var(--border-color));
+}
+
+body.is-todos-view .projects-rail-item__count {
+  min-width: 18px;
+  padding: 0 5px;
+  font-size: 10px;
+  font-weight: 500;
+  color: color-mix(in oklab, var(--text-secondary) 72%, var(--text-muted));
+  background: color-mix(in oklab, var(--surface) 90%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 45%, transparent);
+}
+
+.home-dashboard {
+  display: grid;
+  gap: 12px;
+}
+
+.home-dashboard__new-task {
+  width: auto;
+  min-width: 112px;
+}
+
+.home-dashboard__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.home-tile--priorities {
+  margin-bottom: 16px;
+}
+.home-priorities-body {
+  min-height: 40px;
+}
+.home-priorities-state {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  padding: 8px 0;
+}
+.home-priorities-state--error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.home-priorities-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 0.5px solid var(--color-border-tertiary);
+}
+.home-priorities-status--warning {
+  color: var(--color-warning-strong, #8a5a00);
+}
+.home-priorities-refresh-btn {
+  font-size: 14px;
+  padding: 2px 8px;
+  line-height: 1;
+}
+.home-priorities-timestamp {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-top: 12px;
+}
+.home-priorities-status + .home-priorities-timestamp {
+  margin-top: 6px;
+}
+
+/* Hide empty warn/card sections when LLM returns empty containers */
+.home-priorities-body .lbl:has(+ .warn:empty),
+.home-priorities-body .warn:empty {
+  display: none;
+}
+
+/* Hide zero-count badges in the sidebar / project rail */
+.projects-rail-item__count:empty,
+.projects-rail-item__count[data-count="0"] {
+  display: none;
+}
+
+.lbl {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 1.5rem 0 0.6rem;
+  display: block;
+}
+.urgent {
+  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  border: 0.5px solid color-mix(in oklab, var(--danger) 40%, transparent);
+  border-radius: var(--border-radius-md);
+  padding: 0.6rem 1rem;
+  font-size: 13px;
+  color: var(--danger);
+  margin-bottom: 0.75rem;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+.warn {
+  background: color-mix(in oklab, var(--warning) 14%, var(--surface));
+  border: 0.5px solid var(--warning);
+  border-radius: var(--border-radius-md);
+  padding: 0.6rem 1rem;
+  font-size: 13px;
+  color: var(--warning);
+  margin-bottom: 0.6rem;
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+.dot-lg {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+.dot-lg.r {
+  background: var(--danger);
+}
+.dot-lg.a {
+  background: var(--warning);
+}
+.track {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 0.5rem;
+}
+.col-head {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: var(--border-radius-md) var(--border-radius-md) 0 0;
+  text-align: center;
+}
+.col-head.now {
+  background: color-mix(in oklab, var(--warning) 14%, var(--surface));
+  color: var(--warning);
+}
+.col-head.soon {
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface));
+  color: var(--accent);
+}
+.col-head.after {
+  background: var(--surface-2);
+  color: var(--muted);
+}
+.col-body {
+  background: var(--color-background-primary);
+  border: 0.5px solid var(--color-border-tertiary);
+  border-radius: 0 0 var(--border-radius-md) var(--border-radius-md);
+  padding: 0.6rem 0.75rem;
+  min-height: 60px;
+}
+.item {
+  font-size: 12px;
+  color: var(--color-text-primary);
+  padding: 4px 0;
+  border-bottom: 0.5px solid var(--color-border-tertiary);
+  display: flex;
+  gap: 6px;
+  line-height: 1.45;
+  align-items: flex-start;
+}
+.item:last-child {
+  border-bottom: none;
+}
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 5px;
+}
+.dot.r {
+  background: var(--danger);
+}
+.dot.a {
+  background: var(--warning);
+}
+.dot.g {
+  background: var(--success);
+}
+.dot.b {
+  background: var(--accent);
+}
+.dot.p {
+  background: var(--accent-2);
+}
+.card {
+  background: var(--color-background-primary);
+  border: 0.5px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-lg);
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.75rem;
+}
+.row {
+  display: flex;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 0.5px solid var(--color-border-tertiary);
+  align-items: flex-start;
+}
+.row:last-child {
+  border-bottom: none;
+}
+.rn {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  width: 18px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.rt {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+.rb {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+  line-height: 1.5;
+}
+
+.home-tile {
+  border: 1px solid color-mix(in oklab, var(--border-color) 52%, transparent);
+  border-radius: 18px;
+  background: color-mix(in oklab, var(--surface) 96%, var(--surface-2));
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+  padding: 15px;
+  display: grid;
+  align-content: start;
+  gap: 9px;
+}
+
+.home-tile__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.home-tile__title {
+  margin: 0;
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  letter-spacing: -0.01em;
+}
+
+.home-tile__subtitle {
+  margin: 3px 0 0;
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  line-height: 1.4;
+  max-width: 32ch;
+}
+
+.home-tile__see-all {
+  white-space: nowrap;
+  background: transparent;
+  border-color: transparent;
+  padding-right: 0;
+}
+
+.home-tile__body {
+  display: grid;
+  gap: 7px;
+}
+
+.home-tile__empty,
+.home-tile__helper {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  padding: 8px 4px;
+}
+
+.home-tile__date-label {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+}
+
+.home-tile__empty--error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.home-upcoming-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.home-upcoming-tab {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border: 0.5px solid var(--color-border-tertiary);
+  border-radius: 99px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    color 0.1s;
+  white-space: nowrap;
+}
+
+.home-upcoming-tab:hover {
+  background: var(--color-background-secondary);
+}
+
+.home-upcoming-tab--active {
+  background: var(--color-background-secondary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-secondary);
+}
+
+.home-tile--plan .home-tile__body {
+  min-height: 48px;
+}
+
+.home-tile--upcoming .home-tile__body {
+  min-height: 40px;
+}
+
+.home-task-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 7px 9px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--surface) 95%, var(--surface-2));
+  border: 1px solid color-mix(in oklab, var(--border-color) 48%, transparent);
+}
+
+.home-task-row__checkbox {
+  margin: 0;
+}
+
+.home-task-row__title {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-task-row__title:hover {
+  color: var(--accent);
+}
+
+.home-task-row__badge {
+  font-size: 0.72rem;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--border-color) 70%, transparent);
+  color: var(--text-secondary);
+  background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
+}
+
+.home-task-row__badge--overdue {
+  color: var(--danger);
+  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  border-color: color-mix(in oklab, var(--danger) 30%, var(--border-color));
+}
+
+.home-task-row__project {
+  justify-self: start;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.home-task-row__project:hover {
+  color: var(--accent);
+}
+
+.home-task-row__reason {
+  grid-column: 2 / -1;
+  margin-top: -2px;
+  color: color-mix(in oklab, var(--text-secondary) 86%, var(--surface));
+  font-size: 0.72rem;
+  line-height: 1.25;
+}
+
+.home-task-row__actions {
+  grid-column: 2 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.home-task-row__action {
+  padding: 4px 8px;
+  font-size: 0.72rem;
+}
+
+.home-task-row__action--secondary {
+  background: transparent;
+}
+
+.home-task-group {
+  display: grid;
+  gap: 4px;
+}
+
+.home-task-group + .home-task-group {
+  margin-top: 2px;
+}
+
+.home-task-group__label {
+  padding: 2px 4px 0;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--text-secondary) 82%, var(--surface));
+}
+
+.home-task-group__items {
+  display: grid;
+  gap: 6px;
+}
+
+.home-project-row {
+  width: 100%;
+  border: 1px solid color-mix(in oklab, var(--border-color) 60%, transparent);
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+  color: var(--text-primary);
+  border-radius: 10px;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  display: grid;
+  gap: 4px;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.home-project-row:hover {
+  border-color: color-mix(in oklab, var(--accent) 26%, var(--border-color));
+}
+
+.home-project-row__name {
+  font-weight: 600;
+}
+
+.home-project-row__meta {
+  font-size: var(--fs-label);
+  color: var(--text-secondary);
+}
+
+.task-composer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.34);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--dur-fast) var(--ease-out);
+  z-index: 1100;
+}
+
+.task-composer-backdrop--open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.task-composer-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1101;
+  margin: 0 auto;
+  width: min(760px, calc(100vw - 16px));
+  max-height: min(82vh, 720px);
+  background: var(--surface);
+  border: 1px solid color-mix(in oklab, var(--border-color) 75%, transparent);
+  border-bottom: 0;
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 -8px 36px rgba(15, 23, 42, 0.18);
+  transform: translateY(calc(100% + 16px));
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform var(--dur-base) var(--ease-out),
+    opacity var(--dur-base) var(--ease-out);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+.task-composer-sheet--open {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.task-composer-sheet__handle {
+  width: 42px;
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--border-color) 85%, transparent);
+  margin: 8px auto 4px;
+}
+
+.task-composer-sheet__header,
+.task-composer-sheet__footer {
+  padding: 8px 14px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.task-composer-sheet__header h3 {
+  margin: 0;
+  font-size: var(--fs-body);
+}
+
+.task-composer-sheet__body {
+  overflow: auto;
+  padding: 0 14px 10px;
+  display: grid;
+  gap: 10px;
+}
+
+.task-composer-sheet #todoInput {
+  width: 100%;
+  min-height: 40px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  font-size: var(--fs-body);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.task-composer-properties {
+  display: grid;
+  gap: 10px;
+}
+
+.task-composer-fields {
+  align-items: center;
+}
+
+.task-composer-advanced {
+  border-top: 1px solid var(--border-color);
+  margin-top: var(--s-2);
+  padding-top: var(--s-2);
+}
+
+.task-composer-advanced__toggle {
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  padding: var(--s-1) 0;
+  user-select: none;
+  list-style: none;
+}
+
+.task-composer-advanced__toggle::-webkit-details-marker {
+  display: none;
+}
+
+.task-composer-advanced__toggle::before {
+  content: "▸ ";
+}
+
+.task-composer-advanced[open] > .task-composer-advanced__toggle::before {
+  content: "▾ ";
+}
+
+.task-composer-fields > select {
+  min-width: 0;
+  flex: 1 1 220px;
+}
+
+.task-composer-inline-field {
+  display: flex;
+  flex: 1 1 180px;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+}
+
+.task-composer-inline-field > input,
+.task-composer-inline-field > select,
+.task-composer-inline-field > textarea {
+  width: 100%;
+}
+
+.task-composer-inline-field__hint {
+  color: var(--muted);
+  font-size: var(--fs-xs);
+  line-height: 1.4;
+}
+
+.task-composer-inline-field--wide {
+  flex-basis: 260px;
+}
+
+.todo-drawer__meta {
+  display: grid;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+}
+
+.task-composer-due-wrap {
+  position: relative;
+  flex: 1 1 240px;
+  min-width: 0;
+}
+
+.task-composer-due-wrap input {
+  width: 100%;
+  padding-right: 34px;
+}
+
+.task-composer-due-clear {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  min-width: 26px;
+  height: 26px;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.task-composer-actions {
+  align-items: center;
+}
+
+.task-composer-sheet__footer {
+  border-top: 1px solid
+    color-mix(in oklab, var(--border-color) 65%, transparent);
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+}
+
+.task-composer-sheet__footer .add-btn,
+.task-composer-sheet__footer .mini-btn {
+  width: auto;
+}
+
+@media (max-width: 900px) {
+  .home-dashboard__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-tile {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .task-composer-sheet {
+    width: 100%;
+    max-height: 88vh;
+    border-left: 0;
+    border-right: 0;
+    border-radius: 16px 16px 0 0;
+  }
+
+  .task-composer-fields,
+  .task-composer-actions {
+    gap: 8px;
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .task-composer-due-wrap {
+    width: 100%;
+  }
+
+  .task-composer-sheet__footer {
+    justify-content: flex-end;
+  }
+}
+
+/* M13: feedback polish (search hint, hierarchy, quick-entry framing, row clarity) */
+#todosView .todos-top-bar-actions .top-add-btn {
+  box-shadow: 0 6px 14px rgb(15 23 42 / 12%);
+}
+
+#todosView .todos-top-bar-actions .more-filters-toggle {
+  background: color-mix(in oklab, var(--surface) 94%, transparent);
+  color: var(--text-secondary);
+  border: 1px solid color-mix(in oklab, var(--border-color) 85%, transparent);
+  box-shadow: none;
+}
+
+#todosView .todos-top-bar-actions .more-filters-toggle:hover,
+#todosView .todos-top-bar-actions .more-filters-toggle[aria-expanded="true"] {
+  background: color-mix(in oklab, var(--surface-2) 88%, var(--surface));
+  color: var(--text-primary);
+  border-color: color-mix(in oklab, var(--border-color) 100%, transparent);
+}
+
+body.is-todos-view .add-todo.quick-entry {
+  border: 1px solid color-mix(in oklab, var(--border-color) 88%, transparent);
+  border-radius: 12px;
+  padding: 10px;
+  background: color-mix(in oklab, var(--surface) 96%, var(--surface-2));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%);
+}
+
+body.is-todos-view .quick-entry-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 0;
+  min-height: 0;
+}
+
+body.is-todos-view .quick-entry-properties-summary {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+body.is-todos-view .quick-entry-properties-summary[hidden] {
+  display: none !important;
+}
+
+body.is-todos-view .quick-entry-properties-panel {
+  border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
+  background: color-mix(in oklab, var(--surface-2) 55%, transparent);
+  border-radius: 10px;
+}
+
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"] {
+  color: var(--text-secondary);
+}
+
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"]:focus,
+body.is-todos-view
+  .quick-entry-properties-panel
+  .field-row
+  input[type="datetime-local"]:not(:placeholder-shown) {
+  color: var(--text-primary);
+}
+
+body.is-todos-view .priority-selector {
+  border-radius: 10px;
+}
+
+body.is-todos-view .priority-btn {
+  border-width: 1px;
+  border-color: color-mix(in oklab, var(--border-color) 80%, transparent);
+  color: var(--text-secondary);
+  background: color-mix(in oklab, var(--surface) 98%, transparent);
+}
+
+body.is-todos-view .priority-btn.active {
+  border-width: 2px;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 22%) inset;
+}
+
+body.is-todos-view .priority-btn.low.active {
+  border-color: color-mix(in oklab, var(--accent-2) 82%, white);
+  background: color-mix(in oklab, var(--accent-2) 88%, black 8%);
+}
+
+body.is-todos-view .priority-btn.medium.active {
+  border-color: var(--warning);
+  background: color-mix(in oklab, var(--warning) 90%, black 8%);
+}
+
+body.is-todos-view .priority-btn.high.active {
+  border-color: color-mix(in oklab, var(--danger) 86%, white);
+  background: color-mix(in oklab, var(--danger) 90%, black 8%);
+}
+
+body.is-todos-view .priority-btn.active::before {
+  content: "●";
+  font-size: 0.7em;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  #todosView .todo-item .bulk-checkbox {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity var(--dur-fast) var(--ease-out);
+  }
+
+  #todosView .todo-item:hover .bulk-checkbox,
+  #todosView .todo-item:focus-within .bulk-checkbox,
+  #todosView .todo-item .bulk-checkbox:checked,
+  #todosView .todo-item.todo-item--bulk-selected .bulk-checkbox {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+}
+
+.keyboard-shortcuts-btn {
+  position: fixed;
+}
+
+.keyboard-shortcuts-btn::after {
+  content: attr(aria-label);
+  position: absolute;
+  right: auto;
+  left: 58px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgb(15 23 42 / 92%);
+  color: #fff;
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+.keyboard-shortcuts-btn:hover::after,
+.keyboard-shortcuts-btn:focus-visible::after {
+  opacity: 1;
+}
+
+/* Spec: calm workspace polish */
+
+/* 1. Remove blue body-gradient bleed around main content in todos view */
+body.is-todos-view #appMainScroll {
+  padding: 0;
+}
+
+/* 2. Sidebar toggle: icon-only hamburger button */
+.sidebar-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+  flex-shrink: 0;
+}
+
+.sidebar-toggle-btn:hover {
+  background: color-mix(in oklab, var(--surface) 82%, var(--surface-2));
+  color: var(--text-primary);
+}
+
+.sidebar-toggle-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.sidebar-toggle-btn__icon {
+  font-size: 16px;
+  line-height: 1;
+  user-select: none;
+}
+
+/* 3. Sidebar header: 48px height, flex row with toggle on left */
+body.is-todos-view .projects-rail__header {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 4px;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--border-color) 60%, transparent);
+  flex-shrink: 0;
+}
+
+/* 4. Home dashboard: single-column layout with header row */
+.home-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  max-width: 880px;
+  padding: 24px 32px 40px;
+}
+
+.home-dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: -8px;
+}
+
+.home-dashboard__title {
+  font-size: 28px;
+  font-weight: 650;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.home-empty-cta {
+  text-align: center;
+  padding: var(--s-6) var(--s-4);
+  max-width: 440px;
+  margin: var(--s-4) auto;
+}
+
+.home-empty-cta .empty-state-illustration {
+  width: 140px;
+  height: 112px;
+  margin-bottom: var(--s-4);
+}
+
+.home-empty-cta__heading {
+  font-size: var(--fs-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 var(--s-2);
+}
+
+.home-empty-cta__sub {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 var(--s-4);
+}
+
+.home-empty-cta__sub kbd {
+  background: var(--surface-2);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: inherit;
+  font-size: var(--fs-body);
+}
+
+.home-dashboard__new-task {
+  flex-shrink: 0;
+  height: 36px;
+  padding: 0 16px;
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.home-dashboard__new-task:hover {
+  filter: saturate(1.05) brightness(1.03);
+}
+
+/* Override old grid-based layout */
+.home-dashboard__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+/* Home tile: section-style for single-column layout */
+body.is-todos-view .home-tile {
+  border-radius: 16px;
+  padding: 16px;
+  gap: 12px;
+}
+
+body.is-todos-view .home-tile__header {
+  margin-bottom: 0;
+}
+
+body.is-todos-view .home-tile__title {
+  font-size: 20px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+/* Focus tile: slightly more prominent surface */
+body.is-todos-view .home-tile[data-home-tile="top_focus"] {
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 60%, transparent);
+}
+
+/* Up Next / Due Soon tile: lighter surface */
+body.is-todos-view .home-tile[data-home-tile="due_soon"],
+body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
+  background: color-mix(in oklab, var(--surface) 98%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 40%, transparent);
+}
+
+/* Override home-dashboard grid on mobile */
+@media (max-width: 900px) {
+  .home-dashboard {
+    padding: 20px 20px 32px;
+    gap: 24px;
+  }
+}
+
+/* Things-inspired surface refinement: final override layer */
+body.is-todos-view #todosView[data-surface-mode="list"] .todos-list-header,
+body.is-todos-view #todosView[data-surface-mode="project"] .todos-list-header {
+  padding: 6px 2px 12px;
+  border: 0;
+  border-radius: 0;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--surface) 96%, transparent) 0%,
+    color-mix(in oklab, var(--surface) 96%, transparent) 78%,
+    transparent 100%
+  );
+}
+
+body.is-todos-view
+  #todosView[data-surface-mode="list"]
+  .todos-list-header__count,
+body.is-todos-view
+  #todosView[data-surface-mode="list"]
+  .todos-list-header__date-badge {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+body.is-todos-view #todosView[data-surface-mode="project"] #todosContent {
+  padding-top: 2px;
+}
+
+body.is-todos-view
+  #todosView[data-surface-mode="project"]
+  .todo-heading-divider {
+  margin-top: 24px;
+}
+
+body.is-todos-view #todosView .todos-top-bar[hidden] {
+  display: none !important;
+}
+
+/* ── Icon & nav polish ────────────────────────────────────────────────────── */
+
+/* Nav icons: shared outline SVG style inside sidebar rows */
+.nav-icon {
+  flex-shrink: 0;
+  display: block;
+  opacity: 0.55;
+  transition: opacity var(--dur-fast) var(--ease-out);
+  color: currentColor;
+}
+
+.projects-rail-item:hover .nav-icon,
+.projects-rail-item--active .nav-icon,
+.projects-rail-item[aria-selected="true"] .nav-icon {
+  opacity: 0.85;
+}
+
+/* Nav labels: flex-grow text in sidebar rows */
+.nav-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Sidebar rows: flex-start layout so icon + label are left-aligned,
+   count floats right via margin-left:auto */
+body.is-todos-view .projects-rail-item {
+  justify-content: flex-start;
+}
+
+body.is-todos-view .projects-rail-item__label {
+  flex: 1 1 auto;
+}
+
+body.is-todos-view .projects-rail-item__count {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Remove the old > span:first-child overflow rule — nav-label handles it */
+body.is-todos-view .projects-rail-item > span:first-child {
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
+}
+
+/* ── Collapsed sidebar: strict icon-only rail ─────────────────────────────── */
+body.is-todos-view .projects-rail.projects-rail--collapsed {
+  width: 64px;
+}
+
+body.is-todos-view.is-projects-rail-collapsed #appSidebar {
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 64px;
+}
+
+body.is-todos-view .projects-rail {
+  display: flex;
+  flex-direction: column;
+}
+
+body.is-todos-view .projects-rail__spacer {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+body.is-todos-view .projects-rail__utility-list {
+  display: grid;
+  gap: 6px;
+}
+
+body.is-todos-view .projects-rail__section--utilities {
+  display: none;
+}
+
+body.is-todos-view .projects-rail-projects-access {
+  display: none;
+}
+
+body.is-todos-view .projects-rail.projects-rail--collapsed .nav-label,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-item__label,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-item__count {
+  display: none;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__section:not(.projects-rail__section--workspace):not(
+    .projects-rail__section--utilities
+  ),
+body.is-todos-view .projects-rail.projects-rail--collapsed #projectsRailList {
+  display: none;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__footer--admin-only {
+  display: none;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__header {
+  justify-content: center;
+  padding-bottom: 8px;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__section--workspace {
+  margin-top: 0;
+  padding-top: 8px;
+  border-top: 0;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__primary {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+}
+
+body.is-todos-view .projects-rail.projects-rail--collapsed .workspace-view-item,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-utility-item {
+  width: 46px;
+  min-width: 46px;
+  justify-content: center;
+  align-items: center;
+  min-height: 46px;
+  height: 46px;
+  padding: 0;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access {
+  display: flex;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-utility-item
+  .nav-icon {
+  width: 18px;
+  height: 18px;
+  opacity: 0.72;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item:hover
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item.projects-rail-item--active
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-projects-access:hover
+  .nav-icon,
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail-utility-item:hover
+  .nav-icon {
+  opacity: 0.92;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .workspace-view-item.projects-rail-item--active {
+  border-radius: 10px;
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__section--utilities {
+  display: block;
+  margin-top: auto;
+  padding-top: 10px;
+  border-top: 1px solid
+    color-mix(in oklab, var(--border-color) 70%, transparent);
+}
+
+body.is-todos-view
+  .projects-rail.projects-rail--collapsed
+  .projects-rail__utility-list {
+  justify-items: center;
+  gap: 8px;
+}
+
+/* Toggle button: SVG replaces the old __icon span (no size change needed) */
+.sidebar-toggle-btn__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Search: leading icon ─────────────────────────────────────────────────── */
+
+body.is-todos-view .search-bar .search-icon {
+  left: 9px;
+  right: auto;
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+}
+
+body.is-todos-view .search-input {
+  padding: 8px 12px 8px 30px;
+}
+
+/* ── Projects section header: quieter ────────────────────────────────────── */
+
+body.is-todos-view .projects-rail__section-label {
+  font-size: 11px;
+  font-weight: var(--fw-medium);
+  letter-spacing: 0.02em;
+  color: color-mix(in oklab, var(--text-muted) 75%, transparent);
+}
+
+body.is-todos-view .projects-rail-create-btn {
+  min-width: 22px;
+  min-height: 22px;
+  padding: 0 5px;
+  font-size: var(--fs-body);
+  opacity: 0.55;
+  transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+body.is-todos-view .projects-rail-create-btn:hover {
+  opacity: 1;
+}
+
+/* ── Home tile hierarchy ──────────────────────────────────────────────────── */
+
+/* Focus: visual hero — strongest surface, more padding, bolder title */
+body.is-todos-view .home-tile[data-home-tile="top_focus"] {
+  background: var(--surface);
+  border-color: color-mix(in oklab, var(--border-color) 75%, transparent);
+  box-shadow:
+    0 1px 4px rgb(15 23 42 / 6%),
+    0 4px 16px rgb(15 23 42 / 5%);
+  padding: 20px;
+}
+
+body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__title {
+  font-size: 22px;
+}
+
+/* Up Next: standard secondary */
+body.is-todos-view .home-tile[data-home-tile="due_soon"] {
+  background: color-mix(in oklab, var(--surface) 97%, var(--surface-2));
+  border-color: color-mix(in oklab, var(--border-color) 55%, transparent);
+}
+
+/* Projects to Nudge: lightest — no card frame, just a quiet list */
+body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 8px 4px 0;
+}
+
+body.is-todos-view
+  .home-tile[data-home-tile="projects_to_nudge"]
+  .home-tile__body {
+  display: grid;
+  gap: 6px;
+}
+
+body.is-todos-view
+  .home-tile[data-home-tile="projects_to_nudge"]
+  .home-tile__title {
+  font-size: 16px;
+  font-weight: var(--fw-semibold);
+  color: var(--text-secondary);
+}
+
+/* Section title row: icon + h3 side by side */
+.home-tile__title-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.home-tile__icon {
+  flex-shrink: 0;
+  opacity: 0.5;
+  color: currentColor;
+}
+
+body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__icon {
+  opacity: 0.65;
+}
+
+/* ── Task badge: icon + label inline ─────────────────────────────────────── */
+
+.home-task-row__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+/* ── Home project row: icon + name header ────────────────────────────────── */
+
+.home-project-row__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.home-project-row__icon {
+  flex-shrink: 0;
+  opacity: 0.5;
+  color: var(--text-secondary);
+}
+
+.home-project-row__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.projects-rail-item--logout {
+  opacity: 0.55;
+  font-size: 0.8125rem;
+}
+
+.projects-rail-item--logout:hover {
+  opacity: 0.8;
+}
+
+/* ========== BOTTOM ACTION DOCK ========== */
+.dock-icon--sun {
+  display: none;
+}
+
+body.dark-mode .dock-icon--moon {
+  display: none;
+}
+
+body.dark-mode .dock-icon--sun {
+  display: block;
+}
+
+#todosScrollRegion {
+  padding-bottom: 72px;
+}
+
+body:has(.todo-kebab-menu--open) .floating-new-task-cta {
+  pointer-events: none;
+}
+
+#projectsRail {
+  padding-bottom: var(--s-5);
+}
+
+.projects-rail__footer--admin-only {
+  display: none;
+}
+
+body.is-admin-user .projects-rail__footer--admin-only {
+  display: flex;
+}
+
+/* ========== PROFILE PANEL (dock) ========== */
+
+.dock-profile-panel {
+  position: fixed;
+  top: 48px;
+  left: var(--s-3);
+  z-index: 55;
+  width: 220px;
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-elevated);
+  padding: var(--s-2);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.dock-profile-panel[hidden] {
+  display: none;
+}
+
+.dock-profile-panel__email {
+  display: block;
+  padding: var(--s-2) var(--s-2);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dock-profile-panel__divider {
+  height: 1px;
+  background: var(--border-color);
+  margin: var(--s-1) 0;
+}
+
+.dock-profile-panel__item {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  width: 100%;
+  padding: var(--s-2);
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.dock-profile-panel__item:hover {
+  background: var(--card-hover);
+  color: var(--text);
+}
+
+.dock-profile-panel__item:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.dock-profile-panel__item--danger {
+  color: var(--danger);
+}
+
+.dock-profile-panel__item--danger:hover {
+  background: color-mix(in oklab, var(--danger) 8%, var(--surface));
+  color: var(--danger);
+}
+
+.todo-drawer__agent-hint {
+  margin: 0 0 var(--s-3);
+  color: var(--muted);
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+}
+
+@media (max-width: 768px) {
+  .dock-profile-panel {
+    display: none !important;
+  }
+}
+
+/* ========== MOBILE LAYOUT IMPROVEMENTS ========== */
+
+/* Mobile top bar base styles — hidden by default, shown only on mobile todos view */
+.todos-mobile-top-bar {
+  display: none;
+}
+
+.todos-mobile-hamburger,
+.todos-mobile-theme-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s ease;
+}
+
+.todos-mobile-hamburger:hover,
+.todos-mobile-theme-btn:hover {
+  background: color-mix(in oklab, var(--surface-2) 85%, var(--surface));
+}
+
+.todos-mobile-title {
+  flex: 1;
+  text-align: center;
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 var(--s-2);
+}
+
+@media (max-width: 768px) {
+  /* 1. Fix sidebar column reservation — prevents gradient bleed from empty grid column */
+  body.is-todos-view #appShell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* 2. Remove body padding that offsets the container */
+  body.is-todos-view {
+    padding: 0;
+    overflow: hidden;
+  }
+
+  /* 3. Reset main scroll for full-viewport flex layout */
+  body.is-todos-view #appMainScroll {
+    padding: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 100dvh;
+    max-height: 100dvh;
+  }
+
+  /* 4. Container fills full viewport — no rounded corners, no offset */
+  body.is-todos-view .container {
+    height: 100dvh;
+    max-height: 100dvh;
+    max-width: 100%;
+    border-radius: 0;
+  }
+
+  /* 5. Hide the old header on mobile todos view — replaced by mobile top bar */
+  body.is-todos-view .header {
+    display: none;
+  }
+
+  /* 6. Show mobile top bar */
+  body.is-todos-view .todos-mobile-top-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 56px;
+    flex-shrink: 0;
+    padding: 0 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  /* 8. Apply consistent mobile padding to the scroll region */
+  body.is-todos-view #todosScrollRegion {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 16px;
+  }
+
+  /* 9. Floating CTA — bottom-right on mobile */
+  .floating-new-task-cta {
+    right: 16px;
+    bottom: 72px;
+  }
+
+  /* 10. Reduce card padding on mobile */
+  .home-tile {
+    padding: 16px;
+  }
+
+  /* 11. Home dashboard: remove extra horizontal padding (scroll region handles it) */
+  .home-dashboard {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+/* DialogManager managed backdrop — pointer-events must be active so clicks reach it */
+.dm-backdrop {
+  pointer-events: auto;
+}
+
+/* ── Inbox view ────────────────────────────────────────────────────────── */
+.inbox-view {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.inbox-capture-form {
+  display: flex;
+  gap: 8px;
+}
+
+.inbox-capture-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-body);
+}
+
+.inbox-capture-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--primary-color) 25%, transparent);
+}
+
+.inbox-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.inbox-btn:hover {
+  background: var(--hover-bg);
+}
+
+.inbox-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.inbox-btn--primary:hover {
+  filter: brightness(1.1);
+  background: var(--primary-color);
+}
+
+.inbox-btn--ghost {
+  background: transparent;
+}
+
+.inbox-view__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.inbox-view__count {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.inbox-view__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inbox-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+}
+
+.inbox-item__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.inbox-item__text {
+  margin: 0 0 4px;
+  font-size: var(--fs-body);
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.inbox-item__age {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.inbox-item__actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.inbox-item__spinner {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
+.inbox-view__loading,
+.inbox-view__error,
+.inbox-view__empty {
+  padding: 24px 0;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+}
+
+.inbox-view__empty .empty-state-illustration {
+  width: 100px;
+  height: 80px;
+  margin-bottom: var(--s-3);
+}
+
+.inbox-view__error {
+  color: var(--danger);
+}
+
+/* ── Day Plan Agent panel ───────────────────────────────────────────────── */
+/* ── Weekly Review view ─────────────────────────────────────────────────── */
+.wr-view {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.wr-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.wr-title {
+  font-size: var(--fs-section);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.wr-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.wr-btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.wr-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.wr-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.wr-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+  background: var(--primary-color);
+}
+
+.wr-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.wr-badge {
+  padding: 4px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  background: var(--input-bg);
+}
+
+.wr-badge strong {
+  color: var(--text-primary);
+}
+
+.wr-section {
+  margin-bottom: 20px;
+}
+
+.wr-section__title {
+  font-size: var(--fs-body);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 10px;
+}
+
+.wr-finding,
+.wr-action {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.wr-finding:last-of-type,
+.wr-action:last-of-type {
+  border-bottom: none;
+}
+
+.wr-finding__type,
+.wr-action__type {
+  font-size: var(--fs-label);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  padding-top: 2px;
+}
+
+.wr-finding__subject,
+.wr-action__title {
+  font-size: var(--fs-meta);
+  color: var(--text-primary);
+}
+
+.wr-finding__reason,
+.wr-action__reason {
+  grid-column: 1 / -1;
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.wr-apply-row {
+  padding-top: 12px;
+}
+
+.wr-applied-msg,
+.wr-empty,
+.wr-intro {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.wr-loading {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  padding: 24px 0;
+  text-align: center;
+}
+
+.wr-error {
+  font-size: var(--fs-meta);
+  color: var(--danger);
+  margin-bottom: 8px;
+}
+
+/* ── Cleanup / Anti-entropy view ────────────────────────────────────────── */
+.cleanup-view {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.cleanup-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.cleanup-title {
+  font-size: var(--fs-section);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.cleanup-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.cleanup-btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+}
+
+.cleanup-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cleanup-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.cleanup-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+  background: var(--primary-color);
+}
+
+.cleanup-section {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.cleanup-section__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--surface-bg, var(--input-bg));
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cleanup-section__title {
+  font-size: var(--fs-body);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.cleanup-section__count {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.cleanup-section__body {
+  padding: 10px 14px;
+}
+
+.cleanup-loading,
+.cleanup-intro,
+.cleanup-empty {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  padding: 24px 0;
+  text-align: center;
+}
+
+.cleanup-error {
+  font-size: var(--fs-meta);
+  color: var(--danger);
+  margin-bottom: 8px;
+}
+
+/* Duplicates */
+.cleanup-dup-group {
+  margin: 0 0 10px;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.cleanup-dup-group:last-child {
+  margin-bottom: 0;
+}
+
+.cleanup-dup-task {
+  font-size: var(--fs-meta);
+  color: var(--text-primary);
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cleanup-dup-task:last-child {
+  border-bottom: none;
+}
+
+/* Stale items */
+.cleanup-stale-item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cleanup-stale-item:last-child {
+  border-bottom: none;
+}
+
+.cleanup-stale-name {
+  font-size: var(--fs-meta);
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cleanup-stale-meta {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Quality issues */
+.cleanup-quality-item {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cleanup-quality-item:last-child {
+  border-bottom: none;
+}
+
+.cleanup-quality-title {
+  font-size: var(--fs-meta);
+  color: var(--text-primary);
+  margin-bottom: 3px;
+}
+
+.cleanup-quality-issues {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.cleanup-quality-suggestions {
+  margin: 4px 0 0 16px;
+  padding: 0;
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+}
+
+.cleanup-quality-suggestions li {
+  margin-bottom: 2px;
+}
+
+/* Taxonomy */
+.cleanup-tax-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cleanup-tax-item:last-child {
+  border-bottom: none;
+}
+
+.cleanup-tax-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  background: var(--input-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 2px 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.cleanup-tax-names {
+  font-size: var(--fs-meta);
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+}
+
+.cleanup-tax-count {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Onboarding flow ── */
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.onboarding-modal,
+.onb-modal {
+  background: var(--modal-bg, var(--sidebar-bg));
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 28px 32px;
+  width: min(480px, 92vw);
+  max-height: min(85vh, 600px);
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+}
+
+.onboarding-modal__title {
+  font-size: var(--fs-section);
+  font-weight: 600;
+  margin: 0 0 6px;
+}
+
+.onboarding-modal__subtitle {
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  margin: 0 0 20px;
+}
+
+.onboarding-area-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.onboarding-area-btn {
+  padding: 12px 8px;
+  border: 2px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  text-align: center;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.onboarding-area-btn:hover {
+  border-color: var(--primary-color);
+}
+
+.onboarding-area-btn.is-selected {
+  border-color: var(--primary-color);
+  background: color-mix(in srgb, var(--primary-color) 12%, transparent);
+}
+
+.onboarding-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.onboarding-btn {
+  padding: 8px 18px;
+  border-radius: 6px;
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.onboarding-btn--primary {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.onboarding-btn--primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.onboarding-banner {
+  background: color-mix(in srgb, var(--primary-color) 8%, var(--input-bg));
+  border: 1px solid color-mix(in srgb, var(--primary-color) 30%, transparent);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+}
+
+.onboarding-banner__title {
+  font-size: var(--fs-body);
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.onboarding-banner__subtitle {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  margin: 0 0 12px;
+}
+
+.onboarding-task-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.onboarding-task-input {
+  flex: 1;
+  padding: 7px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+}
+
+.onboarding-task-add-btn {
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.onboarding-task-list {
+  margin-bottom: 10px;
+  font-size: var(--fs-meta);
+}
+
+.onboarding-task-list li {
+  padding: 3px 0;
+  color: var(--text-primary);
+}
+
+.onboarding-date-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.onboarding-date-label {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.onboarding-date-input {
+  padding: 6px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  font-size: var(--fs-meta);
+}
+
+.onboarding-banner__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.onboarding-brief-preview {
+  font-size: var(--fs-meta);
+  color: var(--text-secondary);
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--input-bg);
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.onboarding-progress {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.onboarding-progress__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border-color);
+}
+
+.onboarding-progress__dot.is-active {
+  background: var(--primary-color);
+}
+
+.onb-modal--wide {
+  width: min(760px, 94vw);
+}
+
+.onb-modal__eyebrow,
+.onboarding-inline-banner__eyebrow,
+.home-rescue-panel__eyebrow {
+  margin: 0 0 8px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.onb-section + .onb-section,
+.onb-inline-grid + .onb-section {
+  margin-top: 18px;
+}
+
+.onb-section__label {
+  margin-bottom: 8px;
+  font-size: var(--fs-body);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.onb-choice-grid,
+.settings-check-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--s-2);
+}
+
+.onb-choice-btn,
+.onb-card-btn {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--card-bg, var(--panel-bg, var(--sidebar-bg)));
+  color: var(--text-primary);
+  padding: 12px 14px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease,
+    transform 0.16s ease;
+}
+
+.onb-choice-btn:hover,
+.onb-card-btn:hover {
+  border-color: rgba(61, 115, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.onb-choice-btn--selected,
+.onb-card-btn--selected {
+  border-color: rgba(61, 115, 255, 0.55);
+  background: color-mix(in srgb, var(--accent-color, #3d73ff) 8%, white);
+}
+
+.onb-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.onb-card-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.onb-inline-grid,
+.settings-support-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--s-3);
+}
+
+.onb-card-btn__label {
+  display: block;
+  font-weight: 600;
+}
+
+.onb-modal__helper {
+  margin: 10px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+}
+
+.onb-modal__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.onb-skip-btn,
+.onb-primary-btn {
+  border-radius: 999px;
+  padding: 10px 16px;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.onb-primary-btn {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.onb-preview-card {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color);
+  background: color-mix(in srgb, var(--accent-color, #3d73ff) 4%, white);
+}
+
+.onb-preview-card + .onb-preview-card {
+  margin-top: 10px;
+}
+
+.onb-preview-card--muted {
+  background: color-mix(in srgb, var(--border-color) 24%, white);
+}
+
+.onb-preview-card__title {
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.onb-preview-card__text {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.onboarding-inline-banner--soul {
+  display: grid;
+  gap: 14px;
+  margin: 4px 0 18px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border-color);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent-color, #3d73ff) 6%, white),
+    color-mix(in srgb, var(--accent-color, #3d73ff) 2%, white)
+  );
+}
+
+.onboarding-inline-banner__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+}
+
+.onboarding-inline-banner__header h3,
+.onboarding-inline-banner__header p,
+.onboarding-inline-banner__helper {
+  margin: 0;
+}
+
+.onboarding-inline-banner__examples,
+.onboarding-inline-banner__capture {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.onb-example-btn {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--text-primary);
+  padding: 10px 14px;
+  cursor: pointer;
+}
+
+.onb-example-btn--added {
+  opacity: 0.7;
+  cursor: default;
+}
+
+#onboardingCustomTaskInput {
+  flex: 1 1 260px;
+}
+
+.settings-support-copy {
+  color: var(--text-secondary);
+  font-size: var(--fs-body);
+}
+
+.settings-support-preview {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  font-style: italic;
+  margin-top: var(--s-2);
+}
+
+.settings-check-grid label {
+  display: flex;
+  gap: var(--s-2);
+  align-items: center;
+  padding: var(--s-2) var(--s-3);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-sm);
+  background: var(--input-bg);
+  font-size: var(--fs-body);
+  cursor: pointer;
+  transition: border-color var(--dur-fast) var(--ease-out);
+}
+
+.settings-check-grid label:hover {
+  border-color: var(--accent);
+}
+
+.home-rescue-panel {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  margin: 18px 0 0;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border-color);
+  background: linear-gradient(
+    180deg,
+    rgba(255, 250, 245, 0.92),
+    rgba(248, 247, 244, 0.92)
+  );
+}
+
+.home-rescue-panel__title,
+.home-rescue-panel__summary {
+  margin: 0;
+}
+
+.home-rescue-panel__summary {
+  margin-top: 6px;
+  color: var(--text-secondary);
+}
+
+.home-task-row__actions--recovery {
+  grid-column: 2 / -1;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.today-recovery-banner {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 14px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: rgba(255, 252, 248, 0.94);
+}
+
+.today-recovery-banner__copy h3,
+.today-recovery-banner__copy p {
+  margin: 0;
+}
+
+.today-recovery-banner__copy p {
+  margin-top: 4px;
+  color: var(--text-secondary);
+}
+
+.today-recovery-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 720px) {
+  .onb-inline-grid,
+  .settings-support-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-rescue-panel,
+  .today-recovery-banner,
+  .onboarding-inline-banner__header {
+    display: grid;
+  }
+
+  .home-rescue-panel__actions,
+  .today-recovery-banner__actions {
+    justify-content: start;
+  }
+}
+
+/* ── Simple mode — hides advanced features for a clean task list ── */
+body.simple-mode #projectsRailHost,
+body.simple-mode .todo-heading-divider,
+body.simple-mode .todo-group-header,
+body.simple-mode .ai-on-create-assist,
+body.simple-mode .home-tile--priorities,
+body.simple-mode .project-filter-label,
+body.simple-mode #categoryFilter,
+body.simple-mode .bulk-checkbox,
+body.simple-mode .drag-handle {
+  display: none !important;
+}
+
+body.simple-mode .todo-item {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+/* Sidebar: hide project tree sections, Home, Inbox, Unsorted, Projects button */
+body.simple-mode
+  .projects-rail__section:not(.projects-rail__section--workspace):not(
+    .projects-rail__section--utilities
+  ),
+body.simple-mode .projects-rail__spacer,
+body.simple-mode [data-workspace-view="inbox"],
+body.simple-mode [data-workspace-view="unsorted"],
+body.simple-mode .projects-rail-projects-access,
+body.simple-mode .projects-rail-mobile-open {
+  display: none !important;
+}
+
+/* Task composer & inline quick-add: hide properties toggle, summary, and panel */
+body.simple-mode .quick-entry-properties-toggle,
+body.simple-mode .quick-entry-properties-summary,
+body.simple-mode #quickEntryPropertiesPanel,
+body.simple-mode .task-composer-sheet .expand-section,
+body.simple-mode .task-composer-sheet .notes-textarea {
+  display: none !important;
+}
+
+/* Todo row chips: keep only due date */
+body.simple-mode .todo-chip--status,
+body.simple-mode .todo-chip--context,
+body.simple-mode .todo-chip--project,
+body.simple-mode .todo-chip--priority {
+  display: none !important;
+}
+
+/* Edit modal: hide project and priority fields */
+body.simple-mode #editTodoModal .form-group:has(#editTodoProjectSelect),
+body.simple-mode #editTodoModal .form-group:has(#editTodoPriority) {
+  display: none !important;
+}
+
+/* Todo drawer Essentials: hide advanced fields, keep title + completed + due date */
+body.simple-mode .todo-drawer__field:has(#drawerStatusSelect),
+body.simple-mode .todo-drawer__field:has(#drawerStartDateInput),
+body.simple-mode .todo-drawer__field:has(#drawerScheduledDateInput),
+body.simple-mode .todo-drawer__field:has(#drawerReviewDateInput),
+body.simple-mode .todo-drawer__field:has(#drawerProjectSelect),
+body.simple-mode .todo-drawer__field:has(#drawerPrioritySelect),
+body.simple-mode .todo-drawer__field:has(#drawerContextInput),
+body.simple-mode .todo-drawer__field:has(#drawerEnergySelect),
+body.simple-mode .todo-drawer__field:has(#drawerEstimateInput) {
+  display: none !important;
+}
+
+/* Todo drawer Details: hide tags, waitingOn, depends, category, archived, meta */
+body.simple-mode .todo-drawer__field:has(#drawerTagsInput),
+body.simple-mode .todo-drawer__field:has(#drawerWaitingOnInput),
+body.simple-mode .todo-drawer__field:has(#drawerDependsOnPicker),
+body.simple-mode .todo-drawer__field:has(#drawerCategoryInput),
+body.simple-mode .todo-drawer__field:has(#drawerArchivedToggle),
+body.simple-mode .todo-drawer__meta {
+  display: none !important;
+}
+
+/* Hide project-edit drawer and AI task-drawer assist */
+body.simple-mode .project-edit-drawer,
+body.simple-mode .todo-drawer-ai-list {
+  display: none !important;
+}
+
+/* Kebab menu: hide move-to-project, move-to-heading, AI breakdown */
+body.simple-mode .todo-kebab-project-label,
+body.simple-mode .todo-kebab-item[data-onclick*="aiBreakdownTodo"] {
+  display: none !important;
+}
+
+/* ==========================================================================
+   Wireframe UX — Inline Quick Add, cleaner rows, hover states, mobile input
+   ========================================================================== */
+
+/* ── Inline Quick Add Bar ── */
+
+.inline-quick-add {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  margin-bottom: var(--s-3);
+  border: 1.5px dashed var(--border-color);
+  border-radius: var(--r-md);
+  background: var(--card-bg);
+  transition:
+    border-color var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+  cursor: text;
+}
+
+.inline-quick-add:focus-within {
+  border-color: var(--accent);
+  border-style: solid;
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 14%, transparent);
+  background: var(--surface);
+}
+
+.inline-quick-add__icon {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklab, var(--accent) 12%, var(--surface-2));
+  color: var(--accent);
+  font-size: var(--fs-section);
+  font-weight: 700;
+  line-height: 1;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.inline-quick-add:focus-within .inline-quick-add__icon {
+  background: var(--accent);
+  color: #fff;
+}
+
+.inline-quick-add__input {
+  flex: 1 1 0;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  font-size: var(--fs-body);
+  color: var(--text-primary);
+  outline: none;
+  padding: 0;
+}
+
+.inline-quick-add__input::placeholder {
+  color: var(--text-muted);
+}
+
+.inline-quick-add__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.inline-quick-add__hint {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  padding: 2px 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-family: inherit;
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease-out);
+  pointer-events: none;
+}
+
+.inline-quick-add:focus-within .inline-quick-add__hint {
+  opacity: 1;
+}
+
+/* Chip reuse inside inline quick-add */
+.inline-quick-add__chips .quick-entry-natural-due-chip {
+  font-size: var(--fs-meta);
+  padding: 3px 8px;
+}
+
+/* ── Cleaner todo-item hover/focus states ── */
+
+.todo-item .drag-handle {
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+.todo-item:hover .drag-handle,
+.todo-item:focus-within .drag-handle {
+  opacity: 1;
+}
+
+.todo-item .todo-row-actions {
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+.todo-item:hover .todo-row-actions,
+.todo-item:focus-within .todo-row-actions,
+.todo-item .todo-row-actions:has(.todo-kebab-menu--open) {
+  opacity: 1;
+}
+
+/* On touch/mobile, always show actions and drag handle */
+@media (hover: none) {
+  .todo-item .todo-row-actions,
+  .todo-item .drag-handle {
+    opacity: 1;
+  }
+}
+
+/* ── Toast / undo feedback bar ── */
+
+.undo-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%) translateY(100%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-radius: var(--r-md);
+  background: var(--text-primary);
+  color: var(--bg);
+  font-size: 0.88rem;
+  box-shadow: 0 8px 28px rgb(15 23 42 / 22%);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    transform 220ms ease,
+    opacity 220ms ease;
+  z-index: 9000;
+}
+
+.undo-toast--visible {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.undo-toast__action {
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* ── Mobile: sticky bottom quick-add ── */
+
+@media (max-width: 640px) {
+  .inline-quick-add {
+    position: sticky;
+    bottom: 0;
+    z-index: 50;
+    margin-bottom: 0;
+    margin-top: auto;
+    border-radius: var(--r-md) var(--r-md) 0 0;
+    border-style: solid;
+    box-shadow: 0 -4px 16px rgb(15 23 42 / 10%);
+  }
+
+  .inline-quick-add__hint {
+    display: none;
+  }
+}
+
+/* ── Dark mode adjustments for wireframe elements ── */
+
+body.dark-mode .inline-quick-add {
+  border-color: color-mix(in oklab, var(--border-color) 65%, transparent);
+}
+
+body.dark-mode .inline-quick-add:focus-within {
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 20%, transparent);
+}
+
+body.dark-mode .undo-toast {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}
+
+/* Calm restoration overrides */
+
+body.is-todos-view .home-dashboard {
+  max-width: 980px;
+  gap: 18px;
+  padding: 24px 28px 40px;
+}
+
+body.is-todos-view .home-dashboard__support-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+body.is-todos-view .home-brief-card {
+  display: grid;
+  gap: 16px;
+  padding: 22px;
+  border: 1px solid color-mix(in oklab, var(--border-color) 72%, transparent);
+  border-radius: 24px;
+  background:
+    radial-gradient(
+      circle at top right,
+      color-mix(in oklab, var(--accent) 10%, transparent),
+      transparent 34%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--surface) 98%, var(--surface-2)) 0%,
+      color-mix(in oklab, var(--surface) 92%, var(--surface-2)) 100%
+    );
+  box-shadow: 0 18px 36px rgb(15 23 42 / 6%);
+}
+
+.home-brief-card__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+}
+
+.home-brief-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.home-brief-card__copy {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.home-brief-card__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+}
+
+.home-brief-card__summary {
+  margin: 0;
+  max-width: 54ch;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.home-brief-card__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(92px, 1fr));
+  gap: 10px;
+  min-width: 220px;
+}
+
+.home-brief-card__stat {
+  display: grid;
+  gap: 2px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in oklab, var(--border-color) 68%, transparent);
+  background: color-mix(in oklab, var(--surface) 88%, var(--surface-2));
+}
+
+.home-brief-card__stat-value {
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-semibold);
+  letter-spacing: -0.02em;
+}
+
+.home-brief-card__stat-label {
+  color: var(--text-secondary);
+  font-size: var(--fs-label);
+}
+
+.home-brief-card__primary {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in oklab, var(--accent) 22%, var(--border-color));
+  background: color-mix(in oklab, var(--surface) 92%, white 8%);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out);
+}
+
+.home-brief-card__primary:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--accent) 40%, var(--border-color));
+  box-shadow: 0 10px 22px rgb(15 23 42 / 7%);
+}
+
+.home-brief-card__primary-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in oklab, var(--text-secondary) 88%, var(--surface));
+}
+
+.home-brief-card__primary-title {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.home-brief-card__primary-meta {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+}
+
+body.is-todos-view .home-brief-card .home-tile--priorities {
+  margin: 0;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: color-mix(in oklab, var(--surface) 88%, var(--surface-2));
+  box-shadow: none;
+}
+
+body.is-todos-view .home-brief-card .home-tile__title {
+  font-size: var(--fs-body);
+}
+
+body.is-todos-view .home-priorities-body {
+  min-height: 0;
+}
+
+body.is-todos-view .home-tile[data-home-tile="due_soon"],
+body.is-todos-view .home-tile[data-home-tile="stale_risks"] {
+  min-height: 100%;
+}
+
+body.is-todos-view .home-tile__subtitle {
+  max-width: 40ch;
+}
+
+body.is-todos-view .home-task-row {
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+}
+
+body.is-todos-view .task-composer-sheet__header {
+  align-items: flex-start;
+}
+
+body.is-todos-view .task-composer-properties {
+  gap: 12px;
+}
+
+body.is-todos-view .task-composer-properties[hidden],
+body.is-todos-view .quick-entry-properties-panel[hidden] {
+  display: none !important;
+}
+
+body.is-todos-view .task-composer-inline-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+body.is-todos-view .task-composer-ai-trigger {
+  background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
+  color: var(--text-secondary);
+  border-color: color-mix(in oklab, var(--border-color) 85%, transparent);
+}
+
+body.is-todos-view .task-composer-project-actions {
+  border-top: 1px solid
+    color-mix(in oklab, var(--border-color) 68%, transparent);
+  padding-top: 10px;
+}
+
+body.is-todos-view .task-composer-project-actions__toggle {
+  cursor: pointer;
+  list-style: none;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+}
+
+body.is-todos-view
+  .task-composer-project-actions__toggle::-webkit-details-marker {
+  display: none;
+}
+
+body.is-todos-view .task-composer-project-actions__toggle::before {
+  content: "▸ ";
+}
+
+body.is-todos-view
+  .task-composer-project-actions[open]
+  > .task-composer-project-actions__toggle::before {
+  content: "▾ ";
+}
+
+body.is-todos-view .task-composer-project-actions__body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 10px;
+}
+
+body.is-todos-view .task-composer-project-action {
+  width: auto;
+}
+
+body.is-todos-view .ai-workspace {
+  padding: 12px 14px;
+  border-radius: 18px;
+  border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
+  background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
+  box-shadow: none;
+}
+
+body.is-todos-view .ai-workspace-header {
+  gap: 10px;
+}
+
+body.is-todos-view .ai-workspace-toggle {
+  background: color-mix(in oklab, var(--surface) 96%, var(--surface-2));
+}
+
+body.is-todos-view .ai-workspace-status-chip {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+body.is-todos-view .ai-workspace-header-actions .mini-btn {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: color-mix(in oklab, var(--border-color) 80%, transparent);
+}
+
+@media (max-width: 900px) {
+  body.is-todos-view .home-dashboard__support-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-brief-card__header {
+    flex-direction: column;
+  }
+
+  .home-brief-card__stats {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/client/styles/auth.css
+++ b/client/styles/auth.css
@@ -1,0 +1,208 @@
+.auth-container {
+  text-align: center;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+/* --- Auth page (separate from landing) --- */
+
+.auth-page {
+  display: none;
+}
+
+.auth-page--active {
+  display: block;
+  min-height: 100dvh;
+  padding: var(--s-10) var(--s-4) var(--s-6);
+}
+
+/* When landing is active, show it; when auth page is active, hide landing */
+.landing:not(.auth-landing-active) {
+  display: none;
+}
+
+.auth-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--s-6);
+}
+
+.auth-page__back {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  text-decoration: none;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease-out);
+}
+
+.auth-page__back:hover {
+  color: var(--text);
+}
+
+.auth-page__logo {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.auth-tabs {
+  display: flex;
+  gap: var(--s-2);
+  margin-bottom: var(--s-6);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.auth-tab {
+  flex: 1;
+  padding: var(--s-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--fs-md);
+  color: var(--text-muted);
+  transition:
+    background var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+  border-bottom: 3px solid transparent;
+}
+
+.auth-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Social / Phone auth */
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  margin: var(--s-5) 0;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.auth-divider span {
+  padding: 0 var(--s-3);
+}
+
+.social-login-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+}
+
+.social-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-3);
+  width: 100%;
+  padding: var(--s-3) var(--s-4);
+  border-radius: var(--r-sm);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  transition:
+    background-color var(--dur-fast),
+    box-shadow var(--dur-fast);
+  border: 1px solid var(--border-color);
+}
+
+.google-btn {
+  background: #fff;
+  color: #3c4043;
+  border-color: #dadce0;
+}
+
+.google-btn:hover {
+  background: #f8f9fa;
+  box-shadow: 0 1px 3px rgb(60 64 67 / 30%);
+}
+
+.apple-btn {
+  background: #000;
+  color: #fff;
+  border-color: #000;
+}
+
+.apple-btn:hover {
+  background: #1a1a1a;
+}
+
+.phone-btn {
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.phone-btn:hover {
+  background: var(--surface-hover, var(--surface));
+}
+
+.otp-hint {
+  margin: var(--s-3) 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+
+#resendOtpBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Dark theme overrides for social buttons */
+body.dark-mode .google-btn {
+  background: #303134;
+  color: #e8eaed;
+  border-color: #5f6368;
+}
+
+body.dark-mode .google-btn:hover {
+  background: #3c4043;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 50%);
+}
+
+body.dark-mode .apple-btn {
+  background: #fff;
+  color: #000;
+  border-color: #fff;
+}
+
+body.dark-mode .apple-btn:hover {
+  background: #e8e8e8;
+}
+
+/* Linked providers (account settings) */
+.linked-provider-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--s-2) 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.linked-provider-row:last-child {
+  border-bottom: none;
+}
+
+.linked-provider-name {
+  font-size: var(--fs-sm);
+  color: var(--text-primary);
+}
+
+.linked-provider-unlink {
+  font-size: var(--fs-xs);
+  color: var(--danger, #dc3545);
+  cursor: pointer;
+}

--- a/client/styles/base.css
+++ b/client/styles/base.css
@@ -1,0 +1,708 @@
+html {
+  scroll-behavior: smooth;
+}
+
+:root {
+  /* Calm SaaS core tokens (light) */
+  --bg: #f4f7fb;
+  --surface: #ffffff;
+  --surface-2: #f8fafc;
+  --surface-3: #334155;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --border: #dbe3ed;
+  --accent: #4f6ef7;
+  --accent-2: #6983ff;
+  --danger: #e05260;
+  --danger-2: #c94855;
+  --success: #2f9e6a;
+  --warning: #d97706;
+  --overlay: rgb(15 23 42 / 55%);
+  --scrim: rgb(15 23 42 / 35%);
+
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+
+  --shadow-1: 0 8px 24px rgb(15 23 42 / 8%);
+  --shadow-2: 0 20px 60px rgb(15 23 42 / 16%);
+
+  --s-0: 2px;
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 24px;
+  --s-6: 32px;
+  --s-7: 40px;
+  --s-8: 48px;
+  --s-9: 64px;
+  --s-10: 80px;
+
+  --font-sans:
+    "Inter", "Avenir Next", "Segoe UI", -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", Arial, sans-serif;
+  /* Typography — explicit scale, fewer sizes */
+  --fs-display: 3rem;
+  --fs-page-title: 2rem;
+  --fs-section: 1.25rem;
+  --fs-body: 1rem;
+  --fs-meta: 0.8125rem;
+  --fs-label: 0.75rem;
+  /* Backward-compat aliases */
+  --fs-xs: var(--fs-label);
+  --fs-sm: var(--fs-meta);
+  --fs-md: var(--fs-body);
+  --fs-lg: 1.125rem;
+  --fs-xl: 1.5rem;
+  --fs-2xl: var(--fs-page-title);
+  --lh-tight: 1.25;
+  --lh-snug: 1.35;
+  --lh-base: 1.5;
+  --lh-loose: 1.7;
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  /* Control heights */
+  --control-sm: 32px;
+  --control-md: 40px;
+  --control-lg: 44px;
+  --row-height: 48px;
+
+  /* Additional radii */
+  --r-full: 999px;
+  --r-circle: 50%;
+
+  /* Elevation shadows */
+  --shadow-0: none;
+  --shadow-hover: 0 2px 8px rgb(15 23 42 / 6%), 0 1px 2px rgb(15 23 42 / 4%);
+  --shadow-card: 0 4px 16px rgb(15 23 42 / 8%);
+  --shadow-elevated: 0 8px 30px rgb(15 23 42 / 12%);
+
+  /* Motion */
+  --ease-spring: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --dur-fast: 120ms;
+  --dur-base: 180ms;
+  --dur-slow: 280ms;
+
+  /* Icon sizes */
+  --icon-sm: 14px;
+  --icon-md: 16px;
+  --icon-lg: 20px;
+  --icon-xl: 24px;
+
+  /* Focus ring (double-ring: surface gap + accent ring) */
+  --ring-color: color-mix(in oklab, var(--accent) 50%, transparent);
+  --ring-width: 2px;
+  --ring-gap: 2px;
+  --focus-ring:
+    0 0 0 var(--ring-gap) var(--surface),
+    0 0 0 calc(var(--ring-gap) + var(--ring-width)) var(--ring-color);
+
+  /* Backward-compat aliases to keep selectors stable in M0 */
+  --bg-gradient-start: var(--accent);
+  --bg-gradient-end: var(--accent-2);
+  --container-bg: var(--surface);
+  --text-primary: var(--text);
+  --text-secondary: var(--muted);
+  --text-muted: #8b95a5;
+  --border-color: var(--border);
+  --input-bg: var(--surface);
+  --card-bg: var(--surface-2);
+  --card-hover: #f1f5f9;
+  --shadow: rgb(15 23 42 / 16%);
+}
+
+body.dark-mode {
+  /* Calm SaaS core tokens (dark) */
+  --bg: #111827;
+  --surface: #182233;
+  --surface-2: #1f2b3d;
+  --surface-3: #2b3a50;
+  --text: #e5e7eb;
+  --muted: #a8b1bd;
+  --border: #2e3c53;
+  --accent: #89a4ff;
+  --accent-2: #6e8df9;
+  --danger: #ff7f8a;
+  --danger-2: #ef6f7b;
+  --success: #5ecf9f;
+  --warning: #fbbf24;
+  --overlay: rgb(2 6 23 / 72%);
+  --scrim: rgb(2 6 23 / 50%);
+  --ring-color: color-mix(in oklab, var(--accent) 50%, transparent);
+  --focus-ring:
+    0 0 0 var(--ring-gap) var(--surface),
+    0 0 0 calc(var(--ring-gap) + var(--ring-width)) var(--ring-color);
+
+  /* Dark mode shadows */
+  --shadow-hover: 0 2px 8px rgb(2 6 23 / 20%), 0 1px 2px rgb(2 6 23 / 14%);
+  --shadow-card: 0 4px 16px rgb(2 6 23 / 22%);
+  --shadow-elevated: 0 8px 30px rgb(2 6 23 / 30%);
+
+  --bg-gradient-start: #111827;
+  --bg-gradient-end: #182233;
+  --container-bg: var(--surface);
+  --text-primary: var(--text);
+  --text-secondary: var(--muted);
+  --text-muted: #7f8ca0;
+  --border-color: var(--border);
+  --input-bg: #1b2738;
+  --card-bg: var(--surface-2);
+  --card-hover: #243249;
+  --shadow: rgb(2 6 23 / 55%);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.app-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-regular);
+  line-height: var(--lh-base);
+  color: var(--text-primary);
+  background: linear-gradient(
+    135deg,
+    var(--bg-gradient-start) 0%,
+    var(--bg-gradient-end) 100%
+  );
+  min-height: 100dvh;
+  padding: 0;
+  overflow: hidden;
+  transition: background var(--dur-base) var(--ease-out);
+}
+
+#appShell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 100dvh;
+}
+
+#appSidebar {
+  display: none;
+  min-height: 0;
+  padding: var(--s-4);
+  border-right: 1px solid var(--border-color);
+  background: var(--surface-2);
+}
+
+#appMain {
+  min-width: 0;
+  min-height: 0;
+}
+
+#appMainScroll {
+  min-height: 100dvh;
+  max-height: 100dvh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: var(--s-5);
+}
+
+body.is-todos-view {
+  --app-shell-sidebar-width: 272px;
+}
+
+body.is-todos-view.is-projects-rail-collapsed {
+  --app-shell-sidebar-width: 64px;
+}
+
+body.is-todos-view #appShell {
+  grid-template-columns: var(--app-shell-sidebar-width) minmax(0, 1fr);
+}
+
+body.is-todos-view #appMainScroll {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+body.is-todos-view #appSidebar {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-sidebar__top {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.app-sidebar__actions {
+  display: grid;
+  gap: 4px;
+}
+
+#projectsRailHost {
+  min-height: 0;
+  flex: 1 1 auto;
+  display: flex;
+}
+
+#projectsRailHost > #projectsRail {
+  position: static;
+  top: auto;
+  height: 100%;
+  max-height: 100%;
+  width: 100%;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+#projectsRailHost > #projectsRail.projects-rail--collapsed {
+  width: 64px;
+}
+
+.app-sidebar__settings {
+  width: 100%;
+  display: grid;
+  gap: 6px;
+}
+
+body.is-todos-view {
+  padding: 0;
+  overflow: hidden;
+}
+
+h1,
+h2,
+h3 {
+  color: var(--text-primary);
+  line-height: var(--lh-tight);
+}
+
+h1 {
+  font-size: var(--fs-2xl);
+  font-weight: var(--fw-bold);
+}
+
+h2 {
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-semibold);
+}
+
+h3 {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+}
+
+p,
+small {
+  line-height: var(--lh-base);
+}
+
+small {
+  font-size: var(--fs-sm);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.container {
+  background: var(--container-bg);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-2);
+  max-width: 800px;
+  margin: 0 auto;
+  overflow: hidden;
+  transition:
+    background var(--dur-base) var(--ease-out),
+    box-shadow var(--dur-base) var(--ease-out);
+}
+
+.header {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: white;
+  padding: var(--s-6);
+}
+
+.header h1 {
+  font-size: var(--fs-2xl);
+  margin-bottom: var(--s-2);
+}
+
+.user-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--s-4);
+  font-size: var(--fs-sm);
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.verified-badge {
+  background: rgba(46, 213, 115, 0.3);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: var(--r-sm);
+  font-size: 0.8em;
+}
+
+.unverified-badge {
+  background: rgba(255, 107, 107, 0.3);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: var(--r-sm);
+  font-size: 0.8em;
+}
+
+.admin-badge {
+  background: rgba(255, 218, 121, 0.3);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: var(--r-sm);
+  font-size: 0.8em;
+  font-weight: 600;
+}
+
+.logout-btn {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  padding: 8px 16px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: var(--fs-body);
+  transition:
+    background var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+}
+
+.logout-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.theme-toggle {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: white;
+  padding: 8px 12px;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: 1.2em;
+  transition:
+    background var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+  margin-left: 10px;
+}
+
+.theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: rotate(180deg);
+}
+
+.nav-tabs {
+  display: flex;
+  background: var(--card-bg);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.nav-tab {
+  flex: 1;
+  padding: 15px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  transition:
+    background var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+  border-bottom: 3px solid transparent;
+}
+
+.nav-tab:hover {
+  background: var(--card-hover);
+}
+
+.nav-tab.active {
+  color: var(--accent);
+  background: var(--surface);
+  border-bottom-color: var(--accent);
+}
+
+body.is-todos-view .header {
+  padding: 12px 16px;
+}
+
+body.is-todos-view .header h1 {
+  font-size: var(--fs-lg);
+  margin-bottom: 0;
+  line-height: 1.2;
+}
+
+body.is-todos-view .theme-toggle {
+  padding: 6px 10px;
+  font-size: var(--fs-body);
+}
+
+body.is-todos-view .user-bar {
+  margin-top: 8px;
+  font-size: var(--fs-xs);
+}
+
+body.is-todos-view .logout-btn {
+  padding: 6px 10px;
+  font-size: var(--fs-xs);
+}
+
+body.is-todos-view .nav-tabs {
+  display: none !important;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 6px 12px;
+  background: color-mix(in oklab, var(--card-bg) 92%, var(--surface));
+  border-bottom: 1px dashed var(--border-color);
+}
+
+body.is-todos-view.is-admin-user .nav-tabs {
+  display: flex !important;
+}
+
+body.is-todos-view.is-admin-user .nav-tab {
+  display: none;
+}
+
+body.is-todos-view.is-admin-user #adminNavTab {
+  display: inline-flex !important;
+}
+
+body.is-todos-view.is-admin-user .nav-tab[data-onclick*="switchView('todos'"] {
+  display: inline-flex !important;
+}
+
+body.is-todos-view .nav-tab {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: var(--fs-xs);
+  line-height: 1.2;
+}
+
+body.is-todos-view .nav-tab.active {
+  border-color: color-mix(in oklab, var(--accent) 44%, var(--border-color));
+  background: color-mix(in oklab, var(--accent) 9%, var(--surface));
+}
+
+.content {
+  padding: var(--s-6);
+}
+
+.view {
+  display: none;
+}
+
+.view.active {
+  display: block;
+}
+
+#todosView.view.active {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+body.is-todos-view .container {
+  height: 100%;
+  max-height: 100%;
+  max-width: none;
+  margin: 0;
+  flex: 1 1 auto;
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
+body.is-todos-view .content {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+body.is-todos-view #todosView.view.active {
+  flex: 1 1 auto;
+}
+
+.form-group {
+  margin-bottom: var(--s-5);
+  text-align: left;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: var(--s-2);
+  color: var(--text-primary);
+  font-weight: var(--fw-medium);
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: var(--s-3) var(--s-4);
+  min-height: var(--control-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-md);
+  font-size: var(--fs-body);
+  transition: border-color var(--dur-base) var(--ease-out);
+  font-family: var(--font-sans);
+  background: var(--input-bg);
+  color: var(--text-primary);
+}
+
+.form-group select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--s-3) center;
+  background-size: var(--icon-sm);
+  padding-right: var(--s-7);
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[role="button"]:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn:active {
+  transform: scale(0.97);
+  transition-duration: 60ms;
+}
+
+/* .btn-secondary old definition removed — superseded by line ~5842 */
+
+.btn-danger {
+  background: var(--danger);
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: var(--fs-sm);
+  margin-top: var(--s-4);
+}
+
+.link-btn:hover {
+  color: var(--accent-2);
+}
+
+.message {
+  padding: var(--s-3);
+  border-radius: var(--r-sm);
+  margin-bottom: var(--s-5);
+  display: none;
+  border: 1px solid transparent;
+  font-size: var(--fs-sm);
+}
+
+.message.show {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.message-dismiss {
+  margin-left: auto;
+  background: rgb(0 0 0 / 8%);
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: var(--r-sm);
+  color: inherit;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  padding: 4px 12px;
+  opacity: 0.8;
+  line-height: 1.4;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.message-dismiss:hover {
+  opacity: 1;
+  background: rgb(0 0 0 / 14%);
+}
+
+.message.error {
+  background: rgb(224 82 96 / 10%);
+  color: var(--danger);
+  border-color: rgb(224 82 96 / 24%);
+}
+
+.message.success {
+  background: rgb(47 158 106 / 12%);
+  color: var(--success);
+  border-color: rgb(47 158 106 / 24%);
+}
+
+.message.warning {
+  background: color-mix(in oklab, var(--warning) 12%, transparent);
+  color: var(--warning);
+  border: 1px solid color-mix(in oklab, var(--warning) 24%, transparent);
+}

--- a/client/styles/landing.css
+++ b/client/styles/landing.css
@@ -1,0 +1,455 @@
+/* ========== LANDING PAGE ========== */
+
+.landing {
+  width: 100%;
+}
+
+/* Hide landing when authenticated */
+body.is-todos-view .landing {
+  display: none;
+}
+
+/* When unauthenticated, strip app chrome so landing page takes over */
+body:not(.is-todos-view) .header {
+  display: none;
+}
+
+body:not(.is-todos-view) #appMainScroll {
+  padding: 0;
+}
+
+body:not(.is-todos-view) .container {
+  max-width: none;
+  border-radius: 0;
+}
+
+/* Nav */
+.landing-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: color-mix(in oklab, var(--surface) 85%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-color);
+  padding: 0 var(--s-4);
+}
+
+.landing-nav__inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 56px;
+}
+
+.landing-nav__logo {
+  font-size: var(--fs-section);
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.landing-nav__links {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+
+.landing-nav__link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.landing-nav__link:hover {
+  color: var(--text-primary);
+}
+
+.landing-nav__cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 18px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.landing-nav__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px color-mix(in oklab, var(--accent) 30%, transparent);
+}
+
+/* Sections */
+.landing-section__inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 var(--s-4);
+}
+
+.landing-section__heading {
+  text-align: center;
+  font-size: var(--fs-page-title);
+  font-weight: 700;
+  margin-bottom: var(--s-6);
+  color: var(--text-primary);
+}
+
+/* Hero */
+.landing-hero {
+  padding: 80px 0 60px;
+  text-align: center;
+}
+
+.landing-hero__title {
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0 0 var(--s-3);
+  color: var(--text-primary);
+}
+
+.landing-hero__sub {
+  font-size: var(--fs-section);
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto var(--s-5);
+}
+
+.landing-hero__ctas {
+  display: flex;
+  gap: var(--s-2);
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: var(--s-6);
+}
+
+.landing-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 28px;
+  border-radius: 999px;
+  font-size: var(--fs-body);
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.landing-btn--primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.landing-btn--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px color-mix(in oklab, var(--accent) 35%, transparent);
+}
+
+.landing-btn--secondary {
+  background: var(--card-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.landing-btn--secondary:hover {
+  background: var(--card-hover);
+  transform: translateY(-1px);
+}
+
+.landing-hero__screenshot {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.landing-hero__img {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 20px 60px
+    color-mix(in oklab, var(--text-primary) 10%, transparent);
+}
+
+.landing-card__img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin-top: var(--s-2);
+  border: 1px solid var(--border-color);
+}
+
+.landing-card--wide {
+  grid-column: span 2;
+}
+
+@media (max-width: 768px) {
+  .landing-card--wide {
+    grid-column: span 1;
+  }
+}
+
+.landing-screenshot-placeholder {
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklab, var(--accent) 8%, var(--card-bg)),
+    color-mix(in oklab, var(--accent) 3%, var(--surface))
+  );
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  aspect-ratio: 16 / 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.landing-screenshot-placeholder__label {
+  color: var(--text-tertiary);
+  font-size: var(--fs-sm);
+  font-style: italic;
+}
+
+/* Features */
+.landing-features {
+  padding: 80px 0;
+  background: color-mix(in oklab, var(--surface) 50%, var(--card-bg));
+}
+
+.landing-feature {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-6);
+  align-items: center;
+  margin-bottom: 64px;
+}
+
+.landing-feature:last-child {
+  margin-bottom: 0;
+}
+
+.landing-feature--reverse {
+  direction: rtl;
+}
+
+.landing-feature--reverse > * {
+  direction: ltr;
+}
+
+.landing-features-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--s-4);
+}
+
+.landing-feature-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: var(--s-5);
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.landing-feature-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px
+    color-mix(in oklab, var(--text-primary) 6%, transparent);
+}
+
+.landing-feature-card__icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-md);
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface-2));
+  color: var(--accent);
+  margin-bottom: var(--s-3);
+}
+
+.landing-feature-card h3 {
+  font-size: var(--fs-section);
+  font-weight: 600;
+  margin: 0 0 var(--s-2);
+  color: var(--text-primary);
+}
+
+.landing-feature-card p {
+  font-size: var(--fs-body);
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .landing-features-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.landing-feature__text h3 {
+  font-size: var(--fs-xl);
+  font-weight: 700;
+  margin: 0 0 var(--s-2);
+  color: var(--text-primary);
+}
+
+.landing-feature__text p {
+  font-size: var(--fs-body);
+  line-height: 1.7;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.landing-feature__visual {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* Capabilities grid */
+.landing-capabilities {
+  padding: 80px 0;
+}
+
+.landing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--s-4);
+}
+
+.landing-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: var(--s-4);
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+
+.landing-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px
+    color-mix(in oklab, var(--text-primary) 6%, transparent);
+}
+
+.landing-card__icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface-2));
+  color: var(--accent);
+  margin-bottom: var(--s-2);
+}
+
+.landing-card h4 {
+  font-size: var(--fs-section);
+  font-weight: 600;
+  margin: 0 0 var(--s-1);
+  color: var(--text-primary);
+}
+
+.landing-card p {
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* CTA section */
+.landing-cta-section {
+  padding: 60px 0 20px;
+  text-align: center;
+}
+
+.landing-cta-section__sub {
+  color: var(--text-secondary);
+  font-size: var(--fs-section);
+  margin: calc(-1 * var(--s-4)) auto var(--s-4);
+  max-width: 400px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .landing-hero {
+    padding: 48px 0 32px;
+  }
+
+  .landing-hero__title {
+    font-size: 2rem;
+  }
+
+  .landing-feature {
+    grid-template-columns: 1fr;
+    gap: var(--s-4);
+  }
+
+  .landing-feature--reverse {
+    direction: ltr;
+  }
+
+  .landing-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-features,
+  .landing-capabilities {
+    padding: 48px 0;
+  }
+
+  .landing-section__heading {
+    font-size: var(--fs-xl);
+  }
+}
+
+@media (min-width: 769px) and (max-width: 1024px) {
+  .landing-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.settings-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.settings-toggle input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.settings-toggle__hint {
+  width: 100%;
+  font-size: var(--fs-xs);
+  color: var(--text-tertiary);
+  padding-left: 26px;
+}
+
+/* ========== END LANDING PAGE ========== */


### PR DESCRIPTION
## Summary
- Phase 1 of the 3-page split refactor (SPA → Landing + Auth + App)
- Extracts monolithic `client/styles.css` (10,710 lines) into 4 files under `client/styles/`:
  - `base.css` (710 lines) — tokens, resets, layout shells, shared form/button/message styles
  - `landing.css` (455 lines) — `.landing-*` rules
  - `auth.css` (209 lines) — `.auth-*`, social buttons, OTP, linked providers
  - `app.css` (9,336 lines) — workspace, todos, sidebar, animations, responsive
- Updates `index.html` to load all 4 CSS files (identical behavior, no visual change)
- Original `styles.css` retained for reference until later phases

## Test plan
- [x] CSS lint passes
- [x] HTML lint passes
- [x] TypeScript check passes
- [x] Prettier format check passes
- [x] Unit tests: 301 pass, 3 pre-existing failures (MCP Google OAuth — unrelated)
- [ ] Fast UI tests (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)