### PR TITLE
feat(ui): make new task the primary capture entry

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -12,7 +12,6 @@ import {
   loadTodos,
   retryLoadTodos,
   addTodo,
-  addTodoFromInlineInput,
   toggleTodo,
   deleteTodo,
   moveTodoToProject,
@@ -281,7 +280,6 @@ import {
   getComposerDependsOnIds,
   bindCaptureComposerHandlers,
   submitTaskComposerCapture,
-  submitInlineCapture,
 } from "./modules/quickEntry.js";
 import {
   getTodoDueDate,
@@ -1226,9 +1224,7 @@ function bindDockHandlers() {
     });
   };
   hooks.addTodo = addTodo;
-  hooks.addTodoFromInlineInput = addTodoFromInlineInput;
   hooks.submitTaskComposerCapture = submitTaskComposerCapture;
-  hooks.submitInlineCapture = submitInlineCapture;
   hooks.addUndoAction = addUndoAction;
   hooks.renderTodos = renderTodos;
   hooks.validateTodoTitle = validateTodoTitle;
@@ -1455,7 +1451,6 @@ window.handleSetPassword = handleSetPassword;
 // Todo CRUD
 window.addTodo = addTodo;
 window.submitTaskComposerCapture = submitTaskComposerCapture;
-window.submitInlineCapture = submitInlineCapture;
 window.filterTodos = filterTodos;
 window.clearFilters = clearFilters;
 window.setDateView = setDateView;
@@ -1684,18 +1679,6 @@ function init() {
   bindDockHandlers();
   OnCreateAssist.bindOnCreateAssistHandlers();
   bindQuickEntryNaturalDateHandlers();
-
-  // Eagerly load chrono when inline quick-add input is focused
-  const inlineQuickAddInput = document.getElementById("inlineQuickAddInput");
-  if (inlineQuickAddInput instanceof HTMLInputElement) {
-    inlineQuickAddInput.addEventListener(
-      "focus",
-      () => {
-        loadChronoNaturalDateModule();
-      },
-      { once: true },
-    );
-  }
 
   // Handle social login callback before anything else — the URL contains
   // ?auth=success&token=...&refreshToken=... after Google/Apple OAuth redirect.

--- a/client/features/todos/initTodosFeature.js
+++ b/client/features/todos/initTodosFeature.js
@@ -26,14 +26,6 @@ function handleTodoKeyPress(event) {
     hooks.submitTaskComposerCapture?.();
   }
 }
-
-function handleInlineQuickAddKeyPress(event) {
-  if (event.key === "Enter") {
-    event.preventDefault();
-    hooks.submitInlineCapture?.();
-  }
-}
-
 function setPriority(priority) {
   state.currentPriority = priority;
 
@@ -201,7 +193,6 @@ async function aiBreakdownTodo(todoId, force = false) {
 
 function registerWindowBridge() {
   window.handleTodoKeyPress = handleTodoKeyPress;
-  window.handleInlineQuickAddKeyPress = handleInlineQuickAddKeyPress;
   window.setPriority = setPriority;
   window.toggleNotesInput = toggleNotesInput;
   window.toggleNotes = toggleNotes;
@@ -234,7 +225,6 @@ export function initTodosFeature() {
 // Re-export for direct use where needed
 export {
   handleTodoKeyPress,
-  handleInlineQuickAddKeyPress,
   setPriority,
   getPriorityIcon,
   toggleNotesInput,

--- a/client/index.html
+++ b/client/index.html
@@ -2594,6 +2594,16 @@
                           >
                         </button>
                       </div>
+                      <div class="todos-top-bar-actions">
+                        <button
+                          id="topBarNewTaskCta"
+                          type="button"
+                          class="add-btn top-add-btn"
+                          data-onclick="openTaskComposer()"
+                        >
+                          New Task
+                        </button>
+                      </div>
                     </div>
 
                     <div id="todosScrollRegion">
@@ -3266,67 +3276,6 @@
                           </button>
                         </div>
                       </div>
-                      <div
-                        id="inlineQuickAdd"
-                        class="inline-quick-add"
-                        role="form"
-                        aria-label="Capture"
-                      >
-                        <span class="inline-quick-add__icon" aria-hidden="true"
-                          >+</span
-                        >
-                        <div class="inline-quick-add__body">
-                          <label for="inlineQuickAddInput" class="sr-only"
-                            >Capture</label
-                          >
-                          <input
-                            type="text"
-                            id="inlineQuickAddInput"
-                            class="inline-quick-add__input"
-                            placeholder="Capture a task or idea..."
-                            autocomplete="off"
-                            data-onkeypress="handleInlineQuickAddKeyPress(event)"
-                          />
-                          <div
-                            id="inlineQuickAddChipRow"
-                            class="inline-quick-add__chips"
-                            hidden
-                            aria-live="polite"
-                          ></div>
-                          <p
-                            id="inlineQuickAddRouteHint"
-                            class="inline-quick-add__route"
-                            hidden
-                          ></p>
-                        </div>
-                        <div class="inline-quick-add__actions">
-                          <button
-                            id="inlineQuickAddPrimaryButton"
-                            class="add-btn"
-                            type="button"
-                            data-onclick="submitInlineCapture()"
-                          >
-                            Create task now
-                          </button>
-                          <button
-                            id="inlineQuickAddSecondaryButton"
-                            class="mini-btn"
-                            type="button"
-                            data-onclick="submitInlineCapture('alternate')"
-                          >
-                            Send to triage
-                          </button>
-                          <button
-                            id="inlineQuickAddDetailsButton"
-                            class="mini-btn"
-                            type="button"
-                            data-onclick="openTaskComposer()"
-                          >
-                            Details
-                          </button>
-                        </div>
-                      </div>
-
                       <div id="todosContent">
                         <div class="loading">
                           <div class="spinner"></div>

--- a/client/modules/homeDashboard.js
+++ b/client/modules/homeDashboard.js
@@ -1222,7 +1222,7 @@ export function renderHomeDashboard() {
     : `<div class="home-empty-cta">
         ${illustrationWelcome()}
         <p class="home-empty-cta__heading">Welcome to your workspace</p>
-        <p class="home-empty-cta__sub">Add your first task to get started. Use the <strong>+ New Task</strong> button below, or press <kbd>/</kbd> to quick-add.</p>
+        <p class="home-empty-cta__sub">Add your first task to get started. Use the <strong>+ New Task</strong> button below, or press <kbd>N</kbd> to open capture.</p>
         <button type="button" class="btn" data-onclick="openTaskComposer()">+ Add your first task</button>
       </div>`;
 

--- a/client/modules/quickEntry.js
+++ b/client/modules/quickEntry.js
@@ -985,14 +985,12 @@ export function inferTaskComposerDefaultProject() {
 
 export function openTaskComposer(triggerEl = null) {
   hooks.ensureTodosShellActive?.();
-  // In simple mode, focus the inline quick-add instead of the full composer
+  // In simple mode, reuse the composer title field instead of opening the sheet
   if (document.body.classList.contains("simple-mode")) {
-    const inlineInput =
-      document.getElementById("inlineQuickAddInput") ||
-      document.getElementById("todoInput");
-    if (inlineInput instanceof HTMLInputElement) {
-      inlineInput.focus();
-      inlineInput.scrollIntoView({ block: "center" });
+    const titleInput = document.getElementById("todoInput");
+    if (titleInput instanceof HTMLInputElement) {
+      titleInput.focus();
+      titleInput.scrollIntoView({ block: "center" });
       return;
     }
   }

--- a/client/modules/todosService.js
+++ b/client/modules/todosService.js
@@ -1063,85 +1063,6 @@ async function restoreTodo(todoData) {
   }
 }
 
-async function addTodoFromInlineInput(options = {}) {
-  const captureSuggestion = options.captureSuggestion || null;
-  const input = document.getElementById("inlineQuickAddInput");
-  if (!(input instanceof HTMLInputElement)) return;
-
-  const title = input.value.trim();
-  if (!title) return;
-
-  const payload = {
-    title: String(captureSuggestion?.cleanedTitle || "").trim() || title,
-    priority: "medium",
-  };
-
-  // Detect natural date inline using chrono (if loaded)
-  const chronoModule = window.__chronoNaturalDateModule || null;
-  if (chronoModule) {
-    const detection = hooks.parseQuickEntryNaturalDue?.(title, chronoModule);
-    if (detection && !detection.isPast) {
-      payload.dueDate = detection.dueDate.toISOString();
-      const cleanedTitle =
-        hooks.removeMatchedDatePhraseFromTitle?.(title, detection) || title;
-      if (cleanedTitle) payload.title = cleanedTitle;
-    }
-  }
-  if (!payload.dueDate && captureSuggestion?.extractedFields?.dueDate) {
-    payload.dueDate = captureSuggestion.extractedFields.dueDate;
-  }
-
-  // Auto-assign project if viewing a specific project
-  const selectedProject = hooks.getSelectedProjectKey?.() || "";
-  if (selectedProject) {
-    payload.category = selectedProject;
-    const projectRecord = hooks.getProjectRecordByName?.(selectedProject);
-    if (projectRecord?.id) {
-      payload.projectId = projectRecord.id;
-    }
-  } else if (captureSuggestion?.extractedFields?.project) {
-    payload.category = captureSuggestion.extractedFields.project;
-    const projectRecord = hooks.getProjectRecordByName?.(
-      captureSuggestion.extractedFields.project,
-    );
-    if (projectRecord?.id) {
-      payload.projectId = projectRecord.id;
-    }
-  }
-
-  try {
-    const response = await hooks.apiCall(`${hooks.API_URL}/todos`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-
-    if (response && response.ok) {
-      const newTodo = await response.json();
-      state.todos.unshift(newTodo);
-      await refreshVisibleTodosIfNeeded();
-      EventBus.dispatch(TODOS_CHANGED, { reason: TODO_ADDED });
-      hooks.updateCategoryFilter?.();
-
-      input.value = "";
-      const chipRow = document.getElementById("inlineQuickAddChipRow");
-      if (chipRow instanceof HTMLElement) {
-        chipRow.hidden = true;
-        chipRow.innerHTML = "";
-      }
-
-      hooks.showMessage?.(
-        "todosMessage",
-        `Task added – "${newTodo.title}"`,
-        "success",
-      );
-      hooks.refreshProjectCatalog?.();
-    }
-  } catch (error) {
-    console.error("Inline add todo error:", error);
-  }
-}
-
 export {
   buildTodosQueryParams,
   buildVisibleTodosQueryParams,
@@ -1153,7 +1074,6 @@ export {
   loadTodos,
   retryLoadTodos,
   addTodo,
-  addTodoFromInlineInput,
   toggleTodo,
   deleteTodo,
   moveTodoToProject,

--- a/client/public/app.html
+++ b/client/public/app.html
@@ -1790,6 +1790,16 @@
                           >
                         </button>
                       </div>
+                      <div class="todos-top-bar-actions">
+                        <button
+                          id="topBarNewTaskCta"
+                          type="button"
+                          class="add-btn top-add-btn"
+                          data-onclick="openTaskComposer()"
+                        >
+                          New Task
+                        </button>
+                      </div>
                     </div>
 
                     <div id="todosScrollRegion">
@@ -2462,67 +2472,6 @@
                           </button>
                         </div>
                       </div>
-                      <div
-                        id="inlineQuickAdd"
-                        class="inline-quick-add"
-                        role="form"
-                        aria-label="Capture"
-                      >
-                        <span class="inline-quick-add__icon" aria-hidden="true"
-                          >+</span
-                        >
-                        <div class="inline-quick-add__body">
-                          <label for="inlineQuickAddInput" class="sr-only"
-                            >Capture</label
-                          >
-                          <input
-                            type="text"
-                            id="inlineQuickAddInput"
-                            class="inline-quick-add__input"
-                            placeholder="Capture a task or idea..."
-                            autocomplete="off"
-                            data-onkeypress="handleInlineQuickAddKeyPress(event)"
-                          />
-                          <div
-                            id="inlineQuickAddChipRow"
-                            class="inline-quick-add__chips"
-                            hidden
-                            aria-live="polite"
-                          ></div>
-                          <p
-                            id="inlineQuickAddRouteHint"
-                            class="inline-quick-add__route"
-                            hidden
-                          ></p>
-                        </div>
-                        <div class="inline-quick-add__actions">
-                          <button
-                            id="inlineQuickAddPrimaryButton"
-                            class="add-btn"
-                            type="button"
-                            data-onclick="submitInlineCapture()"
-                          >
-                            Create task now
-                          </button>
-                          <button
-                            id="inlineQuickAddSecondaryButton"
-                            class="mini-btn"
-                            type="button"
-                            data-onclick="submitInlineCapture('alternate')"
-                          >
-                            Send to triage
-                          </button>
-                          <button
-                            id="inlineQuickAddDetailsButton"
-                            class="mini-btn"
-                            type="button"
-                            data-onclick="openTaskComposer()"
-                          >
-                            Details
-                          </button>
-                        </div>
-                      </div>
-
                       <div id="todosContent">
                         <div class="loading">
                           <div class="spinner"></div>

--- a/client/styles.css
+++ b/client/styles.css
@@ -7348,9 +7348,8 @@ textarea:disabled {
     grid-template-columns: 1fr;
   }
 
-  .floating-new-task-cta {
-    right: 16px;
-    bottom: 72px;
+  body.is-todos-view .floating-new-task-cta {
+    display: none;
   }
 
   .todos-top-bar {

--- a/tests/ui/command-palette.spec.ts
+++ b/tests/ui/command-palette.spec.ts
@@ -221,10 +221,10 @@ test.describe("Command palette", () => {
     page,
     isMobile,
   }) => {
-    // On mobile, #searchInput is in the hidden desktop rail; use the floating
-    // CTA button (always visible) as the pre-palette focus target instead.
+    // On mobile, #searchInput is in the hidden desktop rail; use the visible
+    // New Task CTA in the top bar as the pre-palette focus target instead.
     const focusTarget = isMobile
-      ? page.locator("#floatingNewTaskCta")
+      ? page.locator("#topBarNewTaskCta")
       : page.locator("#searchInput");
     await focusTarget.focus();
 

--- a/tests/ui/helpers/todos-view.ts
+++ b/tests/ui/helpers/todos-view.ts
@@ -62,11 +62,17 @@ export async function ensureAllTasksListActive(page: Page) {
 }
 
 export async function openTaskComposerSheet(page: Page) {
-  // Use global openTaskComposer() — floating CTA hidden on desktop since the
-  // home dashboard hero button serves that role.
-  await page.evaluate(() =>
-    (window as unknown as Record<string, () => void>).openTaskComposer(),
-  );
+  const topBarCta = page.locator("#topBarNewTaskCta");
+  const floatingCta = page.locator("#floatingNewTaskCta");
+  if (await topBarCta.isVisible()) {
+    await topBarCta.click();
+  } else if (await floatingCta.isVisible()) {
+    await floatingCta.click();
+  } else {
+    await page.evaluate(() =>
+      (window as unknown as Record<string, () => void>).openTaskComposer(),
+    );
+  }
   await expect(page.locator("#taskComposerSheet")).toHaveAttribute(
     "aria-hidden",
     "false",

--- a/tests/ui/home-focus-dashboard.spec.ts
+++ b/tests/ui/home-focus-dashboard.spec.ts
@@ -828,10 +828,20 @@ test.describe("Home focus dashboard + sheet composer", () => {
     await expect(page.locator("#todoInput")).toBeVisible();
   });
 
-  test("All tasks keeps the list surface primary", async ({ page }) => {
+  test("All tasks keeps the list surface primary", async ({
+    page,
+    isMobile,
+  }) => {
     await clickWorkspaceView(page, "all");
     await expect(page.locator("#todosListHeader")).toBeVisible();
-    await expect(page.locator("#inlineQuickAdd")).toBeVisible();
+    await expect(page.locator("#inlineQuickAdd")).toHaveCount(0);
+    if (isMobile) {
+      await expect(page.locator("#topBarNewTaskCta")).toBeVisible();
+      await expect(page.locator("#floatingNewTaskCta")).toBeHidden();
+    } else {
+      await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
+      await expect(page.locator("#topBarNewTaskCta")).toBeHidden();
+    }
     await expect(page.locator('[data-testid="home-dashboard"]')).toHaveCount(0);
     await expect(page.locator("#aiWorkspace")).toBeHidden();
   });

--- a/tests/ui/layout-invariants.spec.ts
+++ b/tests/ui/layout-invariants.spec.ts
@@ -199,7 +199,7 @@ test.describe("Todos layout invariants", () => {
 
     // Topbar hidden on desktop; shortcuts btn removed; floating CTA visible.
     await expect(page.locator(".todos-top-bar")).toBeHidden();
-    await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
+    await expect(page.locator(".todos-top-bar .top-add-btn")).toBeHidden();
     await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
     await expect(page.locator(".keyboard-shortcuts-btn")).toHaveCount(0);
 

--- a/tests/ui/topbar-no-cta-clipping.spec.ts
+++ b/tests/ui/topbar-no-cta-clipping.spec.ts
@@ -195,7 +195,7 @@ test.describe("Top bar and rail ellipsis hardening", () => {
 
     // Floating CTA visible on desktop; search is in the sidebar rail.
     await expect(page.locator("#floatingNewTaskCta")).toBeVisible();
-    await expect(page.locator(".todos-top-bar .top-add-btn")).toHaveCount(0);
+    await expect(page.locator(".todos-top-bar .top-add-btn")).toBeHidden();
     const searchArea = page.locator("#railSearchContainer .search-bar");
     await expect(searchArea).toBeVisible();
 


### PR DESCRIPTION
## Summary\n- remove the distracting inline top-level capture from the todos surface\n- make New Task the single shared capture entry path\n- move the mobile capture CTA into the top bar so row actions stay accessible\n\n## Testing\n- npx tsc --noEmit\n- npm run format:check\n- npm run lint:html\n- npm run lint:css\n- npm run test:unit\n- CI=1 npm run test:ui:fast