### PR TITLE
fix(ui): keep high-signal row chips in compact density

### DIFF
--- a/client-react/src/utils/buildChips.test.ts
+++ b/client-react/src/utils/buildChips.test.ts
@@ -20,9 +20,38 @@ function makeTodo(overrides: Partial<Todo> = {}): Todo {
 }
 
 describe("buildChips", () => {
-  it("returns empty for compact density", () => {
-    const todo = makeTodo({ priority: "high", category: "Work" });
-    expect(buildChips(todo, "compact")).toEqual([]);
+  it("keeps only the highest-signal chips in compact density", () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const todo = makeTodo({
+      dueDate: tomorrow.toISOString(),
+      dependsOnTaskIds: ["dep1"],
+      priority: "high",
+      category: "Work",
+      tags: ["ops"],
+      estimateMinutes: 30,
+    });
+
+    expect(buildChips(todo, "compact")).toEqual([
+      expect.objectContaining({ variant: "blocked", label: "Blocked by 1" }),
+      expect.objectContaining({ variant: "priority-high", label: "high" }),
+    ]);
+  });
+
+  it("uses due date and project as compact fallback metadata", () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const todo = makeTodo({
+      dueDate: tomorrow.toISOString(),
+      category: "Work",
+      tags: ["ops"],
+      estimateMinutes: 30,
+    });
+
+    expect(buildChips(todo, "compact")).toEqual([
+      expect.objectContaining({ variant: "date", label: "Tomorrow" }),
+      expect.objectContaining({ variant: "project", label: "Work" }),
+    ]);
   });
 
   it("orders overdue before blocked before priority", () => {

--- a/client-react/src/utils/buildChips.ts
+++ b/client-react/src/utils/buildChips.ts
@@ -22,14 +22,21 @@ export interface ChipData {
 }
 
 const MAX_TAGS = 2;
+const COMPACT_VARIANTS = new Set<ChipData["variant"]>([
+  "overdue",
+  "blocked",
+  "waiting",
+  "priority-high",
+  "date",
+  "project",
+]);
+const COMPACT_MAX_CHIPS = 2;
 
 export function buildChips(
   todo: Todo,
   density: Density,
   groupBy: GroupBy = "none",
 ): ChipData[] {
-  if (density === "compact") return [];
-
   const candidates: ChipData[] = [];
 
   // 1. Overdue due date (hidden when grouped by dueDate)
@@ -183,6 +190,12 @@ export function buildChips(
       variant: "overflow",
       family: "meta",
     });
+  }
+
+  if (density === "compact") {
+    return candidates
+      .filter((chip) => COMPACT_VARIANTS.has(chip.variant))
+      .slice(0, COMPACT_MAX_CHIPS);
   }
 
   // Truncation for normal mode


### PR DESCRIPTION
## Summary
- keep a minimal row-chip set in compact density instead of suppressing chips entirely
- preserve only the highest-signal compact chips: overdue, blocked, waiting, high priority, due date, and project
- add focused buildChips coverage for compact prioritization and fallback behavior

## Verification
- cd client-react && npx vitest run src/utils/buildChips.test.ts
- npx tsc --noEmit
- npm run build:react
- npm run check:architecture
- npm run format:check
- npm run lint:html
- npm run lint:css
- npm run test:unit
- npm run test:coverage:check
- CI=1 npm run test:ui:fast  # still fails in existing unrelated suites: admin-feedback-queue, ai-workspace-collapsed, auth-routing, auth-ui, command-palette*