### PR TITLE
chore(ui): replace app logo with new organic design

### DIFF
--- a/client/favicon.svg
+++ b/client/favicon.svg
@@ -1,6 +1,119 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" version="1.2" baseProfile="tiny-ps">
-  <title>Todos App Favicon</title>
-  <rect width="512" height="512" fill="#4F46E5"/>
-  <circle cx="256" cy="256" r="150" fill="white"/>
-  <path d="M 200 256 L 230 286 L 312 204" stroke="#4F46E5" stroke-width="20" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <!-- Warm gradient background -->
+    <radialGradient id="bgGrad" cx="50%" cy="45%" r="65%">
+      <stop offset="0%" stop-color="#F5EDE0"/>
+      <stop offset="100%" stop-color="#E8D5BE"/>
+    </radialGradient>
+
+    <!-- Coral/salmon gradient for main shape -->
+    <linearGradient id="shapeGrad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#E8856A"/>
+      <stop offset="60%" stop-color="#C96B50"/>
+      <stop offset="100%" stop-color="#A84F38"/>
+    </linearGradient>
+
+    <!-- Inner warm highlight -->
+    <linearGradient id="shapeGrad2" x1="20%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0%" stop-color="#F0A080" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#D06848" stop-opacity="0.6"/>
+    </linearGradient>
+
+    <!-- Soft glow filter -->
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="6" result="blur"/>
+      <feColorMatrix in="blur" type="matrix"
+        values="1 0.3 0.1 0 0  0.3 0.2 0.1 0 0  0.1 0.1 0.1 0 0  0 0 0 0.35 0" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <!-- Subtle shadow -->
+    <filter id="dropShadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="12" flood-color="#B05A3A" flood-opacity="0.25"/>
+    </filter>
+
+    <!-- Clip for rounded square frame -->
+    <clipPath id="frameClip">
+      <rect x="40" y="40" width="320" height="320" rx="72" ry="72"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background rounded square -->
+  <rect x="40" y="40" width="320" height="320" rx="72" ry="72" fill="url(#bgGrad)"/>
+
+  <!-- Subtle background texture ring -->
+  <circle cx="200" cy="195" r="170" fill="none" stroke="#D4B89A" stroke-width="0.6" opacity="0.4" clip-path="url(#frameClip)"/>
+  <circle cx="200" cy="195" r="130" fill="none" stroke="#D4B89A" stroke-width="0.4" opacity="0.3" clip-path="url(#frameClip)"/>
+
+  <!-- === ABSTRACT FORM: flowing organic hexagonal/floral core === -->
+  <!-- Outer petal layer — coral -->
+  <g filter="url(#dropShadow)" clip-path="url(#frameClip)">
+    <path d="
+      M200,108
+      C228,108 252,128 258,155
+      C282,148 306,158 316,180
+      C326,202 318,228 300,240
+      C314,260 312,286 294,300
+      C276,314 252,310 238,298
+      C232,322 212,338 190,336
+      C168,334 152,318 148,296
+      C130,306 106,300 94,284
+      C82,268 86,244 100,232
+      C84,218 80,194 92,174
+      C104,154 128,146 150,154
+      C158,130 176,108 200,108Z
+    " fill="url(#shapeGrad1)" opacity="0.95"/>
+
+    <!-- Inner layer — lighter, slightly rotated -->
+    <path d="
+      M200,130
+      C220,130 238,144 243,163
+      C261,157 279,166 286,183
+      C293,200 287,220 274,230
+      C285,246 283,266 269,277
+      C255,288 237,285 226,275
+      C221,292 207,303 192,301
+      C177,299 165,288 162,272
+      C148,280 130,275 121,262
+      C112,249 116,231 127,222
+      C115,211 112,193 121,177
+      C130,161 148,155 165,162
+      C171,145 184,130 200,130Z
+    " fill="url(#shapeGrad2)" opacity="0.7"/>
+
+    <!-- Central circle -->
+    <circle cx="200" cy="213" r="36" fill="#E8856A" opacity="0.85"/>
+    <circle cx="200" cy="213" r="22" fill="#F5EDE0" opacity="0.55"/>
+    <circle cx="200" cy="213" r="10" fill="#C96B50" opacity="0.9"/>
+  </g>
+
+  <!-- === ORBITING ACCENT MARKS (like Claude's orbiting dots/dashes) === -->
+  <!-- These suggest intelligence, structure, thought -->
+  <g clip-path="url(#frameClip)" opacity="0.85">
+    <!-- Top arc -->
+    <path d="M170,80 Q200,68 230,80" fill="none" stroke="#C96B50" stroke-width="3.5" stroke-linecap="round"/>
+    <!-- Bottom arc -->
+    <path d="M172,346 Q200,358 228,346" fill="none" stroke="#C96B50" stroke-width="3.5" stroke-linecap="round"/>
+    <!-- Left arc -->
+    <path d="M80,170 Q68,200 80,230" fill="none" stroke="#C96B50" stroke-width="3.5" stroke-linecap="round"/>
+    <!-- Right arc -->
+    <path d="M320,172 Q332,200 320,228" fill="none" stroke="#C96B50" stroke-width="3.5" stroke-linecap="round"/>
+
+    <!-- Corner dots — elegant punctuation -->
+    <circle cx="130" cy="88" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="270" cy="88" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="88" cy="132" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="312" cy="132" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="88" cy="268" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="312" cy="268" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="130" cy="312" r="4.5" fill="#C96B50" opacity="0.7"/>
+    <circle cx="270" cy="312" r="4.5" fill="#C96B50" opacity="0.7"/>
+  </g>
+
+  <!-- Rounded square border - refined -->
+  <rect x="40" y="40" width="320" height="320" rx="72" ry="72"
+        fill="none" stroke="#C08060" stroke-width="1.5" opacity="0.35"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace the simple indigo checkmark favicon with a new warm coral/salmon organic logo design

## Test plan
- [x] Verify favicon.svg renders correctly in browser tab
- [x] SVG has square aspect ratio (400x400) suitable for favicons and touch icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)