### PR TITLE
feat(api): add LLM soft inference layer (phase 4)

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,6 +1,6 @@
 {
-  "statements": 37.79,
-  "branches": 28.18,
-  "functions": 35.68,
-  "lines": 38.96
+  "statements": 38.06,
+  "branches": 28.35,
+  "functions": 36.2,
+  "lines": 39.22
 }

--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -26,5 +26,6 @@ module.exports = {
     "**/src/services/userAdaptationScoring.test.ts",
     "**/src/services/userAdaptationService.test.ts",
     "**/src/services/surfacePolicy.test.ts",
+    "**/src/services/adaptationLlmInference.test.ts",
   ],
 };

--- a/src/adaptation.api.integration.test.ts
+++ b/src/adaptation.api.integration.test.ts
@@ -138,4 +138,21 @@ describe("Adaptation API Integration", () => {
       expect(getResponse.body.eligibility).toBe(computeResponse.body.eligibility);
     });
   });
+
+  describe("GET /adaptation/projects/:projectId/soft-inference", () => {
+    it("returns 401 without auth token", async () => {
+      await request(app)
+        .get("/adaptation/projects/some-id/soft-inference")
+        .expect(401);
+    });
+
+    it("returns 404 for non-existent project", async () => {
+      const response = await request(app)
+        .get("/adaptation/projects/00000000-0000-0000-0000-000000000001/soft-inference")
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(404);
+
+      expect(response.body.error).toBe("Project not found");
+    });
+  });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,6 +65,7 @@ import { createStaticPagesRouter } from "./routes/staticPagesRouter";
 import { createAdaptationRouter } from "./routes/adaptationRouter";
 import { DayPlanService } from "./services/dayPlanService";
 import { UserAdaptationService } from "./services/userAdaptationService";
+import { AdaptationLlmInferenceService } from "./services/adaptationLlmInference";
 import { AreaService } from "./services/areaService";
 import { GoalService } from "./services/goalService";
 import {
@@ -493,10 +494,13 @@ export function createApp(deps: AppDependencies = {}) {
       persistencePrisma,
       activityEventService,
     );
+    const llmInferenceService = new AdaptationLlmInferenceService();
     app.use(
       "/adaptation",
       createAdaptationRouter({
         adaptationService,
+        llmInferenceService,
+        prisma: persistencePrisma,
         resolveUserId: resolveAiUserId,
       }),
     );

--- a/src/routes/adaptationRouter.ts
+++ b/src/routes/adaptationRouter.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response, NextFunction } from "express";
+import { PrismaClient } from "@prisma/client";
 import { UserAdaptationService } from "../services/userAdaptationService";
+import { AdaptationLlmInferenceService } from "../services/adaptationLlmInference";
 import {
   AdaptationFlags,
   getDefaultFlags,
@@ -14,6 +16,8 @@ const log = createLogger("adaptationRouter");
 
 interface AdaptationRouterDeps {
   adaptationService: UserAdaptationService;
+  llmInferenceService?: AdaptationLlmInferenceService;
+  prisma?: PrismaClient;
   flags?: AdaptationFlags;
   resolveUserId: (req: Request, res: Response) => string | null;
 }
@@ -22,6 +26,8 @@ interface AdaptationRouterDeps {
 
 export function createAdaptationRouter({
   adaptationService,
+  llmInferenceService,
+  prisma,
   flags,
   resolveUserId,
 }: AdaptationRouterDeps): Router {
@@ -101,6 +107,101 @@ export function createAdaptationRouter({
           eligibleUserIds: activeFlags.eligibleUserIds
             ? `[${activeFlags.eligibleUserIds.length} users]`
             : undefined,
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  /**
+   * GET /adaptation/projects/:projectId/soft-inference
+   * Returns LLM-based soft inference for a project.
+   * Only used when behavioral confidence is low (< 0.4).
+   * Never feeds the UserAdaptationProfile directly — advisory only.
+   */
+  router.get(
+    "/projects/:projectId/soft-inference",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const userId = resolveUserId(req, res);
+        if (!userId) return;
+
+        const projectId = req.params.projectId;
+        if (Array.isArray(projectId)) {
+          return res.status(400).json({ error: "Invalid project ID" });
+        }
+
+        if (!llmInferenceService || !prisma) {
+          return res.status(503).json({
+            error: "LLM inference not configured",
+            inference: null,
+          });
+        }
+
+        // Fetch project data for inference
+        const project = await prisma.project.findFirst({
+          where: { id: projectId, userId },
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            targetDate: true,
+            createdAt: true,
+          },
+        });
+
+        if (!project) {
+          return res.status(404).json({ error: "Project not found" });
+        }
+
+        // Fetch tasks and headings
+        const [todos, headings] = await Promise.all([
+          prisma.todo.findMany({
+            where: { userId, projectId, archived: false },
+            select: { title: true, headingId: true, dueDate: true },
+            take: 50,
+          }),
+          prisma.heading.findMany({
+            where: { projectId },
+            select: { name: true },
+          }),
+        ]);
+
+        // Check behavioral confidence — only use LLM when low
+        const profileResult = await adaptationService.getOrCreateProfile(userId);
+        if (profileResult.profile.confidence >= 0.4) {
+          // Behavioral data is sufficient — don't use LLM
+          return res.json({
+            inference: null,
+            reason: "behavioral confidence sufficient — LLM inference skipped",
+            behavioralConfidence: profileResult.profile.confidence,
+          });
+        }
+
+        // Run LLM inference
+        const inference = await llmInferenceService.inferProjectIntent({
+          projectName: project.name,
+          projectDescription: project.description,
+          taskTitles: todos.map((t) => t.title),
+          existingSectionNames: headings.map((h) => h.name),
+        });
+
+        log.info("Soft inference result", {
+          userId,
+          projectId,
+          projectName: project.name,
+          behavioralConfidence: profileResult.profile.confidence,
+          llmConfidence: inference?.confidence ?? 0,
+          inferredType: inference?.inferredProjectType,
+        });
+
+        res.json({
+          inference,
+          reason: inference
+            ? "llm soft inference"
+            : "llm provider not available",
+          behavioralConfidence: profileResult.profile.confidence,
         });
       } catch (error) {
         next(error);

--- a/src/services/adaptationLlmInference.test.ts
+++ b/src/services/adaptationLlmInference.test.ts
@@ -1,0 +1,244 @@
+import { AdaptationLlmInferenceService } from "./adaptationLlmInference";
+import * as llmService from "./llmService";
+
+// Mock the LLM service
+jest.mock("./llmService", () => ({
+  callLlm: jest.fn(),
+  LlmProviderNotConfiguredError: class LlmProviderNotConfiguredError extends Error {
+    constructor() {
+      super("AI provider not configured");
+      this.name = "LlmProviderNotConfiguredError";
+    }
+  },
+}));
+
+const mockCallLlm = llmService.callLlm as jest.MockedFunction<typeof llmService.callLlm>;
+const MockLlmProviderNotConfiguredError = llmService.LlmProviderNotConfiguredError;
+
+describe("AdaptationLlmInferenceService", () => {
+  let service: AdaptationLlmInferenceService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AdaptationLlmInferenceService();
+  });
+
+  describe("inferProjectIntent", () => {
+    it("returns parsed inference from valid LLM response", async () => {
+      mockCallLlm.mockResolvedValue(JSON.stringify({
+        inferredProjectType: "trip planning",
+        suggestedSections: ["Flights", "Accommodation", "Itinerary"],
+        recommendedHintStyle: "structured",
+        confidence: 0.85,
+      }));
+
+      const result = await service.inferProjectIntent({
+        projectName: "Japan Trip",
+        projectDescription: "Planning a 2-week trip to Japan",
+        taskTitles: ["Book flights", "Research hotels"],
+        existingSectionNames: [],
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.inferredProjectType).toBe("trip planning");
+      expect(result!.suggestedSections).toEqual(["Flights", "Accommodation", "Itinerary"]);
+      expect(result!.recommendedHintStyle).toBe("structured");
+      expect(result!.confidence).toBe(0.85);
+    });
+
+    it("returns null when LLM provider not configured", async () => {
+      mockCallLlm.mockRejectedValue(new MockLlmProviderNotConfiguredError());
+
+      const result = await service.inferProjectIntent({
+        projectName: "Test Project",
+        taskTitles: [],
+        existingSectionNames: [],
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null on LLM error", async () => {
+      mockCallLlm.mockRejectedValue(new Error("Network error"));
+
+      const result = await service.inferProjectIntent({
+        projectName: "Test Project",
+        taskTitles: [],
+        existingSectionNames: [],
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("handles malformed JSON response gracefully", async () => {
+      mockCallLlm.mockResolvedValue("not valid json");
+
+      const result = await service.inferProjectIntent({
+        projectName: "Test Project",
+        taskTitles: ["task 1"],
+        existingSectionNames: [],
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.confidence).toBe(0);
+    });
+
+    it("strips markdown code blocks from response", async () => {
+      mockCallLlm.mockResolvedValue(
+        '```json\n{"inferredProjectType": "work project", "suggestedSections": [], "recommendedHintStyle": "minimal", "confidence": 0.7}\n```',
+      );
+
+      const result = await service.inferProjectIntent({
+        projectName: "Q4 Report",
+        taskTitles: [],
+        existingSectionNames: [],
+      });
+
+      expect(result!.inferredProjectType).toBe("work project");
+      expect(result!.confidence).toBe(0.7);
+    });
+
+    it("clamps confidence to [0, 1]", async () => {
+      mockCallLlm.mockResolvedValue(JSON.stringify({
+        inferredProjectType: "test",
+        suggestedSections: [],
+        recommendedHintStyle: "minimal",
+        confidence: 1.5,
+      }));
+
+      const result = await service.inferProjectIntent({
+        projectName: "Test",
+        taskTitles: [],
+        existingSectionNames: [],
+      });
+
+      expect(result!.confidence).toBe(1);
+    });
+
+    it("handles missing optional fields gracefully", async () => {
+      mockCallLlm.mockResolvedValue(JSON.stringify({
+        confidence: 0.5,
+      }));
+
+      const result = await service.inferProjectIntent({
+        projectName: "Test",
+        taskTitles: [],
+        existingSectionNames: [],
+      });
+
+      expect(result!.inferredProjectType).toBeUndefined();
+      expect(result!.suggestedSections).toEqual([]);
+      expect(result!.recommendedHintStyle).toBeUndefined();
+      expect(result!.confidence).toBe(0.5);
+    });
+
+    it("limits task titles in prompt to 15", async () => {
+      mockCallLlm.mockResolvedValue(JSON.stringify({
+        confidence: 0.5,
+      }));
+
+      const taskTitles = Array.from({ length: 20 }, (_, i) => `Task ${i + 1}`);
+      await service.inferProjectIntent({
+        projectName: "Test",
+        taskTitles,
+        existingSectionNames: [],
+      });
+
+      const callArgs = mockCallLlm.mock.calls[0][0];
+      expect(callArgs.userPrompt).toContain("... and 5 more");
+      expect(callArgs.userPrompt).toContain("Task 15");
+      expect(callArgs.userPrompt).not.toContain("Task 16");
+    });
+  });
+
+  describe("suggestStarterSections", () => {
+    it("returns parsed sections from valid LLM response", async () => {
+      mockCallLlm.mockResolvedValue(JSON.stringify(["Planning", "Execution", "Review"]));
+
+      const result = await service.suggestStarterSections({
+        projectName: "New Project",
+        taskTitles: ["Task 1"],
+      });
+
+      expect(result).toEqual(["Planning", "Execution", "Review"]);
+    });
+
+    it("returns empty array when LLM provider not configured", async () => {
+      mockCallLlm.mockRejectedValue(new MockLlmProviderNotConfiguredError());
+
+      const result = await service.suggestStarterSections({
+        projectName: "Test",
+        taskTitles: [],
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("falls back to plain text parsing for non-JSON response", async () => {
+      mockCallLlm.mockResolvedValue("- Planning\n- Execution\n- Review");
+
+      const result = await service.suggestStarterSections({
+        projectName: "Test",
+        taskTitles: [],
+      });
+
+      expect(result).toContain("Planning");
+      expect(result).toContain("Execution");
+      expect(result).toContain("Review");
+    });
+
+    it("limits sections to 5 from plain text", async () => {
+      mockCallLlm.mockResolvedValue(
+        "- A\n- B\n- C\n- D\n- E\n- F\n- G",
+      );
+
+      const result = await service.suggestStarterSections({
+        projectName: "Test",
+        taskTitles: [],
+      });
+
+      expect(result.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe("recommendHintStyle", () => {
+    it("returns valid hint style from LLM response", async () => {
+      mockCallLlm.mockResolvedValue("structured");
+
+      const result = await service.recommendHintStyle({
+        projectName: "Complex Project",
+        taskCount: 20,
+        sectionCount: 0,
+        hasDates: false,
+      });
+
+      expect(result).toBe("structured");
+    });
+
+    it("returns supportive for unrecognized response", async () => {
+      mockCallLlm.mockResolvedValue("aggressive");
+
+      const result = await service.recommendHintStyle({
+        projectName: "Test",
+        taskCount: 5,
+        sectionCount: 0,
+        hasDates: false,
+      });
+
+      expect(result).toBe("supportive");
+    });
+
+    it("returns supportive when LLM provider not configured", async () => {
+      mockCallLlm.mockRejectedValue(new MockLlmProviderNotConfiguredError());
+
+      const result = await service.recommendHintStyle({
+        projectName: "Test",
+        taskCount: 5,
+        sectionCount: 0,
+        hasDates: false,
+      });
+
+      expect(result).toBe("supportive");
+    });
+  });
+});

--- a/src/services/adaptationLlmInference.ts
+++ b/src/services/adaptationLlmInference.ts
@@ -1,0 +1,262 @@
+import type { SoftInference, ProjectContext } from "../types";
+import { callLlm, LlmProviderNotConfiguredError } from "./llmService";
+import { createLogger } from "../infra/logging/logger";
+
+const log = createLogger("adaptationLlmInference");
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const LLM_INFERENCE_CONFIDENCE_THRESHOLD = 0.6;
+
+// ─── Service ────────────────────────────────────────────────────────────────
+
+export class AdaptationLlmInferenceService {
+  /**
+   * Infer project intent and suggest starter sections based on project content.
+   *
+   * This is a SOFT inference — it never feeds the UserAdaptationProfile directly.
+   * It is only used when behavioral confidence is low (< 0.4) and the result
+   * is reversible and non-destructive.
+   *
+   * Returns null if the LLM provider is not configured.
+   */
+  async inferProjectIntent(input: {
+    projectName: string;
+    projectDescription?: string | null;
+    taskTitles: string[];
+    existingSectionNames: string[];
+  }): Promise<SoftInference | null> {
+    try {
+      const response = await callLlm({
+        systemPrompt: this._buildSystemPrompt(),
+        userPrompt: this._buildUserPrompt(input),
+        maxTokens: 300,
+        temperature: 0.3,
+      });
+
+      return this._parseLlmResponse(response);
+    } catch (err) {
+      if (err instanceof LlmProviderNotConfiguredError) {
+        log.debug("LLM provider not configured, skipping soft inference", {
+          projectName: input.projectName,
+        });
+        return null;
+      }
+
+      log.warn("LLM inference failed for project intent", {
+        projectName: input.projectName,
+        error: (err as Error).message,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Suggest starter sections for a new or sparse project.
+   * Returns an empty array if the LLM provider is not configured.
+   */
+  async suggestStarterSections(input: {
+    projectName: string;
+    projectDescription?: string | null;
+    taskTitles: string[];
+  }): Promise<string[]> {
+    try {
+      const response = await callLlm({
+        systemPrompt: `You are a helpful project organization assistant. Suggest 2-4 starter sections for a project. Return ONLY a JSON array of section name strings. No explanation, no markdown.`,
+        userPrompt: this._buildSuggestionPrompt(input),
+        maxTokens: 150,
+        temperature: 0.4,
+      });
+
+      return this._parseSectionSuggestion(response);
+    } catch (err) {
+      if (err instanceof LlmProviderNotConfiguredError) {
+        return [];
+      }
+
+      log.warn("LLM section suggestion failed", {
+        projectName: input.projectName,
+        error: (err as Error).message,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Determine the recommended hint style for guidance prompts.
+   * Only used when behavioral confidence is low.
+   */
+  async recommendHintStyle(input: {
+    projectName: string;
+    taskCount: number;
+    sectionCount: number;
+    hasDates: boolean;
+  }): Promise<"minimal" | "supportive" | "structured"> {
+    try {
+      const response = await callLlm({
+        systemPrompt: `You recommend how much guidance to show for a project. Return ONLY one word: "minimal", "supportive", or "structured". No explanation.
+
+- minimal: for simple, self-evident projects
+- supportive: for projects that could benefit from light guidance
+- structured: for complex projects that need clear organization`,
+        userPrompt: `Project: "${input.projectName}"
+Tasks: ${input.taskCount}
+Sections: ${input.sectionCount}
+Has dates: ${input.hasDates}
+
+What guidance style is appropriate?`,
+        maxTokens: 10,
+        temperature: 0.2,
+      });
+
+      const trimmed = response.trim().toLowerCase();
+      if (["minimal", "supportive", "structured"].includes(trimmed)) {
+        return trimmed as "minimal" | "supportive" | "structured";
+      }
+      return "supportive";
+    } catch (err) {
+      if (err instanceof LlmProviderNotConfiguredError) {
+        return "supportive";
+      }
+      log.warn("LLM hint style recommendation failed", {
+        projectName: input.projectName,
+        error: (err as Error).message,
+      });
+      return "supportive";
+    }
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────────
+
+  private _buildSystemPrompt(): string {
+    return `You analyze project content and infer the project's intent and type.
+Return ONLY a JSON object with these fields:
+- inferredProjectType: string (e.g. "trip planning", "event planning", "work project", "home improvement", "learning goal")
+- suggestedSections: string[] (2-4 suggested section names, or empty array if project is too vague)
+- recommendedHintStyle: "minimal" | "supportive" | "structured"
+- confidence: number (0.0-1.0, how confident you are in this inference)
+
+No explanation, no markdown. Return only valid JSON.`;
+  }
+
+  private _buildUserPrompt(input: {
+    projectName: string;
+    projectDescription?: string | null;
+    taskTitles: string[];
+    existingSectionNames: string[];
+  }): string {
+    const lines: string[] = [];
+    lines.push(`Project: "${input.projectName}"`);
+
+    if (input.projectDescription) {
+      lines.push(`Description: "${input.projectDescription}"`);
+    }
+
+    if (input.taskTitles.length > 0) {
+      lines.push(`Tasks (${input.taskTitles.length}):`);
+      const titles = input.taskTitles.slice(0, 15);
+      for (const t of titles) {
+        lines.push(`  - ${t}`);
+      }
+      if (input.taskTitles.length > 15) {
+        lines.push(`  ... and ${input.taskTitles.length - 15} more`);
+      }
+    }
+
+    if (input.existingSectionNames.length > 0) {
+      lines.push(`Existing sections: ${input.existingSectionNames.join(", ")}`);
+    }
+
+    if (input.taskTitles.length === 0 && !input.projectDescription) {
+      lines.push("(No tasks or description yet — infer from name only)");
+    }
+
+    return lines.join("\n");
+  }
+
+  private _buildSuggestionPrompt(input: {
+    projectName: string;
+    projectDescription?: string | null;
+    taskTitles: string[];
+  }): string {
+    const lines: string[] = [];
+    lines.push(`Suggest starter sections for: "${input.projectName}"`);
+
+    if (input.projectDescription) {
+      lines.push(`Description: "${input.projectDescription}"`);
+    }
+
+    if (input.taskTitles.length > 0) {
+      lines.push(`Existing tasks:`);
+      for (const t of input.taskTitles.slice(0, 10)) {
+        lines.push(`  - ${t}`);
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  private _parseLlmResponse(response: string): SoftInference {
+    try {
+      // Strip markdown code blocks if present
+      const cleaned = response
+        .replace(/^```json\s*/m, "")
+        .replace(/^```\s*/m, "")
+        .replace(/\s*```\s*$/m, "")
+        .trim();
+
+      const parsed = JSON.parse(cleaned);
+
+      return {
+        inferredProjectType:
+          typeof parsed.inferredProjectType === "string"
+            ? parsed.inferredProjectType
+            : undefined,
+        suggestedSections: Array.isArray(parsed.suggestedSections)
+          ? parsed.suggestedSections.filter(
+              (s: unknown) => typeof s === "string",
+            )
+          : [],
+        recommendedHintStyle: ["minimal", "supportive", "structured"].includes(
+          parsed.recommendedHintStyle,
+        )
+          ? parsed.recommendedHintStyle
+          : undefined,
+        confidence:
+          typeof parsed.confidence === "number"
+            ? Math.max(0, Math.min(1, parsed.confidence))
+            : 0.5,
+      };
+    } catch {
+      log.warn("Failed to parse LLM inference response as JSON", {
+        response: response.slice(0, 200),
+      });
+      return {
+        confidence: 0,
+      };
+    }
+  }
+
+  private _parseSectionSuggestion(response: string): string[] {
+    try {
+      const cleaned = response
+        .replace(/^```json\s*/m, "")
+        .replace(/^```\s*/m, "")
+        .replace(/\s*```\s*$/m, "")
+        .trim();
+
+      const parsed = JSON.parse(cleaned);
+      if (Array.isArray(parsed)) {
+        return parsed.filter((s: unknown) => typeof s === "string");
+      }
+      return [];
+    } catch {
+      // Try to extract section names from plain text (one per line)
+      return response
+        .split("\n")
+        .map((line) => line.replace(/^[-*•]\s*/, "").trim())
+        .filter((line) => line.length > 0 && line.length < 50)
+        .slice(0, 5);
+    }
+  }
+}


### PR DESCRIPTION
## LLM Soft Inference Layer (Phase 4)

Add LLM-based soft inference as an advisory layer on top of the behavioral adaptation system.

### What's Included

- **`AdaptationLlmInferenceService`** — LLM-based project intent inference
  - `inferProjectIntent()`: analyzes project name, description, tasks, and existing sections to infer project type and suggest structure
  - `suggestStarterSections()`: returns 2-4 starter section names for new/sparse projects
  - `recommendHintStyle()`: returns minimal/supportive/structured guidance level

- **`GET /adaptation/projects/:projectId/soft-inference`** — new endpoint
  - Only called when behavioral confidence < 0.4
  - Returns inference + behavioral confidence + reason
  - Never feeds UserAdaptationProfile directly — advisory only
  - Graceful fallback when LLM provider not configured

### Design Guardrails

| Guardrail | Implementation |
|-----------|---------------|
| LLM never drives profile | SoftInference stored separately, never feeds UserAdaptationProfile |
| Only used with low confidence | Endpoint checks behavioral confidence ≥ 0.4 before calling LLM |
| Reversible and non-destructive | Returns suggestions only — no automatic UI changes |
| Graceful degradation | Returns null/empty when LLM provider not configured |

### Verification
- ✅ TypeScript: `tsc --noEmit` clean
- ✅ Unit tests: 413 passed, 23 suites (15 new LLM inference tests)
- ✅ Integration tests: 9 passed, 1 suite (2 new soft-inference tests)
- ✅ Coverage ratchet: passes (statements 38.06%, branches 28.35%, functions 36.2%, lines 39.22%)

### Files Changed (7 files, +633 lines)
- `src/services/adaptationLlmInference.ts` — LLM inference service
- `src/services/adaptationLlmInference.test.ts` — 15 unit tests
- `src/routes/adaptationRouter.ts` — soft-inference endpoint
- `src/adaptation.api.integration.test.ts` — 2 integration tests
- `src/app.ts` — wire LLM service
- `jest.unit.config.js` — include new test file
- `.coverage-baseline.json` — updated

### Cross-Client Impact
`SoftInference` type already in `src/types.ts` from Phase 1. No new type changes.