### PR TITLE
[codex] Redirect authenticated root to /app

### DIFF
--- a/client/bootstrap/initApp.js
+++ b/client/bootstrap/initApp.js
@@ -81,6 +81,11 @@ function init(d) {
   const urlParams = new URLSearchParams(window.location.search);
   const isSocialCallback = urlParams.has("auth");
   const resetToken = !isSocialCallback ? urlParams.get("token") : null;
+  const shouldStayOnRootAuthShell =
+    isSocialCallback ||
+    !!resetToken ||
+    urlParams.has("tab") ||
+    urlParams.has("verified");
 
   if (resetToken) {
     d.showResetPassword(resetToken);
@@ -108,6 +113,13 @@ function init(d) {
       refreshToken: null,
       currentUser: null,
     });
+  }
+
+  if (window.location.pathname === "/" && !shouldStayOnRootAuthShell && token) {
+    window.location.replace(
+      `/app${window.location.search}${window.location.hash}`,
+    );
+    return;
   }
 
   // Listen for offline sync completion from service worker

--- a/tests/ui/auth-ui.spec.ts
+++ b/tests/ui/auth-ui.spec.ts
@@ -64,6 +64,7 @@ test.describe("Auth UI", () => {
   test("resend verification click shows response message", async ({ page }) => {
     await page.addInitScript(() => {
       window.localStorage.setItem("authToken", "test-token");
+      window.localStorage.setItem("refreshToken", "test-refresh");
       window.localStorage.setItem(
         "user",
         JSON.stringify({
@@ -77,23 +78,32 @@ test.describe("Auth UI", () => {
       );
     });
 
-    await page.goto("/");
-    // The Settings rail button is visible on desktop; on mobile the sheet is
-    // closed so no Settings button is reachable via role. Use evaluate fallback.
-    const settingsButton = page.getByRole("button", { name: "Settings" });
-    if (await settingsButton.first().isVisible()) {
-      await settingsButton.first().click();
-    } else {
-      await page.evaluate(() =>
-        (window as Window & { switchView: (v: string) => void }).switchView(
-          "settings",
-        ),
-      );
-    }
+    await page.goto("/app");
     await expect(page.locator("#verificationBanner")).toBeVisible();
 
-    await page.getByRole("button", { name: "Resend Email" }).click();
-    await expect(page.locator("#profileMessage")).toHaveClass(/show/);
+    await page.getByRole("button", { name: "Resend" }).click();
+    await expect(page.getByText("Sent!")).toBeVisible();
+  });
+
+  test("authenticated root redirects to /app", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("authToken", "test-token");
+      window.localStorage.setItem("refreshToken", "test-refresh");
+      window.localStorage.setItem(
+        "user",
+        JSON.stringify({
+          id: "user-1",
+          email: "user@example.com",
+          name: "Test User",
+          role: "user",
+          isVerified: true,
+          createdAt: "2026-02-09T00:00:00.000Z",
+        }),
+      );
+    });
+
+    await page.goto("/");
+    await page.waitForURL(/\/app\/?$/);
   });
 
   test("forgot password still works with corrupted stored user state", async ({


### PR DESCRIPTION
## Summary
This follow-up fixes the authenticated root fallback so users who manually return to `/` after logging in are sent to `/app` instead of being dropped back into the classic shell.

## Root cause
The classic bootstrap logic in `client/bootstrap/initApp.js` still treated any authenticated visit to `/` as a signal to render the legacy app shell. That meant the earlier post-login fix correctly sent users to `/app`, but a later manual visit to `/` could still re-enter the old flow.

## What changed
- redirect authenticated visits to plain `/` over to `/app`
- preserve intentional root-only auth flows on `/`, including social auth callbacks, password reset tokens, verification banners, and tab-driven auth states
- update UI coverage so the verification banner assertion runs in the current `/app` experience
- add a regression test proving authenticated root visits redirect to `/app`

## Validation
- `npx tsc --noEmit`
- `npm run check:architecture`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `npm run test:coverage:check`
- `CI=1 npm run test:ui:fast` could not complete in this sandbox because Playwright's web server failed to bind `127.0.0.1:4173` with `listen EPERM: operation not permitted`