### PR TITLE
refactor(ui): simplify tests, remove dead auth guards and landing CSS

### DIFF
--- a/client/modules/authUi.js
+++ b/client/modules/authUi.js
@@ -205,11 +205,6 @@ export async function handleLogin(event) {
           currentUser: state.currentUser,
         });
       }
-      // On multi-page layout (auth.html), redirect; on single-page, toggle view
-      if (!document.getElementById("todosView")) {
-        window.location.href = "/app";
-        return;
-      }
       showAppView();
       loadUserProfile().then(() => {
         initOnboarding();
@@ -271,19 +266,12 @@ export async function handleRegister(event) {
         });
       }
       showMessage("authMessage", "Account created successfully!", "success");
-      // On multi-page layout (auth.html), redirect; on single-page, toggle view
-      if (!document.getElementById("todosView")) {
-        setTimeout(() => {
-          window.location.href = "/app";
-        }, 1000);
-      } else {
-        setTimeout(() => {
-          showAppView();
-          loadUserProfile().then(() => {
-            initOnboarding();
-          });
-        }, 1000);
-      }
+      setTimeout(() => {
+        showAppView();
+        loadUserProfile().then(() => {
+          initOnboarding();
+        });
+      }, 1000);
     } else {
       if (data.errors) {
         const errorMsg = data.errors.map((e) => e.message).join(", ");
@@ -1163,11 +1151,6 @@ export function handleSocialCallback() {
       // Clean URL
       window.history.replaceState({}, document.title, window.location.pathname);
 
-      // On multi-page layout, redirect; on single-page, toggle view
-      if (!document.getElementById("todosView")) {
-        window.location.href = "/app";
-        return;
-      }
       showAppView();
       loadUserProfile().then(() => {
         initOnboarding();
@@ -1475,11 +1458,6 @@ export async function handleVerifyOtp() {
       });
     }
 
-    // On multi-page layout, redirect; on single-page, toggle view
-    if (!document.getElementById("todosView")) {
-      window.location.href = "/app";
-      return;
-    }
     showAppView();
     loadUserProfile().then(() => {
       initOnboarding();

--- a/client/styles/landing.css
+++ b/client/styles/landing.css
@@ -4,25 +4,6 @@
   width: 100%;
 }
 
-/* Hide landing when authenticated */
-body.is-todos-view .landing {
-  display: none;
-}
-
-/* When unauthenticated, strip app chrome so landing page takes over */
-body:not(.is-todos-view) .header {
-  display: none;
-}
-
-body:not(.is-todos-view) #appMainScroll {
-  padding: 0;
-}
-
-body:not(.is-todos-view) .container {
-  max-width: none;
-  border-radius: 0;
-}
-
 /* Nav */
 .landing-nav {
   position: sticky;

--- a/tests/ui/ai-brain-dump.spec.ts
+++ b/tests/ui/ai-brain-dump.spec.ts
@@ -218,8 +218,7 @@ async function installBrainDumpMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/?ai_debug=1");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register&ai_debug=1");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Brain Dump User");
   await page.locator("#registerEmail").fill("brain-dump@example.com");

--- a/tests/ui/ai-critic-panel.spec.ts
+++ b/tests/ui/ai-critic-panel.spec.ts
@@ -191,8 +191,7 @@ async function installCriticMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/?ai_debug=1");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register&ai_debug=1");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Critic User");
   await page.locator("#registerEmail").fill("critic@example.com");

--- a/tests/ui/ai-debug-mode.spec.ts
+++ b/tests/ui/ai-debug-mode.spec.ts
@@ -269,8 +269,7 @@ async function installAiUiMockApi(page: Page) {
 }
 
 async function registerAndOpenTodos(page: Page, debug = false) {
-  await page.goto(debug ? "/?ai_debug=1" : "/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto(debug ? "/?tab=register&ai_debug=1" : "/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("AI Debug User");
   await page

--- a/tests/ui/ai-on-create-assist.spec.ts
+++ b/tests/ui/ai-on-create-assist.spec.ts
@@ -168,8 +168,7 @@ async function installOnCreateMockApi(page: Page) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("On Create User");
   await page.locator("#registerEmail").fill("on-create-user@example.com");

--- a/tests/ui/ai-on-create-live.spec.ts
+++ b/tests/ui/ai-on-create-live.spec.ts
@@ -329,8 +329,7 @@ async function installOnCreateLiveMockApi(page: Page) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("On Create User");
   await page.locator("#registerEmail").fill("oncreate-live@example.com");

--- a/tests/ui/ai-plan-draft.spec.ts
+++ b/tests/ui/ai-plan-draft.spec.ts
@@ -230,8 +230,7 @@ async function installAiPlanMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/?ai_debug=1");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register&ai_debug=1");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Plan User");
   await page.locator("#registerEmail").fill("plan@example.com");

--- a/tests/ui/ai-task-drawer-live.spec.ts
+++ b/tests/ui/ai-task-drawer-live.spec.ts
@@ -382,8 +382,7 @@ async function registerAndOpenTodos(page: Page) {
     window.localStorage.setItem("feature.taskDrawerDecisionAssist", "1");
   });
 
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Drawer Live User");
   await page.locator("#registerEmail").fill("drawer-live-user@example.com");

--- a/tests/ui/app-smoke.spec.ts
+++ b/tests/ui/app-smoke.spec.ts
@@ -254,10 +254,7 @@ test.describe("App smoke flows", () => {
     page,
   }) => {
     await installMockApi(page);
-    await page.goto("/");
-
-    // Navigate from landing to auth page (register tab)
-    await page.evaluate(() => (window as any).showAuthPage?.("register"));
+    await page.goto("/?tab=register");
     await page.locator("#registerName").fill("User One");
     await page.locator("#registerEmail").fill("user1@example.com");
     await page.locator("#registerPassword").fill("Password123!");
@@ -295,7 +292,7 @@ test.describe("App smoke flows", () => {
     await clickLogout(page);
     await expect(page.locator("#authView")).toHaveClass(/active/);
 
-    await page.evaluate(() => (window as any).showAuthPage?.("register"));
+    await page.goto("/?tab=register");
     await page.locator("#registerName").fill("User Two");
     await page.locator("#registerEmail").fill("user2@example.com");
     await page.locator("#registerPassword").fill("Password123!");
@@ -307,9 +304,7 @@ test.describe("App smoke flows", () => {
 
   test("logout resets date view filter for next session", async ({ page }) => {
     await installMockApi(page);
-    await page.goto("/");
-
-    await page.evaluate(() => (window as any).showAuthPage?.("register"));
+    await page.goto("/?tab=register");
     await page.locator("#registerName").fill("Date View User One");
     await page.locator("#registerEmail").fill("date-view-one@example.com");
     await page.locator("#registerPassword").fill("Password123!");
@@ -328,7 +323,7 @@ test.describe("App smoke flows", () => {
     await clickLogout(page);
     await expect(page.locator("#authView")).toHaveClass(/active/);
 
-    await page.evaluate(() => (window as any).showAuthPage?.("register"));
+    await page.goto("/?tab=register");
     await page.locator("#registerName").fill("Date View User Two");
     await page.locator("#registerEmail").fill("date-view-two@example.com");
     await page.locator("#registerPassword").fill("Password123!");

--- a/tests/ui/auth-ui.spec.ts
+++ b/tests/ui/auth-ui.spec.ts
@@ -24,8 +24,7 @@ test.describe("Auth UI", () => {
   });
 
   test("login tab baseline @visual", async ({ page }, testInfo) => {
-    await page.goto("/");
-    await page.evaluate(() => (window as any).showAuthPage?.("login"));
+    await page.goto("/?tab=login");
     await expect(page.locator("#authView")).toHaveClass(/active/);
     await expect(page.locator("#loginForm")).toBeVisible();
     await expect(page.locator("#registerForm")).toBeHidden();
@@ -39,8 +38,7 @@ test.describe("Auth UI", () => {
   });
 
   test("register tab baseline @visual", async ({ page }, testInfo) => {
-    await page.goto("/");
-    await page.evaluate(() => (window as any).showAuthPage?.("register"));
+    await page.goto("/?tab=register");
 
     await page.getByRole("button", { name: "Register" }).click();
     await expect(page.locator("#registerForm")).toBeVisible();
@@ -55,8 +53,7 @@ test.describe("Auth UI", () => {
   });
 
   test("forgot password link opens reset form", async ({ page }) => {
-    await page.goto("/");
-    await page.evaluate(() => (window as any).showAuthPage?.("login"));
+    await page.goto("/?tab=login");
 
     await page.getByRole("button", { name: "Forgot Password?" }).click();
 
@@ -107,8 +104,7 @@ test.describe("Auth UI", () => {
       window.localStorage.setItem("user", "{invalid-json");
     });
 
-    await page.goto("/");
-    await page.evaluate(() => (window as any).showAuthPage?.("login"));
+    await page.goto("/?tab=login");
     await page.getByRole("button", { name: "Forgot Password?" }).click();
     await expect(page.locator("#forgotPasswordForm")).toBeVisible();
   });

--- a/tests/ui/composition-spacing.spec.ts
+++ b/tests/ui/composition-spacing.spec.ts
@@ -181,8 +181,7 @@ async function installMockApi(
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Composition Spacing User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/filter-pipeline-regression.spec.ts
+++ b/tests/ui/filter-pipeline-regression.spec.ts
@@ -305,8 +305,7 @@ async function installFilterPipelineMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Filter Pipeline");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/header-rail-sync.spec.ts
+++ b/tests/ui/header-rail-sync.spec.ts
@@ -150,8 +150,7 @@ async function installHeaderRailSyncMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Header Sync User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/helpers/todos-view.ts
+++ b/tests/ui/helpers/todos-view.ts
@@ -80,11 +80,7 @@ export async function registerAndOpenTodosView(
   { name, email, password = "Password123!" }: RegisterOptions,
   { preserveLandingDefault = false }: TodosViewOpenOptions = {},
 ) {
-  await page.goto("/");
-  // Navigate from landing to auth page, then switch to Register tab
-  await page.evaluate(() => {
-    (window as any).showAuthPage?.("register");
-  });
+  await page.goto("/?tab=register");
   await page.locator("#registerName").fill(name);
   await page.locator("#registerEmail").fill(email);
   await page.locator("#registerPassword").fill(password);

--- a/tests/ui/ics-export.spec.ts
+++ b/tests/ui/ics-export.spec.ts
@@ -153,8 +153,7 @@ async function installIcsMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("ICS User");
   await page.locator("#registerEmail").fill("ics@example.com");

--- a/tests/ui/layout-invariants.spec.ts
+++ b/tests/ui/layout-invariants.spec.ts
@@ -152,8 +152,7 @@ async function installLayoutInvariantMockApi(
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Layout Invariants User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/lint-chip.spec.ts
+++ b/tests/ui/lint-chip.spec.ts
@@ -186,8 +186,7 @@ async function installMockApi(page: Page) {
 }
 
 async function registerAndOpen(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Lint Test User");
   await page.locator("#registerEmail").fill("lint-test@example.com");

--- a/tests/ui/project-crud.spec.ts
+++ b/tests/ui/project-crud.spec.ts
@@ -339,8 +339,7 @@ async function installProjectCrudMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Project Crud User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/project-filter-regression.spec.ts
+++ b/tests/ui/project-filter-regression.spec.ts
@@ -283,8 +283,7 @@ async function installProjectFilterRegressionMockApi(
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Project Filter User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/projects-rail.spec.ts
+++ b/tests/ui/projects-rail.spec.ts
@@ -177,8 +177,7 @@ async function installProjectsRailMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Rail User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/single-scroll-container.spec.ts
+++ b/tests/ui/single-scroll-container.spec.ts
@@ -148,8 +148,7 @@ async function installSingleScrollMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Single Scroll User");
   await page.locator("#registerEmail").fill("single-scroll@example.com");

--- a/tests/ui/text-clipping.spec.ts
+++ b/tests/ui/text-clipping.spec.ts
@@ -148,8 +148,7 @@ async function installTextClippingMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Text Clipping User");
   await page.locator("#registerEmail").fill("text-clipping@example.com");

--- a/tests/ui/todo-drawer-edit.spec.ts
+++ b/tests/ui/todo-drawer-edit.spec.ts
@@ -262,8 +262,7 @@ async function installDrawerEditMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Drawer User");
   await page.locator("#registerEmail").fill("drawer@example.com");

--- a/tests/ui/todo-drawer-mobile-polish.spec.ts
+++ b/tests/ui/todo-drawer-mobile-polish.spec.ts
@@ -201,8 +201,7 @@ async function installDrawerMockApi(
 }
 
 async function registerAndOpenTodos(page: Page, email: string) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Drawer Mobile User");
   await page.locator("#registerEmail").fill(email);

--- a/tests/ui/todo-list-states.spec.ts
+++ b/tests/ui/todo-list-states.spec.ts
@@ -178,8 +178,7 @@ async function installMockApi(
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("List States User");
   await page.locator("#registerEmail").fill("list-states@example.com");

--- a/tests/ui/topbar-no-cta-clipping.spec.ts
+++ b/tests/ui/topbar-no-cta-clipping.spec.ts
@@ -148,8 +148,7 @@ async function installTopbarLayoutMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Topbar Layout User");
   await page.locator("#registerEmail").fill("topbar-layout@example.com");

--- a/tests/ui/topbar-projects.spec.ts
+++ b/tests/ui/topbar-projects.spec.ts
@@ -156,8 +156,7 @@ async function installTopbarProjectsMockApi(page: Page, todosSeed: TodoSeed[]) {
 }
 
 async function registerAndOpenTodos(page: Page) {
-  await page.goto("/");
-  await page.evaluate(() => (window as any).showAuthPage?.("register"));
+  await page.goto("/?tab=register");
   await page.getByRole("button", { name: "Register" }).click();
   await page.locator("#registerName").fill("Topbar User");
   await page.locator("#registerEmail").fill("topbar-projects@example.com");


### PR DESCRIPTION
## Summary

Final cleanup pass for the 3-page split refactor.

### Test simplification (26 files, -77 lines)
Replace two-line `page.goto("/")` + `showAuthPage` eval pattern with single `page.goto("/?tab=register")`. The `?tab=` URL param handling in app.js (added in PR #559) auto-shows the auth form, eliminating the need for explicit `page.evaluate` calls.

### Dead code removal (authUi.js, -30 lines)
Remove multi-page redirect guards (`if (!document.getElementById("todosView"))`) from `handleLogin`, `handleRegister`, `handleSocialCallback`, `handleVerifyOtp`. These branches are unreachable: `authUi.js` only runs via `app.js` on pages where `#todosView` exists. `auth.html` uses `auth-page.js` instead.

Kept: logout redirect guard (needed on `app.html` where `#authView` absent) and `showAppView`/`showAuthView` null guards (needed on `app.html`).

### Landing CSS cleanup (-19 lines)
Remove `body.is-todos-view` and `body:not(.is-todos-view)` conditional rules from `landing.css`. These only applied in the legacy SPA shell; the standalone `public/index.html` has no app chrome to hide/show.

## Test plan
- [x] TypeScript passes
- [x] Prettier format check passes
- [x] HTML lint passes
- [x] Unit tests: 301 pass, 3 pre-existing failures
- [ ] CI: all gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)