### PR TITLE
fix(ui): smooth auth route transitions

### DIFF
--- a/client-react/src/App.tsx
+++ b/client-react/src/App.tsx
@@ -1,9 +1,19 @@
+import { useEffect } from "react";
 import { AuthProvider, useAuth } from "./auth/AuthProvider";
 import { AppShell } from "./components/layout/AppShell";
 import "./styles/app.css";
+import { navigateWithFade } from "./utils/pageTransitions";
 
 function AuthGate() {
   const { user, loading } = useAuth();
+  const hasToken =
+    typeof window !== "undefined" && !!localStorage.getItem("authToken");
+
+  useEffect(() => {
+    if (!loading && !user && !hasToken) {
+      navigateWithFade("/auth?next=/app", { replace: true });
+    }
+  }, [hasToken, loading, user]);
 
   if (loading) {
     return (
@@ -15,13 +25,8 @@ function AuthGate() {
     );
   }
 
-  if (!user) {
-    // Check if we have a token but user fetch is still pending
-    const token = localStorage.getItem("authToken");
-    if (!token) {
-      window.location.href = "/auth?next=/app";
-      return null;
-    }
+  if (!user && !hasToken) {
+    return null;
   }
 
   return (

--- a/client-react/src/api/client.ts
+++ b/client-react/src/api/client.ts
@@ -1,3 +1,5 @@
+import { navigateWithFade } from "../utils/pageTransitions";
+
 const API_URL = window.location.origin;
 
 let refreshInFlight: Promise<boolean> | null = null;
@@ -76,7 +78,7 @@ export async function apiCall(
       }
       return fetch(`${API_URL}${path}`, { ...options, headers });
     }
-    window.location.href = "/auth?next=/app";
+    navigateWithFade("/auth?next=/app", { replace: true });
   }
 
   return res;

--- a/client-react/src/auth/AuthProvider.tsx
+++ b/client-react/src/auth/AuthProvider.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { User } from "../types";
 import { apiCall } from "../api/client";
+import { navigateWithFade } from "../utils/pageTransitions";
 
 interface AuthContextValue {
   user: User | null;
@@ -58,7 +59,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem("authToken");
     localStorage.removeItem("refreshToken");
     localStorage.removeItem("user");
-    window.location.href = "/auth?next=/app";
+    navigateWithFade("/", { replace: true });
   }, []);
 
   return (

--- a/client-react/src/main.tsx
+++ b/client-react/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { fadeInOnLoad } from "./utils/pageTransitions";
+
+fadeInOnLoad();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -41,6 +41,20 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+.view-transition-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  opacity: 0;
+  pointer-events: none;
+  z-index: 9999;
+  transition: opacity var(--dur-view) var(--ease-out);
+}
+
+.view-transition-overlay.active {
+  opacity: 1;
+}
+
 ::selection {
   background: color-mix(in oklab, var(--accent) 25%, transparent);
   color: var(--text-strong);
@@ -8309,7 +8323,6 @@ body {
   white-space: nowrap;
   border-width: 0;
 }
-
 /* === ViewRouter === */
 .view-router__slot {
   display: flex;
@@ -8318,5 +8331,3 @@ body {
   min-height: 0;
   overflow: hidden;
 }
-
-

--- a/client-react/src/styles/tokens.css
+++ b/client-react/src/styles/tokens.css
@@ -99,6 +99,7 @@
   --dur-fast: 120ms;
   --dur-base: 180ms;
   --dur-slow: 280ms;
+  --dur-view: var(--dur-slow);
 }
 
 /* --- Dark mode (warmer, more vibrant) --- */

--- a/client-react/src/utils/pageTransitions.ts
+++ b/client-react/src/utils/pageTransitions.ts
@@ -1,0 +1,100 @@
+const TRANSITION_KEY = "todos:cross-page-transition";
+const TRANSITION_TTL_MS = 4000;
+const DEFAULT_DURATION_MS = 280;
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function getDurationMs(): number {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--dur-view")
+    .trim();
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DURATION_MS;
+}
+
+function getOrCreateOverlay(): HTMLDivElement {
+  let overlay = document.querySelector<HTMLDivElement>(".view-transition-overlay");
+  if (!overlay) {
+    overlay = document.createElement("div");
+    overlay.className = "view-transition-overlay";
+    document.body.appendChild(overlay);
+  }
+  return overlay;
+}
+
+function writePendingTransition(href: string) {
+  try {
+    window.sessionStorage.setItem(
+      TRANSITION_KEY,
+      JSON.stringify({
+        href,
+        at: Date.now(),
+      }),
+    );
+  } catch {}
+}
+
+function consumePendingTransition(): boolean {
+  try {
+    const raw = window.sessionStorage.getItem(TRANSITION_KEY);
+    if (!raw) return false;
+
+    window.sessionStorage.removeItem(TRANSITION_KEY);
+    const parsed = JSON.parse(raw) as { at?: number } | null;
+    if (!parsed || typeof parsed.at !== "number") {
+      return false;
+    }
+
+    return Date.now() - parsed.at <= TRANSITION_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+function performNavigation(href: string, replace?: boolean) {
+  if (replace) {
+    window.location.replace(href);
+    return;
+  }
+
+  window.location.href = href;
+}
+
+export function navigateWithFade(
+  href: string,
+  options: { replace?: boolean } = {},
+) {
+  if (prefersReducedMotion()) {
+    performNavigation(href, options.replace);
+    return;
+  }
+
+  writePendingTransition(href);
+  const overlay = getOrCreateOverlay();
+  overlay.offsetHeight;
+  overlay.classList.add("active");
+
+  window.setTimeout(() => {
+    performNavigation(href, options.replace);
+  }, getDurationMs());
+}
+
+export function fadeInOnLoad() {
+  if (prefersReducedMotion()) return;
+  if (!consumePendingTransition()) return;
+
+  const overlay = getOrCreateOverlay();
+  overlay.classList.add("active");
+
+  requestAnimationFrame(() => {
+    overlay.classList.remove("active");
+
+    window.setTimeout(() => {
+      if (overlay.parentNode && !overlay.classList.contains("active")) {
+        overlay.parentNode.removeChild(overlay);
+      }
+    }, getDurationMs() + 50);
+  });
+}

--- a/client/bootstrap/initApp.js
+++ b/client/bootstrap/initApp.js
@@ -16,6 +16,10 @@ export function initApp(d) {
   // Initialize theme immediately
   d.initTheme();
 
+  if (window.StandaloneTransitions) {
+    window.StandaloneTransitions.fadeInOnLoad();
+  }
+
   // Initialize UI mode from localStorage (canonical key: todos:ui-mode)
   try {
     let mode = localStorage.getItem("todos:ui-mode");

--- a/client/index.html
+++ b/client/index.html
@@ -3649,6 +3649,7 @@
     <script src="/utils/theme.js" defer></script>
     <script src="/utils/aiSuggestionUtils.js" defer></script>
     <script src="/utils/domSelectors.js" defer></script>
+    <script src="/utils/standaloneTransitions.js" defer></script>
     <script type="module" src="/app.js"></script>
 
     <!-- BEGIN:app-overlays -->

--- a/client/public/app-page.js
+++ b/client/public/app-page.js
@@ -160,7 +160,16 @@
           // showAuthView() may throw on missing DOM — that's fine, we redirect
         }
         AppState.clearSession();
-        window.location.replace(buildAuthUrl());
+        try {
+          window.sessionStorage.setItem(
+            "todos:cross-page-transition",
+            JSON.stringify({
+              href: "/",
+              at: Date.now(),
+            }),
+          );
+        } catch (_) {}
+        window.location.replace("/");
       }, dur);
     };
   }

--- a/client/public/auth-page.js
+++ b/client/public/auth-page.js
@@ -13,6 +13,7 @@
 
   var AppState = window.AppState;
   var ApiClient = window.ApiClient;
+  var StandaloneTransitions = window.StandaloneTransitions;
   var Utils = window.Utils;
 
   // -- dependency guard -----------------------------------------------------
@@ -206,7 +207,12 @@
   }
 
   function redirectToApp() {
-    window.location.href = getValidatedPostAuthDestination() || "/app";
+    var destination = getValidatedPostAuthDestination() || "/app";
+    if (StandaloneTransitions) {
+      StandaloneTransitions.navigateWithFade(destination);
+      return;
+    }
+    window.location.href = destination;
   }
 
   function buildSocialAuthStartUrl(providerPath) {
@@ -796,6 +802,11 @@
   // ---------------------------------------------------------------------------
   function boot() {
     initTheme();
+
+    if (StandaloneTransitions) {
+      StandaloneTransitions.fadeInOnLoad();
+      StandaloneTransitions.bindNavigateLinks();
+    }
 
     // If already authenticated, redirect to app
     var session = AppState.loadStoredSession();

--- a/client/public/auth.html
+++ b/client/public/auth.html
@@ -10,7 +10,9 @@
   <body>
     <div class="auth-standalone">
       <div class="auth-standalone__header">
-        <a href="/" class="auth-standalone__back">&larr; Home</a>
+        <a href="/" data-navigate="/" class="auth-standalone__back"
+          >&larr; Home</a
+        >
         <span class="auth-standalone__logo">Todos</span>
       </div>
 
@@ -386,6 +388,7 @@
     <script src="/utils/authSession.js"></script>
     <script src="/utils/apiClient.js"></script>
     <script src="/utils/utils.js"></script>
+    <script src="/utils/standaloneTransitions.js"></script>
     <!-- Standalone auth controller -->
     <script src="/public/auth-page.js"></script>
   </body>

--- a/client/utils/standaloneTransitions.js
+++ b/client/utils/standaloneTransitions.js
@@ -7,6 +7,9 @@
 (function (globalScope) {
   "use strict";
 
+  var TRANSITION_KEY = "todos:cross-page-transition";
+  var TRANSITION_TTL_MS = 4000;
+
   function prefersReducedMotion() {
     return globalScope.matchMedia("(prefers-reduced-motion: reduce)").matches;
   }
@@ -32,23 +35,61 @@
     return overlay;
   }
 
+  function writePendingTransition(href) {
+    try {
+      globalScope.sessionStorage.setItem(
+        TRANSITION_KEY,
+        JSON.stringify({
+          href: href,
+          at: Date.now(),
+        }),
+      );
+    } catch (_) {}
+  }
+
+  function consumePendingTransition() {
+    try {
+      var raw = globalScope.sessionStorage.getItem(TRANSITION_KEY);
+      if (!raw) return false;
+
+      globalScope.sessionStorage.removeItem(TRANSITION_KEY);
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed.at !== "number") {
+        return false;
+      }
+
+      return Date.now() - parsed.at <= TRANSITION_TTL_MS;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function performNavigation(href, options) {
+    if (options && options.replace) {
+      globalScope.location.replace(href);
+      return;
+    }
+    globalScope.location.href = href;
+  }
+
   /**
    * Fade overlay in, then navigate to href.
    * Under reduced motion, navigates immediately.
    */
-  function navigateWithFade(href) {
+  function navigateWithFade(href, options) {
     if (prefersReducedMotion()) {
-      globalScope.location.href = href;
+      performNavigation(href, options);
       return;
     }
 
+    writePendingTransition(href);
     var overlay = getOrCreateOverlay();
     // Force reflow so the browser registers opacity:0 before transition
     overlay.offsetHeight; // eslint-disable-line no-unused-expressions
     overlay.classList.add("active");
 
     setTimeout(function () {
-      globalScope.location.href = href;
+      performNavigation(href, options);
     }, getDurationMs());
   }
 
@@ -58,6 +99,7 @@
    */
   function fadeInOnLoad() {
     if (prefersReducedMotion()) return;
+    if (!consumePendingTransition()) return;
 
     var overlay = getOrCreateOverlay();
     overlay.classList.add("active");
@@ -99,5 +141,6 @@
     navigateWithFade: navigateWithFade,
     fadeInOnLoad: fadeInOnLoad,
     bindNavigateLinks: bindNavigateLinks,
+    consumePendingTransition: consumePendingTransition,
   };
 })(window);


### PR DESCRIPTION
## Summary
- smooth the landing -> auth -> app handoff with a shared cross-page fade transition
- route explicit logout from the app back to the landing page instead of the auth page
- reuse the same transition overlay behavior across the standalone auth page, landing shell, and React app

## Root Cause
- route changes between `/`, `/auth`, and `/app` were using direct document navigations with no shared transition state, so the UI snapped between pages
- logout in the React app hard-coded `/auth?next=/app`, which bypassed the landing page entirely

## Validation
- `npx tsc --noEmit`
- `npm run check:architecture`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `npm run test:coverage:check`
- `CI=1 npm run test:ui:fast`