### PR TITLE
feat(react-mobile): interactive fields, settings, snooze, animations

### DIFF
--- a/client-react/src/mobile/MobileShell.tsx
+++ b/client-react/src/mobile/MobileShell.tsx
@@ -8,7 +8,10 @@ import { useBottomSheet } from "./hooks/useBottomSheet";
 import { TabBar } from "./components/TabBar";
 import { BottomSheet } from "./components/BottomSheet";
 import { QuickCapture } from "./components/QuickCapture";
+import { ProfileSheet } from "./components/ProfileSheet";
+import { FieldPicker } from "./components/FieldPicker";
 import { PullToSearch } from "./components/PullToSearch";
+import type { TodoStatus, Priority } from "../types";
 import { FocusScreen } from "./screens/FocusScreen";
 import { TodayScreen } from "./screens/TodayScreen";
 import { ProjectsScreen } from "./screens/ProjectsScreen";
@@ -17,13 +20,14 @@ import { apiCall } from "../api/client";
 import "./mobile.css";
 
 export function MobileShell() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const { dark, toggle: toggleDarkMode } = useDarkMode();
   const { todos, loadTodos, addTodo, toggleTodo, editTodo, removeTodo } = useTodosStore();
   const { projects, loadProjects } = useProjectsStore();
-  const { activeTab, setActiveTab, customView } = useTabBar();
+  const { activeTab, setActiveTab, customView, setCustomView } = useTabBar();
   const bottomSheet = useBottomSheet();
   const [captureOpen, setCaptureOpen] = useState(false);
+  const [profileOpen, setProfileOpen] = useState(false);
 
   useEffect(() => { loadTodos({}); loadProjects(); }, [loadTodos, loadProjects]);
 
@@ -34,7 +38,7 @@ export function MobileShell() {
     await apiCall("/projects", { method: "POST", body: JSON.stringify({ name }) });
     await loadProjects();
   }, [loadProjects]);
-  const handleAvatarClick = useCallback(() => { /* Settings — future task */ }, []);
+  const handleAvatarClick = useCallback(() => { setProfileOpen(true); }, []);
 
   const sheetTodo = useMemo(
     () => (bottomSheet.taskId ? todos.find((t) => t.id === bottomSheet.taskId) ?? null : null),
@@ -128,6 +132,16 @@ export function MobileShell() {
       <PullToSearch todos={todos} onSelectResult={handleTodoClick} />
       <BottomSheet snap={bottomSheet.snap} onClose={bottomSheet.close} onExpandFull={bottomSheet.expandFull} halfContent={halfContent} fullContent={fullContent} />
       <QuickCapture open={captureOpen} projects={projects} onClose={() => setCaptureOpen(false)} onCreateTask={handleCreateTask} onCreateProject={handleCreateProject} />
+      <ProfileSheet
+        open={profileOpen}
+        onClose={() => setProfileOpen(false)}
+        user={user}
+        dark={dark}
+        onToggleDark={toggleDarkMode}
+        customView={customView}
+        onChangeCustomView={setCustomView}
+        onLogout={logout}
+      />
       <TabBar activeTab={activeTab} customView={customView} onTabChange={setActiveTab} onFabPress={() => setCaptureOpen(true)} />
     </div>
   );

--- a/client-react/src/mobile/MobileShell.tsx
+++ b/client-react/src/mobile/MobileShell.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useAuth } from "../auth/AuthProvider";
 import { useTodosStore } from "../store/useTodosStore";
 import { useProjectsStore } from "../store/useProjectsStore";
 import { useDarkMode } from "../hooks/useDarkMode";
 import { useTabBar } from "./hooks/useTabBar";
+import { useScrollPersistence } from "./hooks/useScrollPersistence";
 import { useBottomSheet } from "./hooks/useBottomSheet";
 import { TabBar } from "./components/TabBar";
 import { BottomSheet } from "./components/BottomSheet";
@@ -11,6 +12,7 @@ import { QuickCapture } from "./components/QuickCapture";
 import { ProfileSheet } from "./components/ProfileSheet";
 import { FieldPicker } from "./components/FieldPicker";
 import { PullToSearch } from "./components/PullToSearch";
+import { SnoozePicker } from "./components/SnoozePicker";
 import type { TodoStatus, Priority } from "../types";
 import { FocusScreen } from "./screens/FocusScreen";
 import { TodayScreen } from "./screens/TodayScreen";
@@ -47,11 +49,24 @@ export function MobileShell() {
   const { todos, loadTodos, addTodo, toggleTodo, editTodo, removeTodo } = useTodosStore();
   const { projects, loadProjects } = useProjectsStore();
   const { activeTab, setActiveTab, customView, setCustomView } = useTabBar();
+  const { save: saveScroll, restore: restoreScroll } = useScrollPersistence();
+  const prevTabRef = useRef<string>(activeTab);
   const bottomSheet = useBottomSheet();
   const [captureOpen, setCaptureOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
+  const [snoozeTargetId, setSnoozeTargetId] = useState<string | null>(null);
 
   useEffect(() => { loadTodos({}); loadProjects(); }, [loadTodos, loadProjects]);
+
+  useEffect(() => {
+    const prev = prevTabRef.current as typeof activeTab;
+    if (prev !== activeTab) {
+      saveScroll(prev);
+      prevTabRef.current = activeTab;
+      // Restore after the new screen renders
+      requestAnimationFrame(() => restoreScroll(activeTab));
+    }
+  }, [activeTab, saveScroll, restoreScroll]);
 
   const handleTodoClick = useCallback((id: string) => bottomSheet.openHalf(id), [bottomSheet]);
   const handleToggleTodo = useCallback((id: string, completed: boolean) => toggleTodo(id, completed), [toggleTodo]);
@@ -61,6 +76,12 @@ export function MobileShell() {
     await loadProjects();
   }, [loadProjects]);
   const handleAvatarClick = useCallback(() => { setProfileOpen(true); }, []);
+  const handleSnoozeTodo = useCallback((id: string) => { setSnoozeTargetId(id); }, []);
+  const handleSnoozeConfirm = useCallback((date: string) => {
+    if (snoozeTargetId) editTodo(snoozeTargetId, { dueDate: date });
+    setSnoozeTargetId(null);
+  }, [snoozeTargetId, editTodo]);
+  const handleSnoozeClose = useCallback(() => { setSnoozeTargetId(null); }, []);
 
   const sheetTodo = useMemo(
     () => (bottomSheet.taskId ? todos.find((t) => t.id === bottomSheet.taskId) ?? null : null),
@@ -182,7 +203,7 @@ export function MobileShell() {
     </div>
   ) : null;
 
-  const screenProps = { todos, projects, user, onTodoClick: handleTodoClick, onToggleTodo: handleToggleTodo, onAvatarClick: handleAvatarClick };
+  const screenProps = { todos, projects, user, onTodoClick: handleTodoClick, onToggleTodo: handleToggleTodo, onAvatarClick: handleAvatarClick, onSnoozeTodo: handleSnoozeTodo };
 
   return (
     <div className="m-shell" data-density="normal">
@@ -205,6 +226,7 @@ export function MobileShell() {
         onChangeCustomView={setCustomView}
         onLogout={logout}
       />
+      <SnoozePicker open={!!snoozeTargetId} onClose={handleSnoozeClose} onSnooze={handleSnoozeConfirm} />
       <TabBar activeTab={activeTab} customView={customView} onTabChange={setActiveTab} onFabPress={() => setCaptureOpen(true)} />
     </div>
   );

--- a/client-react/src/mobile/MobileShell.tsx
+++ b/client-react/src/mobile/MobileShell.tsx
@@ -19,6 +19,28 @@ import { CustomScreen } from "./screens/CustomScreen";
 import { apiCall } from "../api/client";
 import "./mobile.css";
 
+const STATUS_OPTIONS: { key: TodoStatus; label: string }[] = [
+  { key: "inbox", label: "Inbox" },
+  { key: "next", label: "Next" },
+  { key: "in_progress", label: "In Progress" },
+  { key: "waiting", label: "Waiting" },
+  { key: "scheduled", label: "Scheduled" },
+  { key: "someday", label: "Someday" },
+];
+
+const PRIORITY_OPTIONS: { key: Priority; label: string; color: string }[] = [
+  { key: "low", label: "Low", color: "var(--muted)" },
+  { key: "medium", label: "Medium", color: "var(--accent)" },
+  { key: "high", label: "High", color: "var(--warning)" },
+  { key: "urgent", label: "Urgent", color: "var(--danger)" },
+];
+
+const ENERGY_OPTIONS: { key: "low" | "medium" | "high"; label: string }[] = [
+  { key: "low", label: "Low" },
+  { key: "medium", label: "Medium" },
+  { key: "high", label: "High" },
+];
+
 export function MobileShell() {
   const { user, logout } = useAuth();
   const { dark, toggle: toggleDarkMode } = useDarkMode();
@@ -46,6 +68,11 @@ export function MobileShell() {
   const sheetProject = useMemo(
     () => (sheetTodo?.projectId ? projects.find((p) => p.id === sheetTodo.projectId) ?? null : null),
     [sheetTodo, projects]);
+
+  const projectOptions = useMemo(
+    () => projects.map((p) => ({ key: p.id, label: p.name })),
+    [projects],
+  );
 
   const halfContent = sheetTodo ? (
     <div className="m-sheet-half">
@@ -85,12 +112,48 @@ export function MobileShell() {
       </div>
       {sheetTodo.description && <div className="m-sheet-full__desc">{sheetTodo.description}</div>}
       <div className="m-sheet-full__fields">
-        <div className="m-sheet-full__field"><div className="m-sheet-full__field-label">Status</div><div className="m-sheet-full__field-value">{sheetTodo.status}</div></div>
-        <div className="m-sheet-full__field"><div className="m-sheet-full__field-label">Priority</div><div className={`m-sheet-full__field-value${sheetTodo.priority ? ` m-priority--${sheetTodo.priority}` : ""}`}>{sheetTodo.priority ?? "—"}</div></div>
-        <div className="m-sheet-full__field"><div className="m-sheet-full__field-label">Due Date</div><div className="m-sheet-full__field-value">{sheetTodo.dueDate ? new Date(sheetTodo.dueDate).toLocaleDateString() : "—"}</div></div>
-        <div className="m-sheet-full__field"><div className="m-sheet-full__field-label">Project</div><div className="m-sheet-full__field-value">{sheetProject?.name ?? "—"}</div></div>
-        <div className="m-sheet-full__field"><div className="m-sheet-full__field-label">Energy</div><div className="m-sheet-full__field-value">{sheetTodo.energy ?? "—"}</div></div>
-        <div className="m-sheet-full__field"><div className="m-sheet-full__field-label">Estimate</div><div className="m-sheet-full__field-value">{sheetTodo.estimateMinutes ? `${sheetTodo.estimateMinutes} min` : "—"}</div></div>
+        <FieldPicker<TodoStatus>
+          label="Status"
+          value={sheetTodo.status}
+          options={STATUS_OPTIONS}
+          onChange={(v) => { if (v) editTodo(sheetTodo.id, { status: v }); }}
+        />
+        <FieldPicker<Priority>
+          label="Priority"
+          value={sheetTodo.priority ?? null}
+          options={PRIORITY_OPTIONS}
+          onChange={(v) => editTodo(sheetTodo.id, { priority: v })}
+          allowClear
+        />
+        <div className="m-field-picker">
+          <div className="m-field-picker__header m-field-picker__header--static">
+            <div className="m-sheet-full__field-label">Due Date</div>
+            <input
+              type="date"
+              className="m-field-picker__date"
+              value={sheetTodo.dueDate ? sheetTodo.dueDate.slice(0, 10) : ""}
+              onChange={(e) => editTodo(sheetTodo.id, { dueDate: e.target.value || null })}
+            />
+          </div>
+        </div>
+        <FieldPicker<string>
+          label="Project"
+          value={sheetTodo.projectId ?? null}
+          options={projectOptions}
+          onChange={(v) => editTodo(sheetTodo.id, { projectId: v })}
+          allowClear
+        />
+        <FieldPicker<"low" | "medium" | "high">
+          label="Energy"
+          value={sheetTodo.energy ?? null}
+          options={ENERGY_OPTIONS}
+          onChange={(v) => editTodo(sheetTodo.id, { energy: v })}
+          allowClear
+        />
+        <div className="m-sheet-full__field">
+          <div className="m-sheet-full__field-label">Estimate</div>
+          <div className="m-sheet-full__field-value">{sheetTodo.estimateMinutes ? `${sheetTodo.estimateMinutes} min` : "—"}</div>
+        </div>
       </div>
       {sheetTodo.tags.length > 0 && (
         <div className="m-sheet-full__tags">

--- a/client-react/src/mobile/components/FieldPicker.tsx
+++ b/client-react/src/mobile/components/FieldPicker.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+
+interface FieldPickerOption<T extends string> {
+  key: T;
+  label: string;
+  color?: string;
+}
+
+interface FieldPickerProps<T extends string> {
+  label: string;
+  value: T | null;
+  options: FieldPickerOption<T>[];
+  onChange: (value: T | null) => void;
+  allowClear?: boolean;
+}
+
+export function FieldPicker<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  allowClear = false,
+}: FieldPickerProps<T>) {
+  const [open, setOpen] = useState(false);
+
+  const selectedOption = value ? options.find((o) => o.key === value) : null;
+
+  function handleSelect(key: T) {
+    onChange(key);
+    setOpen(false);
+  }
+
+  function handleClear() {
+    onChange(null);
+    setOpen(false);
+  }
+
+  return (
+    <div className={`m-field-picker${open ? " m-field-picker--open" : ""}`}>
+      <button
+        className="m-field-picker__header"
+        onClick={() => setOpen((v) => !v)}
+        type="button"
+      >
+        <div className="m-sheet-full__field-label">{label}</div>
+        <div
+          className="m-sheet-full__field-value"
+          style={selectedOption?.color ? { color: selectedOption.color } : undefined}
+        >
+          {selectedOption ? selectedOption.label : "—"}
+          <span className="m-field-picker__chevron">{open ? "▲" : "▼"}</span>
+        </div>
+      </button>
+      {open && (
+        <div className="m-field-picker__options">
+          {options.map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              className={`m-field-picker__option${value === opt.key ? " m-field-picker__option--active" : ""}`}
+              style={opt.color ? { color: opt.color } : undefined}
+              onClick={() => handleSelect(opt.key)}
+            >
+              {value === opt.key && (
+                <span className="m-field-picker__option-check">✓</span>
+              )}
+              {opt.label}
+            </button>
+          ))}
+          {allowClear && value !== null && (
+            <button
+              type="button"
+              className="m-field-picker__clear"
+              onClick={handleClear}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-react/src/mobile/components/ProfileSheet.tsx
+++ b/client-react/src/mobile/components/ProfileSheet.tsx
@@ -1,0 +1,111 @@
+import type { User } from "../../types";
+import type { WorkspaceView } from "../../components/projects/Sidebar";
+import { CUSTOM_TAB_OPTIONS } from "../hooks/useTabBar";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  user: User | null;
+  dark: boolean;
+  onToggleDark: () => void;
+  customView: WorkspaceView;
+  onChangeCustomView: (view: WorkspaceView) => void;
+  onLogout: () => void;
+}
+
+function getUserInitial(user: User | null): string {
+  if (!user) return "?";
+  if (user.name) return user.name.charAt(0).toUpperCase();
+  return user.email.charAt(0).toUpperCase();
+}
+
+function getNextCustomView(current: WorkspaceView): WorkspaceView {
+  const idx = CUSTOM_TAB_OPTIONS.findIndex((o) => o.key === current);
+  const next = CUSTOM_TAB_OPTIONS[(idx + 1) % CUSTOM_TAB_OPTIONS.length];
+  return next.key;
+}
+
+function getCustomViewLabel(view: WorkspaceView): string {
+  return CUSTOM_TAB_OPTIONS.find((o) => o.key === view)?.label ?? view;
+}
+
+export function ProfileSheet({
+  open,
+  onClose,
+  user,
+  dark,
+  onToggleDark,
+  customView,
+  onChangeCustomView,
+  onLogout,
+}: Props) {
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="m-capture__backdrop" onClick={onClose} />
+      <div className="m-profile" role="dialog" aria-modal="true" aria-label="Profile and settings">
+        <div className="m-bottom-sheet__handle">
+          <div className="m-bottom-sheet__handle-bar" />
+        </div>
+
+        {/* User info section */}
+        <div className="m-profile__user">
+          <div className="m-profile__avatar">{getUserInitial(user)}</div>
+          <div className="m-profile__user-text">
+            {user?.name && <div className="m-profile__user-name">{user.name}</div>}
+            <div className="m-profile__user-email">{user?.email ?? ""}</div>
+            {user?.plan && <div className="m-profile__user-plan">{user.plan}</div>}
+          </div>
+        </div>
+
+        <div className="m-profile__divider" />
+
+        {/* Appearance section */}
+        <div className="m-profile__section">
+          <div className="m-profile__section-label">Appearance</div>
+          <div className="m-profile__row">
+            <span className="m-profile__row-label">Dark mode</span>
+            <button
+              className={`m-profile__toggle${dark ? " m-profile__toggle--on" : ""}`}
+              onClick={onToggleDark}
+              aria-pressed={dark}
+              aria-label="Toggle dark mode"
+            >
+              <span className="m-profile__toggle-knob" />
+            </button>
+          </div>
+        </div>
+
+        <div className="m-profile__divider" />
+
+        {/* Custom tab section */}
+        <div className="m-profile__section">
+          <div className="m-profile__section-label">Custom Tab</div>
+          <div className="m-profile__row">
+            <span className="m-profile__row-label">4th tab shows</span>
+            <button
+              className="m-profile__cycle-btn"
+              onClick={() => onChangeCustomView(getNextCustomView(customView))}
+              aria-label={`Custom tab: ${getCustomViewLabel(customView)}, tap to change`}
+            >
+              {getCustomViewLabel(customView)} ›
+            </button>
+          </div>
+        </div>
+
+        <div className="m-profile__divider" />
+
+        {/* Logout */}
+        <div className="m-profile__footer">
+          <button
+            className="m-profile__logout"
+            onClick={() => { onLogout(); onClose(); }}
+          >
+            Log out
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client-react/src/mobile/components/SnoozePicker.tsx
+++ b/client-react/src/mobile/components/SnoozePicker.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSnooze: (date: string) => void;
+}
+
+function laterToday(): string {
+  const now = new Date();
+  const target = new Date(now);
+  const fivePm = new Date(now);
+  fivePm.setHours(17, 0, 0, 0);
+  if (now < fivePm) {
+    target.setHours(17, 0, 0, 0);
+  } else {
+    target.setTime(now.getTime() + 3 * 60 * 60 * 1000);
+  }
+  return target.toISOString().slice(0, 10);
+}
+
+function tomorrow(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+function nextMonday(): string {
+  const d = new Date();
+  const day = d.getDay(); // 0=Sun, 1=Mon...
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  d.setDate(d.getDate() + daysUntilMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+function formatDisplay(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+export function SnoozePicker({ open, onClose, onSnooze }: Props) {
+  const [showDateInput, setShowDateInput] = useState(false);
+  const [pickedDate, setPickedDate] = useState("");
+
+  if (!open) return null;
+
+  const laterTodayDate = laterToday();
+  const tomorrowDate = tomorrow();
+  const nextMondayDate = nextMonday();
+
+  const handleOption = (date: string) => {
+    onSnooze(date);
+    setShowDateInput(false);
+    setPickedDate("");
+  };
+
+  const handlePickDate = () => {
+    if (showDateInput) {
+      if (pickedDate) handleOption(pickedDate);
+    } else {
+      setShowDateInput(true);
+    }
+  };
+
+  const handleBackdropClick = () => {
+    setShowDateInput(false);
+    setPickedDate("");
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="m-snooze__backdrop" onClick={handleBackdropClick} />
+      <div className="m-snooze" role="dialog" aria-modal="true" aria-label="Snooze task">
+        <div className="m-snooze__handle-bar" />
+        <div className="m-snooze__title">Snooze until…</div>
+        <button className="m-snooze__option" onClick={() => handleOption(laterTodayDate)}>
+          <span className="m-snooze__option-label">Later Today</span>
+          <span className="m-snooze__option-detail">{formatDisplay(laterTodayDate)} · 5 pm</span>
+        </button>
+        <button className="m-snooze__option" onClick={() => handleOption(tomorrowDate)}>
+          <span className="m-snooze__option-label">Tomorrow</span>
+          <span className="m-snooze__option-detail">{formatDisplay(tomorrowDate)} · 9 am</span>
+        </button>
+        <button className="m-snooze__option" onClick={() => handleOption(nextMondayDate)}>
+          <span className="m-snooze__option-label">Next Week</span>
+          <span className="m-snooze__option-detail">{formatDisplay(nextMondayDate)} · Mon 9 am</span>
+        </button>
+        <button className="m-snooze__option" onClick={handlePickDate}>
+          <span className="m-snooze__option-label">Pick a date</span>
+          {showDateInput ? (
+            <input
+              className="m-snooze__date"
+              type="date"
+              value={pickedDate}
+              min={new Date().toISOString().slice(0, 10)}
+              autoFocus
+              onChange={(e) => setPickedDate(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span className="m-snooze__option-detail">Choose a date</span>
+          )}
+        </button>
+        {showDateInput && pickedDate && (
+          <button className="m-snooze__confirm" onClick={() => handleOption(pickedDate)}>
+            Snooze to {formatDisplay(pickedDate)}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/client-react/src/mobile/components/SwipeRow.tsx
+++ b/client-react/src/mobile/components/SwipeRow.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from "react";
+import { useRef, useState, useCallback, type ReactNode } from "react";
 import { useSwipeAction, SWIPE_THRESHOLD } from "../hooks/useSwipeAction";
 
 interface Props {
@@ -15,20 +15,30 @@ export function SwipeRow({
 }: Props) {
   const { offsetX, state, onTouchStart, onTouchMove, onTouchEnd, reset } = useSwipeAction();
   const rowRef = useRef<HTMLDivElement>(null);
+  const [completing, setCompleting] = useState(false);
 
   const handleTouchStart = (e: React.TouchEvent) => onTouchStart(e.touches[0].clientX);
   const handleTouchMove = (e: React.TouchEvent) => onTouchMove(e.touches[0].clientX);
   const handleTouchEnd = () => onTouchEnd();
 
-  if (state === "triggered-right" && onSwipeRight) { onSwipeRight(); reset(); }
+  const handleComplete = useCallback(() => {
+    setCompleting(true);
+    setTimeout(() => {
+      onSwipeRight?.();
+      reset();
+    }, 280);
+  }, [onSwipeRight, reset]);
+
+  if (state === "triggered-right" && onSwipeRight && !completing) { handleComplete(); }
+  else if (state === "triggered-right" && !onSwipeRight) { reset(); }
   else if (state === "triggered-left" && onSwipeLeft) { onSwipeLeft(); reset(); }
-  else if ((state === "triggered-right" || state === "triggered-left")) { reset(); }
+  else if (state === "triggered-left") { reset(); }
 
   const isSwipingRight = offsetX > 0;
   const progress = Math.min(Math.abs(offsetX) / SWIPE_THRESHOLD, 1);
 
   return (
-    <div className="m-swipe-row" ref={rowRef}>
+    <div className={`m-swipe-row${completing ? " m-swipe-row--completing" : ""}`} ref={rowRef}>
       <div
         className={`m-swipe-row__action m-swipe-row__action--right${isSwipingRight ? " m-swipe-row__action--visible" : ""}`}
         style={{ opacity: isSwipingRight ? progress : 0 }}

--- a/client-react/src/mobile/hooks/useScrollPersistence.ts
+++ b/client-react/src/mobile/hooks/useScrollPersistence.ts
@@ -1,0 +1,18 @@
+import { useRef, useCallback } from "react";
+import type { MobileTab } from "./useTabBar";
+
+export function useScrollPersistence() {
+  const positions = useRef<Record<string, number>>({});
+
+  const save = useCallback((tab: MobileTab) => {
+    const el = document.querySelector(".m-shell__content");
+    if (el) positions.current[tab] = el.scrollTop;
+  }, []);
+
+  const restore = useCallback((tab: MobileTab) => {
+    const el = document.querySelector(".m-shell__content");
+    if (el) el.scrollTop = positions.current[tab] ?? 0;
+  }, []);
+
+  return { save, restore };
+}

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1051,6 +1051,170 @@
   color: var(--danger);
 }
 
+/* --- Profile sheet --- */
+.m-profile {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--surface);
+  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  z-index: 105;
+  box-shadow: var(--shadow-xl);
+  padding-bottom: calc(var(--s-5) + env(safe-area-inset-bottom, 0px));
+}
+
+.m-profile__user {
+  display: flex;
+  align-items: center;
+  gap: var(--s-4);
+  padding: var(--s-3) var(--s-5) var(--s-4);
+}
+
+.m-profile__avatar {
+  width: 48px;
+  height: 48px;
+  min-width: 48px;
+  background: var(--accent-light);
+  color: var(--accent);
+  border-radius: var(--r-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--fs-xl);
+  font-weight: var(--fw-bold);
+  flex-shrink: 0;
+}
+
+.m-profile__user-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.m-profile__user-name {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.m-profile__user-email {
+  font-size: var(--fs-meta);
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.m-profile__user-plan {
+  font-size: var(--fs-xs);
+  color: var(--accent);
+  font-weight: var(--fw-medium);
+  text-transform: capitalize;
+  margin-top: var(--s-0);
+}
+
+.m-profile__divider {
+  height: 1px;
+  background: var(--border-light);
+  margin: 0 var(--s-5);
+}
+
+.m-profile__section {
+  padding: var(--s-3) var(--s-5);
+}
+
+.m-profile__section-label {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  margin-bottom: var(--s-3);
+}
+
+.m-profile__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 44px;
+}
+
+.m-profile__row-label {
+  font-size: var(--fs-body);
+  color: var(--text);
+}
+
+/* Toggle switch */
+.m-profile__toggle {
+  width: 48px;
+  height: 28px;
+  border-radius: var(--r-full);
+  border: none;
+  background: var(--surface-3);
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  transition: background var(--dur-fast);
+  flex-shrink: 0;
+}
+
+.m-profile__toggle--on {
+  background: var(--accent);
+}
+
+.m-profile__toggle-knob {
+  display: block;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-full);
+  background: white;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
+.m-profile__toggle--on .m-profile__toggle-knob {
+  transform: translateX(20px);
+}
+
+/* Custom view cycle button */
+.m-profile__cycle-btn {
+  background: var(--surface-3);
+  border: none;
+  border-radius: var(--r-sm);
+  padding: var(--s-2) var(--s-3h);
+  color: var(--accent);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-medium);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  min-height: 36px;
+}
+
+/* Footer */
+.m-profile__footer {
+  padding: var(--s-3) var(--s-5) var(--s-2);
+}
+
+.m-profile__logout {
+  width: 100%;
+  padding: var(--s-3h);
+  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  border: none;
+  border-radius: var(--r-md);
+  color: var(--danger);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  min-height: 44px;
+}
+
 /* --- Screens base --- */
 .m-screen {
   min-height: 100%;

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1215,6 +1215,116 @@
   min-height: 44px;
 }
 
+/* --- Field picker (inline expandable) --- */
+.m-field-picker {
+  background: var(--surface-3);
+  border-radius: var(--r-sm);
+  overflow: hidden;
+}
+
+.m-field-picker--open {
+  border: 1px solid var(--border);
+}
+
+.m-field-picker__header {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: var(--s-3);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  color: var(--text);
+}
+
+.m-field-picker__header--static {
+  cursor: default;
+}
+
+.m-field-picker__header .m-sheet-full__field-value {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.m-field-picker__chevron {
+  font-size: var(--fs-xs);
+  color: var(--muted-light);
+  margin-left: var(--s-1);
+}
+
+.m-field-picker__options {
+  border-top: 1px solid var(--border-light);
+  padding: var(--s-1) 0;
+}
+
+.m-field-picker__option {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  width: 100%;
+  padding: var(--s-2h) var(--s-3);
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: var(--fs-meta);
+  font-family: var(--font-sans);
+  color: var(--text);
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.m-field-picker__option:active {
+  background: var(--surface);
+}
+
+.m-field-picker__option--active {
+  background: var(--accent-light);
+  color: var(--accent);
+  font-weight: var(--fw-medium);
+}
+
+.m-field-picker__option-check {
+  font-size: var(--fs-xs);
+  color: var(--accent);
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.m-field-picker__clear {
+  display: block;
+  width: 100%;
+  padding: var(--s-2h) var(--s-3);
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border-light);
+  text-align: left;
+  font-size: var(--fs-meta);
+  font-family: var(--font-sans);
+  color: var(--muted);
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.m-field-picker__date {
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: var(--fs-meta);
+  font-family: var(--font-sans);
+  padding: 0;
+  margin-top: var(--s-1);
+  width: 100%;
+  cursor: pointer;
+}
+
+.m-field-picker__date::-webkit-calendar-picker-indicator {
+  opacity: 0.4;
+  cursor: pointer;
+}
+
 /* --- Screens base --- */
 .m-screen {
   min-height: 100%;

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -18,6 +18,15 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.m-screen {
+  animation: m-fade-in var(--dur-base) var(--ease-out);
+}
+
+@keyframes m-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 /* --- Header --- */
 .m-header {
   display: flex;
@@ -188,12 +197,23 @@
   background: var(--surface);
 }
 
+.m-swipe-row--completing .m-swipe-row__content {
+  animation: m-row-complete var(--dur-slow) var(--ease-out) forwards;
+}
+
+@keyframes m-row-complete {
+  0% { opacity: 1; max-height: 80px; }
+  50% { opacity: 0; max-height: 80px; }
+  100% { opacity: 0; max-height: 0; padding: 0; overflow: hidden; }
+}
+
 /* --- Bottom sheet --- */
 .m-bottom-sheet__backdrop {
   position: fixed;
   inset: 0;
   background: var(--overlay);
   z-index: 90;
+  animation: m-fade-in var(--dur-base) var(--ease-out);
 }
 
 .m-bottom-sheet {
@@ -1323,6 +1343,116 @@
 .m-field-picker__date::-webkit-calendar-picker-indicator {
   opacity: 0.4;
   cursor: pointer;
+}
+
+/* --- Snooze picker --- */
+.m-snooze__backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay);
+  z-index: 100;
+}
+
+.m-snooze {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--surface);
+  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  z-index: 105;
+  padding: var(--s-3) 0 var(--s-6);
+  box-shadow: var(--shadow-xl);
+  display: flex;
+  flex-direction: column;
+}
+
+.m-snooze__handle-bar {
+  width: 36px;
+  height: 4px;
+  background: var(--muted-light);
+  border-radius: var(--r-full);
+  margin: 0 auto var(--s-3);
+}
+
+.m-snooze__title {
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  padding: 0 var(--s-5) var(--s-2);
+}
+
+.m-snooze__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 52px;
+  padding: 0 var(--s-5);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-light);
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.m-snooze__option:last-of-type {
+  border-bottom: none;
+}
+
+.m-snooze__option:active {
+  background: var(--bg);
+}
+
+.m-snooze__option-label {
+  font-size: var(--fs-body);
+  color: var(--text);
+  font-weight: var(--fw-medium);
+}
+
+.m-snooze__option-detail {
+  font-size: var(--fs-meta);
+  color: var(--muted);
+}
+
+.m-snooze__date {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: var(--fs-meta);
+  font-family: var(--font-sans);
+  padding: var(--s-1) var(--s-2);
+  cursor: pointer;
+}
+
+.m-snooze__date::-webkit-calendar-picker-indicator {
+  opacity: 0.5;
+  cursor: pointer;
+}
+
+.m-snooze__confirm {
+  display: block;
+  width: calc(100% - 48px);
+  margin: var(--s-3) var(--s-5) 0;
+  padding: var(--s-3);
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: var(--r-md);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: center;
+  min-height: 48px;
+}
+
+.m-snooze__confirm:active {
+  opacity: 0.85;
 }
 
 /* --- Screens base --- */

--- a/client-react/src/mobile/screens/CustomScreen.tsx
+++ b/client-react/src/mobile/screens/CustomScreen.tsx
@@ -13,6 +13,7 @@ interface Props {
   onTodoClick: (id: string) => void;
   onToggleTodo: (id: string, completed: boolean) => void;
   onAvatarClick: () => void;
+  onSnoozeTodo: (id: string) => void;
 }
 
 function daysUntil(dateStr: string): number {
@@ -34,7 +35,7 @@ function filterForView(todos: Todo[], view: WorkspaceView): Todo[] {
   }
 }
 
-export function CustomScreen({ view, todos, projects, user, onTodoClick, onToggleTodo, onAvatarClick }: Props) {
+export function CustomScreen({ view, todos, projects, user, onTodoClick, onToggleTodo, onAvatarClick, onSnoozeTodo }: Props) {
   const label = CUSTOM_TAB_OPTIONS.find((o) => o.key === view)?.label ?? "Tasks";
   const filteredTodos = useMemo(() => filterForView(todos, view), [todos, view]);
   const projectMap = useMemo(() => {
@@ -50,7 +51,7 @@ export function CustomScreen({ view, todos, projects, user, onTodoClick, onToggl
         <div className="m-today__pull-hint">↓ pull to search</div>
         <div className="m-custom__list">
           {filteredTodos.map((t) => (
-            <SwipeRow key={t.id} onSwipeRight={() => onToggleTodo(t.id, !t.completed)}>
+            <SwipeRow key={t.id} onSwipeRight={() => onToggleTodo(t.id, !t.completed)} onSwipeLeft={() => onSnoozeTodo(t.id)}>
               <button className="m-todo-row" onClick={() => onTodoClick(t.id)}>
                 <span className={`m-todo-row__check${t.completed ? " m-todo-row__check--done" : ""}`}
                   onClick={(e) => { e.stopPropagation(); onToggleTodo(t.id, !t.completed); }} />

--- a/client-react/src/mobile/screens/FocusScreen.tsx
+++ b/client-react/src/mobile/screens/FocusScreen.tsx
@@ -9,6 +9,7 @@ interface Props {
   onTodoClick: (id: string) => void;
   onToggleTodo: (id: string, completed: boolean) => void;
   onAvatarClick: () => void;
+  onSnoozeTodo: (id: string) => void;
 }
 
 function getGreeting(): string {

--- a/client-react/src/mobile/screens/ProjectsScreen.tsx
+++ b/client-react/src/mobile/screens/ProjectsScreen.tsx
@@ -10,6 +10,7 @@ interface Props {
   onTodoClick: (id: string) => void;
   onToggleTodo: (id: string, completed: boolean) => void;
   onAvatarClick: () => void;
+  onSnoozeTodo: (id: string) => void;
 }
 
 function groupProjectsByArea(projects: Project[]): { area: string; projects: Project[] }[] {
@@ -24,7 +25,7 @@ function groupProjectsByArea(projects: Project[]): { area: string; projects: Pro
   return Array.from(map.entries()).map(([area, projects]) => ({ area, projects }));
 }
 
-export function ProjectsScreen({ todos, projects, user, onTodoClick, onToggleTodo, onAvatarClick }: Props) {
+export function ProjectsScreen({ todos, projects, user, onTodoClick, onToggleTodo, onAvatarClick, onSnoozeTodo }: Props) {
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const groups = useMemo(() => groupProjectsByArea(projects), [projects]);
   const projectTodos = useMemo(() => {
@@ -44,7 +45,7 @@ export function ProjectsScreen({ todos, projects, user, onTodoClick, onToggleTod
         </header>
         <div className="m-projects__task-list">
           {projectTodos.map((t) => (
-            <SwipeRow key={t.id} onSwipeRight={() => onToggleTodo(t.id, true)}>
+            <SwipeRow key={t.id} onSwipeRight={() => onToggleTodo(t.id, true)} onSwipeLeft={() => onSnoozeTodo(t.id)}>
               <button className="m-todo-row" onClick={() => onTodoClick(t.id)}>
                 <span className={`m-todo-row__check${t.completed ? " m-todo-row__check--done" : ""}`}
                   onClick={(e) => { e.stopPropagation(); onToggleTodo(t.id, !t.completed); }} />

--- a/client-react/src/mobile/screens/TodayScreen.tsx
+++ b/client-react/src/mobile/screens/TodayScreen.tsx
@@ -10,6 +10,7 @@ interface Props {
   onTodoClick: (id: string) => void;
   onToggleTodo: (id: string, completed: boolean) => void;
   onAvatarClick: () => void;
+  onSnoozeTodo: (id: string) => void;
 }
 
 function daysUntil(dateStr: string): number {
@@ -40,7 +41,7 @@ function TodoRowInner({ todo, project, onClick, onToggle }: {
   );
 }
 
-export function TodayScreen({ todos, projects, user, onTodoClick, onToggleTodo, onAvatarClick }: Props) {
+export function TodayScreen({ todos, projects, user, onTodoClick, onToggleTodo, onAvatarClick, onSnoozeTodo }: Props) {
   const openTodos = useMemo(() => todos.filter((t) => !t.completed && !t.archived), [todos]);
   const projectMap = useMemo(() => {
     const m = new Map<string, Project>();
@@ -72,7 +73,7 @@ export function TodayScreen({ todos, projects, user, onTodoClick, onToggleTodo, 
         <h2 className={`m-today__group-title${className ? ` ${className}` : ""}`}>{label}</h2>
         <div className="m-today__group-list">
           {items.map((t) => (
-            <SwipeRow key={t.id} onSwipeRight={() => onToggleTodo(t.id, true)}>
+            <SwipeRow key={t.id} onSwipeRight={() => onToggleTodo(t.id, true)} onSwipeLeft={() => onSnoozeTodo(t.id)}>
               <TodoRowInner todo={t} project={t.projectId ? projectMap.get(t.projectId) : undefined}
                 onClick={() => onTodoClick(t.id)} onToggle={() => onToggleTodo(t.id, !t.completed)} />
             </SwipeRow>


### PR DESCRIPTION
## Summary

Enhancements to the mobile shell (PR #780), making it fully interactive:

- **Profile/Settings sheet** — avatar tap opens bottom sheet with dark mode toggle, custom tab selector, and logout
- **Interactive field editing** — tappable fields in the full bottom sheet with inline pickers for status, priority, project, energy, and a native date input for due date
- **Snooze date picker** — left-swipe reveals snooze action; opening a picker with Later Today, Tomorrow, Next Week, and custom date options
- **Completion animation** — swipe-right triggers a fade-out + height-collapse animation before removing the row
- **Tab cross-fade** — screen transitions use a subtle fade-in + translateY animation
- **Scroll position persistence** — switching tabs saves/restores scroll position so you don't lose your place

## New files

- `ProfileSheet.tsx` — settings bottom sheet component
- `FieldPicker.tsx` — reusable inline option picker for task fields
- `SnoozePicker.tsx` — snooze date selection bottom sheet
- `useScrollPersistence.ts` — hook for saving/restoring scroll per tab

## Modified files

- `MobileShell.tsx` — wired all new components, added snooze + profile state
- `SwipeRow.tsx` — completion animation state + delay
- `TodayScreen.tsx`, `ProjectsScreen.tsx`, `CustomScreen.tsx` — added onSnoozeTodo prop
- `mobile.css` — styles for all new components + keyframe animations

## Test plan

- [x] Typecheck passes
- [x] Format check passes
- [x] React unit tests: 98 passed
- [x] Production build passes (`npm run build:react`)
- [ ] Manual test: profile sheet opens/closes, dark mode toggles
- [ ] Manual test: field pickers change values and persist
- [ ] Manual test: snooze picker reschedules tasks
- [ ] Manual test: swipe-right completion animates smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)