### PR TITLE
feat(ui): tier 2+3 empty-state illustrations across all views

### DIFF
--- a/client/modules/cleanupUi.js
+++ b/client/modules/cleanupUi.js
@@ -6,6 +6,7 @@
 import { state, hooks } from "./store.js";
 import { applyAsyncAction } from "./stateActions.js";
 import { callAgentAction } from "./agentApiClient.js";
+import { illustrationCleanupClear } from "../utils/illustrations.js";
 
 // ---------------------------------------------------------------------------
 // Data loading — calls all four endpoints in parallel, merges into one state
@@ -217,7 +218,7 @@ function buildResultsHtml(s, escapeHtml) {
 
   return (
     sections.join("") ||
-    `<div class="cleanup-empty">No issues found — your task list looks clean!</div>`
+    `<div class="cleanup-empty">${illustrationCleanupClear()}<p>No issues found — your task list looks clean!</p></div>`
   );
 }
 

--- a/client/modules/commandPalette.js
+++ b/client/modules/commandPalette.js
@@ -8,6 +8,7 @@ import { getAllProjects } from "./projectsState.js";
 import { setSelectedProjectKey } from "./filterLogic.js";
 import { applyUiAction } from "./stateActions.js";
 import { toggleShortcuts, closeShortcutsOverlay } from "./shortcuts.js";
+import { illustrationCommandEmpty } from "../utils/illustrations.js";
 
 function getCommandPaletteElements() {
   const overlay = document.getElementById("commandPaletteOverlay");
@@ -197,7 +198,7 @@ function renderCommandPalette() {
         return `<div class="command-palette-section" role="presentation">${hooks.escapeHtml(row.label)}</div>`;
       }
       if (row.kind === "empty") {
-        return `<div class="command-palette-inline-empty" role="status">${hooks.escapeHtml(row.label)}</div>`;
+        return `<div class="command-palette-inline-empty" role="status">${illustrationCommandEmpty()}${hooks.escapeHtml(row.label)}</div>`;
       }
 
       selectableIndex += 1;

--- a/client/modules/drawerUi.js
+++ b/client/modules/drawerUi.js
@@ -13,6 +13,7 @@ import { applyAsyncAction, applyUiAction } from "./stateActions.js";
 import { callAgentAction } from "./agentApiClient.js";
 import { getEffortScoreLabel, getEffortScoreValue } from "./soulConfig.js";
 import { STORAGE_KEYS } from "../utils/storageKeys.js";
+import { illustrationSubtasksEmpty } from "../utils/illustrations.js";
 import { mountTaskPicker } from "../utils/taskPicker.js";
 import {
   hasTodoRow,
@@ -1009,7 +1010,7 @@ export function onDrawerCategoryBlur() {
 function renderDrawerSubtasks(todo) {
   const escapeHtml = hooks.escapeHtml || ((s) => String(s));
   if (!Array.isArray(todo.subtasks) || todo.subtasks.length === 0) {
-    return '<p class="todo-drawer__subtasks-empty">No subtasks</p>';
+    return `<p class="todo-drawer__subtasks-empty">${illustrationSubtasksEmpty()}No subtasks</p>`;
   }
   return `
     <ul class="todo-drawer__subtasks-list">

--- a/client/modules/filterLogic.js
+++ b/client/modules/filterLogic.js
@@ -27,6 +27,10 @@ import {
   illustrationNoTasks,
   illustrationNoMatches,
   illustrationEmptyProject,
+  illustrationTodayClear,
+  illustrationUpcomingEmpty,
+  illustrationCompletedEmpty,
+  illustrationSomedayEmpty,
 } from "../utils/illustrations.js";
 
 // ---------------------------------------------------------------------------
@@ -1176,9 +1180,17 @@ function renderTodos() {
       heading: "No matching tasks",
       sub: "Try adjusting your filters.",
     };
+    const viewIllustrations = {
+      today: illustrationTodayClear,
+      upcoming: illustrationUpcomingEmpty,
+      completed: illustrationCompletedEmpty,
+      someday: illustrationSomedayEmpty,
+    };
+    const illustrationFn =
+      viewIllustrations[state.currentDateView] || illustrationNoMatches;
     container.innerHTML =
       '<div class="empty-state">' +
-      illustrationNoMatches() +
+      illustrationFn() +
       "<h3>" +
       msg.heading +
       "</h3><p>" +

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -33,7 +33,10 @@ import {
   maybeRenderOnboardingModal,
 } from "./onboardingFlow.js";
 import { SOUL_COPY, buildRescueSuggestion } from "./soulConfig.js";
-import { illustrationWelcome } from "../utils/illustrations.js";
+import {
+  illustrationWelcome,
+  illustrationTileEmpty,
+} from "../utils/illustrations.js";
 
 const { escapeHtml } = window.Utils || {};
 const { getProjectLeafName, normalizeProjectPath } =
@@ -809,7 +812,7 @@ export function renderHomeTaskTile({
               }),
             )
             .join("")
-      : `<div class="home-tile__empty">${escapeHtml(emptyText)}</div>`;
+      : `<div class="home-tile__empty">${illustrationTileEmpty()}${escapeHtml(emptyText)}</div>`;
   const TILE_ICON_SVG = {
     top_focus: `<svg class="home-tile__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>`,
     due_soon: `<svg class="home-tile__icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16.5 12"/></svg>`,
@@ -1039,7 +1042,7 @@ export function renderTodaysPlanZone() {
                    data-onclick="retryTodaysPlan()">Retry</button>
          </div>`
       : pd.tasks.length === 0
-        ? `<div class="home-tile__empty">No plan yet — add tasks with due dates to get started.</div>`
+        ? `<div class="home-tile__empty">${illustrationTileEmpty()}No plan yet — add tasks with due dates to get started.</div>`
         : pd.tasks
             .map((task) => {
               const taskId = escapeHtml(String(task.taskId || ""));
@@ -1107,7 +1110,7 @@ function _renderUpcomingTabBody() {
   }
 
   if (items.length === 0) {
-    return `<div class="home-tile__empty">${escapeHtml(emptyText)}</div>`;
+    return `<div class="home-tile__empty">${illustrationTileEmpty()}${escapeHtml(emptyText)}</div>`;
   }
 
   return items.map((todo) => renderHomeTaskRow(todo, { reason: "" })).join("");

--- a/client/modules/taskDrawerAssist.js
+++ b/client/modules/taskDrawerAssist.js
@@ -6,6 +6,7 @@
 import { state, hooks } from "./store.js";
 import { getAllProjects } from "./projectsState.js";
 import { STORAGE_KEYS } from "../utils/storageKeys.js";
+import { illustrationAiEmpty } from "../utils/illustrations.js";
 
 function taskDrawerDismissKey(todoId) {
   return `${STORAGE_KEYS.TASK_DRAWER_DISMISSED_PREFIX}${todoId}`;
@@ -150,7 +151,7 @@ function renderTaskDrawerAssistSection(todoId) {
         !assistState.unavailable &&
         !assistState.error &&
         (assistState.mustAbstain || assistState.suggestions.length === 0)
-          ? '<div class="ai-empty" role="status">No suggestions right now.</div>'
+          ? `<div class="ai-empty" role="status">${illustrationAiEmpty()}No suggestions right now.</div>`
           : ""
       }
       ${

--- a/client/modules/weeklyReviewUi.js
+++ b/client/modules/weeklyReviewUi.js
@@ -10,6 +10,7 @@ import { state, hooks } from "./store.js";
 import { applyAsyncAction } from "./stateActions.js";
 import { callAgentAction } from "./agentApiClient.js";
 import { SOUL_COPY } from "./soulConfig.js";
+import { illustrationWeeklyReviewClean } from "../utils/illustrations.js";
 
 // ---------------------------------------------------------------------------
 // Render
@@ -167,7 +168,7 @@ export function renderWeeklyReviewView() {
                 : `<p class="wr-applied-msg">Actions applied.</p>`
             }
           </section>`
-        : `<p class="wr-empty">Nothing urgent to clean up this week.</p>`;
+        : `<div class="wr-empty">${illustrationWeeklyReviewClean()}<p>Nothing urgent to clean up this week.</p></div>`;
 
     bodyHtml = `${renderSummaryBadges(s.summary)}${reflectionHtml}${rolloverHtml}${findingsHtml}${anchorsHtml}${adjustmentHtml}${actionsHtml}`;
   } else {

--- a/client/styles.css
+++ b/client/styles.css
@@ -1596,6 +1596,11 @@ textarea:focus-visible,
 .ai-empty {
   font-size: var(--fs-sm);
   color: var(--text-muted);
+  text-align: center;
+}
+
+.ai-empty .empty-state-illustration--micro {
+  margin-bottom: var(--s-1);
 }
 
 .ai-tooltip {
@@ -3999,7 +4004,12 @@ body.is-todos-view .floating-new-task-cta {
 .command-palette-inline-empty {
   color: var(--text-secondary);
   font-size: var(--fs-sm);
-  padding: 8px 10px;
+  padding: var(--s-4) var(--s-3);
+  text-align: center;
+}
+
+.command-palette-inline-empty .empty-state-illustration--micro {
+  margin-bottom: var(--s-2);
 }
 
 .command-palette-empty {
@@ -4716,6 +4726,20 @@ body.is-todos-view .floating-new-task-cta {
   height: 96px;
   margin: 0 auto var(--s-4);
   display: block;
+}
+
+/* Micro illustrations — AI suggestions, command palette (48×40 viewBox) */
+.empty-state-illustration--micro {
+  width: 40px;
+  height: 32px;
+  margin: 0 auto var(--s-2);
+}
+
+/* Inline illustrations — subtask lists, task pickers (36×28 viewBox) */
+.empty-state-illustration--inline {
+  width: 28px;
+  height: 22px;
+  margin: 0 auto var(--s-1);
 }
 
 .empty-state-hint {
@@ -5784,9 +5808,14 @@ body.is-todos-view .floating-new-task-cta {
 }
 
 .task-picker__empty {
-  padding: 8px 10px;
+  padding: var(--s-3) var(--s-2);
   font-size: var(--fs-sm);
   color: var(--muted);
+  text-align: center;
+}
+
+.task-picker__empty .empty-state-illustration--inline {
+  margin-bottom: var(--s-1);
 }
 
 .todo-drawer__field input[type="text"],
@@ -5884,6 +5913,12 @@ body.is-todos-view .floating-new-task-cta {
 .todo-drawer__subtasks-empty {
   color: var(--text-secondary);
   font-size: 0.88rem;
+  text-align: center;
+  padding: var(--s-2) 0;
+}
+
+.todo-drawer__subtasks-empty .empty-state-illustration--inline {
+  margin-bottom: var(--s-1);
 }
 
 .todo-drawer-ai-list {
@@ -7723,7 +7758,12 @@ body.is-todos-view .projects-rail-item__count {
 .home-tile__helper {
   color: var(--text-secondary);
   font-size: var(--fs-meta);
-  padding: 8px 4px;
+  padding: var(--s-3) var(--s-1);
+  text-align: center;
+}
+
+.home-tile__empty .empty-state-illustration--inline {
+  margin-bottom: var(--s-1);
 }
 
 .home-tile__date-label {
@@ -9392,6 +9432,17 @@ body.is-admin-user .projects-rail__footer--admin-only {
   color: var(--text-secondary);
 }
 
+.wr-empty {
+  text-align: center;
+  padding: var(--s-4) 0;
+}
+
+.wr-empty .empty-state-illustration {
+  width: 100px;
+  height: 80px;
+  margin-bottom: var(--s-3);
+}
+
 .wr-loading {
   font-size: var(--fs-meta);
   color: var(--text-secondary);
@@ -9500,6 +9551,12 @@ body.is-admin-user .projects-rail__footer--admin-only {
   color: var(--text-secondary);
   padding: 24px 0;
   text-align: center;
+}
+
+.cleanup-empty .empty-state-illustration {
+  width: 100px;
+  height: 80px;
+  margin-bottom: var(--s-3);
 }
 
 .cleanup-error {

--- a/client/utils/illustrations.js
+++ b/client/utils/illustrations.js
@@ -131,3 +131,244 @@ export function illustrationEmptyProject() {
   <circle cx="132" cy="56" r="1.5" fill="var(--accent)" opacity="0.15"/>
 </svg>`;
 }
+
+// ─── Tier 2: View-specific filter empty states ────────────────────────────
+
+/**
+ * Sunny day with a checkmark cloud — "all caught up for today."
+ * Used for the Today view zero-task state.
+ */
+export function illustrationTodayClear() {
+  return `<svg viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration" aria-hidden="true">
+  <!-- Sun -->
+  <circle cx="160" cy="36" r="20" fill="var(--warning)" opacity="0.7"/>
+  <!-- Small rays -->
+  <line x1="160" y1="8" x2="160" y2="16" stroke="var(--warning)" stroke-width="2" stroke-linecap="round" opacity="0.3"/>
+  <line x1="184" y1="36" x2="180" y2="36" stroke="var(--warning)" stroke-width="2" stroke-linecap="round" opacity="0.25"/>
+  <line x1="178" y1="18" x2="174" y2="22" stroke="var(--warning)" stroke-width="2" stroke-linecap="round" opacity="0.2"/>
+  <line x1="142" y1="18" x2="146" y2="22" stroke="var(--warning)" stroke-width="2" stroke-linecap="round" opacity="0.2"/>
+  <!-- Cloud -->
+  <ellipse cx="90" cy="72" rx="44" ry="22" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <ellipse cx="72" cy="60" rx="20" ry="16" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <ellipse cx="108" cy="56" rx="24" ry="18" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <!-- Cloud fill to clean up strokes -->
+  <ellipse cx="90" cy="68" rx="38" ry="18" fill="var(--surface)"/>
+  <!-- Checkmark in cloud -->
+  <path d="M80 68l7 7 16-16" stroke="var(--success)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Ground line -->
+  <rect x="24" y="116" width="152" height="2" rx="1" fill="var(--border)" opacity="0.3"/>
+  <!-- Small grass tufts -->
+  <path d="M50 116c0-6 3-10 3-10s3 4 3 10" stroke="var(--success)" stroke-width="1.5" stroke-linecap="round" opacity="0.3"/>
+  <path d="M140 116c0-5 2-8 2-8s2 3 2 8" stroke="var(--success)" stroke-width="1.5" stroke-linecap="round" opacity="0.25"/>
+</svg>`;
+}
+
+/**
+ * Calendar page with a calm horizon — forward-looking emptiness.
+ * Used for the Upcoming view zero-task state.
+ */
+export function illustrationUpcomingEmpty() {
+  return `<svg viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration" aria-hidden="true">
+  <!-- Calendar page -->
+  <rect x="55" y="36" width="90" height="80" rx="8" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <!-- Calendar header bar -->
+  <rect x="55" y="36" width="90" height="20" rx="8" fill="var(--accent)" opacity="0.12"/>
+  <rect x="55" y="48" width="90" height="8" fill="var(--accent)" opacity="0.12"/>
+  <!-- Binding rings -->
+  <circle cx="78" cy="36" r="4" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <circle cx="122" cy="36" r="4" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <!-- Blank date grid dots -->
+  <circle cx="74" cy="72" r="2.5" fill="var(--border)" opacity="0.2"/>
+  <circle cx="92" cy="72" r="2.5" fill="var(--border)" opacity="0.2"/>
+  <circle cx="110" cy="72" r="2.5" fill="var(--border)" opacity="0.2"/>
+  <circle cx="128" cy="72" r="2.5" fill="var(--border)" opacity="0.2"/>
+  <circle cx="74" cy="88" r="2.5" fill="var(--border)" opacity="0.15"/>
+  <circle cx="92" cy="88" r="2.5" fill="var(--border)" opacity="0.15"/>
+  <circle cx="110" cy="88" r="2.5" fill="var(--border)" opacity="0.15"/>
+  <circle cx="128" cy="88" r="2.5" fill="var(--border)" opacity="0.15"/>
+  <circle cx="74" cy="104" r="2.5" fill="var(--border)" opacity="0.1"/>
+  <circle cx="92" cy="104" r="2.5" fill="var(--border)" opacity="0.1"/>
+  <!-- Horizon accent -->
+  <rect x="20" y="128" width="160" height="2" rx="1" fill="var(--border)" opacity="0.25"/>
+</svg>`;
+}
+
+/**
+ * Trophy/ribbon with a progress arc — "nothing completed yet" encouragement.
+ * Used for the Completed view zero-task state.
+ */
+export function illustrationCompletedEmpty() {
+  return `<svg viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration" aria-hidden="true">
+  <!-- Trophy cup -->
+  <rect x="76" y="48" width="48" height="44" rx="6" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <!-- Trophy handles -->
+  <path d="M76 58c-10 0-16 6-16 14s6 14 14 14h2" stroke="var(--border)" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M124 58c10 0 16 6 16 14s-6 14-14 14h-2" stroke="var(--border)" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <!-- Trophy base -->
+  <rect x="88" y="92" width="24" height="6" rx="2" fill="var(--border)" opacity="0.35"/>
+  <rect x="82" y="98" width="36" height="8" rx="3" fill="var(--border)" opacity="0.25"/>
+  <!-- Star inside trophy -->
+  <path d="M100 58l3 6.5 7 1-5 5 1.2 7-6.2-3.3-6.2 3.3 1.2-7-5-5 7-1z" fill="var(--warning)" opacity="0.5"/>
+  <!-- Progress arc (empty) -->
+  <path d="M58 30 A50 50 0 0 1 142 30" stroke="var(--border)" stroke-width="2" stroke-linecap="round" stroke-dasharray="6 4" fill="none" opacity="0.2"/>
+  <!-- Sparkle hints -->
+  <circle cx="52" cy="44" r="2" fill="var(--accent)" opacity="0.2"/>
+  <circle cx="150" cy="42" r="1.5" fill="var(--accent)" opacity="0.15"/>
+</svg>`;
+}
+
+/**
+ * Floating thought bubble / cloud — dreamy "someday" feeling.
+ * Used for the Someday view zero-task state.
+ */
+export function illustrationSomedayEmpty() {
+  return `<svg viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration" aria-hidden="true">
+  <!-- Main thought bubble -->
+  <ellipse cx="100" cy="58" rx="52" ry="32" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <!-- Thought trail -->
+  <circle cx="62" cy="104" r="8" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <circle cx="48" cy="118" r="5" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <!-- Dreamy stars inside bubble -->
+  <path d="M82 52l2 4 4 .8-3 3 .7 4.2-3.7-2-3.7 2 .7-4.2-3-3 4-.8z" fill="var(--accent)" opacity="0.2"/>
+  <path d="M110 48l1.5 3 3.5 .5-2.5 2.5.6 3.5-3.1-1.6-3.1 1.6.6-3.5-2.5-2.5 3.5-.5z" fill="var(--accent)" opacity="0.15"/>
+  <path d="M96 68l1 2 2.5.4-1.8 1.8.4 2.5-2.1-1.1-2.1 1.1.4-2.5-1.8-1.8 2.5-.4z" fill="var(--accent)" opacity="0.12"/>
+  <!-- Ellipsis inside bubble -->
+  <circle cx="88" cy="58" r="3" fill="var(--border)" opacity="0.25"/>
+  <circle cx="100" cy="58" r="3" fill="var(--border)" opacity="0.25"/>
+  <circle cx="112" cy="58" r="3" fill="var(--border)" opacity="0.25"/>
+</svg>`;
+}
+
+// ─── Tier 2: Feature-area empty states ────────────────────────────────────
+
+/**
+ * Clipboard with a sparkle wand — weekly review / reflection.
+ * Used for the Weekly Review "nothing to clean up" state.
+ */
+export function illustrationWeeklyReviewClean() {
+  return `<svg viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration" aria-hidden="true">
+  <!-- Clipboard -->
+  <rect x="60" y="36" width="72" height="88" rx="8" fill="var(--surface)" stroke="var(--border)" stroke-width="1.5"/>
+  <rect x="82" y="30" width="28" height="10" rx="4" fill="var(--accent)" opacity="0.7"/>
+  <!-- Checked rows -->
+  <path d="M74 58l4 4 8-8" stroke="var(--success)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.6"/>
+  <rect x="92" y="56" width="30" height="3" rx="1.5" fill="var(--border)" opacity="0.3"/>
+  <path d="M74 76l4 4 8-8" stroke="var(--success)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  <rect x="92" y="74" width="26" height="3" rx="1.5" fill="var(--border)" opacity="0.25"/>
+  <path d="M74 94l4 4 8-8" stroke="var(--success)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.4"/>
+  <rect x="92" y="92" width="22" height="3" rx="1.5" fill="var(--border)" opacity="0.2"/>
+  <!-- Sparkle wand -->
+  <line x1="148" y1="30" x2="136" y2="68" stroke="var(--accent)" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M148 26l2 5 5 2-5 2-2 5-2-5-5-2 5-2z" fill="var(--accent)" opacity="0.7"/>
+  <circle cx="155" cy="44" r="2" fill="var(--accent)" opacity="0.3"/>
+  <circle cx="142" cy="20" r="1.5" fill="var(--accent)" opacity="0.25"/>
+</svg>`;
+}
+
+/**
+ * Broom sweeping sparkles — cleanup analysis found nothing.
+ * Used for the Cleanup "no issues" state.
+ */
+export function illustrationCleanupClear() {
+  return `<svg viewBox="0 0 200 140" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration" aria-hidden="true">
+  <!-- Broom handle -->
+  <line x1="85" y1="20" x2="105" y2="90" stroke="var(--border)" stroke-width="3" stroke-linecap="round"/>
+  <!-- Broom head -->
+  <path d="M90 90 Q88 110 78 120 L132 120 Q122 110 120 90 Z" fill="var(--accent)" opacity="0.15" stroke="var(--accent)" stroke-width="1.5" stroke-linejoin="round"/>
+  <!-- Bristle lines -->
+  <line x1="90" y1="100" x2="85" y2="118" stroke="var(--accent)" stroke-width="1" opacity="0.3"/>
+  <line x1="100" y1="98" x2="100" y2="118" stroke="var(--accent)" stroke-width="1" opacity="0.3"/>
+  <line x1="110" y1="100" x2="115" y2="118" stroke="var(--accent)" stroke-width="1" opacity="0.3"/>
+  <!-- Sparkles (cleanliness) -->
+  <path d="M140 40l2 4.5 4.5 2-4.5 2-2 4.5-2-4.5-4.5-2 4.5-2z" fill="var(--success)" opacity="0.5"/>
+  <path d="M56 52l1.5 3 3 1.5-3 1.5-1.5 3-1.5-3-3-1.5 3-1.5z" fill="var(--success)" opacity="0.35"/>
+  <circle cx="150" cy="64" r="2" fill="var(--success)" opacity="0.25"/>
+  <circle cx="48" cy="38" r="1.5" fill="var(--success)" opacity="0.2"/>
+  <!-- Ground line -->
+  <rect x="40" y="124" width="120" height="1.5" rx="0.75" fill="var(--border)" opacity="0.2"/>
+</svg>`;
+}
+
+/**
+ * Small lightbulb — AI has no suggestions right now.
+ * Used for AI suggestion empty states in the task drawer.
+ */
+export function illustrationAiEmpty() {
+  return `<svg viewBox="0 0 48 40" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration empty-state-illustration--micro" aria-hidden="true">
+  <!-- Bulb -->
+  <circle cx="24" cy="16" r="10" fill="var(--surface)" stroke="var(--accent)" stroke-width="1.5"/>
+  <!-- Filament glow -->
+  <circle cx="24" cy="16" r="5" fill="var(--accent)" opacity="0.06"/>
+  <!-- Filament -->
+  <path d="M22 14c0-2 1-3 2-3s2 1 2 3" stroke="var(--accent)" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+  <!-- Base -->
+  <rect x="21" y="26" width="6" height="4" rx="1" fill="var(--border)" opacity="0.4"/>
+  <rect x="22" y="30" width="4" height="2" rx="1" fill="var(--border)" opacity="0.3"/>
+  <!-- Subtle rays (dimmed = no suggestion) -->
+  <line x1="24" y1="2" x2="24" y2="4" stroke="var(--accent)" stroke-width="1" stroke-linecap="round" opacity="0.15"/>
+  <line x1="36" y1="16" x2="34" y2="16" stroke="var(--accent)" stroke-width="1" stroke-linecap="round" opacity="0.12"/>
+  <line x1="12" y1="16" x2="14" y2="16" stroke="var(--accent)" stroke-width="1" stroke-linecap="round" opacity="0.12"/>
+</svg>`;
+}
+
+/**
+ * Small command line prompt — command palette has no matches.
+ * Used for the Command Palette empty state.
+ */
+export function illustrationCommandEmpty() {
+  return `<svg viewBox="0 0 48 40" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration empty-state-illustration--micro" aria-hidden="true">
+  <!-- Terminal window -->
+  <rect x="6" y="6" width="36" height="28" rx="4" fill="var(--surface)" stroke="var(--border)" stroke-width="1.2"/>
+  <!-- Title bar dots -->
+  <circle cx="13" cy="12" r="1.5" fill="var(--border)" opacity="0.4"/>
+  <circle cx="18" cy="12" r="1.5" fill="var(--border)" opacity="0.4"/>
+  <circle cx="23" cy="12" r="1.5" fill="var(--border)" opacity="0.4"/>
+  <!-- Prompt line -->
+  <path d="M12 22l3 3-3 3" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+  <!-- Blinking cursor -->
+  <rect x="20" y="23" width="1.5" height="5" rx="0.5" fill="var(--accent)" opacity="0.35"/>
+  <!-- Faded placeholder text -->
+  <rect x="24" y="24" width="12" height="2" rx="1" fill="var(--border)" opacity="0.15"/>
+</svg>`;
+}
+
+// ─── Tier 3: Micro-illustrations for small inline contexts ────────────────
+
+/**
+ * Tiny checklist — subtasks area is empty.
+ * Used for the "No subtasks" drawer state.
+ */
+export function illustrationSubtasksEmpty() {
+  return `<svg viewBox="0 0 36 28" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration empty-state-illustration--inline" aria-hidden="true">
+  <circle cx="8" cy="7" r="3" fill="none" stroke="var(--border)" stroke-width="1" opacity="0.4"/>
+  <rect x="14" y="5.5" width="16" height="2.5" rx="1.25" fill="var(--border)" opacity="0.25"/>
+  <circle cx="8" cy="17" r="3" fill="none" stroke="var(--border)" stroke-width="1" opacity="0.3"/>
+  <rect x="14" y="15.5" width="12" height="2.5" rx="1.25" fill="var(--border)" opacity="0.18"/>
+</svg>`;
+}
+
+/**
+ * Tiny magnifier — task picker search has no results.
+ * Used for the task picker dropdown empty state.
+ */
+export function illustrationPickerEmpty() {
+  return `<svg viewBox="0 0 36 28" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration empty-state-illustration--inline" aria-hidden="true">
+  <circle cx="15" cy="12" r="7" fill="none" stroke="var(--border)" stroke-width="1.2" opacity="0.4"/>
+  <line x1="20" y1="17" x2="26" y2="23" stroke="var(--border)" stroke-width="1.5" stroke-linecap="round" opacity="0.35"/>
+  <!-- X inside lens -->
+  <line x1="12.5" y1="9.5" x2="17.5" y2="14.5" stroke="var(--border)" stroke-width="1" stroke-linecap="round" opacity="0.2"/>
+  <line x1="17.5" y1="9.5" x2="12.5" y2="14.5" stroke="var(--border)" stroke-width="1" stroke-linecap="round" opacity="0.2"/>
+</svg>`;
+}
+
+/**
+ * Small horizontal bar chart — home tile has no data.
+ * Used for home dashboard tile empty states.
+ */
+export function illustrationTileEmpty() {
+  return `<svg viewBox="0 0 36 28" fill="none" xmlns="http://www.w3.org/2000/svg" class="empty-state-illustration empty-state-illustration--inline" aria-hidden="true">
+  <rect x="4" y="6" width="18" height="3" rx="1.5" fill="var(--border)" opacity="0.2"/>
+  <rect x="4" y="12.5" width="14" height="3" rx="1.5" fill="var(--border)" opacity="0.15"/>
+  <rect x="4" y="19" width="10" height="3" rx="1.5" fill="var(--border)" opacity="0.1"/>
+</svg>`;
+}

--- a/client/utils/taskPicker.js
+++ b/client/utils/taskPicker.js
@@ -6,6 +6,8 @@
 // drawerUi.js and the rest of the frontend.
 // =============================================================================
 
+import { illustrationPickerEmpty } from "./illustrations.js";
+
 /**
  * Mount a task picker inside a container element.
  *
@@ -116,7 +118,8 @@ export function mountTaskPicker(container, opts) {
       if (searchInput.value.trim()) {
         const empty = document.createElement("div");
         empty.className = "task-picker__empty";
-        empty.textContent = "No matching tasks";
+        // Hardcoded SVG + label — no user input, safe for innerHTML
+        empty.innerHTML = illustrationPickerEmpty() + "No matching tasks";
         dropdown.appendChild(empty);
         dropdown.classList.add("task-picker__dropdown--open");
       }


### PR DESCRIPTION
## Summary
- Add 9 new SVG illustrations to `client/utils/illustrations.js` covering every remaining empty state
- Wire view-specific illustrations into Today/Upcoming/Completed/Someday filter views (no more generic magnifying glass for all)
- Add illustrations to Weekly Review, Cleanup Analysis, AI Suggestions, Command Palette, Subtasks drawer, Task Picker, and Home Dashboard tiles
- Implement three-tier CSS sizing: Hero (120×96), Micro (40×32), Inline (28×22) for context-appropriate scaling

## Design rationale
World-class SaaS products give each empty state a unique visual identity. This PR replaces generic "no results" illustrations with view-specific ones:
- **Today clear** → sunny day with checkmark cloud (celebration)
- **Upcoming empty** → calm calendar with blank grid (forward-looking)
- **Completed empty** → trophy with progress arc (encouragement)
- **Someday empty** → thought bubble with stars (dreamy potential)
- **Weekly Review clean** → clipboard + sparkle wand (satisfaction)
- **Cleanup clear** → broom with sparkles (cleanliness)
- **AI empty** → dimmed lightbulb (waiting)
- **Command palette** → terminal prompt (searching)
- **Subtasks/Picker/Tiles** → tiny inline micro-illustrations (visual seasoning)

All illustrations auto-theme via CSS custom properties (`--accent`, `--success`, `--warning`, `--border`, `--surface`).

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run format:check` — passes (ARCHITECTURE_SUMMARY.md warning is pre-existing)
- [x] `npm run lint:html` — passes
- [x] `npm run lint:css` — passes
- [x] `npm run test:unit` — passes (3 pre-existing mcpPublicRouter failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)