### PR TITLE
[codex] Fix priorities brief tile test matcher typing

### DIFF
--- a/client-react/src/components/ai/PrioritiesBriefTile.test.tsx
+++ b/client-react/src/components/ai/PrioritiesBriefTile.test.tsx
@@ -9,6 +9,10 @@ vi.mock("../../api/ai", () => ({
   refreshPrioritiesBrief: vi.fn(),
 }));
 
+function expectTileText(text: string) {
+  expect(screen.getByTestId("home-priorities-tile").textContent).toContain(text);
+}
+
 describe("PrioritiesBriefTile", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -50,23 +54,13 @@ describe("PrioritiesBriefTile", () => {
 
     render(<PrioritiesBriefTile />);
 
-    expect(screen.getByTestId("home-priorities-tile")).toHaveTextContent(
-      "Cached priorities",
-    );
+    expectTileText("Cached priorities");
 
-    await waitFor(() =>
-      expect(screen.getByTestId("home-priorities-tile")).toHaveTextContent(
-        "Updating priorities in the background",
-      ),
-    );
+    await waitFor(() => expectTileText("Updating priorities in the background"));
 
     await vi.advanceTimersByTimeAsync(1500);
 
-    await waitFor(() =>
-      expect(screen.getByTestId("home-priorities-tile")).toHaveTextContent(
-        "Fresh priorities",
-      ),
-    );
+    await waitFor(() => expectTileText("Fresh priorities"));
   });
 
   it("keeps the last visible priorities when refresh fails", async () => {
@@ -83,21 +77,11 @@ describe("PrioritiesBriefTile", () => {
 
     render(<PrioritiesBriefTile />);
 
-    await waitFor(() =>
-      expect(screen.getByTestId("home-priorities-tile")).toHaveTextContent(
-        "Visible priorities",
-      ),
-    );
+    await waitFor(() => expectTileText("Visible priorities"));
 
     screen.getByRole("button", { name: "Refresh" }).click();
 
-    await waitFor(() =>
-      expect(screen.getByTestId("home-priorities-tile")).toHaveTextContent(
-        "Showing the last update.",
-      ),
-    );
-    expect(screen.getByTestId("home-priorities-tile")).toHaveTextContent(
-      "Visible priorities",
-    );
+    await waitFor(() => expectTileText("Showing the last update."));
+    expectTileText("Visible priorities");
   });
 });


### PR DESCRIPTION
## Summary
This fixes a React test typing issue that was breaking the production React build path in CI and Docker.

The immediate user-facing effect was that `npm run build:react` failed during TypeScript compilation, which caused the container build to fail before the app image could be produced.

## Root cause
`client-react/src/components/ai/PrioritiesBriefTile.test.tsx` used the `toHaveTextContent` matcher, but the React package does not currently install or configure `@testing-library/jest-dom` matcher types.

That meant TypeScript could not resolve `toHaveTextContent` on Vitest assertions, even though the rest of the test file was valid.

## Fix
The test now uses a small local helper that asserts against the tile element's `textContent` via standard Vitest expectations.

This keeps the test intent the same without widening the React test setup, adding a new dependency, or changing the build/test infrastructure for the package.

## Validation
Checks run:
- `npm run build:react`
- `npx tsc --noEmit`
- `npm run check:architecture`
- `npm run lint:html`
- `npm run lint:css`
- `npm run test:unit`

Known unrelated repo issues observed during verification:
- `npm run format:check` still reports pre-existing formatting issues in `.github/workflows/claude-code-review.yml` and `.github/workflows/claude.yml`
- `CI=1 npm run test:ui:fast` still reports unrelated existing UI failures, starting with `tests/ui/admin-feedback-queue.spec.ts`
