### PR TITLE
[codex] fix quick entry capture prop wiring

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -1013,7 +1013,9 @@ export function AppShell() {
                     onBulkDelete={handleBulkDelete}
                     onCancelBulk={handleCancelBulk}
                     uiMode={uiMode}
+                    workspaceView={activeView}
                     onAddTodo={addTodo}
+                    onCaptureToDesk={handleCaptureToDesk}
                     quickEntryPlaceholder={quickEntryPlaceholder}
                     activeHeadingId={null}
                     onSelectHeading={() => {}}
@@ -1106,7 +1108,9 @@ export function AppShell() {
                     onBulkDelete={handleBulkDelete}
                     onCancelBulk={handleCancelBulk}
                     uiMode={uiMode}
+                    workspaceView={activeView}
                     onAddTodo={addTodo}
+                    onCaptureToDesk={handleCaptureToDesk}
                     quickEntryPlaceholder={quickEntryPlaceholder}
                     activeHeadingId={activeHeadingId}
                     onSelectHeading={setActiveHeadingId}

--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -75,7 +75,9 @@ export interface ListViewHeaderProps {
 
   // Quick entry
   uiMode: UiMode;
+  workspaceView?: string;
   onAddTodo: (dto: CreateTodoDto) => Promise<unknown>;
+  onCaptureToDesk: (text: string) => Promise<unknown>;
   quickEntryPlaceholder: string;
 
   // Project headings
@@ -127,7 +129,9 @@ export function ListViewHeader({
   onBulkDelete,
   onCancelBulk,
   uiMode,
+  workspaceView,
   onAddTodo,
+  onCaptureToDesk,
   quickEntryPlaceholder,
   activeHeadingId,
   onSelectHeading,
@@ -376,7 +380,9 @@ export function ListViewHeader({
       {uiMode === "normal" && (
         <QuickEntry
           projectId={selectedProjectId}
-          onAdd={onAddTodo}
+          workspaceView={workspaceView}
+          onAddTask={onAddTodo}
+          onCaptureToDesk={onCaptureToDesk}
           placeholder={quickEntryPlaceholder}
         />
       )}


### PR DESCRIPTION
This fixes the Railway PR preview deploy failure caused by the React quick-entry wiring falling out of sync with the newer capture-routing API.

Recent PR preview environments were failing in Railway during `npm run build:react` because `ListViewHeader` still rendered `QuickEntry` with the legacy `onAdd` prop. `QuickEntry` now expects route-aware props: `onAddTask`, `onCaptureToDesk`, and optionally `workspaceView`. That mismatch caused TypeScript to fail during the React build, which blocked the main web service deploy and left many sibling Railway preview services in cancelled state.

The fix keeps the existing architecture intact and wires the header through the same capture flow already used by the full task composer. `AppShell` now passes `workspaceView={activeView}` and `onCaptureToDesk={handleCaptureToDesk}` into `ListViewHeader`, and `ListViewHeader` forwards those values to `QuickEntry` using the current prop names. This restores both the compile-time contract and the intended “create task now” versus “add to Desk” quick-entry behavior.

Validation:
- `npm run build:react`
- `npx tsc --noEmit`
- `npm run check:architecture`
- `npm run format:check`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`
- `npm run test:coverage:check`

Additional note: `CI=1 npm run test:ui:fast` was rerun after clearing port 4173, but the suite still has unrelated existing failures in admin/auth/feedback/AI-workspace/command-palette specs. I did not change those flows in this fix.
