### PR TITLE
fix(ui): redesign sidebar bottom nav with icon + label pattern

### DIFF
--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -11,6 +11,11 @@ import {
   IconSettings,
   IconFeedback,
   IconPlus,
+  IconMoon,
+  IconSun,
+  IconUser,
+  IconKeyboard,
+  IconShield,
 } from "../shared/Icons";
 
 // Internal keys match classic store.js currentWorkspaceView values
@@ -107,19 +112,21 @@ export function Sidebar({
       groups.set(area, list);
     }
 
-    // Sort: known areas first in order, then unknown alphabetically, then ungrouped last
     const sorted: Array<{ area: string; label: string; projects: Project[] }> =
       [];
 
     for (const area of AREA_ORDER) {
       const list = groups.get(area);
       if (list?.length) {
-        sorted.push({ area, label: AREA_LABELS[area] || area, projects: list });
+        sorted.push({
+          area,
+          label: AREA_LABELS[area] || area,
+          projects: list,
+        });
         groups.delete(area);
       }
     }
 
-    // Unknown areas
     const unknownAreas = [...groups.entries()]
       .filter(([a]) => a !== "")
       .sort(([a], [b]) => a.localeCompare(b));
@@ -131,7 +138,6 @@ export function Sidebar({
       });
     }
 
-    // Ungrouped (no area)
     const ungrouped = groups.get("");
     if (ungrouped?.length) {
       sorted.push({ area: "", label: "", projects: ungrouped });
@@ -172,7 +178,6 @@ export function Sidebar({
     });
   };
 
-  // Filter views based on UI mode (classic hides Focus and Desk in simple mode)
   const visibleViews = isSimple
     ? WORKSPACE_VIEWS.filter((v) => v.key !== "home" && v.key !== "triage")
     : WORKSPACE_VIEWS;
@@ -304,7 +309,9 @@ export function Sidebar({
             <button
               className="context-menu__item"
               onClick={async () => {
-                const project = projects.find((p) => p.id === contextMenu.id);
+                const project = projects.find(
+                  (p) => p.id === contextMenu.id,
+                );
                 setContextMenu(null);
                 await apiCall(`/projects/${contextMenu.id}`, {
                   method: "PUT",
@@ -330,55 +337,37 @@ export function Sidebar({
       {/* Spacer */}
       <div className="projects-rail__spacer" />
 
-      {/* Section 3: Utilities (matches classic order) */}
-      <div className="projects-rail__section--utilities">
-        <div className="projects-rail__utility-list">
-          <button
-            className="projects-rail-utility-item"
-            data-sidebar-view="feedback"
-            onClick={onOpenFeedback}
-          >
-            <IconFeedback /> Feedback
-          </button>
-          <button
-            className="projects-rail-utility-item"
-            data-sidebar-view="settings"
-            onClick={onOpenSettings}
-          >
-            <IconSettings /> Settings
-          </button>
-          <button
-            className="projects-rail-utility-item"
-            onClick={onToggleTheme}
-          >
+      {/* Section 3: Bottom nav — icon + label, compact */}
+      <div className="sidebar-nav-bottom">
+        <button className="sidebar-nav-item" onClick={onOpenFeedback}>
+          <IconFeedback />
+          <span className="sidebar-nav-item__label">Feedback</span>
+        </button>
+        <button className="sidebar-nav-item" onClick={onOpenShortcuts}>
+          <IconKeyboard />
+          <span className="sidebar-nav-item__label">Shortcuts</span>
+        </button>
+        <button className="sidebar-nav-item" onClick={onToggleTheme}>
+          {dark ? <IconSun /> : <IconMoon />}
+          <span className="sidebar-nav-item__label">
             {dark ? "Light mode" : "Dark mode"}
+          </span>
+        </button>
+        <button className="sidebar-nav-item" onClick={onOpenSettings}>
+          <IconSettings />
+          <span className="sidebar-nav-item__label">Settings</span>
+        </button>
+        <button className="sidebar-nav-item" onClick={onOpenProfile}>
+          <IconUser />
+          <span className="sidebar-nav-item__label">Profile</span>
+        </button>
+        {isAdmin && (
+          <button className="sidebar-nav-item" onClick={onOpenAdmin}>
+            <IconShield />
+            <span className="sidebar-nav-item__label">Admin</span>
           </button>
-          <button
-            className="projects-rail-utility-item"
-            onClick={onOpenProfile}
-          >
-            Profile
-          </button>
-          <button
-            className="projects-rail-utility-item"
-            onClick={onOpenShortcuts}
-          >
-            Shortcuts
-          </button>
-        </div>
+        )}
       </div>
-
-      {/* Admin footer (classic: projects-rail__footer--admin-only) */}
-      {isAdmin && (
-        <div className="projects-rail__footer projects-rail__footer--admin-only">
-          <button
-            className="projects-rail-utility-item"
-            onClick={onOpenAdmin}
-          >
-            Admin
-          </button>
-        </div>
-      )}
     </>
   );
 }

--- a/client-react/src/components/shared/Icons.tsx
+++ b/client-react/src/components/shared/Icons.tsx
@@ -286,3 +286,37 @@ export function IconBoard({ size = 14, className = "app-icon" }: IconProps) {
     </Icon>
   );
 }
+
+export function IconKeyboard({ size = 15, className = "nav-icon" }: IconProps) {
+  return (
+    <Icon size={size} className={className}>
+      <rect width="20" height="16" x="2" y="4" rx="2" />
+      <path d="M6 8h.001" />
+      <path d="M10 8h.001" />
+      <path d="M14 8h.001" />
+      <path d="M18 8h.001" />
+      <path d="M8 12h.001" />
+      <path d="M12 12h.001" />
+      <path d="M16 12h.001" />
+      <path d="M7 16h10" />
+    </Icon>
+  );
+}
+
+export function IconShield({ size = 15, className = "nav-icon" }: IconProps) {
+  return (
+    <Icon size={size} className={className}>
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67 0C8.5 20.5 5 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+    </Icon>
+  );
+}
+
+export function IconDownload({ size = 15, className = "nav-icon" }: IconProps) {
+  return (
+    <Icon size={size} className={className}>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" x2="12" y1="15" y2="3" />
+    </Icon>
+  );
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -1076,44 +1076,57 @@ body {
   min-height: var(--s-4);
 }
 
-/* Utilities section (bottom of sidebar) */
-.projects-rail__section--utilities {
+/* --- Bottom nav (icon + label, compact) --- */
+.sidebar-nav-bottom {
   padding-top: var(--s-3);
   border-top: 1px solid var(--border);
-}
-
-.projects-rail__utility-list {
   display: flex;
   flex-direction: column;
-  gap: var(--s-0);
+  gap: 1px;
 }
 
-/* Admin footer */
-.projects-rail__footer {
-  padding-top: var(--s-2);
-  border-top: 1px solid var(--border);
-  margin-top: var(--s-2);
-}
-
-.projects-rail-utility-item {
+.sidebar-nav-item {
   display: flex;
   align-items: center;
-  gap: var(--s-2);
+  gap: var(--s-3);
   padding: var(--s-2) var(--s-3);
   border-radius: var(--r-sm);
-  font-size: var(--fs-meta);
-  color: var(--muted);
-  cursor: pointer;
   border: none;
   background: none;
   width: 100%;
   text-align: left;
   font-family: inherit;
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
 }
 
-.projects-rail-utility-item:hover {
+.sidebar-nav-item:hover {
   background: var(--surface-2);
   color: var(--text);
+}
+
+.sidebar-nav-item .nav-icon,
+.sidebar-nav-item .app-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
+  transition: opacity var(--dur-fast);
+}
+
+.sidebar-nav-item:hover .nav-icon,
+.sidebar-nav-item:hover .app-icon {
+  opacity: 1;
+}
+
+.sidebar-nav-item__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Nav label */


### PR DESCRIPTION
## Summary

Redesigns the sidebar bottom section with a clean icon + label pattern, inspired by Claude's lower-left navigation.

### Before
```
── divider ──
Feedback          (text only, no icon for most items)
Settings          (icon)
Dark mode         (no icon)
Profile           (no icon)
Shortcuts         (no icon)
── divider ──
Admin             (separate footer)
```

### After
```
── divider ──
💬 Feedback       (IconFeedback)
⌨️ Shortcuts      (IconKeyboard)
🌙 Dark mode      (IconMoon / IconSun)
⚙️ Settings       (IconSettings)
👤 Profile        (IconUser)
🛡️ Admin          (IconShield, admin-only)
```

### Design principles
- Every item has a **15px SVG icon** + **label text**
- Icons at **0.7 opacity**, brighten to **1.0 on hover**
- Smooth color + opacity transitions (`--dur-fast`)
- **1px gap** between items for compact density
- Clean divider separates from projects section above
- Admin integrated into the same list (no separate footer)

### New icons
- `IconKeyboard` — keyboard with key layout (Shortcuts)
- `IconShield` — shield shape (Admin)
- `IconDownload` — download arrow (future use)

## Test plan

- [ ] CI gates remain green
- [ ] Bottom nav shows icon + label for each item
- [ ] Icons are muted, brighten on hover
- [ ] Dark mode toggle shows moon/sun icon and correct label
- [ ] Admin only visible for admin users

https://claude.ai/code/session_01FJctDf9yKcvyXBeGbBS284