### PR TITLE
fix(css): restore body.is-todos-view qualifier on body-level rules

### DIFF
--- a/client/styles/base.css
+++ b/client/styles/base.css
@@ -184,10 +184,13 @@ body {
     var(--bg-gradient-start) 0%,
     var(--bg-gradient-end) 100%
   );
+  transition: background var(--dur-base) var(--ease-out);
+}
+
+body.is-todos-view {
   min-height: 100dvh;
   padding: 0;
   overflow: hidden;
-  transition: background var(--dur-base) var(--ease-out);
 }
 
 #appShell {
@@ -217,25 +220,25 @@ body {
   padding: var(--s-5);
 }
 
-body {
+body.is-todos-view {
   --app-shell-sidebar-width: 272px;
 }
 
-.is-projects-rail-collapsed {
+body.is-todos-view.is-projects-rail-collapsed {
   --app-shell-sidebar-width: 64px;
 }
 
-#appShell {
+body.is-todos-view #appShell {
   grid-template-columns: var(--app-shell-sidebar-width) minmax(0, 1fr);
 }
 
-#appMainScroll {
+body.is-todos-view #appMainScroll {
   overflow: hidden;
   display: flex;
   flex-direction: column;
 }
 
-#appSidebar {
+body.is-todos-view #appSidebar {
   display: flex;
   flex-direction: column;
 }

--- a/client/styles/landing.css
+++ b/client/styles/landing.css
@@ -4,6 +4,25 @@
   width: 100%;
 }
 
+/* Hide landing when authenticated workspace is active */
+body.is-todos-view .landing {
+  display: none;
+}
+
+/* When unauthenticated, strip app chrome so landing page takes over */
+body:not(.is-todos-view) .header {
+  display: none;
+}
+
+body:not(.is-todos-view) #appMainScroll {
+  padding: 0;
+}
+
+body:not(.is-todos-view) .container {
+  max-width: none;
+  border-radius: 0;
+}
+
 /* Nav */
 .landing-nav {
   position: sticky;


### PR DESCRIPTION
## Summary

Fixes two regressions from PR #563 (CSS prefix removal):

### Fix 1: Landing page scrolling broken
The prefix removal changed `body.is-todos-view { overflow: hidden }` to `body { overflow: hidden }`, preventing all scrolling on the landing page. Restored the `.is-todos-view` qualifier on body-level properties: `overflow`, `min-height`, `padding`.

### Fix 2: Workspace layout leaking to landing
`body.is-todos-view { --app-shell-sidebar-width; grid-template-columns }` became unconditional, applying workspace grid layout to non-workspace pages. Restored qualifier on sidebar width, grid layout, and sidebar display rules.

### Also restored
- `landing.css` conditionals (`body:not(.is-todos-view)`) that hide app chrome on the legacy SPA landing view
- `body.is-todos-view .landing { display: none }` to hide landing content in workspace mode

### Root cause
The PostCSS transform correctly removed the prefix from **descendant** selectors (`body.is-todos-view .header` → `.header`) but incorrectly removed it from **body-level** selectors where the qualifier changes which pages the rule applies to.

## Test plan
- [x] All checks pass
- [ ] Manual: landing page scrolls correctly
- [ ] Manual: workspace layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)