### PR TITLE
fix(ui): inject DOM stubs synchronously so app.js boot succeeds

### DIFF
--- a/client/public/app-page.js
+++ b/client/public/app-page.js
@@ -51,8 +51,13 @@
   // 2. Inject stub DOM elements that app.js/authUi.js reference without
   //    null guards. These are invisible and exist solely to prevent
   //    "cannot read property of null" errors.
+  //
+  //    IMPORTANT: these must be injected synchronously (not in a
+  //    DOMContentLoaded listener) because module scripts like app.js
+  //    execute BEFORE DOMContentLoaded fires. If we defer injection,
+  //    showAppView() hits null elements and throws.
   // -------------------------------------------------------------------------
-  document.addEventListener("DOMContentLoaded", function () {
+  function injectStubs() {
     // showAppView() calls: getElementById("authView").classList.remove("active")
     // showAuthView() calls: getElementById("authView").classList.add("active")
     if (!document.getElementById("authView")) {
@@ -83,7 +88,16 @@
         document.body.appendChild(el);
       }
     });
-  });
+  }
+
+  // Inject immediately if <body> is available (defer scripts run after
+  // parsing, so document.body exists). Fall back to DOMContentLoaded
+  // only if body is somehow unavailable.
+  if (document.body) {
+    injectStubs();
+  } else {
+    document.addEventListener("DOMContentLoaded", injectStubs);
+  }
 
   // -------------------------------------------------------------------------
   // 3. Patch showAuthView / logout to redirect instead of toggling DOM.


### PR DESCRIPTION
## Summary
Fixes two issues on the standalone `/app` page:
1. **Todos loading forever** after email login
2. **Google login appearing broken** (showAppView throws, session left incomplete)

**Root cause**: `app-page.js` injected stub DOM elements (`#authView`, `#profileView`) inside a `DOMContentLoaded` listener. But `app.js` is a `type="module"` script, which executes **before** `DOMContentLoaded` fires. When `app.js` called `showAppView()` → `getElementById("authView").classList.remove("active")`, it hit `null` and threw — silently breaking the entire boot sequence.

**Fix**: Inject stubs synchronously. `defer` scripts run after DOM parsing, so `document.body` is already available. Stubs are now in place before `app.js` module executes.

## Test plan
- [ ] Email login → `/app` → todos load successfully
- [ ] Google OAuth → `/auth` → `/app` → workspace loads with todos
- [ ] Apple OAuth → same flow
- [ ] Logout → redirects to `/auth`
- [ ] `GET /` → legacy shell still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)