### PR TITLE
fix(ui): route landing login to app

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -111,20 +111,18 @@
                         <a href="#landing-features" class="landing-nav__link"
                           >Features</a
                         >
-                        <button
-                          type="button"
+                        <a
+                          href="/auth?next=%2Fapp&tab=login"
                           class="landing-nav__link"
-                          data-onclick="showAuthPage('login')"
                         >
                           Log in
-                        </button>
-                        <button
-                          type="button"
+                        </a>
+                        <a
+                          href="/auth?next=%2Fapp&tab=register"
                           class="landing-nav__cta"
-                          data-onclick="showAuthPage('register')"
                         >
                           Start for free
-                        </button>
+                        </a>
                       </div>
                     </div>
                   </nav>
@@ -142,13 +140,12 @@
                         goals. A calm workspace, not another dashboard.
                       </p>
                       <div class="landing-hero__ctas">
-                        <button
-                          type="button"
+                        <a
+                          href="/auth?next=%2Fapp&tab=register"
                           class="landing-btn landing-btn--primary"
-                          data-onclick="showAuthPage('register')"
                         >
                           Start for free
-                        </button>
+                        </a>
                         <a
                           href="#landing-features"
                           class="landing-btn landing-btn--secondary"
@@ -482,13 +479,12 @@
                       <p class="landing-cta-section__sub">
                         No credit card required. Start planning in seconds.
                       </p>
-                      <button
-                        type="button"
+                      <a
+                        href="/auth?next=%2Fapp&tab=register"
                         class="landing-btn landing-btn--primary"
-                        data-onclick="showAuthPage('register')"
                       >
                         Create free account
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </div>

--- a/client/public/app-page.js
+++ b/client/public/app-page.js
@@ -23,6 +23,12 @@
     return;
   }
 
+  function buildAuthUrl() {
+    var next =
+      window.location.pathname + window.location.search + window.location.hash;
+    return "/auth?next=" + encodeURIComponent(next);
+  }
+
   // -------------------------------------------------------------------------
   // 1. Auth gate — redirect immediately if not authenticated.
   //    Token alone is sufficient: social OAuth callbacks only carry
@@ -31,7 +37,7 @@
   // -------------------------------------------------------------------------
   var session = AppState.loadStoredSession();
   if (!session.token) {
-    window.location.replace("/auth");
+    window.location.replace(buildAuthUrl());
     return; // stop all further execution
   }
 
@@ -154,7 +160,7 @@
           // showAuthView() may throw on missing DOM — that's fine, we redirect
         }
         AppState.clearSession();
-        window.location.replace("/auth");
+        window.location.replace(buildAuthUrl());
       }, dur);
     };
   }

--- a/client/public/auth-page.js
+++ b/client/public/auth-page.js
@@ -170,22 +170,52 @@
   }
 
   // ---------------------------------------------------------------------------
-  // Post-auth redirect — go to main app
+  // Post-auth redirect — default to the primary app, but preserve
+  // validated deep links to protected standalone pages.
   // ---------------------------------------------------------------------------
-  function redirectToApp() {
-    var ALLOWED_PREFIXES = ["/app", "/app-react"];
+  var ALLOWED_POST_AUTH_PREFIXES = [
+    "/app",
+    "/app-react",
+    "/app-classic",
+    "/feedback",
+  ];
+
+  function getValidatedPostAuthDestination() {
     var params = new URLSearchParams(window.location.search);
     var next = params.get("next");
-    if (
-      next &&
-      ALLOWED_PREFIXES.some(function (p) {
-        return next === p || next.startsWith(p + "/");
-      })
-    ) {
-      window.location.href = next;
-      return;
+    if (!next) return null;
+
+    try {
+      var url = new URL(next, window.location.origin);
+      if (url.origin !== window.location.origin) {
+        return null;
+      }
+
+      var pathname = url.pathname;
+      var isAllowed = ALLOWED_POST_AUTH_PREFIXES.some(function (prefix) {
+        return pathname === prefix || pathname.startsWith(prefix + "/");
+      });
+      if (!isAllowed) {
+        return null;
+      }
+
+      return pathname + url.search + url.hash;
+    } catch (_) {
+      return null;
     }
-    window.location.href = "/app";
+  }
+
+  function redirectToApp() {
+    window.location.href = getValidatedPostAuthDestination() || "/app";
+  }
+
+  function buildSocialAuthStartUrl(providerPath) {
+    var next = getValidatedPostAuthDestination();
+    if (!next) return providerPath;
+
+    var params = new URLSearchParams();
+    params.set("next", next);
+    return providerPath + "?" + params.toString();
   }
 
   // ---------------------------------------------------------------------------
@@ -418,11 +448,11 @@
   // Social login
   // ---------------------------------------------------------------------------
   function handleGoogleLogin() {
-    window.location.href = "/auth/google/start";
+    window.location.href = buildSocialAuthStartUrl("/auth/google/start");
   }
 
   function handleAppleLogin() {
-    window.location.href = "/auth/apple/start";
+    window.location.href = buildSocialAuthStartUrl("/auth/apple/start");
   }
 
   function initSocialLogin() {

--- a/client/public/feedback-list-page.js
+++ b/client/public/feedback-list-page.js
@@ -14,10 +14,16 @@
     return;
   }
 
+  function buildAuthUrl() {
+    var next =
+      window.location.pathname + window.location.search + window.location.hash;
+    return "/auth?next=" + encodeURIComponent(next);
+  }
+
   // Auth gate — read token directly to avoid loadStoredSession user-object coupling
   var token = localStorage.getItem("authToken");
   if (!token) {
-    window.location.replace("/auth");
+    window.location.replace(buildAuthUrl());
     return;
   }
 
@@ -38,7 +44,7 @@
     setAuthState: function () {},
     onAuthFailure: function () {
       AppState.clearSession();
-      window.location.replace("/auth");
+      window.location.replace(buildAuthUrl());
     },
     onAuthTokens: function (nextToken, nextRefreshToken) {
       localStorage.setItem("authToken", nextToken);

--- a/client/public/feedback-new-page.js
+++ b/client/public/feedback-new-page.js
@@ -14,10 +14,16 @@
     return;
   }
 
+  function buildAuthUrl() {
+    var next =
+      window.location.pathname + window.location.search + window.location.hash;
+    return "/auth?next=" + encodeURIComponent(next);
+  }
+
   // Auth gate — read token directly to avoid loadStoredSession user-object coupling
   var token = localStorage.getItem("authToken");
   if (!token) {
-    window.location.replace("/auth");
+    window.location.replace(buildAuthUrl());
     return;
   }
 
@@ -38,7 +44,7 @@
     setAuthState: function () {},
     onAuthFailure: function () {
       AppState.clearSession();
-      window.location.replace("/auth");
+      window.location.replace(buildAuthUrl());
     },
     onAuthTokens: function (nextToken, nextRefreshToken) {
       localStorage.setItem("authToken", nextToken);

--- a/client/shell/app-shell.fragment
+++ b/client/shell/app-shell.fragment
@@ -113,20 +113,18 @@
                         <a href="#landing-features" class="landing-nav__link"
                           >Features</a
                         >
-                        <button
-                          type="button"
+                        <a
+                          href="/auth?next=%2Fapp&tab=login"
                           class="landing-nav__link"
-                          data-onclick="showAuthPage('login')"
                         >
                           Log in
-                        </button>
-                        <button
-                          type="button"
+                        </a>
+                        <a
+                          href="/auth?next=%2Fapp&tab=register"
                           class="landing-nav__cta"
-                          data-onclick="showAuthPage('register')"
                         >
                           Start for free
-                        </button>
+                        </a>
                       </div>
                     </div>
                   </nav>
@@ -144,13 +142,12 @@
                         goals. A calm workspace, not another dashboard.
                       </p>
                       <div class="landing-hero__ctas">
-                        <button
-                          type="button"
+                        <a
+                          href="/auth?next=%2Fapp&tab=register"
                           class="landing-btn landing-btn--primary"
-                          data-onclick="showAuthPage('register')"
                         >
                           Start for free
-                        </button>
+                        </a>
                         <a
                           href="#landing-features"
                           class="landing-btn landing-btn--secondary"
@@ -484,13 +481,12 @@
                       <p class="landing-cta-section__sub">
                         No credit card required. Start planning in seconds.
                       </p>
-                      <button
-                        type="button"
+                      <a
+                        href="/auth?next=%2Fapp&tab=register"
                         class="landing-btn landing-btn--primary"
-                        data-onclick="showAuthPage('register')"
                       >
                         Create free account
-                      </button>
+                      </a>
                     </div>
                   </section>
                 </div>

--- a/src/routes/authRouter.ts
+++ b/src/routes/authRouter.ts
@@ -40,6 +40,67 @@ interface AuthRouterDeps {
   requireAuthIfConfigured: RequestHandler;
 }
 
+const POST_AUTH_REDIRECT_COOKIE = "post_auth_redirect";
+const POST_AUTH_REDIRECT_COOKIE_MAX_AGE_MS = 10 * 60 * 1000;
+const ALLOWED_POST_AUTH_PREFIXES = [
+  "/app",
+  "/app-react",
+  "/app-classic",
+  "/feedback",
+];
+
+function normalizePostAuthRedirect(input: unknown): string | null {
+  if (typeof input !== "string") {
+    return null;
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed, config.baseUrl);
+    if (url.origin !== config.baseUrl) {
+      return null;
+    }
+
+    const pathname = url.pathname;
+    const isAllowed = ALLOWED_POST_AUTH_PREFIXES.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    );
+    if (!isAllowed) {
+      return null;
+    }
+
+    return `${pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+function getPostAuthRedirectCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: config.nodeEnv === "production",
+    sameSite: "lax" as const,
+    path: "/auth",
+  };
+}
+
+function setPostAuthRedirect(res: Response, next: string | null) {
+  const cookieOptions = getPostAuthRedirectCookieOptions();
+  if (next) {
+    res.cookie(POST_AUTH_REDIRECT_COOKIE, next, {
+      ...cookieOptions,
+      maxAge: POST_AUTH_REDIRECT_COOKIE_MAX_AGE_MS,
+    });
+    return;
+  }
+
+  res.clearCookie(POST_AUTH_REDIRECT_COOKIE, cookieOptions);
+}
+
 function buildLinkRequestId(req: Request): string {
   const headerId =
     req.header("x-mcp-request-id") || req.header("x-agent-request-id");
@@ -1024,6 +1085,7 @@ export function createAuthRouter({
     }
 
     const { url, state } = googleAuthService.generateAuthUrl();
+    const next = normalizePostAuthRedirect(req.query.next);
 
     // Store state in httpOnly cookie for CSRF validation
     res.cookie("oauth_state", state, {
@@ -1033,6 +1095,7 @@ export function createAuthRouter({
       maxAge: 10 * 60 * 1000, // 10 minutes
       path: "/auth/google",
     });
+    setPostAuthRedirect(res, next);
 
     // If user is authenticated, store userId for linking
     const authHeader = req.header("authorization");
@@ -1075,9 +1138,18 @@ export function createAuthRouter({
             hasStoredState: !!storedState,
             cookieKeys: Object.keys(req.cookies || {}),
           });
-          return res.redirect(
-            `/auth?auth=error&message=${encodeURIComponent("Invalid OAuth state — please try again")}`,
+          const next = normalizePostAuthRedirect(
+            req.cookies?.[POST_AUTH_REDIRECT_COOKIE],
           );
+          setPostAuthRedirect(res, null);
+          const params = new URLSearchParams({
+            auth: "error",
+            message: "Invalid OAuth state — please try again",
+          });
+          if (next) {
+            params.set("next", next);
+          }
+          return res.redirect(`/auth?${params.toString()}`);
         }
 
         // Clear state cookie (include all original options so the browser matches it)
@@ -1087,12 +1159,21 @@ export function createAuthRouter({
           secure: config.nodeEnv === "production",
           sameSite: "lax",
         });
+        const next = normalizePostAuthRedirect(
+          req.cookies?.[POST_AUTH_REDIRECT_COOKIE],
+        );
+        setPostAuthRedirect(res, null);
 
         const code = req.query.code as string;
         if (!code) {
-          return res.redirect(
-            `/auth?auth=error&message=${encodeURIComponent("Missing authorization code")}`,
-          );
+          const params = new URLSearchParams({
+            auth: "error",
+            message: "Missing authorization code",
+          });
+          if (next) {
+            params.set("next", next);
+          }
+          return res.redirect(`/auth?${params.toString()}`);
         }
 
         const profile = await googleAuthService.handleCallback(code);
@@ -1138,9 +1219,16 @@ export function createAuthRouter({
           token: result.token,
           refreshToken: result.refreshToken,
         });
+        if (next) {
+          params.set("next", next);
+        }
         res.redirect(`/auth?${params.toString()}`);
       } catch (error) {
         console.error("Google OAuth callback error:", error);
+        const next = normalizePostAuthRedirect(
+          req.cookies?.[POST_AUTH_REDIRECT_COOKIE],
+        );
+        setPostAuthRedirect(res, null);
 
         // Check for CLI flow on error too
         const cliPort = req.cookies?.cli_port;
@@ -1159,9 +1247,14 @@ export function createAuthRouter({
           }
         }
 
-        res.redirect(
-          `/auth?auth=error&message=${encodeURIComponent("Google login failed")}`,
-        );
+        const params = new URLSearchParams({
+          auth: "error",
+          message: "Google login failed",
+        });
+        if (next) {
+          params.set("next", next);
+        }
+        res.redirect(`/auth?${params.toString()}`);
       }
     },
   );
@@ -1174,6 +1267,7 @@ export function createAuthRouter({
     }
 
     const { url, state, nonce } = appleAuthService.generateAuthUrl();
+    const next = normalizePostAuthRedirect(req.query.next);
 
     // Store state + nonce in httpOnly cookie
     res.cookie("apple_oauth", JSON.stringify({ state, nonce }), {
@@ -1183,6 +1277,7 @@ export function createAuthRouter({
       maxAge: 10 * 60 * 1000,
       path: "/auth/apple",
     });
+    setPostAuthRedirect(res, next);
 
     res.redirect(url);
   });
@@ -1211,18 +1306,36 @@ export function createAuthRouter({
         }
 
         if (!state || !storedState || state !== storedState) {
-          return res.redirect(
-            `/auth?auth=error&message=${encodeURIComponent("Invalid OAuth state")}`,
+          const next = normalizePostAuthRedirect(
+            req.cookies?.[POST_AUTH_REDIRECT_COOKIE],
           );
+          setPostAuthRedirect(res, null);
+          const params = new URLSearchParams({
+            auth: "error",
+            message: "Invalid OAuth state",
+          });
+          if (next) {
+            params.set("next", next);
+          }
+          return res.redirect(`/auth?${params.toString()}`);
         }
 
         res.clearCookie("apple_oauth", { path: "/auth/apple" });
+        const next = normalizePostAuthRedirect(
+          req.cookies?.[POST_AUTH_REDIRECT_COOKIE],
+        );
+        setPostAuthRedirect(res, null);
 
         const idToken = req.body.id_token as string;
         if (!idToken) {
-          return res.redirect(
-            `/auth?auth=error&message=${encodeURIComponent("Missing ID token")}`,
-          );
+          const params = new URLSearchParams({
+            auth: "error",
+            message: "Missing ID token",
+          });
+          if (next) {
+            params.set("next", next);
+          }
+          return res.redirect(`/auth?${params.toString()}`);
         }
 
         // Apple sends user info only on first auth
@@ -1265,12 +1378,24 @@ export function createAuthRouter({
           token: result.token,
           refreshToken: result.refreshToken,
         });
+        if (next) {
+          params.set("next", next);
+        }
         res.redirect(`/auth?${params.toString()}`);
       } catch (error) {
         console.error("Apple Sign-In callback error:", error);
-        res.redirect(
-          `/auth?auth=error&message=${encodeURIComponent("Apple login failed")}`,
+        const next = normalizePostAuthRedirect(
+          req.cookies?.[POST_AUTH_REDIRECT_COOKIE],
         );
+        setPostAuthRedirect(res, null);
+        const params = new URLSearchParams({
+          auth: "error",
+          message: "Apple login failed",
+        });
+        if (next) {
+          params.set("next", next);
+        }
+        res.redirect(`/auth?${params.toString()}`);
       }
     },
   );

--- a/tests/ui-react/react-smoke.spec.ts
+++ b/tests/ui-react/react-smoke.spec.ts
@@ -51,7 +51,7 @@ test.describe("React preview – smoke", () => {
 
     await page.goto("/");
 
-    // The React app should redirect to /auth?next=/app-react
-    await page.waitForURL(/\/auth\?next=\/app-react/);
+    // The React app should redirect to /auth?next=/app
+    await page.waitForURL(/\/auth\?next=\/app/);
   });
 });

--- a/tests/ui/auth-routing.spec.ts
+++ b/tests/ui/auth-routing.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+async function clickLogout(page: Page) {
+  const profileBtn = page.locator("#dockProfileBtn");
+  if (await profileBtn.isVisible({ timeout: 500 }).catch(() => false)) {
+    await profileBtn.scrollIntoViewIfNeeded();
+    await profileBtn.click();
+    await page.getByRole("menuitem", { name: "Logout" }).click();
+  } else {
+    await page.getByRole("button", { name: "Logout" }).click();
+  }
+}
+
+type UserRecord = {
+  id: string;
+  email: string;
+  password: string;
+  name: string | null;
+  isVerified: boolean;
+  role: "user" | "admin";
+  createdAt: string;
+  updatedAt: string;
+};
+
+async function installMockApi(page: Page) {
+  const users = new Map<string, UserRecord>();
+  const accessTokens = new Map<string, string>();
+  const refreshTokens = new Map<string, string>();
+
+  let userSeq = 1;
+  let tokenSeq = 1;
+
+  const now = () => new Date().toISOString();
+  const mkUserId = () => `user-${userSeq++}`;
+  const mkToken = (prefix: string) => `${prefix}-${tokenSeq++}`;
+
+  const parseBody = async (route: Route) => {
+    const raw = route.request().postData();
+    if (!raw) return {};
+    return JSON.parse(raw);
+  };
+
+  const seedUser = (overrides: Partial<UserRecord> = {}) => {
+    const email = overrides.email || "returning@example.com";
+    const user: UserRecord = {
+      id: overrides.id || mkUserId(),
+      email,
+      password: overrides.password || "Password123!",
+      name: overrides.name ?? "Returning User",
+      isVerified: overrides.isVerified ?? true,
+      role: overrides.role || "user",
+      createdAt: overrides.createdAt || now(),
+      updatedAt: overrides.updatedAt || now(),
+    };
+    users.set(email, user);
+    return user;
+  };
+
+  const bearerUserId = (route: Route) => {
+    const auth = route.request().headers()["authorization"] || "";
+    const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+    return accessTokens.get(token) || null;
+  };
+
+  const userDto = (user: UserRecord) => ({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+  });
+
+  const profileDto = (user: UserRecord) => ({
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    isVerified: user.isVerified,
+    role: user.role,
+    createdAt: user.createdAt,
+    updatedAt: user.updatedAt,
+    onboardingCompletedAt: user.createdAt,
+  });
+
+  seedUser();
+
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+
+    const json = (status: number, body: unknown) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+
+    if (pathname === "/auth/providers" && method === "GET") {
+      return json(200, { google: false, apple: false, phone: false });
+    }
+
+    if (pathname === "/auth/bootstrap-admin/status" && method === "GET") {
+      return json(200, { enabled: false, reason: "already_provisioned" });
+    }
+
+    if (pathname === "/auth/login" && method === "POST") {
+      const body = await parseBody(route);
+      const email = String(body.email || "")
+        .trim()
+        .toLowerCase();
+      const password = String(body.password || "");
+      const user = users.get(email);
+      if (!user || user.password !== password) {
+        return json(401, { error: "Invalid credentials" });
+      }
+
+      const token = mkToken("access");
+      const refreshToken = mkToken("refresh");
+      accessTokens.set(token, user.id);
+      refreshTokens.set(refreshToken, user.id);
+      return json(200, { user: userDto(user), token, refreshToken });
+    }
+
+    if (pathname === "/auth/logout" && method === "POST") {
+      const body = await parseBody(route);
+      refreshTokens.delete(String(body.refreshToken || ""));
+      return json(200, { message: "Logged out successfully" });
+    }
+
+    if (pathname === "/auth/refresh" && method === "POST") {
+      const body = await parseBody(route);
+      const userId = refreshTokens.get(String(body.refreshToken || ""));
+      if (!userId) {
+        return json(401, { error: "Invalid refresh token" });
+      }
+
+      const token = mkToken("access");
+      const refreshToken = mkToken("refresh");
+      accessTokens.set(token, userId);
+      refreshTokens.set(refreshToken, userId);
+      return json(200, { token, refreshToken });
+    }
+
+    if (pathname === "/users/me" && method === "GET") {
+      const userId = bearerUserId(route);
+      if (!userId) {
+        return json(401, { error: "Unauthorized" });
+      }
+
+      const user = Array.from(users.values()).find(
+        (candidate) => candidate.id === userId,
+      );
+      if (!user) {
+        return json(404, { error: "User not found" });
+      }
+
+      return json(200, profileDto(user));
+    }
+
+    if (pathname === "/todos" && method === "GET") {
+      const userId = bearerUserId(route);
+      if (!userId) {
+        return json(401, { error: "Unauthorized" });
+      }
+
+      return json(200, []);
+    }
+
+    return route.continue();
+  });
+}
+
+async function login(page: Page) {
+  await page.locator("#loginEmail").fill("returning@example.com");
+  await page.locator("#loginPassword").fill("Password123!");
+  await page.getByRole("button", { name: "Login" }).click();
+}
+
+test.describe("Auth routing", () => {
+  test("login from landing page redirects to /app", async ({ page }) => {
+    await installMockApi(page);
+
+    await page.goto("/");
+    await page.getByRole("link", { name: "Log in" }).click();
+    await page.waitForURL(
+      /\/auth\?next=%2Fapp&tab=login|\/auth\?next=\/app&tab=login/,
+    );
+
+    await login(page);
+
+    await page.waitForURL(/\/app\/?$/);
+  });
+
+  test("direct access to a protected route returns there after login", async ({
+    page,
+  }) => {
+    await installMockApi(page);
+
+    await page.goto("/app-classic");
+    await page.waitForURL(
+      /\/auth\?next=%2Fapp-classic|\/auth\?next=\/app-classic/,
+    );
+
+    await login(page);
+
+    await page.waitForURL(/\/app-classic\/?$/);
+  });
+
+  test("logout/login flow preserves the protected route", async ({ page }) => {
+    await installMockApi(page);
+
+    await page.goto("/app-classic");
+    await page.waitForURL(
+      /\/auth\?next=%2Fapp-classic|\/auth\?next=\/app-classic/,
+    );
+
+    await login(page);
+    await page.waitForURL(/\/app-classic\/?$/);
+    await expect(page.locator("#todosView")).toHaveClass(/active/);
+
+    await clickLogout(page);
+    await page.waitForURL(
+      /\/auth\?next=%2Fapp-classic|\/auth\?next=\/app-classic/,
+    );
+
+    await login(page);
+    await page.waitForURL(/\/app-classic\/?$/);
+  });
+});


### PR DESCRIPTION
## Summary
- route landing-page login and signup CTAs through `/auth?next=/app` so the default authenticated destination is the primary app instead of `/`
- preserve intentional deep-link behavior by carrying validated `next` destinations through standalone auth and Google/Apple OAuth callbacks
- update standalone protected-page guards and add auth-routing coverage for landing login, protected-route return, and logout/login round-trips

## Root Cause
The landing page was still opening the legacy inline auth flow on `/`, so a successful login stayed on the root shell instead of moving to the primary authenticated app. The OAuth start/callback flow also did not round-trip the post-auth destination, which risked dropping valid deep links.

## Verification
- `npx tsc --noEmit`
- `npm run check:architecture`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `npm run test:coverage:check`