### PR TITLE
feat(ui): React preview — Phase 8-9: dashboard, composer, onboarding, headings

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -21,10 +21,13 @@ import { SettingsPage } from "./SettingsPage";
 import { HomeDashboard } from "./HomeDashboard";
 import { ProjectCrud } from "../projects/ProjectCrud";
 import { VerificationBanner } from "../shared/VerificationBanner";
+import { OnboardingFlow } from "../shared/OnboardingFlow";
+import { ProjectHeadings } from "../projects/ProjectHeadings";
 import * as todosApi from "../../api/todos";
 
 type AppPage = "todos" | "settings";
 type ViewMode = "list" | "board";
+type UiMode = "normal" | "simple";
 
 interface UndoAction {
   message: string;
@@ -70,6 +73,13 @@ export function AppShell() {
   const [activeTagFilter, setActiveTagFilter] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [composerOpen, setComposerOpen] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(
+    () => !localStorage.getItem("todos:onboarding-complete"),
+  );
+  const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
+  const [uiMode, setUiMode] = useState<UiMode>(
+    () => (localStorage.getItem("todos:ui-mode") as UiMode) || "normal",
+  );
   const exportIcs = useIcsExport();
 
   // Bulk selection
@@ -175,8 +185,12 @@ export function AppShell() {
       );
     }
 
+    if (activeHeadingId && selectedProjectId) {
+      filtered = filtered.filter((t) => t.headingId === activeHeadingId);
+    }
+
     return filtered;
-  }, [todos, activeView, selectedProjectId, searchQuery, activeTagFilter]);
+  }, [todos, activeView, selectedProjectId, searchQuery, activeTagFilter, activeHeadingId]);
 
   const activeTodo = useMemo(
     () => todos.find((t) => t.id === activeTodoId) ?? null,
@@ -458,6 +472,12 @@ export function AppShell() {
           <SettingsPage
             dark={dark}
             onToggleDark={toggleDarkMode}
+            uiMode={uiMode}
+            onToggleUiMode={() => {
+              const next = uiMode === "normal" ? "simple" : "normal";
+              setUiMode(next);
+              localStorage.setItem("todos:ui-mode", next);
+            }}
             onBack={() => setPage("todos")}
           />
         ) : activeView === "home" && !selectedProjectId ? (
@@ -675,7 +695,18 @@ export function AppShell() {
               />
             )}
 
-            <QuickEntry projectId={selectedProjectId} onAdd={addTodo} />
+            {uiMode === "normal" && (
+              <QuickEntry projectId={selectedProjectId} onAdd={addTodo} />
+            )}
+
+            {/* Project headings */}
+            {selectedProjectId && uiMode === "normal" && (
+              <ProjectHeadings
+                projectId={selectedProjectId}
+                activeHeadingId={activeHeadingId}
+                onSelectHeading={setActiveHeadingId}
+              />
+            )}
 
             {/* Mobile search */}
             {isMobile && (
@@ -774,6 +805,13 @@ export function AppShell() {
       />
 
       <UndoToast action={undoAction} onDismiss={() => setUndoAction(null)} />
+
+      {showOnboarding && (
+        <OnboardingFlow
+          onComplete={() => setShowOnboarding(false)}
+          onAddTodo={addTodo}
+        />
+      )}
     </div>
   );
 }

--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -3,10 +3,12 @@ import { useAuth } from "../../auth/AuthProvider";
 import { useTodosStore } from "../../store/useTodosStore";
 import { useProjectsStore } from "../../store/useProjectsStore";
 import { useDarkMode } from "../../hooks/useDarkMode";
+import { useIcsExport } from "../../hooks/useIcsExport";
 import { Sidebar, type DateView } from "../projects/Sidebar";
 import { QuickEntry } from "../todos/QuickEntry";
 import { SortableTodoList } from "../todos/SortableTodoList";
 import { BoardView } from "../todos/BoardView";
+import { TaskComposer } from "../todos/TaskComposer";
 import { TodoDrawer } from "../todos/TodoDrawer";
 import { BulkToolbar } from "../todos/BulkToolbar";
 import { SortControl, type SortField, type SortOrder } from "../todos/SortControl";
@@ -16,6 +18,7 @@ import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { CommandPalette } from "../shared/CommandPalette";
 import { ShortcutsOverlay } from "../shared/ShortcutsOverlay";
 import { SettingsPage } from "./SettingsPage";
+import { HomeDashboard } from "./HomeDashboard";
 import { ProjectCrud } from "../projects/ProjectCrud";
 import { VerificationBanner } from "../shared/VerificationBanner";
 import * as todosApi from "../../api/todos";
@@ -66,6 +69,8 @@ export function AppShell() {
   const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
   const [activeTagFilter, setActiveTagFilter] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>("list");
+  const [composerOpen, setComposerOpen] = useState(false);
+  const exportIcs = useIcsExport();
 
   // Bulk selection
   const [bulkMode, setBulkMode] = useState(false);
@@ -91,6 +96,15 @@ export function AppShell() {
       params.projectId = selectedProjectId;
     } else {
       switch (activeView) {
+        case "home":
+          // Home fetches all active todos for dashboard tiles
+          break;
+        case "triage":
+          params.status = "inbox";
+          break;
+        case "unsorted":
+          // Unsorted = no project — filter client-side
+          break;
         case "today":
           params.sortBy = "dueDate";
           params.sortOrder = "asc";
@@ -131,11 +145,17 @@ export function AppShell() {
   const visibleTodos = useMemo(() => {
     let filtered = todos;
 
-    if (activeView === "today" && !selectedProjectId) {
-      const today = new Date().toISOString().split("T")[0];
-      filtered = filtered.filter(
-        (t) => !t.completed && t.dueDate && t.dueDate.split("T")[0] <= today,
-      );
+    if (!selectedProjectId) {
+      if (activeView === "today") {
+        const today = new Date().toISOString().split("T")[0];
+        filtered = filtered.filter(
+          (t) => !t.completed && t.dueDate && t.dueDate.split("T")[0] <= today,
+        );
+      } else if (activeView === "unsorted") {
+        filtered = filtered.filter(
+          (t) => !t.completed && !t.projectId && !t.category,
+        );
+      }
     }
 
     if (searchQuery.trim()) {
@@ -357,11 +377,21 @@ export function AppShell() {
 
   // --- Derived ---
 
+  const VIEW_LABELS: Record<string, string> = {
+    home: "Home",
+    triage: "Triage",
+    all: "Everything",
+    today: "Today",
+    upcoming: "Upcoming",
+    someday: "Someday",
+    waiting: "Waiting",
+    completed: "Completed",
+    unsorted: "Unsorted",
+  };
+
   const headerTitle = selectedProjectId
     ? projects.find((p) => p.id === selectedProjectId)?.name ?? "Project"
-    : activeView === "all"
-      ? "Everything"
-      : activeView.charAt(0).toUpperCase() + activeView.slice(1);
+    : VIEW_LABELS[activeView] ?? activeView;
 
   const handlePaletteNavigate = useCallback(
     (view: DateView) => {
@@ -430,6 +460,68 @@ export function AppShell() {
             onToggleDark={toggleDarkMode}
             onBack={() => setPage("todos")}
           />
+        ) : activeView === "home" && !selectedProjectId ? (
+          <>
+            {!isMobile && (
+              <header className="app-header">
+                <span className="app-header__title">Home</span>
+                <button
+                  className="btn"
+                  onClick={() => setComposerOpen(true)}
+                  id="topBarNewTaskCta"
+                >
+                  + New Task
+                </button>
+                <button
+                  className="btn"
+                  onClick={toggleDarkMode}
+                  aria-label="Toggle dark mode"
+                  style={{ fontSize: "var(--fs-label)" }}
+                >
+                  {dark ? "☀️" : "🌙"}
+                </button>
+                {user && (
+                  <button
+                    className="btn"
+                    style={{ fontSize: "var(--fs-label)" }}
+                    onClick={logout}
+                  >
+                    Logout
+                  </button>
+                )}
+              </header>
+            )}
+            {isMobile && (
+              <div className="mobile-header">
+                <button
+                  id="projectsRailMobileOpen"
+                  className="mobile-header__menu-btn"
+                  onClick={() => setMobileNavOpen(true)}
+                  aria-label="Open navigation"
+                >
+                  ☰
+                </button>
+                <span className="app-header__title">Home</span>
+                <button
+                  className="btn"
+                  onClick={() => setComposerOpen(true)}
+                  style={{ marginLeft: "auto", fontSize: "var(--fs-label)" }}
+                >
+                  + New
+                </button>
+              </div>
+            )}
+            <div className="app-content">
+              <HomeDashboard
+                todos={todos}
+                onTodoClick={handleTodoClick}
+                onNavigate={(v) => {
+                  handleSelectView(v);
+                  handleSelectProject(null);
+                }}
+              />
+            </div>
+          </>
         ) : (
           <>
             {/* Mobile header */}
@@ -445,6 +537,13 @@ export function AppShell() {
                 </button>
                 <span className="app-header__title">{headerTitle}</span>
                 <div style={{ marginLeft: "auto", display: "flex", gap: "var(--s-2)" }}>
+                  <button
+                    className="btn"
+                    onClick={() => setComposerOpen(true)}
+                    style={{ fontSize: "var(--fs-label)" }}
+                  >
+                    + New
+                  </button>
                   <button
                     className="btn"
                     onClick={toggleDarkMode}
@@ -504,6 +603,23 @@ export function AppShell() {
                   />
                 )}
                 <SearchBar value={searchQuery} onChange={setSearchQuery} />
+                <button
+                  className="btn"
+                  onClick={() => setComposerOpen(true)}
+                  style={{ fontSize: "var(--fs-label)" }}
+                >
+                  + New Task
+                </button>
+                <button
+                  id="exportIcsButton"
+                  className="btn"
+                  onClick={() => exportIcs(visibleTodos)}
+                  aria-label="Export to calendar"
+                  style={{ fontSize: "var(--fs-label)" }}
+                  title="Export visible tasks to .ics"
+                >
+                  📅
+                </button>
                 <button
                   className="btn"
                   onClick={toggleDarkMode}
@@ -645,6 +761,16 @@ export function AppShell() {
       <ShortcutsOverlay
         isOpen={shortcutsOpen}
         onClose={() => setShortcutsOpen(false)}
+      />
+
+      <TaskComposer
+        isOpen={composerOpen}
+        projects={projects}
+        defaultProjectId={selectedProjectId}
+        onSubmit={async (dto) => {
+          await addTodo(dto);
+        }}
+        onClose={() => setComposerOpen(false)}
       />
 
       <UndoToast action={undoAction} onDismiss={() => setUndoAction(null)} />

--- a/client-react/src/components/layout/HomeDashboard.tsx
+++ b/client-react/src/components/layout/HomeDashboard.tsx
@@ -1,0 +1,189 @@
+import { useMemo } from "react";
+import type { Todo } from "../../types";
+
+interface Props {
+  todos: Todo[];
+  onTodoClick: (id: string) => void;
+  onNavigate: (view: "today" | "upcoming" | "all") => void;
+}
+
+function isOverdue(todo: Todo): boolean {
+  if (!todo.dueDate || todo.completed) return false;
+  return new Date(todo.dueDate) < new Date(new Date().toDateString());
+}
+
+function isDueSoon(todo: Todo): boolean {
+  if (!todo.dueDate || todo.completed) return false;
+  const due = new Date(todo.dueDate);
+  const now = new Date(new Date().toDateString());
+  const diff = (due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  return diff >= 0 && diff <= 3;
+}
+
+function isStale(todo: Todo): boolean {
+  if (todo.completed) return false;
+  const updated = new Date(todo.updatedAt);
+  const diff =
+    (Date.now() - updated.getTime()) / (1000 * 60 * 60 * 24);
+  return diff > 14;
+}
+
+export function HomeDashboard({ todos, onTodoClick, onNavigate }: Props) {
+  const activeTodos = useMemo(
+    () => todos.filter((t) => !t.completed),
+    [todos],
+  );
+
+  const overdue = useMemo(
+    () => activeTodos.filter(isOverdue),
+    [activeTodos],
+  );
+  const dueSoon = useMemo(
+    () => activeTodos.filter(isDueSoon),
+    [activeTodos],
+  );
+  const stale = useMemo(() => activeTodos.filter(isStale), [activeTodos]);
+  const highPriority = useMemo(
+    () =>
+      activeTodos.filter(
+        (t) => t.priority === "high" || t.priority === "urgent",
+      ),
+    [activeTodos],
+  );
+
+  const completedToday = useMemo(() => {
+    const today = new Date().toDateString();
+    return todos.filter(
+      (t) => t.completed && t.completedAt && new Date(t.completedAt).toDateString() === today,
+    ).length;
+  }, [todos]);
+
+  return (
+    <div data-testid="home-dashboard" className="home-dashboard">
+      <h2 className="home-dashboard__greeting">
+        {getGreeting()}
+      </h2>
+
+      <div className="home-dashboard__stats">
+        <div className="home-stat">
+          <span className="home-stat__number">{activeTodos.length}</span>
+          <span className="home-stat__label">Open tasks</span>
+        </div>
+        <div className="home-stat">
+          <span className="home-stat__number">{completedToday}</span>
+          <span className="home-stat__label">Done today</span>
+        </div>
+        <div className="home-stat">
+          <span className="home-stat__number">{overdue.length}</span>
+          <span className="home-stat__label">Overdue</span>
+        </div>
+      </div>
+
+      <div className="home-dashboard__tiles">
+        {overdue.length > 0 && (
+          <HomeTile
+            title="Overdue"
+            color="var(--danger)"
+            items={overdue}
+            onItemClick={onTodoClick}
+            onViewAll={() => onNavigate("today")}
+          />
+        )}
+        {dueSoon.length > 0 && (
+          <HomeTile
+            data-home-tile="due_soon"
+            title="Due Soon"
+            color="var(--warning)"
+            items={dueSoon}
+            onItemClick={onTodoClick}
+            onViewAll={() => onNavigate("upcoming")}
+          />
+        )}
+        {highPriority.length > 0 && (
+          <HomeTile
+            title="High Priority"
+            color="var(--accent)"
+            items={highPriority}
+            onItemClick={onTodoClick}
+            onViewAll={() => onNavigate("all")}
+          />
+        )}
+        {stale.length > 0 && (
+          <HomeTile
+            data-home-tile="stale_risks"
+            title="Stale (14+ days)"
+            color="var(--muted)"
+            items={stale}
+            onItemClick={onTodoClick}
+            onViewAll={() => onNavigate("all")}
+          />
+        )}
+      </div>
+
+      {activeTodos.length === 0 && (
+        <div className="home-dashboard__empty">
+          <p>No open tasks. Enjoy your day!</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return "Good morning";
+  if (hour < 17) return "Good afternoon";
+  return "Good evening";
+}
+
+interface TileProps {
+  title: string;
+  color: string;
+  items: Todo[];
+  onItemClick: (id: string) => void;
+  onViewAll: () => void;
+  "data-home-tile"?: string;
+}
+
+function HomeTile({
+  title,
+  color,
+  items,
+  onItemClick,
+  onViewAll,
+  ...rest
+}: TileProps) {
+  return (
+    <div className="home-tile" {...rest}>
+      <div className="home-tile__header">
+        <span className="home-tile__dot" style={{ background: color }} />
+        <span className="home-tile__title">{title}</span>
+        <span className="home-tile__count">{items.length}</span>
+      </div>
+      <div className="home-tile__body">
+        {items.slice(0, 5).map((todo) => (
+          <div
+            key={todo.id}
+            className="home-tile__item"
+            onClick={() => onItemClick(todo.id)}
+          >
+            <span className="home-tile__item-title">{todo.title}</span>
+            {todo.dueDate && (
+              <span className="home-tile__item-date">
+                {new Date(todo.dueDate).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </span>
+            )}
+          </div>
+        ))}
+        {items.length > 5 && (
+          <button className="home-tile__more" onClick={onViewAll}>
+            +{items.length - 5} more
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/components/layout/SettingsPage.tsx
+++ b/client-react/src/components/layout/SettingsPage.tsx
@@ -5,10 +5,12 @@ import { apiCall } from "../../api/client";
 interface Props {
   dark: boolean;
   onToggleDark: () => void;
+  uiMode: string;
+  onToggleUiMode: () => void;
   onBack: () => void;
 }
 
-export function SettingsPage({ dark, onToggleDark, onBack }: Props) {
+export function SettingsPage({ dark, onToggleDark, uiMode, onToggleUiMode, onBack }: Props) {
   const { user } = useAuth();
   const [name, setName] = useState(user?.name || "");
   const [saving, setSaving] = useState(false);
@@ -95,6 +97,12 @@ export function SettingsPage({ dark, onToggleDark, onBack }: Props) {
           <span className="settings-field__label">Dark mode</span>
           <button className="btn" onClick={onToggleDark}>
             {dark ? "☀️ Switch to light" : "🌙 Switch to dark"}
+          </button>
+        </div>
+        <div className="settings-field settings-field--row">
+          <span className="settings-field__label">UI complexity</span>
+          <button className="btn" onClick={onToggleUiMode}>
+            {uiMode === "simple" ? "Switch to normal" : "Switch to simple"}
           </button>
         </div>
       </section>

--- a/client-react/src/components/projects/ProjectHeadings.tsx
+++ b/client-react/src/components/projects/ProjectHeadings.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiCall } from "../../api/client";
+import type { Heading } from "../../types";
+
+interface Props {
+  projectId: string;
+  activeHeadingId: string | null;
+  onSelectHeading: (id: string | null) => void;
+}
+
+export function ProjectHeadings({
+  projectId,
+  activeHeadingId,
+  onSelectHeading,
+}: Props) {
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    apiCall(`/projects/${projectId}/headings`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setHeadings(data))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [projectId]);
+
+  const addHeading = useCallback(async () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    try {
+      const res = await apiCall(`/projects/${projectId}/headings`, {
+        method: "POST",
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (res.ok) {
+        const created = await res.json();
+        setHeadings((prev) => [...prev, created]);
+        setNewName("");
+      }
+    } catch {}
+  }, [projectId, newName]);
+
+  if (loading && headings.length === 0) return null;
+
+  return (
+    <div className="project-headings">
+      <button
+        className={`project-headings__item${activeHeadingId === null ? " project-headings__item--active" : ""}`}
+        onClick={() => onSelectHeading(null)}
+      >
+        All
+      </button>
+      {headings.map((h) => (
+        <button
+          key={h.id}
+          className={`project-headings__item${activeHeadingId === h.id ? " project-headings__item--active" : ""}`}
+          onClick={() => onSelectHeading(h.id)}
+        >
+          {h.name}
+        </button>
+      ))}
+      <div className="project-headings__add">
+        <input
+          className="project-headings__input"
+          type="text"
+          placeholder="+ Add section"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") addHeading();
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -54,6 +54,8 @@ export function Sidebar({
     y: number;
   } | null>(null);
 
+  const [showArchived, setShowArchived] = useState(false);
+
   const handleContextMenu = (e: React.MouseEvent, projectId: string) => {
     e.preventDefault();
     e.stopPropagation();
@@ -127,6 +129,35 @@ export function Sidebar({
           ))}
       </div>
 
+      {projects.some((p) => p.archived) && (
+        <>
+          <button
+            className="projects-archived-toggle"
+            onClick={() => setShowArchived((o) => !o)}
+          >
+            {showArchived ? "▾" : "▸"} Archived (
+            {projects.filter((p) => p.archived).length})
+          </button>
+          {showArchived && (
+            <div className="projects-archived-list">
+              {projects
+                .filter((p) => p.archived)
+                .map((p) => (
+                  <button
+                    key={p.id}
+                    className="projects-rail-item projects-rail-item--archived"
+                    data-project-key={p.name}
+                    onClick={() => onSelectProject(p.id)}
+                    onContextMenu={(e) => handleContextMenu(e, p.id)}
+                  >
+                    {p.name}
+                  </button>
+                ))}
+            </div>
+          )}
+        </>
+      )}
+
       {/* Project context menu */}
       {contextMenu && (
         <>
@@ -143,6 +174,22 @@ export function Sidebar({
               onClick={() => handleRenameProject(contextMenu.id)}
             >
               Rename
+            </button>
+            <button
+              className="context-menu__item"
+              onClick={async () => {
+                const project = projects.find((p) => p.id === contextMenu.id);
+                setContextMenu(null);
+                await apiCall(`/projects/${contextMenu.id}`, {
+                  method: "PUT",
+                  body: JSON.stringify({ archived: !project?.archived }),
+                });
+                onRefreshProjects();
+              }}
+            >
+              {projects.find((p) => p.id === contextMenu.id)?.archived
+                ? "Unarchive"
+                : "Archive"}
             </button>
             <button
               className="context-menu__item context-menu__item--danger"

--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -3,20 +3,26 @@ import type { Project } from "../../types";
 import { apiCall } from "../../api/client";
 
 export type DateView =
+  | "home"
+  | "triage"
   | "all"
   | "today"
   | "upcoming"
   | "someday"
   | "waiting"
-  | "completed";
+  | "completed"
+  | "unsorted";
 
 const WORKSPACE_VIEWS: { key: DateView; label: string }[] = [
+  { key: "home", label: "Home" },
+  { key: "triage", label: "Triage" },
   { key: "all", label: "Everything" },
   { key: "today", label: "Today" },
   { key: "upcoming", label: "Upcoming" },
   { key: "someday", label: "Someday" },
   { key: "waiting", label: "Waiting" },
   { key: "completed", label: "Completed" },
+  { key: "unsorted", label: "Unsorted" },
 ];
 
 interface Props {

--- a/client-react/src/components/shared/OnboardingFlow.tsx
+++ b/client-react/src/components/shared/OnboardingFlow.tsx
@@ -1,0 +1,129 @@
+import { useState, useCallback } from "react";
+import type { CreateTodoDto } from "../../types";
+
+interface Props {
+  onComplete: () => void;
+  onAddTodo: (dto: CreateTodoDto) => Promise<unknown>;
+}
+
+const STEPS = [
+  {
+    title: "Welcome to Todos",
+    description:
+      "Your personal task manager. Let's get you set up in a few quick steps.",
+  },
+  {
+    title: "Add your first tasks",
+    description:
+      "Here are some sample tasks to get started. You can edit or delete them later.",
+    sampleTasks: [
+      "Review my weekly goals",
+      "Organize my inbox",
+      "Plan tomorrow's priorities",
+    ],
+  },
+  {
+    title: "You're all set!",
+    description:
+      "Start adding tasks, create projects, and use keyboard shortcuts (press ? for help).",
+  },
+];
+
+export function OnboardingFlow({ onComplete, onAddTodo }: Props) {
+  const [step, setStep] = useState(0);
+  const [addedSamples, setAddedSamples] = useState(false);
+
+  const current = STEPS[step];
+
+  const handleAddSamples = useCallback(async () => {
+    if (addedSamples) return;
+    const tasks = STEPS[1].sampleTasks || [];
+    for (const title of tasks) {
+      await onAddTodo({ title });
+    }
+    setAddedSamples(true);
+  }, [addedSamples, onAddTodo]);
+
+  const handleNext = useCallback(() => {
+    if (step < STEPS.length - 1) {
+      setStep(step + 1);
+    } else {
+      localStorage.setItem("todos:onboarding-complete", "true");
+      onComplete();
+    }
+  }, [step, onComplete]);
+
+  const handleSkip = useCallback(() => {
+    localStorage.setItem("todos:onboarding-complete", "true");
+    onComplete();
+  }, [onComplete]);
+
+  return (
+    <div className="onboarding-overlay">
+      <div className="onboarding-card">
+        <div className="onboarding-card__progress">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={`onboarding-card__dot${i === step ? " onboarding-card__dot--active" : ""}${i < step ? " onboarding-card__dot--done" : ""}`}
+            />
+          ))}
+        </div>
+
+        <h2 className="onboarding-card__title">{current.title}</h2>
+        <p className="onboarding-card__desc">{current.description}</p>
+
+        {step === 1 && current.sampleTasks && (
+          <div className="onboarding-card__samples">
+            {current.sampleTasks.map((task) => (
+              <div key={task} className="onboarding-card__sample">
+                ✓ {task}
+              </div>
+            ))}
+            {!addedSamples ? (
+              <button
+                className="btn"
+                style={{
+                  background: "var(--accent)",
+                  color: "#fff",
+                  borderColor: "var(--accent)",
+                  marginTop: "var(--s-3)",
+                }}
+                onClick={handleAddSamples}
+              >
+                Add these tasks
+              </button>
+            ) : (
+              <p
+                style={{
+                  color: "var(--success)",
+                  fontSize: "var(--fs-meta)",
+                  marginTop: "var(--s-3)",
+                }}
+              >
+                Tasks added!
+              </p>
+            )}
+          </div>
+        )}
+
+        <div className="onboarding-card__actions">
+          <button className="btn" onClick={handleSkip}>
+            Skip
+          </button>
+          <button
+            className="btn"
+            style={{
+              background: "var(--accent)",
+              color: "#fff",
+              borderColor: "var(--accent)",
+            }}
+            onClick={handleNext}
+          >
+            {step === STEPS.length - 1 ? "Get Started" : "Next"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/components/todos/TaskComposer.tsx
+++ b/client-react/src/components/todos/TaskComposer.tsx
@@ -1,0 +1,232 @@
+import { useState, useEffect, useRef } from "react";
+import type { CreateTodoDto, TodoStatus, Priority, Project } from "../../types";
+
+interface Props {
+  isOpen: boolean;
+  projects: Project[];
+  defaultProjectId?: string | null;
+  onSubmit: (dto: CreateTodoDto) => Promise<unknown>;
+  onClose: () => void;
+}
+
+const STATUS_OPTIONS: TodoStatus[] = [
+  "inbox",
+  "next",
+  "in_progress",
+  "waiting",
+  "scheduled",
+  "someday",
+];
+const PRIORITY_OPTIONS: (Priority | "")[] = [
+  "",
+  "low",
+  "medium",
+  "high",
+  "urgent",
+];
+
+export function TaskComposer({
+  isOpen,
+  projects,
+  defaultProjectId,
+  onSubmit,
+  onClose,
+}: Props) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState<TodoStatus>("inbox");
+  const [priority, setPriority] = useState<string>("");
+  const [projectId, setProjectId] = useState(defaultProjectId || "");
+  const [dueDate, setDueDate] = useState("");
+  const [tags, setTags] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle("");
+      setDescription("");
+      setStatus("inbox");
+      setPriority("");
+      setProjectId(defaultProjectId || "");
+      setDueDate("");
+      setTags("");
+      requestAnimationFrame(() => titleRef.current?.focus());
+    }
+  }, [isOpen, defaultProjectId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  const handleSubmit = async () => {
+    const trimmed = title.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      const dto: CreateTodoDto = {
+        title: trimmed,
+        ...(description.trim() ? { description: description.trim() } : {}),
+        ...(status !== "inbox" ? { status } : {}),
+        ...(priority ? { priority: priority as Priority } : {}),
+        ...(projectId ? { projectId } : {}),
+        ...(dueDate ? { dueDate } : {}),
+        ...(tags.trim()
+          ? {
+              tags: tags
+                .split(",")
+                .map((t) => t.trim())
+                .filter(Boolean),
+            }
+          : {}),
+      };
+      await onSubmit(dto);
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="composer-overlay" onClick={onClose}>
+      <div
+        className="composer"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="New task"
+      >
+        <div className="composer__header">
+          <h3 className="composer__title">New Task</h3>
+          <button className="todo-drawer__close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+        <div className="composer__body">
+          <input
+            ref={titleRef}
+            className="composer__input composer__input--title"
+            type="text"
+            placeholder="Task title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleSubmit();
+              }
+            }}
+          />
+          <textarea
+            className="composer__textarea"
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+          />
+
+          <div className="composer__row">
+            <div className="composer__field">
+              <label className="todo-drawer__label">Status</label>
+              <select
+                id="todoStatusSelect"
+                className="todo-drawer__select"
+                value={status}
+                onChange={(e) => setStatus(e.target.value as TodoStatus)}
+              >
+                {STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s.replace("_", " ")}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="composer__field">
+              <label className="todo-drawer__label">Priority</label>
+              <select
+                id="todoPrioritySelect"
+                className="todo-drawer__select"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+              >
+                {PRIORITY_OPTIONS.map((p) => (
+                  <option key={p} value={p}>
+                    {p || "None"}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="composer__row">
+            <div className="composer__field">
+              <label className="todo-drawer__label">Project</label>
+              <select
+                id="todoProjectSelect"
+                className="todo-drawer__select"
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+              >
+                <option value="">None</option>
+                {projects
+                  .filter((p) => !p.archived)
+                  .map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+              </select>
+            </div>
+            <div className="composer__field">
+              <label className="todo-drawer__label">Due date</label>
+              <input
+                id="todoDueDateInput"
+                className="todo-drawer__input"
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="composer__field">
+            <label className="todo-drawer__label">
+              Tags (comma-separated)
+            </label>
+            <input
+              id="todoTagsInput"
+              className="todo-drawer__input"
+              type="text"
+              placeholder="e.g. work, important"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="composer__footer">
+          <button className="btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            className="btn"
+            style={{
+              background: "var(--accent)",
+              color: "#fff",
+              borderColor: "var(--accent)",
+            }}
+            onClick={handleSubmit}
+            disabled={!title.trim() || submitting}
+          >
+            {submitting ? "Creating…" : "Create Task"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/hooks/useIcsExport.ts
+++ b/client-react/src/hooks/useIcsExport.ts
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+import type { Todo } from "../types";
+
+function escapeIcs(text: string): string {
+  return text.replace(/[\\;,\n]/g, (c) => (c === "\n" ? "\\n" : `\\${c}`));
+}
+
+function formatIcsDate(date: string): string {
+  return new Date(date).toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+}
+
+export function useIcsExport() {
+  return useCallback((todos: Todo[], filename = "todos.ics") => {
+    const events = todos
+      .filter((t) => t.dueDate)
+      .map((t) => {
+        const dtStart = formatIcsDate(t.dueDate!);
+        return [
+          "BEGIN:VEVENT",
+          `UID:${t.id}@todos-app`,
+          `DTSTART;VALUE=DATE:${dtStart.slice(0, 8)}`,
+          `SUMMARY:${escapeIcs(t.title)}`,
+          t.description
+            ? `DESCRIPTION:${escapeIcs(t.description)}`
+            : "",
+          `STATUS:${t.completed ? "COMPLETED" : "NEEDS-ACTION"}`,
+          "END:VEVENT",
+        ]
+          .filter(Boolean)
+          .join("\r\n");
+      });
+
+    if (events.length === 0) return;
+
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Todos App//React Preview//EN",
+      ...events,
+      "END:VCALENDAR",
+    ].join("\r\n");
+
+    const blob = new Blob([ics], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -1400,3 +1400,242 @@ body {
     width: 100%;
   }
 }
+
+/* --- Home dashboard --- */
+.home-dashboard {
+  max-width: 800px;
+}
+
+.home-dashboard__greeting {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  margin-bottom: var(--s-5);
+}
+
+.home-dashboard__stats {
+  display: flex;
+  gap: var(--s-4);
+  margin-bottom: var(--s-6);
+}
+
+.home-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--s-4);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  min-width: 100px;
+}
+
+.home-stat__number {
+  font-size: 1.5rem;
+  font-weight: var(--fw-bold);
+}
+
+.home-stat__label {
+  font-size: var(--fs-label);
+  color: var(--muted);
+}
+
+.home-dashboard__tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--s-4);
+}
+
+.home-tile {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
+.home-tile__header {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-3) var(--s-4);
+  border-bottom: 1px solid var(--border);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+}
+
+.home-tile__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.home-tile__title {
+  flex: 1;
+}
+
+.home-tile__count {
+  font-size: var(--fs-label);
+  color: var(--muted);
+  font-weight: var(--fw-regular);
+}
+
+.home-tile__body {
+  padding: var(--s-2);
+}
+
+.home-tile__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+  padding: var(--s-2) var(--s-3);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  font-size: var(--fs-meta);
+}
+
+.home-tile__item:hover {
+  background: var(--surface-2);
+}
+
+.home-tile__item-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-tile__item-date {
+  font-size: var(--fs-label);
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.home-tile__more {
+  display: block;
+  width: 100%;
+  padding: var(--s-2);
+  border: none;
+  background: none;
+  color: var(--accent);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  text-align: center;
+}
+
+.home-tile__more:hover {
+  text-decoration: underline;
+}
+
+.home-dashboard__empty {
+  text-align: center;
+  padding: var(--s-8);
+  color: var(--muted);
+}
+
+/* --- Task composer modal --- */
+.composer-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  z-index: 350;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+}
+
+.composer {
+  background: var(--surface);
+  border-radius: var(--r-md);
+  width: min(560px, calc(100vw - var(--s-6)));
+  box-shadow: var(--shadow-elevated);
+  display: flex;
+  flex-direction: column;
+}
+
+.composer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--s-4) var(--s-5);
+  border-bottom: 1px solid var(--border);
+}
+
+.composer__title {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+}
+
+.composer__body {
+  padding: var(--s-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+}
+
+.composer__input {
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: var(--s-2) var(--s-3);
+  font-size: var(--fs-body);
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.composer__input--title {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  border: none;
+  outline: none;
+  padding: 0;
+}
+
+.composer__input--title::placeholder {
+  color: var(--muted);
+  font-weight: var(--fw-regular);
+}
+
+.composer__textarea {
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: var(--s-2) var(--s-3);
+  font-size: var(--fs-meta);
+  font-family: inherit;
+  background: var(--surface);
+  color: var(--text);
+  resize: vertical;
+}
+
+.composer__row {
+  display: flex;
+  gap: var(--s-3);
+}
+
+.composer__field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+.composer__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--s-2);
+  padding: var(--s-4) var(--s-5);
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 700px) {
+  .home-dashboard__stats {
+    flex-wrap: wrap;
+  }
+
+  .home-stat {
+    flex: 1;
+    min-width: 80px;
+  }
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -1639,3 +1639,155 @@ body {
     min-width: 80px;
   }
 }
+
+/* --- Onboarding overlay --- */
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  z-index: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.onboarding-card {
+  background: var(--surface);
+  border-radius: var(--r-lg);
+  padding: var(--s-7) var(--s-6);
+  max-width: 480px;
+  width: calc(100% - var(--s-6));
+  box-shadow: var(--shadow-elevated);
+  text-align: center;
+}
+
+.onboarding-card__progress {
+  display: flex;
+  justify-content: center;
+  gap: var(--s-2);
+  margin-bottom: var(--s-5);
+}
+
+.onboarding-card__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+}
+
+.onboarding-card__dot--active {
+  background: var(--accent);
+  width: 24px;
+  border-radius: 4px;
+}
+
+.onboarding-card__dot--done {
+  background: var(--success);
+}
+
+.onboarding-card__title {
+  font-size: var(--fs-section);
+  font-weight: var(--fw-semibold);
+  margin-bottom: var(--s-3);
+}
+
+.onboarding-card__desc {
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  margin-bottom: var(--s-5);
+  line-height: var(--lh-base);
+}
+
+.onboarding-card__samples {
+  text-align: left;
+  margin-bottom: var(--s-4);
+}
+
+.onboarding-card__sample {
+  padding: var(--s-2) var(--s-3);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  font-size: var(--fs-meta);
+  margin-bottom: var(--s-1);
+}
+
+.onboarding-card__actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--s-3);
+}
+
+/* --- Project headings tabs --- */
+.project-headings {
+  display: flex;
+  align-items: center;
+  gap: var(--s-1);
+  padding: var(--s-2) var(--s-4);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+}
+
+.project-headings__item {
+  padding: var(--s-1) var(--s-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  background: var(--surface);
+  color: var(--muted);
+  font-size: var(--fs-label);
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.project-headings__item:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.project-headings__item--active {
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.project-headings__add {
+  flex-shrink: 0;
+}
+
+.project-headings__input {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: var(--fs-label);
+  font-family: inherit;
+  color: var(--muted);
+  width: 100px;
+  padding: var(--s-1) var(--s-2);
+}
+
+.project-headings__input::placeholder {
+  color: var(--muted);
+}
+
+/* --- Archived projects toggle --- */
+.projects-archived-toggle {
+  display: block;
+  width: 100%;
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: var(--fs-label);
+  padding: var(--s-2) var(--s-3);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.projects-archived-toggle:hover {
+  color: var(--text);
+}
+
+.projects-rail-item--archived {
+  opacity: 0.6;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary

Phases 8-9 of the React `/app-react` preview workspace.

### Phase 8: Home dashboard, task composer, ICS export, workspace views
- **Home dashboard** — Time-based greeting, stats bar (open/done/overdue), tile grid (Overdue, Due Soon, High Priority, Stale 14d+)
- **Full task composer** — Modal with title, description, status, priority, project, due date, tags; Enter submits
- **ICS export** — 📅 button downloads `.ics` file from visible todos with due dates
- **Workspace views** — Added Home (dashboard), Triage (inbox status), Unsorted (no project); 9 views total

### Phase 9: Onboarding, headings, archive, UI mode
- **Onboarding** — 3-step wizard (welcome → sample tasks → done); persists to localStorage
- **Project headings** — Tab-style section filters within projects; create via inline input
- **Archive/unarchive** — Context menu option on sidebar projects; collapsible archived section
- **UI mode** — Simple/Normal toggle in Settings; simple hides quick entry and headings

No classic files changed.

## Test plan

- [ ] Classic CI gates remain green
- [ ] Home dashboard renders tiles with correct counts
- [ ] Task composer creates todos with all fields
- [ ] ICS export downloads file with due-dated tasks
- [ ] Triage shows inbox-status only; Unsorted shows no-project only
- [ ] Onboarding shows for new users; skip persists; sample tasks seed
- [ ] Project headings filter todos within a project
- [ ] Archive/unarchive in context menu; archived section toggles
- [ ] Simple mode hides quick entry and headings

https://claude.ai/code/session_01FJctDf9yKcvyXBeGbBS284