### PR TITLE
fix(ui): narrow horizon segment tab keys

### DIFF
--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -28,6 +28,16 @@ type ViewMode = "list" | "board";
 type UiMode = "normal" | "simple";
 type HorizonSegment = "due" | "planned" | "pending" | "later";
 
+const HORIZON_SEGMENT_OPTIONS = [
+  { key: "due", label: "Due" },
+  { key: "planned", label: "Planned" },
+  { key: "pending", label: "Pending" },
+  { key: "later", label: "Later" },
+] as const satisfies ReadonlyArray<{
+  key: HorizonSegment;
+  label: string;
+}>;
+
 export interface ListViewHeaderProps {
   // Identity
   headerTitle: string;
@@ -342,12 +352,7 @@ export function ListViewHeader({
           onChange={(next) => onHorizonSegmentChange(next as HorizonSegment)}
           ariaLabel="Horizon views"
           className="horizon-segment-bar"
-          options={[
-            { key: "due", label: "Due" },
-            { key: "planned", label: "Planned" },
-            { key: "pending", label: "Pending" },
-            { key: "later", label: "Later" },
-          ].map(({ key, label }) => ({
+          options={HORIZON_SEGMENT_OPTIONS.map(({ key, label }) => ({
             value: key,
             label,
             buttonId: `horizonSegment${label}`,


### PR DESCRIPTION
## Summary
- keep Horizon segment option keys narrowed to the HorizonSegment union instead of widening to string in ListViewHeader
- fix the horizonSegmentCounts badge lookup so TypeScript and production React builds succeed again

## Verification
- npx tsc --noEmit
- npm run build
- npm run build:react