### PR TITLE
refactor(css): remove body.is-todos-view prefix from 265 selectors

### DIFF
--- a/client/styles/app.css
+++ b/client/styles/app.css
@@ -2074,15 +2074,14 @@ button.projects-rail-item {
   display: none !important;
 }
 
-/* Top bar hidden on desktop (body.is-todos-view raises specificity to 0,2,0
-   so it beats the base .todos-top-bar{display:grid} rule at 0,1,0). */
+/* Top bar hidden on desktop */
 @media (min-width: 769px) {
-  body.is-todos-view .todos-top-bar {
+  .todos-top-bar {
     display: none;
   }
   /* Header is redundant on desktop todos view — sidebar handles all navigation
      and account actions. It remains visible on mobile and auth view. */
-  body.is-todos-view .header {
+  .header {
     display: none;
   }
 }
@@ -2218,7 +2217,7 @@ button.projects-rail-item {
   box-shadow: var(--shadow-1);
 }
 
-body.is-todos-view .floating-new-task-cta {
+.floating-new-task-cta {
   display: inline-flex;
   align-items: center;
 }
@@ -3024,11 +3023,11 @@ body.is-todos-view .floating-new-task-cta {
   }
 
   #appSidebar,
-  body.is-todos-view #appSidebar {
+  #appSidebar {
     display: none;
   }
 
-  body.is-todos-view .nav-tabs {
+  .nav-tabs {
     display: flex !important;
   }
 
@@ -3038,7 +3037,7 @@ body.is-todos-view .floating-new-task-cta {
     padding: 10px;
   }
 
-  body.is-todos-view {
+  body {
     padding: 10px;
     overflow: auto;
   }
@@ -3070,7 +3069,7 @@ body.is-todos-view .floating-new-task-cta {
     padding: 15px;
   }
 
-  body.is-todos-view .container {
+  .container {
     height: calc(100dvh - 20px);
     max-height: calc(100dvh - 20px);
     border-radius: var(--r-md);
@@ -5530,9 +5529,9 @@ textarea:disabled {
 }
 
 /* M8: Notion-like calm density (single strong CTA in Todos) */
-body.is-todos-view .add-btn,
-body.is-todos-view .btn,
-body.is-todos-view .mini-btn {
+.add-btn,
+.btn,
+.mini-btn {
   background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
   color: var(--text-secondary);
   border: 1px solid color-mix(in oklab, var(--border-color) 80%, var(--surface));
@@ -5540,87 +5539,87 @@ body.is-todos-view .mini-btn {
   box-shadow: none;
 }
 
-body.is-todos-view .add-btn:hover,
-body.is-todos-view .btn:hover,
-body.is-todos-view .mini-btn:hover {
+.add-btn:hover,
+.btn:hover,
+.mini-btn:hover {
   background: color-mix(in oklab, var(--surface) 78%, var(--surface-2));
   color: var(--text-primary);
   border-color: color-mix(in oklab, var(--border-color) 66%, var(--text-muted));
 }
 
-body.is-todos-view .top-add-btn {
+.top-add-btn {
   background: linear-gradient(135deg, var(--accent) 0%, var(--accent-2) 100%);
   color: #fff;
   border-color: transparent;
   font-weight: var(--fw-semibold);
 }
 
-body.is-todos-view .top-add-btn:hover {
+.top-add-btn:hover {
   filter: saturate(1.05) brightness(1.02);
 }
 
-body.is-todos-view .todos-top-bar,
-body.is-todos-view .more-filters-panel,
-body.is-todos-view .todos-list-header,
-body.is-todos-view .quick-entry-properties-panel {
+.todos-top-bar,
+.more-filters-panel,
+.todos-list-header,
+.quick-entry-properties-panel {
   border-color: color-mix(in oklab, var(--border-color) 72%, var(--surface));
   background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
 }
 
-body.is-todos-view .todos-top-bar {
+.todos-top-bar {
   padding: 14px;
 }
 
-body.is-todos-view .todos-list-header {
+.todos-list-header {
   padding: 14px;
 }
 
-body.is-todos-view .projects-rail {
+.projects-rail {
   background: transparent;
   border-color: color-mix(in oklab, var(--border-color) 72%, transparent);
   box-shadow: none;
 }
 
-body.is-todos-view .projects-rail-item,
-body.is-todos-view .todo-item {
+.projects-rail-item,
+.todo-item {
   border-color: color-mix(in oklab, var(--border-color) 74%, var(--surface));
 }
 
 /* M9: Sidebar hierarchy + density polish */
-body.is-todos-view #appSidebar {
+#appSidebar {
   padding: 12px 10px;
   background: color-mix(in oklab, var(--surface-2) 90%, var(--surface));
 }
 
-body.is-todos-view .app-sidebar__top {
+.app-sidebar__top {
   gap: 10px;
 }
 
-body.is-todos-view #projectsRailHost > #projectsRail {
+#projectsRailHost > #projectsRail {
   padding: 0 2px;
 }
 
-body.is-todos-view .projects-rail {
+.projects-rail {
   gap: 10px;
 }
 
-body.is-todos-view .projects-rail__header {
+.projects-rail__header {
   padding: 0 6px 6px;
   border-bottom: 1px solid
     color-mix(in oklab, var(--border-color) 70%, transparent);
 }
 
-body.is-todos-view .projects-rail__section {
+.projects-rail__section {
   padding-top: 10px;
   margin-top: 2px;
   border-top-color: color-mix(in oklab, var(--border-color) 70%, transparent);
 }
 
-body.is-todos-view .projects-rail__section--workspace {
+.projects-rail__section--workspace {
   margin-top: 0;
 }
 
-body.is-todos-view .projects-rail__section-header {
+.projects-rail__section-header {
   margin-bottom: 6px;
   padding: 0 6px;
   font-size: 12px;
@@ -5628,18 +5627,18 @@ body.is-todos-view .projects-rail__section-header {
   color: color-mix(in oklab, var(--text-secondary) 84%, var(--text-muted));
 }
 
-body.is-todos-view .projects-rail__primary,
-body.is-todos-view .projects-rail__list,
-body.is-todos-view .app-sidebar__settings {
+.projects-rail__primary,
+.projects-rail__list,
+.app-sidebar__settings {
   gap: 4px;
 }
 
-body.is-todos-view .projects-rail-row {
+.projects-rail-row {
   padding-right: 30px;
 }
 
-body.is-todos-view .projects-rail-item,
-body.is-todos-view .sidebar-nav-item {
+.projects-rail-item,
+.sidebar-nav-item {
   border-radius: 8px;
   padding: 6px 8px;
   min-height: 34px;
@@ -5647,23 +5646,23 @@ body.is-todos-view .sidebar-nav-item {
   border-color: transparent;
 }
 
-body.is-todos-view .workspace-view-item,
-body.is-todos-view .sidebar-nav-item {
+.workspace-view-item,
+.sidebar-nav-item {
   font-weight: var(--fw-medium);
 }
 
-body.is-todos-view .projects-rail-item:hover {
+.projects-rail-item:hover {
   background: color-mix(in oklab, var(--surface) 86%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
 }
 
-body.is-todos-view .projects-rail-item--active,
-body.is-todos-view .projects-rail-item[role="option"][aria-selected="true"] {
+.projects-rail-item--active,
+.projects-rail-item[role="option"][aria-selected="true"] {
   background: color-mix(in oklab, var(--accent) 7%, var(--surface));
   border-color: color-mix(in oklab, var(--accent) 22%, var(--border-color));
 }
 
-body.is-todos-view .projects-rail-item__count {
+.projects-rail-item__count {
   font-size: 11px;
   color: color-mix(in oklab, var(--text-secondary) 82%, var(--text-muted));
   background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
@@ -5672,323 +5671,317 @@ body.is-todos-view .projects-rail-item__count {
   min-width: 20px;
 }
 
-body.is-todos-view .projects-rail-kebab {
+.projects-rail-kebab {
   width: 22px;
   height: 22px;
   right: 2px;
   background: transparent;
 }
 
-body.is-todos-view .app-sidebar__settings .projects-rail-item {
+.app-sidebar__settings .projects-rail-item {
   justify-content: flex-start;
 }
 
 /* M9: Main panel compaction (keep behavior unchanged) */
-body.is-todos-view #appMainScroll {
+#appMainScroll {
   padding: 12px;
 }
 
-body.is-todos-view .content {
+.content {
   padding: 0;
 }
 
-body.is-todos-view .header {
+.header {
   padding: 8px 12px;
 }
 
-body.is-todos-view .user-bar {
+.user-bar {
   margin-top: 6px;
 }
 
-body.is-todos-view .nav-tabs {
+.nav-tabs {
   padding: 4px 10px;
   gap: 6px;
 }
 
-body.is-todos-view .nav-tab {
+.nav-tab {
   padding: 4px 9px;
   font-size: 11px;
   color: color-mix(in oklab, var(--text-secondary) 90%, var(--text-muted));
   background: color-mix(in oklab, var(--surface) 96%, transparent);
 }
 
-body.is-todos-view .nav-tab.active {
+.nav-tab.active {
   color: color-mix(in oklab, var(--accent) 70%, var(--text-primary));
   border-color: color-mix(in oklab, var(--accent) 28%, var(--border-color));
   background: color-mix(in oklab, var(--accent) 6%, var(--surface));
 }
 
-body.is-todos-view .todos-top-bar {
+.todos-top-bar {
   gap: 10px;
   margin-bottom: 8px;
   padding: 10px 12px;
 }
 
-body.is-todos-view .search-input {
+.search-input {
   padding: 10px 38px 10px 12px;
 }
 
-body.is-todos-view #todosScrollRegion {
+#todosScrollRegion {
   gap: 8px;
   padding-bottom: 8px;
 }
 
-body.is-todos-view .more-filters-panel {
+.more-filters-panel {
   padding: 10px 12px;
 }
 
-body.is-todos-view .add-todo.quick-entry {
+.add-todo.quick-entry {
   gap: 8px;
 }
 
-body.is-todos-view .quick-entry > input,
-body.is-todos-view .field-row input,
-body.is-todos-view .field-row select {
+.quick-entry > input,
+.field-row input,
+.field-row select {
   padding: 10px 12px;
 }
 
-body.is-todos-view .quick-entry-toolbar {
+.quick-entry-toolbar {
   margin-top: -2px;
 }
 
-body.is-todos-view .quick-entry-properties-panel {
+.quick-entry-properties-panel {
   gap: 10px;
   padding: 10px 12px;
 }
 
-body.is-todos-view .field-row {
+.field-row {
   gap: 10px;
 }
 
-body.is-todos-view .action-row {
+.action-row {
   gap: 10px;
 }
 
-body.is-todos-view .todos-list-header {
+.todos-list-header {
   align-items: center;
   padding: 10px 12px;
 }
 
 /* M9a: keep legacy top tabs available (less dominant) for Todos<->Settings switching */
-body.is-todos-view .nav-tabs {
+.nav-tabs {
   display: flex !important;
 }
 
 /* M9a: preserve topbar/quick-entry/AI goal input height parity for CTA invariants */
-body.is-todos-view .ai-workspace-inputs input {
+.ai-workspace-inputs input {
   padding: 10px 12px;
 }
 
 /* M10: Density tighten follow-up (reduce pre-list vertical stack) */
-body.is-todos-view #appSidebar {
+#appSidebar {
   padding: 10px 8px;
 }
 
-body.is-todos-view #appMainScroll {
+#appMainScroll {
   padding: 10px;
 }
 
-body.is-todos-view .projects-rail__header {
+.projects-rail__header {
   padding: 0 4px 5px;
 }
 
-body.is-todos-view .projects-rail__section-header {
+.projects-rail__section-header {
   margin-bottom: 4px;
   padding: 0 4px;
 }
 
-body.is-todos-view .projects-rail-item,
-body.is-todos-view .sidebar-nav-item {
+.projects-rail-item,
+.sidebar-nav-item {
   padding: 5px 7px;
   min-height: 32px;
 }
 
-body.is-todos-view .projects-rail-item__count {
+.projects-rail-item__count {
   padding: 1px 5px;
 }
 
-body.is-todos-view .todos-top-bar {
+.todos-top-bar {
   gap: 8px;
   margin-bottom: 6px;
   padding: 8px 10px;
 }
 
-body.is-todos-view .todos-top-bar-actions {
+.todos-top-bar-actions {
   gap: 6px;
 }
 
-body.is-todos-view #todosScrollRegion {
+#todosScrollRegion {
   gap: 6px;
   padding-bottom: 6px;
 }
 
-body.is-todos-view .more-filters-panel,
-body.is-todos-view .todos-list-header {
+.more-filters-panel,
+.todos-list-header {
   padding: 8px 10px;
 }
 
-body.is-todos-view .add-todo.quick-entry {
+.add-todo.quick-entry {
   gap: 6px;
 }
 
-body.is-todos-view .quick-entry > input {
+.quick-entry > input {
   padding-top: 9px;
   padding-bottom: 9px;
 }
 
-body.is-todos-view .quick-entry-toolbar {
+.quick-entry-toolbar {
   margin-top: -4px;
 }
 
-body.is-todos-view .quick-entry-properties-panel {
+.quick-entry-properties-panel {
   gap: 8px;
   padding: 8px 10px;
 }
 
-body.is-todos-view .quick-entry-properties-panel .field-row {
+.quick-entry-properties-panel .field-row {
   gap: 8px;
   align-items: center;
 }
 
-body.is-todos-view .quick-entry-properties-panel .action-row {
+.quick-entry-properties-panel .action-row {
   gap: 8px;
   align-items: center;
 }
 
-body.is-todos-view .quick-entry-properties-panel .field-row select {
+.quick-entry-properties-panel .field-row select {
   min-width: 150px;
 }
 
-body.is-todos-view
-  .quick-entry-properties-panel
-  .field-row
-  input[type="datetime-local"] {
+.quick-entry-properties-panel .field-row input[type="datetime-local"] {
   min-width: 170px;
 }
 
-body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+.quick-entry-properties-panel .field-row .add-btn {
   padding: 8px 10px !important;
   font-size: 12px;
   min-height: 36px;
 }
 
-body.is-todos-view .action-label {
+.action-label {
   font-size: 12px;
 }
 
-body.is-todos-view .priority-selector {
+.priority-selector {
   gap: 6px;
   flex-wrap: wrap;
 }
 
-body.is-todos-view .priority-btn {
+.priority-btn {
   padding: 6px 10px;
   font-size: 0.8em;
   line-height: 1.1;
 }
 
-body.is-todos-view .priority-btn:hover {
+.priority-btn:hover {
   transform: none;
 }
 
 @media (min-width: 1180px) {
-  body.is-todos-view .quick-entry-properties-panel {
+  .quick-entry-properties-panel {
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
   }
 
-  body.is-todos-view .quick-entry-properties-panel > .field-row {
+  .quick-entry-properties-panel > .field-row {
     grid-column: 1;
   }
 
-  body.is-todos-view .quick-entry-properties-panel > .action-row {
+  .quick-entry-properties-panel > .action-row {
     grid-column: 2;
     justify-self: end;
     margin: 0;
   }
 
-  body.is-todos-view
-    .quick-entry-properties-panel
-    > .action-row
-    #critiqueDraftButton {
+  .quick-entry-properties-panel > .action-row #critiqueDraftButton {
     max-width: 170px;
   }
 }
 
 @media (max-width: 1179px) {
-  body.is-todos-view .quick-entry-properties-panel {
+  .quick-entry-properties-panel {
     grid-template-columns: 1fr;
   }
 }
 
 /* M11: Quick-entry accordion density pass (reduce pre-list stack height) */
-body.is-todos-view .add-todo.quick-entry {
+.add-todo.quick-entry {
   gap: 4px;
 }
 
-body.is-todos-view .quick-entry > input {
+.quick-entry > input {
   padding-top: 8px;
   padding-bottom: 8px;
 }
 
-body.is-todos-view .quick-entry-toolbar {
+.quick-entry-toolbar {
   margin-top: -6px;
   min-height: 28px;
 }
 
-body.is-todos-view .quick-entry-properties-toggle {
+.quick-entry-properties-toggle {
   padding: 4px 8px;
   font-size: 12px;
   min-height: 28px;
 }
 
-body.is-todos-view .quick-entry-properties-panel {
+.quick-entry-properties-panel {
   gap: 6px;
   padding: 6px 8px;
   margin-top: 0;
 }
 
-body.is-todos-view .quick-entry-properties-panel .field-row,
-body.is-todos-view .quick-entry-properties-panel .action-row {
+.quick-entry-properties-panel .field-row,
+.quick-entry-properties-panel .action-row {
   gap: 6px;
 }
 
-body.is-todos-view .quick-entry-properties-panel .field-row input,
-body.is-todos-view .quick-entry-properties-panel .field-row select,
-body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+.quick-entry-properties-panel .field-row input,
+.quick-entry-properties-panel .field-row select,
+.quick-entry-properties-panel .field-row .add-btn {
   min-height: 34px;
 }
 
-body.is-todos-view .quick-entry-properties-panel .field-row .add-btn {
+.quick-entry-properties-panel .field-row .add-btn {
   padding: 6px 9px !important;
   font-size: 11px;
 }
 
-body.is-todos-view .action-label {
+.action-label {
   font-size: 11px;
 }
 
-body.is-todos-view .priority-selector {
+.priority-selector {
   gap: 4px;
 }
 
-body.is-todos-view .priority-btn {
+.priority-btn {
   padding: 4px 8px;
   font-size: 0.76em;
 }
 
-body.is-todos-view .expand-section {
+.expand-section {
   margin-top: 4px;
   padding: 4px 6px;
   font-size: 0.8em;
 }
 
-body.is-todos-view .notes-textarea {
+.notes-textarea {
   margin-top: 4px !important;
 }
 
 /* M12: secondary top tabs + unified rail row polish */
-body.is-todos-view .nav-tabs {
+.nav-tabs {
   gap: 4px;
   padding: 3px 8px;
   background: color-mix(in oklab, var(--card-bg) 96%, var(--surface));
@@ -5999,7 +5992,7 @@ body.is-todos-view .nav-tabs {
   );
 }
 
-body.is-todos-view .nav-tab {
+.nav-tab {
   padding: 3px 8px;
   font-size: 10px;
   line-height: 1.15;
@@ -6009,66 +6002,66 @@ body.is-todos-view .nav-tab {
   color: color-mix(in oklab, var(--text-secondary) 78%, var(--text-muted));
 }
 
-body.is-todos-view .nav-tab:hover {
+.nav-tab:hover {
   background: color-mix(in oklab, var(--surface) 88%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 68%, transparent);
   color: var(--text-secondary);
 }
 
-body.is-todos-view .nav-tab.active {
+.nav-tab.active {
   color: color-mix(in oklab, var(--accent) 62%, var(--text-primary));
   border-color: color-mix(in oklab, var(--accent) 20%, var(--border-color));
   background: color-mix(in oklab, var(--accent) 4%, var(--surface));
   box-shadow: none;
 }
 
-body.is-todos-view .projects-rail {
+.projects-rail {
   gap: 8px;
 }
 
-body.is-todos-view .projects-rail__section {
+.projects-rail__section {
   padding-top: 8px;
   margin-top: 0;
 }
 
-body.is-todos-view .projects-rail__section-header {
+.projects-rail__section-header {
   margin-bottom: 3px;
   padding: 0 3px;
   font-size: 11px;
   letter-spacing: 0.01em;
 }
 
-body.is-todos-view .projects-rail__primary,
-body.is-todos-view .projects-rail__list,
-body.is-todos-view .app-sidebar__settings {
+.projects-rail__primary,
+.projects-rail__list,
+.app-sidebar__settings {
   gap: 2px;
 }
 
-body.is-todos-view .projects-rail-row {
+.projects-rail-row {
   padding-right: 28px;
 }
 
-body.is-todos-view .projects-rail-item,
-body.is-todos-view .sidebar-nav-item {
+.projects-rail-item,
+.sidebar-nav-item {
   min-height: 30px;
   padding: 4px 7px;
   border-radius: 7px;
   border-color: transparent;
 }
 
-body.is-todos-view .projects-rail-item:hover,
-body.is-todos-view .sidebar-nav-item:hover {
+.projects-rail-item:hover,
+.sidebar-nav-item:hover {
   background: color-mix(in oklab, var(--surface) 84%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 60%, transparent);
 }
 
-body.is-todos-view .projects-rail-item--active,
-body.is-todos-view .projects-rail-item[role="option"][aria-selected="true"] {
+.projects-rail-item--active,
+.projects-rail-item[role="option"][aria-selected="true"] {
   background: color-mix(in oklab, var(--accent) 6%, var(--surface));
   border-color: color-mix(in oklab, var(--accent) 18%, var(--border-color));
 }
 
-body.is-todos-view .projects-rail-item__count {
+.projects-rail-item__count {
   min-width: 18px;
   padding: 0 5px;
   font-size: 10px;
@@ -6791,7 +6784,7 @@ body.is-todos-view .projects-rail-item__count {
   border-color: color-mix(in oklab, var(--border-color) 100%, transparent);
 }
 
-body.is-todos-view .add-todo.quick-entry {
+.add-todo.quick-entry {
   border: 1px solid color-mix(in oklab, var(--border-color) 88%, transparent);
   border-radius: 12px;
   padding: 10px;
@@ -6799,7 +6792,7 @@ body.is-todos-view .add-todo.quick-entry {
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 20%);
 }
 
-body.is-todos-view .quick-entry-toolbar {
+.quick-entry-toolbar {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -6808,7 +6801,7 @@ body.is-todos-view .quick-entry-toolbar {
   min-height: 0;
 }
 
-body.is-todos-view .quick-entry-properties-summary {
+.quick-entry-properties-summary {
   font-size: 12px;
   color: var(--text-secondary);
   white-space: nowrap;
@@ -6816,66 +6809,59 @@ body.is-todos-view .quick-entry-properties-summary {
   text-overflow: ellipsis;
 }
 
-body.is-todos-view .quick-entry-properties-summary[hidden] {
+.quick-entry-properties-summary[hidden] {
   display: none !important;
 }
 
-body.is-todos-view .quick-entry-properties-panel {
+.quick-entry-properties-panel {
   border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
   background: color-mix(in oklab, var(--surface-2) 55%, transparent);
   border-radius: 10px;
 }
 
-body.is-todos-view
-  .quick-entry-properties-panel
-  .field-row
-  input[type="datetime-local"] {
+.quick-entry-properties-panel .field-row input[type="datetime-local"] {
   color: var(--text-secondary);
 }
 
-body.is-todos-view
-  .quick-entry-properties-panel
-  .field-row
-  input[type="datetime-local"]:focus,
-body.is-todos-view
-  .quick-entry-properties-panel
+.quick-entry-properties-panel .field-row input[type="datetime-local"]:focus,
+.quick-entry-properties-panel
   .field-row
   input[type="datetime-local"]:not(:placeholder-shown) {
   color: var(--text-primary);
 }
 
-body.is-todos-view .priority-selector {
+.priority-selector {
   border-radius: 10px;
 }
 
-body.is-todos-view .priority-btn {
+.priority-btn {
   border-width: 1px;
   border-color: color-mix(in oklab, var(--border-color) 80%, transparent);
   color: var(--text-secondary);
   background: color-mix(in oklab, var(--surface) 98%, transparent);
 }
 
-body.is-todos-view .priority-btn.active {
+.priority-btn.active {
   border-width: 2px;
   box-shadow: 0 0 0 1px rgb(255 255 255 / 22%) inset;
 }
 
-body.is-todos-view .priority-btn.low.active {
+.priority-btn.low.active {
   border-color: color-mix(in oklab, var(--accent-2) 82%, white);
   background: color-mix(in oklab, var(--accent-2) 88%, black 8%);
 }
 
-body.is-todos-view .priority-btn.medium.active {
+.priority-btn.medium.active {
   border-color: var(--warning);
   background: color-mix(in oklab, var(--warning) 90%, black 8%);
 }
 
-body.is-todos-view .priority-btn.high.active {
+.priority-btn.high.active {
   border-color: color-mix(in oklab, var(--danger) 86%, white);
   background: color-mix(in oklab, var(--danger) 90%, black 8%);
 }
 
-body.is-todos-view .priority-btn.active::before {
+.priority-btn.active::before {
   content: "●";
   font-size: 0.7em;
   margin-right: 4px;
@@ -6931,7 +6917,7 @@ body.is-todos-view .priority-btn.active::before {
 /* Spec: calm workspace polish */
 
 /* 1. Remove blue body-gradient bleed around main content in todos view */
-body.is-todos-view #appMainScroll {
+#appMainScroll {
   padding: 0;
 }
 
@@ -6970,7 +6956,7 @@ body.is-todos-view #appMainScroll {
 }
 
 /* 3. Sidebar header: 48px height, flex row with toggle on left */
-body.is-todos-view .projects-rail__header {
+.projects-rail__header {
   display: flex;
   align-items: center;
   height: 48px;
@@ -7067,31 +7053,31 @@ body.is-todos-view .projects-rail__header {
 }
 
 /* Home tile: section-style for single-column layout */
-body.is-todos-view .home-tile {
+.home-tile {
   border-radius: 16px;
   padding: 16px;
   gap: 12px;
 }
 
-body.is-todos-view .home-tile__header {
+.home-tile__header {
   margin-bottom: 0;
 }
 
-body.is-todos-view .home-tile__title {
+.home-tile__title {
   font-size: 20px;
   font-weight: 650;
   letter-spacing: -0.01em;
 }
 
 /* Focus tile: slightly more prominent surface */
-body.is-todos-view .home-tile[data-home-tile="top_focus"] {
+.home-tile[data-home-tile="top_focus"] {
   background: color-mix(in oklab, var(--surface) 94%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 60%, transparent);
 }
 
 /* Up Next / Due Soon tile: lighter surface */
-body.is-todos-view .home-tile[data-home-tile="due_soon"],
-body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
+.home-tile[data-home-tile="due_soon"],
+.home-tile[data-home-tile="projects_to_nudge"] {
   background: color-mix(in oklab, var(--surface) 98%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 40%, transparent);
 }
@@ -7105,8 +7091,8 @@ body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
 }
 
 /* Things-inspired surface refinement: final override layer */
-body.is-todos-view #todosView[data-surface-mode="list"] .todos-list-header,
-body.is-todos-view #todosView[data-surface-mode="project"] .todos-list-header {
+#todosView[data-surface-mode="list"] .todos-list-header,
+#todosView[data-surface-mode="project"] .todos-list-header {
   padding: 6px 2px 12px;
   border: 0;
   border-radius: 0;
@@ -7118,28 +7104,22 @@ body.is-todos-view #todosView[data-surface-mode="project"] .todos-list-header {
   );
 }
 
-body.is-todos-view
-  #todosView[data-surface-mode="list"]
-  .todos-list-header__count,
-body.is-todos-view
-  #todosView[data-surface-mode="list"]
-  .todos-list-header__date-badge {
+#todosView[data-surface-mode="list"] .todos-list-header__count,
+#todosView[data-surface-mode="list"] .todos-list-header__date-badge {
   border: 0;
   background: transparent;
   padding: 0;
 }
 
-body.is-todos-view #todosView[data-surface-mode="project"] #todosContent {
+#todosView[data-surface-mode="project"] #todosContent {
   padding-top: 2px;
 }
 
-body.is-todos-view
-  #todosView[data-surface-mode="project"]
-  .todo-heading-divider {
+#todosView[data-surface-mode="project"] .todo-heading-divider {
   margin-top: 24px;
 }
 
-body.is-todos-view #todosView .todos-top-bar[hidden] {
+#todosView .todos-top-bar[hidden] {
   display: none !important;
 }
 
@@ -7171,115 +7151,98 @@ body.is-todos-view #todosView .todos-top-bar[hidden] {
 
 /* Sidebar rows: flex-start layout so icon + label are left-aligned,
    count floats right via margin-left:auto */
-body.is-todos-view .projects-rail-item {
+.projects-rail-item {
   justify-content: flex-start;
 }
 
-body.is-todos-view .projects-rail-item__label {
+.projects-rail-item__label {
   flex: 1 1 auto;
 }
 
-body.is-todos-view .projects-rail-item__count {
+.projects-rail-item__count {
   margin-left: auto;
   flex-shrink: 0;
 }
 
 /* Remove the old > span:first-child overflow rule — nav-label handles it */
-body.is-todos-view .projects-rail-item > span:first-child {
+.projects-rail-item > span:first-child {
   overflow: visible;
   text-overflow: unset;
   white-space: normal;
 }
 
 /* ── Collapsed sidebar: strict icon-only rail ─────────────────────────────── */
-body.is-todos-view .projects-rail.projects-rail--collapsed {
+.projects-rail.projects-rail--collapsed {
   width: 64px;
 }
 
-body.is-todos-view.is-projects-rail-collapsed #appSidebar {
+.is-projects-rail-collapsed #appSidebar {
   padding-left: 0;
   padding-right: 0;
   padding-bottom: 64px;
 }
 
-body.is-todos-view .projects-rail {
+.projects-rail {
   display: flex;
   flex-direction: column;
 }
 
-body.is-todos-view .projects-rail__spacer {
+.projects-rail__spacer {
   flex: 1 1 auto;
   min-height: 0;
 }
 
-body.is-todos-view .projects-rail__utility-list {
+.projects-rail__utility-list {
   display: grid;
   gap: 6px;
 }
 
-body.is-todos-view .projects-rail__section--utilities {
+.projects-rail__section--utilities {
   display: none;
 }
 
-body.is-todos-view .projects-rail-projects-access {
+.projects-rail-projects-access {
   display: none;
 }
 
-body.is-todos-view .projects-rail.projects-rail--collapsed .nav-label,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail-item__label,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail-item__count {
+.projects-rail.projects-rail--collapsed .nav-label,
+.projects-rail.projects-rail--collapsed .projects-rail-item__label,
+.projects-rail.projects-rail--collapsed .projects-rail-item__count {
   display: none;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
+.projects-rail.projects-rail--collapsed
   .projects-rail__section:not(.projects-rail__section--workspace):not(
     .projects-rail__section--utilities
   ),
-body.is-todos-view .projects-rail.projects-rail--collapsed #projectsRailList {
+.projects-rail.projects-rail--collapsed #projectsRailList {
   display: none;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail__footer--admin-only {
+.projects-rail.projects-rail--collapsed .projects-rail__footer--admin-only {
   display: none;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail__header {
+.projects-rail.projects-rail--collapsed .projects-rail__header {
   justify-content: center;
   padding-bottom: 8px;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail__section--workspace {
+.projects-rail.projects-rail--collapsed .projects-rail__section--workspace {
   margin-top: 0;
   padding-top: 8px;
   border-top: 0;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail__primary {
+.projects-rail.projects-rail--collapsed .projects-rail__primary {
   display: grid;
   justify-items: center;
   gap: 8px;
 }
 
-body.is-todos-view .projects-rail.projects-rail--collapsed .workspace-view-item,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail-projects-access,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail-utility-item {
+.projects-rail.projects-rail--collapsed .workspace-view-item,
+.projects-rail.projects-rail--collapsed .projects-rail-projects-access,
+.projects-rail.projects-rail--collapsed .projects-rail-utility-item {
   width: 46px;
   min-width: 46px;
   justify-content: center;
@@ -7289,57 +7252,39 @@ body.is-todos-view
   padding: 0;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail-projects-access {
+.projects-rail.projects-rail--collapsed .projects-rail-projects-access {
   display: flex;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .workspace-view-item
-  .nav-icon,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
+.projects-rail.projects-rail--collapsed .workspace-view-item .nav-icon,
+.projects-rail.projects-rail--collapsed
   .projects-rail-projects-access
   .nav-icon,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail-utility-item
-  .nav-icon {
+.projects-rail.projects-rail--collapsed .projects-rail-utility-item .nav-icon {
   width: 18px;
   height: 18px;
   opacity: 0.72;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .workspace-view-item:hover
-  .nav-icon,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
+.projects-rail.projects-rail--collapsed .workspace-view-item:hover .nav-icon,
+.projects-rail.projects-rail--collapsed
   .workspace-view-item.projects-rail-item--active
   .nav-icon,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
+.projects-rail.projects-rail--collapsed
   .projects-rail-projects-access:hover
   .nav-icon,
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
+.projects-rail.projects-rail--collapsed
   .projects-rail-utility-item:hover
   .nav-icon {
   opacity: 0.92;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
+.projects-rail.projects-rail--collapsed
   .workspace-view-item.projects-rail-item--active {
   border-radius: 10px;
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail__section--utilities {
+.projects-rail.projects-rail--collapsed .projects-rail__section--utilities {
   display: block;
   margin-top: auto;
   padding-top: 10px;
@@ -7347,9 +7292,7 @@ body.is-todos-view
     color-mix(in oklab, var(--border-color) 70%, transparent);
 }
 
-body.is-todos-view
-  .projects-rail.projects-rail--collapsed
-  .projects-rail__utility-list {
+.projects-rail.projects-rail--collapsed .projects-rail__utility-list {
   justify-items: center;
   gap: 8px;
 }
@@ -7363,7 +7306,7 @@ body.is-todos-view
 
 /* ── Search: leading icon ─────────────────────────────────────────────────── */
 
-body.is-todos-view .search-bar .search-icon {
+.search-bar .search-icon {
   left: 9px;
   right: auto;
   display: flex;
@@ -7371,20 +7314,20 @@ body.is-todos-view .search-bar .search-icon {
   color: var(--text-muted);
 }
 
-body.is-todos-view .search-input {
+.search-input {
   padding: 8px 12px 8px 30px;
 }
 
 /* ── Projects section header: quieter ────────────────────────────────────── */
 
-body.is-todos-view .projects-rail__section-label {
+.projects-rail__section-label {
   font-size: 11px;
   font-weight: var(--fw-medium);
   letter-spacing: 0.02em;
   color: color-mix(in oklab, var(--text-muted) 75%, transparent);
 }
 
-body.is-todos-view .projects-rail-create-btn {
+.projects-rail-create-btn {
   min-width: 22px;
   min-height: 22px;
   padding: 0 5px;
@@ -7393,14 +7336,14 @@ body.is-todos-view .projects-rail-create-btn {
   transition: opacity var(--dur-fast) var(--ease-out);
 }
 
-body.is-todos-view .projects-rail-create-btn:hover {
+.projects-rail-create-btn:hover {
   opacity: 1;
 }
 
 /* ── Home tile hierarchy ──────────────────────────────────────────────────── */
 
 /* Focus: visual hero — strongest surface, more padding, bolder title */
-body.is-todos-view .home-tile[data-home-tile="top_focus"] {
+.home-tile[data-home-tile="top_focus"] {
   background: var(--surface);
   border-color: color-mix(in oklab, var(--border-color) 75%, transparent);
   box-shadow:
@@ -7409,34 +7352,30 @@ body.is-todos-view .home-tile[data-home-tile="top_focus"] {
   padding: 20px;
 }
 
-body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__title {
+.home-tile[data-home-tile="top_focus"] .home-tile__title {
   font-size: 22px;
 }
 
 /* Up Next: standard secondary */
-body.is-todos-view .home-tile[data-home-tile="due_soon"] {
+.home-tile[data-home-tile="due_soon"] {
   background: color-mix(in oklab, var(--surface) 97%, var(--surface-2));
   border-color: color-mix(in oklab, var(--border-color) 55%, transparent);
 }
 
 /* Projects to Nudge: lightest — no card frame, just a quiet list */
-body.is-todos-view .home-tile[data-home-tile="projects_to_nudge"] {
+.home-tile[data-home-tile="projects_to_nudge"] {
   background: transparent;
   border: none;
   box-shadow: none;
   padding: 8px 4px 0;
 }
 
-body.is-todos-view
-  .home-tile[data-home-tile="projects_to_nudge"]
-  .home-tile__body {
+.home-tile[data-home-tile="projects_to_nudge"] .home-tile__body {
   display: grid;
   gap: 6px;
 }
 
-body.is-todos-view
-  .home-tile[data-home-tile="projects_to_nudge"]
-  .home-tile__title {
+.home-tile[data-home-tile="projects_to_nudge"] .home-tile__title {
   font-size: 16px;
   font-weight: var(--fw-semibold);
   color: var(--text-secondary);
@@ -7455,7 +7394,7 @@ body.is-todos-view
   color: currentColor;
 }
 
-body.is-todos-view .home-tile[data-home-tile="top_focus"] .home-tile__icon {
+.home-tile[data-home-tile="top_focus"] .home-tile__icon {
   opacity: 0.65;
 }
 
@@ -7664,18 +7603,18 @@ body.is-admin-user .projects-rail__footer--admin-only {
 
 @media (max-width: 768px) {
   /* 1. Fix sidebar column reservation — prevents gradient bleed from empty grid column */
-  body.is-todos-view #appShell {
+  #appShell {
     grid-template-columns: minmax(0, 1fr);
   }
 
   /* 2. Remove body padding that offsets the container */
-  body.is-todos-view {
+  body {
     padding: 0;
     overflow: hidden;
   }
 
   /* 3. Reset main scroll for full-viewport flex layout */
-  body.is-todos-view #appMainScroll {
+  #appMainScroll {
     padding: 0;
     overflow: hidden;
     display: flex;
@@ -7685,7 +7624,7 @@ body.is-admin-user .projects-rail__footer--admin-only {
   }
 
   /* 4. Container fills full viewport — no rounded corners, no offset */
-  body.is-todos-view .container {
+  .container {
     height: 100dvh;
     max-height: 100dvh;
     max-width: 100%;
@@ -7693,12 +7632,12 @@ body.is-admin-user .projects-rail__footer--admin-only {
   }
 
   /* 5. Hide the old header on mobile todos view — replaced by mobile top bar */
-  body.is-todos-view .header {
+  .header {
     display: none;
   }
 
   /* 6. Show mobile top bar */
-  body.is-todos-view .todos-mobile-top-bar {
+  .todos-mobile-top-bar {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -7710,7 +7649,7 @@ body.is-admin-user .projects-rail__footer--admin-only {
   }
 
   /* 8. Apply consistent mobile padding to the scroll region */
-  body.is-todos-view #todosScrollRegion {
+  #todosScrollRegion {
     padding-left: 16px;
     padding-right: 16px;
     padding-top: 16px;
@@ -9063,20 +9002,20 @@ body.dark-mode .undo-toast {
 
 /* Calm restoration overrides */
 
-body.is-todos-view .home-dashboard {
+.home-dashboard {
   max-width: 980px;
   gap: 18px;
   padding: 24px 28px 40px;
 }
 
-body.is-todos-view .home-dashboard__support-grid {
+.home-dashboard__support-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
   align-items: start;
 }
 
-body.is-todos-view .home-brief-card {
+.home-brief-card {
   display: grid;
   gap: 16px;
   padding: 22px;
@@ -9199,7 +9138,7 @@ body.is-todos-view .home-brief-card {
   font-size: var(--fs-meta);
 }
 
-body.is-todos-view .home-brief-card .home-tile--priorities {
+.home-brief-card .home-tile--priorities {
   margin: 0;
   padding: 16px 18px;
   border-radius: 18px;
@@ -9207,93 +9146,91 @@ body.is-todos-view .home-brief-card .home-tile--priorities {
   box-shadow: none;
 }
 
-body.is-todos-view .home-brief-card .home-tile__title {
+.home-brief-card .home-tile__title {
   font-size: var(--fs-body);
 }
 
-body.is-todos-view .home-priorities-body {
+.home-priorities-body {
   min-height: 0;
 }
 
-body.is-todos-view .home-tile[data-home-tile="due_soon"],
-body.is-todos-view .home-tile[data-home-tile="stale_risks"] {
+.home-tile[data-home-tile="due_soon"],
+.home-tile[data-home-tile="stale_risks"] {
   min-height: 100%;
 }
 
-body.is-todos-view .home-tile__subtitle {
+.home-tile__subtitle {
   max-width: 40ch;
 }
 
-body.is-todos-view .home-task-row {
+.home-task-row {
   gap: 10px;
   padding: 10px 12px;
   border-radius: 14px;
 }
 
-body.is-todos-view .task-composer-sheet__header {
+.task-composer-sheet__header {
   align-items: flex-start;
 }
 
-body.is-todos-view .task-composer-properties {
+.task-composer-properties {
   gap: 12px;
 }
 
-body.is-todos-view .task-composer-properties[hidden],
-body.is-todos-view .quick-entry-properties-panel[hidden] {
+.task-composer-properties[hidden],
+.quick-entry-properties-panel[hidden] {
   display: none !important;
 }
 
-body.is-todos-view .task-composer-inline-actions {
+.task-composer-inline-actions {
   display: flex;
   justify-content: flex-start;
 }
 
-body.is-todos-view .task-composer-ai-trigger {
+.task-composer-ai-trigger {
   background: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
   color: var(--text-secondary);
   border-color: color-mix(in oklab, var(--border-color) 85%, transparent);
 }
 
-body.is-todos-view .task-composer-project-actions {
+.task-composer-project-actions {
   border-top: 1px solid
     color-mix(in oklab, var(--border-color) 68%, transparent);
   padding-top: 10px;
 }
 
-body.is-todos-view .task-composer-project-actions__toggle {
+.task-composer-project-actions__toggle {
   cursor: pointer;
   list-style: none;
   color: var(--text-secondary);
   font-size: var(--fs-sm);
 }
 
-body.is-todos-view
-  .task-composer-project-actions__toggle::-webkit-details-marker {
+.task-composer-project-actions__toggle::-webkit-details-marker {
   display: none;
 }
 
-body.is-todos-view .task-composer-project-actions__toggle::before {
+.task-composer-project-actions__toggle::before {
   content: "▸ ";
 }
 
-body.is-todos-view
-  .task-composer-project-actions[open]
+.task-composer-project-actions[open]
   > .task-composer-project-actions__toggle::before {
   content: "▾ ";
 }
 
-body.is-todos-view .task-composer-project-actions__body {
+.task-composer-project-actions__body {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   padding-top: 10px;
 }
 
-body.is-todos-view .task-composer-project-action {
+.task-composer-project-action {
   width: auto;
 }
 
-body.is-todos-view .ai-workspace {
+.ai-workspace {
   padding: 12px 14px;
   border-radius: 18px;
   border-color: color-mix(in oklab, var(--border-color) 70%, transparent);
@@ -9301,27 +9238,27 @@ body.is-todos-view .ai-workspace {
   box-shadow: none;
 }
 
-body.is-todos-view .ai-workspace-header {
+.ai-workspace-header {
   gap: 10px;
 }
 
-body.is-todos-view .ai-workspace-toggle {
+.ai-workspace-toggle {
   background: color-mix(in oklab, var(--surface) 96%, var(--surface-2));
 }
 
-body.is-todos-view .ai-workspace-status-chip {
+.ai-workspace-status-chip {
   background: transparent;
   color: var(--text-secondary);
 }
 
-body.is-todos-view .ai-workspace-header-actions .mini-btn {
+.ai-workspace-header-actions .mini-btn {
   background: transparent;
   color: var(--text-secondary);
   border-color: color-mix(in oklab, var(--border-color) 80%, transparent);
 }
 
 @media (max-width: 900px) {
-  body.is-todos-view .home-dashboard__support-grid {
+  .home-dashboard__support-grid {
     grid-template-columns: 1fr;
   }
 

--- a/client/styles/base.css
+++ b/client/styles/base.css
@@ -217,25 +217,25 @@ body {
   padding: var(--s-5);
 }
 
-body.is-todos-view {
+body {
   --app-shell-sidebar-width: 272px;
 }
 
-body.is-todos-view.is-projects-rail-collapsed {
+.is-projects-rail-collapsed {
   --app-shell-sidebar-width: 64px;
 }
 
-body.is-todos-view #appShell {
+#appShell {
   grid-template-columns: var(--app-shell-sidebar-width) minmax(0, 1fr);
 }
 
-body.is-todos-view #appMainScroll {
+#appMainScroll {
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
-body.is-todos-view #appSidebar {
+#appSidebar {
   display: flex;
   flex-direction: column;
 }
@@ -281,7 +281,7 @@ body.is-todos-view #appSidebar {
   gap: 6px;
 }
 
-body.is-todos-view {
+body {
   padding: 0;
   overflow: hidden;
 }
@@ -460,32 +460,32 @@ small {
   border-bottom-color: var(--accent);
 }
 
-body.is-todos-view .header {
+.header {
   padding: 12px 16px;
 }
 
-body.is-todos-view .header h1 {
+.header h1 {
   font-size: var(--fs-lg);
   margin-bottom: 0;
   line-height: 1.2;
 }
 
-body.is-todos-view .theme-toggle {
+.theme-toggle {
   padding: 6px 10px;
   font-size: var(--fs-body);
 }
 
-body.is-todos-view .user-bar {
+.user-bar {
   margin-top: 8px;
   font-size: var(--fs-xs);
 }
 
-body.is-todos-view .logout-btn {
+.logout-btn {
   padding: 6px 10px;
   font-size: var(--fs-xs);
 }
 
-body.is-todos-view .nav-tabs {
+.nav-tabs {
   display: none !important;
   justify-content: flex-start;
   gap: 8px;
@@ -494,23 +494,23 @@ body.is-todos-view .nav-tabs {
   border-bottom: 1px dashed var(--border-color);
 }
 
-body.is-todos-view.is-admin-user .nav-tabs {
+.is-admin-user .nav-tabs {
   display: flex !important;
 }
 
-body.is-todos-view.is-admin-user .nav-tab {
+.is-admin-user .nav-tab {
   display: none;
 }
 
-body.is-todos-view.is-admin-user #adminNavTab {
+.is-admin-user #adminNavTab {
   display: inline-flex !important;
 }
 
-body.is-todos-view.is-admin-user .nav-tab[data-onclick*="switchView('todos'"] {
+.is-admin-user .nav-tab[data-onclick*="switchView('todos'"] {
   display: inline-flex !important;
 }
 
-body.is-todos-view .nav-tab {
+.nav-tab {
   flex: 0 0 auto;
   border: 1px solid var(--border-color);
   border-bottom: 1px solid var(--border-color);
@@ -520,7 +520,7 @@ body.is-todos-view .nav-tab {
   line-height: 1.2;
 }
 
-body.is-todos-view .nav-tab.active {
+.nav-tab.active {
   border-color: color-mix(in oklab, var(--accent) 44%, var(--border-color));
   background: color-mix(in oklab, var(--accent) 9%, var(--surface));
 }
@@ -544,7 +544,7 @@ body.is-todos-view .nav-tab.active {
   min-width: 0;
 }
 
-body.is-todos-view .container {
+.container {
   height: 100%;
   max-height: 100%;
   max-width: none;
@@ -557,7 +557,7 @@ body.is-todos-view .container {
   min-width: 0;
 }
 
-body.is-todos-view .content {
+.content {
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;
@@ -566,7 +566,7 @@ body.is-todos-view .content {
   flex-direction: column;
 }
 
-body.is-todos-view #todosView.view.active {
+#todosView.view.active {
   flex: 1 1 auto;
 }
 


### PR DESCRIPTION
## Summary

Removes the `body.is-todos-view` selector prefix from 265 CSS selectors across `app.css` and `base.css` using a PostCSS AST transform.

On `app.html`, `<body class="is-todos-view">` is set statically — the prefix was always true and added no value. This was the last remaining CSS coupling to the legacy single-shell view-toggle system.

### What changed
- `app.css`: 244 selectors simplified (e.g., `body.is-todos-view .header` → `.header`)
- `base.css`: 21 selectors simplified
- Compound selectors handled correctly: `body.is-todos-view.is-admin-user` → `.is-admin-user`
- Multi-line selectors inside `@media` blocks handled via AST (not sed)
- Stale specificity comment removed
- Net: -63 lines

### Why PostCSS, not sed
A previous sed attempt broke multi-line selectors inside `@media` blocks — removing `body.is-todos-view` from one line of a multi-line selector left orphaned `{` braces. PostCSS parses selectors as whole nodes regardless of line breaks.

## Test plan
- [x] Prettier formats both files (no syntax errors)
- [x] CSS lint passes
- [x] HTML lint passes
- [x] Unit tests pass (3 pre-existing failures only)
- [ ] CI: all gates
- [ ] Visual: workspace renders identically (no specificity regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)