### PR TITLE
feat(react): align project complexity ui with core design language

### DIFF
--- a/client-react/src/components/projects/ProjectWorkspaceView.tsx
+++ b/client-react/src/components/projects/ProjectWorkspaceView.tsx
@@ -117,7 +117,7 @@ interface Props {
 function formatSectionName(name: string) {
   const normalized = name.trim().toLowerCase();
   if (["first", "new section", "untitled", ""].includes(normalized)) {
-    return "Phase 1";
+    return "Getting started";
   }
   return name;
 }
@@ -567,12 +567,6 @@ export function ProjectWorkspaceView({
                   color: COMPLEXITY_STYLES[overviewProfile.mode].color,
                 }}
               >
-                <span
-                  className="project-complexity-badge__icon"
-                  aria-hidden="true"
-                >
-                  {COMPLEXITY_STYLES[overviewProfile.mode].icon}
-                </span>
                 <span className="project-complexity-badge__label">
                   {COMPLEXITY_LABELS[overviewProfile.mode]}
                 </span>

--- a/client-react/src/components/projects/projectWorkspaceModels.ts
+++ b/client-react/src/components/projects/projectWorkspaceModels.ts
@@ -19,25 +19,22 @@ export const COMPLEXITY_LABELS: Record<ProjectOverviewMode, ComplexityLabel> = {
 
 export const COMPLEXITY_STYLES: Record<
   ProjectOverviewMode,
-  { background: string; border: string; color: string; icon: string }
+  { background: string; border: string; color: string }
 > = {
   simple: {
     background: "color-mix(in oklab, var(--success) 8%, transparent)",
     border: "1px solid color-mix(in oklab, var(--success) 20%, transparent)",
     color: "var(--success)",
-    icon: "●",
   },
   guided: {
     background: "color-mix(in oklab, var(--info) 8%, transparent)",
     border: "1px solid color-mix(in oklab, var(--info) 20%, transparent)",
     color: "var(--info)",
-    icon: "◆",
   },
   rich: {
     background: "color-mix(in oklab, var(--warning) 8%, transparent)",
     border: "1px solid color-mix(in oklab, var(--warning) 20%, transparent)",
     color: "var(--warning)",
-    icon: "▲",
   },
 };
 
@@ -449,9 +446,17 @@ export function buildSnapshotItemsEnhanced(
         const daysUntil = Math.ceil(
           (dueDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
         );
+        let dateValue = "Set";
+        if (daysUntil === 1) {
+          dateValue = "Tomorrow";
+        } else if (daysUntil < 7) {
+          dateValue = dueDate.toLocaleDateString("en-US", { weekday: "short" });
+        } else {
+          dateValue = formatProjectDate(dueDate.toISOString()) ?? "Set";
+        }
         items.push({
           label: "Next",
-          value: daysUntil === 1 ? "Tomorrow" : (formatProjectDate(dueDate.toISOString()) ?? "Set"),
+          value: dateValue,
           actionable: daysUntil <= 3,
         });
       }

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -10778,24 +10778,16 @@ body.dark-mode {
 .project-complexity-badge {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  gap: var(--s-1);
+  padding: var(--s-1) var(--s-3);
+  border-radius: var(--r-full);
+  font-size: var(--fs-label);
+  font-weight: 500;
   margin: 0;
   transition: all 0.15s ease;
 }
 
-.project-complexity-badge__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 8px;
-  opacity: 0.8;
-}
+/* (removed project-complexity-badge__icon since it's no longer used) */
 
 .project-complexity-badge__label {
   letter-spacing: 0.01em;


### PR DESCRIPTION
## Overview

Addresses final polish items to ensure the project workspace UI strictly adheres to the repo's existing design language, emphasizing a calm, lightweight, and non-enterprise tone.

## Changes
- Removed the `●` / `◆` / `▲` bullets from the complexity badge.
- Re-styled the complexity badge. Replaced the heavy, uppercase treatment with a soft, lightweight pill that mirrors existing `.project-workspace__meta-pill` tokens (`var(--r-full)` radius, `var(--s-1) var(--s-3)` padding, standard label font weight).
- Unified date formatting: The "Next" metric row now perfectly matches the footer summary logic (using short weekday names like "Thu" for dates within 7 days, falling back to "Apr 9" beyond that).
- Changed the fallback for weak section names (e.g., "first") from "Phase 1" to "Getting started", which feels much more natural for personal projects.