### PR TITLE
fix(react): sync RecurrenceType and TodoRecurrence with canonical types

### DIFF
--- a/client-react/src/types/index.ts
+++ b/client-react/src/types/index.ts
@@ -34,11 +34,18 @@ export interface Todo {
   updatedAt: string;
 }
 
-export type RecurrenceType = "none" | "daily" | "weekly" | "monthly" | "yearly";
+export type RecurrenceType =
+  | "none"
+  | "daily"
+  | "weekly"
+  | "monthly"
+  | "yearly"
+  | "rrule";
 
 export interface TodoRecurrence {
   type: RecurrenceType;
   interval?: number | null;
+  rrule?: string | null;
   nextOccurrence?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Adds missing `"rrule"` variant to `RecurrenceType` in the React client to match the canonical `src/types.ts`
- Adds missing `rrule?: string | null` field to `TodoRecurrence` interface

## Cross-client impact
This is a cross-client contract sync fix. `src/types.ts` already has these types — the React client had drifted.

## Test plan
- [x] `tsc --noEmit` passes (backend + React client)
- [x] `npm run test:unit` — 321/321 passed
- [x] `npm run test:coverage:check` — ratchet passed
- [x] `npm run format:check`, `lint:html`, `lint:css`, `check:architecture` — all pass