### PR TITLE
fix(auth): break social login redirect loop on /auth → /app

### DIFF
--- a/client/public/app-page.js
+++ b/client/public/app-page.js
@@ -24,10 +24,13 @@
   }
 
   // -------------------------------------------------------------------------
-  // 1. Auth gate — redirect immediately if not authenticated
+  // 1. Auth gate — redirect immediately if not authenticated.
+  //    Token alone is sufficient: social OAuth callbacks only carry
+  //    token + refreshToken (no user object). The user profile is loaded
+  //    by app.js after boot via loadUserProfile().
   // -------------------------------------------------------------------------
   var session = AppState.loadStoredSession();
-  if (!session.token || !session.user) {
+  if (!session.token) {
     window.location.replace("/auth");
     return; // stop all further execution
   }

--- a/client/public/auth-page.js
+++ b/client/public/auth-page.js
@@ -64,11 +64,10 @@
   function onAuthTokens(nextToken, nextRefreshToken) {
     authToken = nextToken;
     refreshToken = nextRefreshToken;
-    AppState.persistSession({
-      authToken: authToken,
-      refreshToken: refreshToken,
-      currentUser: null,
-    });
+    // Write tokens directly — persistSession() would clear the user key
+    // because we have no user object on the standalone auth page.
+    localStorage.setItem("authToken", nextToken);
+    localStorage.setItem("refreshToken", nextRefreshToken);
   }
 
   var api = ApiClient.createApiClient({
@@ -476,11 +475,12 @@
       authToken = token;
       refreshToken = rt;
       setAuthState(AppState.AUTH_STATE.AUTHENTICATED);
-      AppState.persistSession({
-        authToken: token,
-        refreshToken: rt,
-        currentUser: null,
-      });
+      // Persist tokens only — no user object is available from the OAuth
+      // callback URL. Write directly to localStorage to avoid
+      // persistSession() clearing the user key (it removes keys whose
+      // value is falsy).
+      localStorage.setItem("authToken", token);
+      localStorage.setItem("refreshToken", rt);
       redirectToApp();
     } else if (auth === "error") {
       showMessage(


### PR DESCRIPTION
## Summary
Fixes infinite redirect loop: Google/Apple OAuth success → `/auth` → `/app` → `/auth` → ...

**Root cause**: `auth-page.js` social callback persisted `currentUser: null`, clearing the user key from localStorage. Then `app-page.js` checked `session.token && session.user`, found user was null, and redirected back to `/auth`.

**Fixes**:
- `app-page.js`: auth gate checks `session.token` only (user profile is loaded by `app.js` after boot)
- `auth-page.js`: social callback + `onAuthTokens` write tokens directly to `localStorage` instead of calling `persistSession()` which clears the user key when `currentUser` is falsy

## Test plan
- [ ] Google OAuth login → lands on `/app` (not redirect loop)
- [ ] Apple OAuth login → lands on `/app`
- [ ] Email/password login on `/auth` → lands on `/app`
- [ ] Unauthenticated `/app` → redirects to `/auth` (no loop)
- [ ] Logout from `/app` → lands on `/auth`
- [ ] Token refresh during session doesn't wipe user data

🤖 Generated with [Claude Code](https://claude.com/claude-code)