### PR TITLE
fix(auth): inject stub user for social OAuth so app.js boots authenticated

### DIFF
--- a/client/public/app-page.js
+++ b/client/public/app-page.js
@@ -36,6 +36,18 @@
   }
 
   // -------------------------------------------------------------------------
+  // 1b. Ensure a user object exists in localStorage.
+  //     app.js init() checks `token && user` before calling showAppView().
+  //     Social OAuth only stores tokens (no user object), so without a
+  //     placeholder app.js treats the session as unauthenticated.
+  //     A stub user lets app.js proceed; loadUserProfile() replaces it
+  //     with real data immediately after boot.
+  // -------------------------------------------------------------------------
+  if (!session.user) {
+    localStorage.setItem("user", JSON.stringify({ _pending: true }));
+  }
+
+  // -------------------------------------------------------------------------
   // 2. Inject stub DOM elements that app.js/authUi.js reference without
   //    null guards. These are invisible and exist solely to prevent
   //    "cannot read property of null" errors.


### PR DESCRIPTION
## Summary
Fixes social OAuth flow on `/app` — after Google/Apple login, the workspace was empty because `app.js` treated the session as unauthenticated.

**Root cause**: `app.js` init() line 1673 checks `token && user` before calling `showAppView()`. Social OAuth only stores tokens in localStorage (no user object), so `app.js` takes the unauthenticated branch — `showAppView()` never runs, no todos/projects load.

**Fix**: `app-page.js` now injects `{ _pending: true }` as a placeholder user when tokens exist but user is missing. This lets `app.js` pass its auth check and call `showAppView()` + `loadUserProfile()`, which immediately replaces the stub with real data from `GET /users/me`.

Previous fix (#571) addressed part of the problem (auth gate in `app-page.js` only checks token), but missed that `app.js` itself also requires the user object.

## Test plan
- [ ] Google OAuth → `/auth` → `/app` → workspace loads with todos
- [ ] Apple OAuth → same flow
- [ ] Email/password login → `/app` → workspace loads (user object present, no stub needed)
- [ ] Unauthenticated `/app` → redirects to `/auth`
- [ ] Logout → redirects to `/auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)