### PR TITLE
fix(auth): resolve Google OAuth redirect loop

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1677,6 +1677,22 @@ function init() {
     setAuthState(AUTH_STATE.AUTHENTICATED);
     showAppView();
     loadUserProfile();
+  } else if (token && !user) {
+    // Social login (Google/Apple) stores tokens but not the user object.
+    // Fetch the profile before giving up — if it succeeds we're authenticated.
+    state.authToken = token;
+    state.refreshToken = refresh;
+    setAuthState(AUTH_STATE.AUTHENTICATED);
+    showAppView();
+    loadUserProfile().catch(() => {
+      // Token was invalid or expired — fall back to login screen.
+      persistSession({
+        authToken: null,
+        refreshToken: null,
+        currentUser: null,
+      });
+      setAuthState(AUTH_STATE.UNAUTHENTICATED);
+    });
   } else {
     setAuthState(AUTH_STATE.UNAUTHENTICATED);
   }


### PR DESCRIPTION
## Summary
- Google/Apple OAuth stores tokens in localStorage but not the `user` object
- On redirect to `/app`, `loadStoredSession()` requires both `token` AND `user` — causing the app to show the auth page again (redirect loop)
- Adds a `token && !user` branch in `init()` that fetches the user profile via `loadUserProfile()` before falling back to UNAUTHENTICATED

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run format:check` — passes
- [x] `npm run lint:html` — passes
- [x] `npm run lint:css` — passes
- [x] `npm run test:unit` — passes (3 pre-existing mcpPublicRouter failures)
- [ ] Manual: Google OAuth login → redirects to `/app` → profile loads → app view shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)