### PR TITLE
feat(ui): add standalone auth page

### DIFF
--- a/client/public/auth-page.css
+++ b/client/public/auth-page.css
@@ -1,0 +1,89 @@
+/* auth-page.css — Standalone auth page layout (supplements styles.css classes) */
+
+/* Override styles.css body defaults that assume the full app shell */
+html,
+body {
+  height: 100%;
+  overflow: auto;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  padding: var(--s-4);
+}
+
+/* Card container */
+.auth-standalone {
+  width: 100%;
+  max-width: 420px;
+  background: var(--surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--r-lg);
+  padding: var(--s-7) var(--s-6);
+  box-shadow: var(--shadow-card);
+}
+
+/* Header row */
+.auth-standalone__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--s-5);
+  padding-bottom: var(--s-4);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.auth-standalone__back {
+  color: var(--text-secondary);
+  font-size: var(--fs-meta);
+  text-decoration: none;
+  transition: color var(--dur-fast) var(--ease-out);
+}
+
+.auth-standalone__back:hover {
+  color: var(--text);
+}
+
+.auth-standalone__logo {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+/* Tighten spacing inside the card for the auth forms */
+.auth-standalone .auth-tabs {
+  margin-bottom: var(--s-5);
+}
+
+.auth-standalone .auth-form h2 {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+}
+
+.auth-standalone .btn[type="submit"],
+.auth-standalone .btn#sendOtpBtn,
+.auth-standalone .btn#verifyOtpBtn {
+  width: 100%;
+}
+
+/* Mobile: drop card shadow and fill the screen */
+@media (max-width: 480px) {
+  body {
+    align-items: flex-start;
+    padding: 0;
+  }
+
+  .auth-standalone {
+    max-width: none;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    box-shadow: none;
+    min-height: 100dvh;
+    padding: var(--s-6) var(--s-4);
+  }
+}

--- a/client/public/auth-page.js
+++ b/client/public/auth-page.js
@@ -1,0 +1,734 @@
+// auth-page.js — Standalone auth page controller.
+// Depends on: window.AppState (authSession.js), window.ApiClient (apiClient.js),
+//             window.Utils (utils.js). No dependency on app.js or store.js.
+(function () {
+  "use strict";
+
+  var AppState = window.AppState;
+  var ApiClient = window.ApiClient;
+  var Utils = window.Utils;
+  var showMessage = Utils.showMessage;
+  var hideMessage = Utils.hideMessage;
+
+  // ---------------------------------------------------------------------------
+  // API URL — same logic as app.js
+  // ---------------------------------------------------------------------------
+  var API_URL =
+    window.location.hostname === "localhost"
+      ? "http://localhost:3000"
+      : window.location.origin;
+
+  // ---------------------------------------------------------------------------
+  // Lightweight state (no store.js import needed)
+  // ---------------------------------------------------------------------------
+  var authState = AppState.AUTH_STATE.UNAUTHENTICATED;
+  var authToken = null;
+  var refreshToken = null;
+
+  function setAuthState(next) {
+    authState = next;
+  }
+
+  function onAuthFailure() {
+    authState = AppState.AUTH_STATE.UNAUTHENTICATED;
+    AppState.clearSession();
+    switchAuthTab("login");
+  }
+
+  function onAuthTokens(nextToken, nextRefreshToken) {
+    authToken = nextToken;
+    refreshToken = nextRefreshToken;
+    AppState.persistSession({
+      authToken: authToken,
+      refreshToken: refreshToken,
+      currentUser: null,
+    });
+  }
+
+  var api = ApiClient.createApiClient({
+    apiUrl: API_URL,
+    getAuthToken: function () {
+      return authToken;
+    },
+    getRefreshToken: function () {
+      return refreshToken;
+    },
+    getAuthState: function () {
+      return authState;
+    },
+    setAuthState: setAuthState,
+    onAuthFailure: onAuthFailure,
+    onAuthTokens: onAuthTokens,
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tab / form navigation
+  // ---------------------------------------------------------------------------
+  function switchAuthTab(tab, triggerEl) {
+    var validTabs = [
+      "login",
+      "register",
+      "phoneLogin",
+      "forgotPassword",
+      "resetPassword",
+    ];
+    if (validTabs.indexOf(tab) === -1) return;
+
+    var tabs = document.querySelectorAll(".auth-tab");
+    tabs.forEach(function (t) {
+      t.classList.remove("active");
+      t.setAttribute("aria-selected", "false");
+    });
+
+    document.querySelectorAll(".auth-form").forEach(function (f) {
+      f.style.display = "none";
+    });
+
+    if (triggerEl) {
+      triggerEl.classList.add("active");
+      triggerEl.setAttribute("aria-selected", "true");
+    } else {
+      var tabBtn = document.getElementById(tab + "TabButton");
+      if (tabBtn) {
+        tabBtn.classList.add("active");
+        tabBtn.setAttribute("aria-selected", "true");
+      }
+    }
+
+    var targetForm = document.getElementById(tab + "Form");
+    if (targetForm) {
+      targetForm.style.display = "block";
+      var firstInput = targetForm.querySelector("input");
+      if (firstInput) firstInput.focus();
+    }
+    hideMessage("authMessage");
+  }
+
+  function showForgotPassword() {
+    document.querySelectorAll(".auth-form").forEach(function (f) {
+      f.style.display = "none";
+    });
+    document.getElementById("forgotPasswordForm").style.display = "block";
+    document.querySelectorAll(".auth-tab").forEach(function (t) {
+      t.classList.remove("active");
+    });
+    hideMessage("authMessage");
+  }
+
+  function showLogin() {
+    document.querySelectorAll(".auth-form").forEach(function (f) {
+      f.style.display = "none";
+    });
+    document.getElementById("loginForm").style.display = "block";
+    var firstTab = document.querySelectorAll(".auth-tab")[0];
+    if (firstTab) firstTab.classList.add("active");
+    hideMessage("authMessage");
+  }
+
+  function showResetPassword(token) {
+    document.getElementById("resetPasswordForm").dataset.token = token;
+    document.querySelectorAll(".auth-form").forEach(function (f) {
+      f.style.display = "none";
+    });
+    document.getElementById("resetPasswordForm").style.display = "block";
+  }
+
+  function showPhoneLogin() {
+    document.querySelectorAll(".auth-form").forEach(function (f) {
+      f.style.display = "none";
+    });
+    document.getElementById("phoneLoginForm").style.display = "block";
+    document.querySelectorAll(".auth-tab").forEach(function (t) {
+      t.classList.remove("active");
+    });
+    hideMessage("authMessage");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Post-auth redirect — go to main app
+  // ---------------------------------------------------------------------------
+  function redirectToApp() {
+    window.location.href = "/";
+  }
+
+  // ---------------------------------------------------------------------------
+  // Login
+  // ---------------------------------------------------------------------------
+  function handleLogin(event) {
+    event.preventDefault();
+    hideMessage("authMessage");
+
+    var email = document.getElementById("loginEmail").value;
+    var password = document.getElementById("loginPassword").value;
+    var submitBtn = document.querySelector("#loginForm button[type='submit']");
+    var origText = submitBtn ? submitBtn.textContent : "";
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = "Signing in\u2026";
+    }
+
+    fetch(API_URL + "/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: email, password: password }),
+    })
+      .then(function (response) {
+        return response.json().then(function (data) {
+          if (response.ok) {
+            authToken = data.token;
+            refreshToken = data.refreshToken;
+            setAuthState(AppState.AUTH_STATE.AUTHENTICATED);
+            AppState.persistSession({
+              authToken: data.token,
+              refreshToken: data.refreshToken,
+              currentUser: data.user,
+            });
+            redirectToApp();
+          } else {
+            showMessage("authMessage", data.error || "Login failed", "error");
+          }
+        });
+      })
+      .catch(function () {
+        showMessage("authMessage", "Network error. Please try again.", "error");
+      })
+      .finally(function () {
+        if (submitBtn) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = origText || "Sign In";
+        }
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Register
+  // ---------------------------------------------------------------------------
+  function handleRegister(event) {
+    event.preventDefault();
+    hideMessage("authMessage");
+
+    var name = document.getElementById("registerName").value;
+    var email = document.getElementById("registerEmail").value;
+    var password = document.getElementById("registerPassword").value;
+    var payload = { email: email, password: password };
+    if (name) payload.name = name;
+
+    var regBtn = document.querySelector("#registerForm button[type='submit']");
+    var origText = regBtn ? regBtn.textContent : "";
+    if (regBtn) {
+      regBtn.disabled = true;
+      regBtn.textContent = "Creating account\u2026";
+    }
+
+    fetch(API_URL + "/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+      .then(function (response) {
+        return response.json().then(function (data) {
+          if (response.ok) {
+            authToken = data.token;
+            refreshToken = data.refreshToken;
+            setAuthState(AppState.AUTH_STATE.AUTHENTICATED);
+            AppState.persistSession({
+              authToken: data.token,
+              refreshToken: data.refreshToken,
+              currentUser: data.user,
+            });
+            showMessage(
+              "authMessage",
+              "Account created successfully!",
+              "success",
+            );
+            setTimeout(redirectToApp, 1000);
+          } else {
+            var errorMsg = data.errors
+              ? data.errors
+                  .map(function (e) {
+                    return e.message;
+                  })
+                  .join(", ")
+              : data.error || "Registration failed";
+            showMessage("authMessage", errorMsg, "error");
+          }
+        });
+      })
+      .catch(function () {
+        showMessage("authMessage", "Network error. Please try again.", "error");
+      })
+      .finally(function () {
+        if (regBtn) {
+          regBtn.disabled = false;
+          regBtn.textContent = origText || "Create Account";
+        }
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Forgot Password
+  // ---------------------------------------------------------------------------
+  function handleForgotPassword(event) {
+    event.preventDefault();
+    hideMessage("authMessage");
+
+    var email = document.getElementById("forgotEmail").value;
+    var submitBtn = document.querySelector(
+      "#forgotPasswordForm button[type='submit']",
+    );
+    var origLabel = submitBtn ? submitBtn.textContent : "";
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = "Sending...";
+    }
+
+    api
+      .fetchWithTimeout(
+        API_URL + "/auth/forgot-password",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: email }),
+        },
+        AppState.EMAIL_ACTION_TIMEOUT_MS,
+      )
+      .then(function (response) {
+        return api.parseApiBody(response).then(function (data) {
+          if (response.ok) {
+            showMessage(
+              "authMessage",
+              data.message || "Reset link sent! Check your email.",
+              "success",
+            );
+            setTimeout(showLogin, 3000);
+          } else {
+            showMessage(
+              "authMessage",
+              data.error || "Failed to send reset link",
+              "error",
+            );
+          }
+        });
+      })
+      .catch(function (error) {
+        if (api.isAbortError(error)) {
+          showMessage(
+            "authMessage",
+            "Request timed out. Please try again in a moment.",
+            "error",
+          );
+        } else {
+          showMessage(
+            "authMessage",
+            "Network error. Please try again.",
+            "error",
+          );
+        }
+      })
+      .finally(function () {
+        if (submitBtn) {
+          submitBtn.disabled = false;
+          submitBtn.textContent = origLabel || "Send Reset Link";
+        }
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reset Password
+  // ---------------------------------------------------------------------------
+  function handleResetPassword(event) {
+    event.preventDefault();
+    hideMessage("authMessage");
+
+    var token = document.getElementById("resetPasswordForm").dataset.token;
+    var password = document.getElementById("newPassword").value;
+    var confirm = document.getElementById("confirmPassword").value;
+
+    if (password !== confirm) {
+      showMessage("authMessage", "Passwords do not match", "error");
+      return;
+    }
+
+    fetch(API_URL + "/auth/reset-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: token, password: password }),
+    })
+      .then(function (response) {
+        return response.json().then(function (data) {
+          if (response.ok) {
+            showMessage(
+              "authMessage",
+              "Password reset successfully! Redirecting to login...",
+              "success",
+            );
+            setTimeout(showLogin, 2000);
+          } else {
+            showMessage(
+              "authMessage",
+              data.error || "Failed to reset password",
+              "error",
+            );
+          }
+        });
+      })
+      .catch(function () {
+        showMessage("authMessage", "Network error. Please try again.", "error");
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Social login
+  // ---------------------------------------------------------------------------
+  function handleGoogleLogin() {
+    window.location.href = "/auth/google/start";
+  }
+
+  function handleAppleLogin() {
+    window.location.href = "/auth/apple/start";
+  }
+
+  function initSocialLogin() {
+    fetch("/auth/providers")
+      .then(function (resp) {
+        if (!resp.ok) return;
+        return resp.json();
+      })
+      .then(function (providers) {
+        if (!providers) return;
+
+        var hasAny = providers.google || providers.apple || providers.phone;
+
+        var loginSection = document.getElementById("loginSocialSection");
+        if (loginSection)
+          loginSection.style.display = hasAny ? "block" : "none";
+
+        var registerSection = document.getElementById("registerSocialSection");
+        if (registerSection)
+          registerSection.style.display = hasAny ? "block" : "none";
+
+        var ids = [
+          ["loginGoogleBtn", providers.google],
+          ["loginAppleBtn", providers.apple],
+          ["loginPhoneBtn", providers.phone],
+          ["registerGoogleBtn", providers.google],
+          ["registerAppleBtn", providers.apple],
+          ["registerPhoneBtn", providers.phone],
+        ];
+        ids.forEach(function (pair) {
+          var el = document.getElementById(pair[0]);
+          if (el) el.style.display = pair[1] ? "flex" : "none";
+        });
+      })
+      .catch(function () {
+        // silently fail — social buttons stay hidden
+      });
+  }
+
+  function handleSocialCallback() {
+    var params = new URLSearchParams(window.location.search);
+    var auth = params.get("auth");
+
+    if (auth === "success") {
+      var token = params.get("token");
+      var rt = params.get("refreshToken");
+
+      if (token && rt) {
+        authToken = token;
+        refreshToken = rt;
+        setAuthState(AppState.AUTH_STATE.AUTHENTICATED);
+        AppState.persistSession({
+          authToken: token,
+          refreshToken: rt,
+          currentUser: null,
+        });
+        window.history.replaceState(
+          {},
+          document.title,
+          window.location.pathname,
+        );
+        redirectToApp();
+      }
+    } else if (auth === "error") {
+      var message = params.get("message") || "Login failed";
+      window.history.replaceState({}, document.title, window.location.pathname);
+      showMessage("authMessage", message, "error");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phone OTP
+  // ---------------------------------------------------------------------------
+  var _resendTimerId = null;
+
+  function maskPhone(phone) {
+    if (!phone || phone.length < 6) return phone;
+    return phone.slice(0, 3) + " *** " + phone.slice(-4);
+  }
+
+  function startResendTimer() {
+    var timerEl = document.getElementById("resendTimer");
+    var btn = document.getElementById("resendOtpBtn");
+    if (!timerEl || !btn) return;
+
+    var remaining = 60;
+    btn.disabled = true;
+    timerEl.textContent = remaining;
+
+    if (_resendTimerId) clearInterval(_resendTimerId);
+    _resendTimerId = setInterval(function () {
+      remaining -= 1;
+      timerEl.textContent = remaining;
+      if (remaining <= 0) {
+        clearInterval(_resendTimerId);
+        _resendTimerId = null;
+        btn.disabled = false;
+      }
+    }, 1000);
+  }
+
+  function handleSendOtp() {
+    var phoneInput = document.getElementById("phoneNumber");
+    var phone = phoneInput ? phoneInput.value.trim() : "";
+    if (!phone) {
+      showMessage("authMessage", "Please enter a phone number", "error");
+      return;
+    }
+
+    var sendBtn = document.getElementById("sendOtpBtn");
+    var origText = sendBtn ? sendBtn.textContent : "";
+    if (sendBtn) {
+      sendBtn.disabled = true;
+      sendBtn.textContent = "Sending\u2026";
+    }
+
+    fetch("/auth/phone/send-otp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ phone: phone }),
+    })
+      .then(function (resp) {
+        return resp.json().then(function (data) {
+          if (!resp.ok) {
+            var msg =
+              data.error ||
+              (data.errors && data.errors[0] && data.errors[0].message) ||
+              "Failed to send code";
+            showMessage("authMessage", msg, "error");
+            return;
+          }
+          var otpSection = document.getElementById("otpSection");
+          if (otpSection) otpSection.style.display = "block";
+          var maskedEl = document.getElementById("otpPhoneMasked");
+          if (maskedEl) maskedEl.textContent = maskPhone(phone);
+          startResendTimer();
+          showMessage("authMessage", "Verification code sent", "success");
+        });
+      })
+      .catch(function () {
+        showMessage("authMessage", "Failed to send code", "error");
+      })
+      .finally(function () {
+        if (sendBtn) {
+          sendBtn.disabled = false;
+          sendBtn.textContent = origText || "Send Code";
+        }
+      });
+  }
+
+  function handleResendOtp() {
+    handleSendOtp();
+  }
+
+  function handleVerifyOtp() {
+    var phoneInput = document.getElementById("phoneNumber");
+    var codeInput = document.getElementById("otpCode");
+    var phone = phoneInput ? phoneInput.value.trim() : "";
+    var code = codeInput ? codeInput.value.trim() : "";
+
+    if (!phone || !code) {
+      showMessage("authMessage", "Please enter phone and code", "error");
+      return;
+    }
+
+    var verifyBtn = document.getElementById("verifyOtpBtn");
+    var origText = verifyBtn ? verifyBtn.textContent : "";
+    if (verifyBtn) {
+      verifyBtn.disabled = true;
+      verifyBtn.textContent = "Verifying\u2026";
+    }
+
+    fetch("/auth/phone/verify-otp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ phone: phone, code: code }),
+    })
+      .then(function (resp) {
+        return resp.json().then(function (data) {
+          if (!resp.ok) {
+            showMessage(
+              "authMessage",
+              data.error || "Invalid or expired code",
+              "error",
+            );
+            return;
+          }
+          authToken = data.token;
+          refreshToken = data.refreshToken;
+          setAuthState(AppState.AUTH_STATE.AUTHENTICATED);
+          AppState.persistSession({
+            authToken: data.token,
+            refreshToken: data.refreshToken,
+            currentUser: data.user,
+          });
+          redirectToApp();
+        });
+      })
+      .catch(function () {
+        showMessage("authMessage", "Verification failed", "error");
+      })
+      .finally(function () {
+        if (verifyBtn) {
+          verifyBtn.disabled = false;
+          verifyBtn.textContent = origText || "Verify";
+        }
+      });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Verification URL handling (?verified=1|0)
+  // ---------------------------------------------------------------------------
+  function handleVerificationStatusFromUrl() {
+    var params = new URLSearchParams(window.location.search);
+    var verified = params.get("verified");
+    if (!verified) return;
+
+    var isSuccess = verified === "1";
+    var message = isSuccess
+      ? "Email verified successfully. You can now log in."
+      : "Email verification failed or expired. Request a new verification email.";
+    var type = isSuccess ? "success" : "error";
+
+    showLogin();
+    showMessage("authMessage", message, type);
+    window.history.replaceState({}, document.title, window.location.pathname);
+  }
+
+  // ---------------------------------------------------------------------------
+  // URL-driven reset-password token (?reset-token=...)
+  // ---------------------------------------------------------------------------
+  function handleResetTokenFromUrl() {
+    var params = new URLSearchParams(window.location.search);
+    var token = params.get("reset-token");
+    if (token) {
+      showResetPassword(token);
+      window.history.replaceState({}, document.title, window.location.pathname);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dark-mode persistence (mirrors app.js theme toggle)
+  // ---------------------------------------------------------------------------
+  function initTheme() {
+    var stored = localStorage.getItem("darkMode");
+    if (stored === "true") {
+      document.body.classList.add("dark-mode");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event delegation (mirrors app.js data-onclick / data-onsubmit pattern)
+  // ---------------------------------------------------------------------------
+  var handlers = {
+    switchAuthTab: switchAuthTab,
+    showForgotPassword: showForgotPassword,
+    showLogin: showLogin,
+    showPhoneLogin: showPhoneLogin,
+    handleGoogleLogin: handleGoogleLogin,
+    handleAppleLogin: handleAppleLogin,
+    handleSendOtp: handleSendOtp,
+    handleResendOtp: handleResendOtp,
+    handleVerifyOtp: handleVerifyOtp,
+  };
+
+  var submitHandlers = {
+    handleLogin: handleLogin,
+    handleRegister: handleRegister,
+    handleForgotPassword: handleForgotPassword,
+    handleResetPassword: handleResetPassword,
+  };
+
+  document.addEventListener("click", function (e) {
+    var target = e.target.closest("[data-onclick]");
+    if (!target) return;
+
+    var expr = target.getAttribute("data-onclick");
+    // Parse "fnName(args)" — support 'this' as first arg for switchAuthTab
+    var match = expr.match(/^(\w+)\(([^)]*)\)$/);
+    if (!match) return;
+
+    var fnName = match[1];
+    var fn = handlers[fnName];
+    if (!fn) return;
+
+    // Parse args — support 'string' literals and `this`
+    var rawArgs = match[2].trim();
+    var args = [];
+    if (rawArgs) {
+      args = rawArgs.split(",").map(function (a) {
+        a = a.trim();
+        if (a === "this") return target;
+        // Strip surrounding quotes
+        if (
+          (a.charAt(0) === "'" && a.charAt(a.length - 1) === "'") ||
+          (a.charAt(0) === '"' && a.charAt(a.length - 1) === '"')
+        ) {
+          return a.slice(1, -1);
+        }
+        return a;
+      });
+    }
+    fn.apply(null, args);
+  });
+
+  document.addEventListener("submit", function (e) {
+    var form = e.target.closest("[data-onsubmit]");
+    if (!form) return;
+
+    var expr = form.getAttribute("data-onsubmit");
+    var match = expr.match(/^(\w+)\(([^)]*)\)$/);
+    if (!match) return;
+
+    var fnName = match[1];
+    var fn = submitHandlers[fnName];
+    if (fn) fn(e);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Boot
+  // ---------------------------------------------------------------------------
+  function boot() {
+    initTheme();
+
+    // If already authenticated, redirect to app
+    var session = AppState.loadStoredSession();
+    if (session.token && session.user) {
+      redirectToApp();
+      return;
+    }
+
+    // Handle URL-driven flows
+    handleSocialCallback();
+    handleVerificationStatusFromUrl();
+    handleResetTokenFromUrl();
+
+    // Probe for social providers
+    initSocialLogin();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/client/public/auth.html
+++ b/client/public/auth.html
@@ -1,0 +1,392 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign In - Todo App</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="/public/auth-page.css" />
+  </head>
+  <body>
+    <div class="auth-standalone">
+      <div class="auth-standalone__header">
+        <a href="/" class="auth-standalone__back">&larr; Home</a>
+        <span class="auth-standalone__logo">Todo App</span>
+      </div>
+
+      <div class="auth-tabs">
+        <button
+          id="loginTabButton"
+          class="auth-tab active"
+          aria-selected="true"
+          data-onclick="switchAuthTab('login', this)"
+        >
+          Login
+        </button>
+        <button
+          id="registerTabButton"
+          class="auth-tab"
+          aria-selected="false"
+          data-onclick="switchAuthTab('register', this)"
+        >
+          Register
+        </button>
+      </div>
+
+      <div
+        class="message"
+        id="authMessage"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      ></div>
+
+      <!-- Login Form -->
+      <form
+        id="loginForm"
+        class="auth-form active"
+        data-onsubmit="handleLogin(event)"
+        style="display: block"
+      >
+        <div class="form-group">
+          <label for="loginEmail">Email</label>
+          <input
+            type="email"
+            id="loginEmail"
+            required
+            placeholder="your@email.com"
+            autocomplete="email"
+          />
+        </div>
+        <div class="form-group">
+          <label for="loginPassword">Password</label>
+          <input
+            type="password"
+            id="loginPassword"
+            required
+            placeholder="&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;"
+            autocomplete="current-password"
+          />
+        </div>
+        <button type="submit" class="btn">Login</button>
+        <div
+          class="social-login-section"
+          id="loginSocialSection"
+          style="display: none"
+        >
+          <div class="auth-divider"><span>or</span></div>
+          <div class="social-login-buttons">
+            <button
+              type="button"
+              class="btn social-btn google-btn"
+              id="loginGoogleBtn"
+              style="display: none"
+              data-onclick="handleGoogleLogin()"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                aria-hidden="true"
+              >
+                <path
+                  fill="#4285F4"
+                  d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58Z"
+                />
+              </svg>
+              Continue with Google
+            </button>
+            <button
+              type="button"
+              class="btn social-btn apple-btn"
+              id="loginAppleBtn"
+              style="display: none"
+              data-onclick="handleAppleLogin()"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M13.545 8.32c-.022-2.276 1.88-3.388 1.966-3.44-1.076-1.56-2.746-1.773-3.332-1.79-1.4-.147-2.77.84-3.488.84-.734 0-1.835-.826-3.024-.802C3.93 3.156 2.3 4.193 1.4 5.79c-1.846 3.172-.47 7.847 1.303 10.414.89 1.26 1.93 2.67 3.295 2.62 1.334-.054 1.833-.847 3.442-.847 1.593 0 2.06.847 3.44.816 1.428-.023 2.326-1.266 3.18-2.536 1.025-1.443 1.44-2.872 1.458-2.944-.032-.012-2.79-1.058-2.818-4.218l-.155.225Z"
+                />
+              </svg>
+              Sign in with Apple
+            </button>
+            <button
+              type="button"
+              class="btn social-btn phone-btn"
+              id="loginPhoneBtn"
+              style="display: none"
+              data-onclick="showPhoneLogin()"
+            >
+              Continue with Phone
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          id="forgotPasswordLink"
+          class="link-btn"
+          data-onclick="showForgotPassword()"
+        >
+          Forgot Password?
+        </button>
+      </form>
+
+      <!-- Register Form -->
+      <form
+        id="registerForm"
+        class="auth-form"
+        data-onsubmit="handleRegister(event)"
+        style="display: none"
+      >
+        <div class="form-group">
+          <label for="registerName">Name</label>
+          <input
+            type="text"
+            id="registerName"
+            placeholder="Your Name (optional)"
+            autocomplete="name"
+          />
+        </div>
+        <div class="form-group">
+          <label for="registerEmail">Email</label>
+          <input
+            type="email"
+            id="registerEmail"
+            required
+            placeholder="your@email.com"
+            autocomplete="email"
+          />
+        </div>
+        <div class="form-group">
+          <label for="registerPassword">Password</label>
+          <input
+            type="password"
+            id="registerPassword"
+            required
+            placeholder="&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;"
+            minlength="8"
+            autocomplete="new-password"
+          />
+        </div>
+        <button type="submit" class="btn">Create Account</button>
+        <div
+          class="social-login-section"
+          id="registerSocialSection"
+          style="display: none"
+        >
+          <div class="auth-divider"><span>or</span></div>
+          <div class="social-login-buttons">
+            <button
+              type="button"
+              class="btn social-btn google-btn"
+              id="registerGoogleBtn"
+              style="display: none"
+              data-onclick="handleGoogleLogin()"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                aria-hidden="true"
+              >
+                <path
+                  fill="#4285F4"
+                  d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58Z"
+                />
+              </svg>
+              Continue with Google
+            </button>
+            <button
+              type="button"
+              class="btn social-btn apple-btn"
+              id="registerAppleBtn"
+              style="display: none"
+              data-onclick="handleAppleLogin()"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M13.545 8.32c-.022-2.276 1.88-3.388 1.966-3.44-1.076-1.56-2.746-1.773-3.332-1.79-1.4-.147-2.77.84-3.488.84-.734 0-1.835-.826-3.024-.802C3.93 3.156 2.3 4.193 1.4 5.79c-1.846 3.172-.47 7.847 1.303 10.414.89 1.26 1.93 2.67 3.295 2.62 1.334-.054 1.833-.847 3.442-.847 1.593 0 2.06.847 3.44.816 1.428-.023 2.326-1.266 3.18-2.536 1.025-1.443 1.44-2.872 1.458-2.944-.032-.012-2.79-1.058-2.818-4.218l-.155.225Z"
+                />
+              </svg>
+              Sign in with Apple
+            </button>
+            <button
+              type="button"
+              class="btn social-btn phone-btn"
+              id="registerPhoneBtn"
+              style="display: none"
+              data-onclick="showPhoneLogin()"
+            >
+              Continue with Phone
+            </button>
+          </div>
+        </div>
+      </form>
+
+      <!-- Phone Login Form -->
+      <form id="phoneLoginForm" class="auth-form" style="display: none">
+        <h2 style="margin-bottom: 20px">Phone Login</h2>
+        <div class="form-group">
+          <label for="phoneNumber">Phone Number</label>
+          <input
+            type="tel"
+            id="phoneNumber"
+            required
+            placeholder="+1 555 123 4567"
+            autocomplete="tel"
+          />
+        </div>
+        <button
+          type="button"
+          class="btn"
+          id="sendOtpBtn"
+          data-onclick="handleSendOtp()"
+        >
+          Send Code
+        </button>
+        <div id="otpSection" style="display: none">
+          <p class="otp-hint">Code sent to <span id="otpPhoneMasked"></span></p>
+          <div class="form-group">
+            <label for="otpCode">Verification Code</label>
+            <input
+              type="text"
+              id="otpCode"
+              required
+              placeholder="123456"
+              maxlength="6"
+              pattern="[0-9]{6}"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+            />
+          </div>
+          <button
+            type="button"
+            class="btn"
+            id="verifyOtpBtn"
+            data-onclick="handleVerifyOtp()"
+          >
+            Verify &amp; Login
+          </button>
+          <button
+            type="button"
+            class="link-btn"
+            id="resendOtpBtn"
+            disabled
+            data-onclick="handleResendOtp()"
+          >
+            Resend code (<span id="resendTimer">60</span>s)
+          </button>
+        </div>
+        <button type="button" class="link-btn" data-onclick="showLogin()">
+          Back to Login
+        </button>
+      </form>
+
+      <!-- Forgot Password Form -->
+      <form
+        id="forgotPasswordForm"
+        class="auth-form"
+        data-onsubmit="handleForgotPassword(event)"
+        style="display: none"
+      >
+        <h2 style="margin-bottom: 20px">Reset Password</h2>
+        <div class="form-group">
+          <label for="forgotEmail">Email</label>
+          <input
+            type="email"
+            id="forgotEmail"
+            required
+            placeholder="your@email.com"
+            autocomplete="email"
+          />
+        </div>
+        <button type="submit" class="btn">Send Reset Link</button>
+        <button
+          type="button"
+          id="forgotBackToLoginButton"
+          class="link-btn"
+          data-onclick="showLogin()"
+        >
+          Back to Login
+        </button>
+      </form>
+
+      <!-- Reset Password Form -->
+      <form
+        id="resetPasswordForm"
+        class="auth-form"
+        data-onsubmit="handleResetPassword(event)"
+        style="display: none"
+        data-token=""
+      >
+        <h2 style="margin-bottom: 20px">Set New Password</h2>
+        <div class="form-group">
+          <label for="newPassword">New Password</label>
+          <input
+            type="password"
+            id="newPassword"
+            required
+            placeholder="&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;"
+            minlength="8"
+            autocomplete="new-password"
+          />
+        </div>
+        <div class="form-group">
+          <label for="confirmPassword">Confirm Password</label>
+          <input
+            type="password"
+            id="confirmPassword"
+            required
+            placeholder="&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;&#x2022;"
+            minlength="8"
+            autocomplete="new-password"
+          />
+        </div>
+        <button type="submit" class="btn">Reset Password</button>
+      </form>
+    </div>
+
+    <!-- Reused utility scripts (IIFE, no ES-module imports, no app.js deps) -->
+    <script src="/utils/authSession.js"></script>
+    <script src="/utils/apiClient.js"></script>
+    <script src="/utils/utils.js"></script>
+    <!-- Standalone auth controller -->
+    <script src="/public/auth-page.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `client/public/auth.html` as a standalone auth page with login, register, forgot password, reset password, and phone OTP flows
- New `auth-page.js` controller (IIFE, no dependency on `store.js` or `app.js`) reuses existing `authSession.js`, `apiClient.js`, and `utils.js` globals
- Card-styled layout with dark mode support and mobile breakpoint via `auth-page.css`
- No existing files modified — the current single-shell app is completely untouched
- No Express route changes, no OAuth callback URL changes, no legacy code removal

## Test plan
- [ ] Visit `/public/auth.html` — card renders centered with proper styling
- [ ] Login flow: submit email/password → redirects to `/` on success
- [ ] Register flow: switch tab, fill form → shows success, redirects
- [ ] Forgot password: click link, enter email → shows confirmation
- [ ] Reset password: visit with `?reset-token=TOKEN` → shows reset form
- [ ] Phone OTP: click phone login → send code → verify code → redirects
- [ ] Social buttons appear when providers are enabled
- [ ] Dark mode: set `localStorage.darkMode = "true"`, reload → dark theme
- [ ] Mobile: resize to <480px → full-width, no card shadow
- [ ] Existing app at `/` still works unchanged
- [ ] All CI gates pass (typecheck, format, lint:html, lint:css, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)