### PR TITLE
feat(react-mobile): visual language — amber palette, DM Sans, Lucide icons, micro-animations

### DIFF
--- a/client-react/index.html
+++ b/client-react/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#4f6ef7" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="/app/favicon.svg" />
     <link rel="manifest" href="/app/manifest.json" />
     <title>Todos</title>

--- a/client-react/package-lock.json
+++ b/client-react/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "lucide-react": "^1.7.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2254,6 +2255,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -17,6 +17,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "lucide-react": "^1.7.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/client-react/src/mobile/MobileHeader.tsx
+++ b/client-react/src/mobile/MobileHeader.tsx
@@ -5,15 +5,16 @@ interface Props {
   subtitle?: string;
   user: User | null;
   onAvatarClick: () => void;
+  animated?: boolean;
 }
 
-export function MobileHeader({ title, subtitle, user, onAvatarClick }: Props) {
+export function MobileHeader({ title, subtitle, user, onAvatarClick, animated }: Props) {
   const initial = user?.name?.[0]?.toUpperCase() ?? user?.email?.[0]?.toUpperCase() ?? "?";
   return (
     <header className="m-header">
       <div className="m-header__text">
-        <h1 className="m-header__title">{title}</h1>
-        {subtitle && <p className="m-header__subtitle">{subtitle}</p>}
+        <h1 className={`m-header__title${animated ? " m-header__title--animate" : ""}`}>{title}</h1>
+        {subtitle && <p className={`m-header__subtitle${animated ? " m-header__subtitle--animate" : ""}`}>{subtitle}</p>}
       </div>
       <button className="m-header__avatar" aria-label="Profile and settings" onClick={onAvatarClick}>
         {initial}

--- a/client-react/src/mobile/MobileShell.tsx
+++ b/client-react/src/mobile/MobileShell.tsx
@@ -6,6 +6,7 @@ import { useDarkMode } from "../hooks/useDarkMode";
 import { useTabBar } from "./hooks/useTabBar";
 import { useScrollPersistence } from "./hooks/useScrollPersistence";
 import { useBottomSheet } from "./hooks/useBottomSheet";
+import { usePalette } from "./hooks/usePalette";
 import { TabBar } from "./components/TabBar";
 import { BottomSheet } from "./components/BottomSheet";
 import { QuickCapture } from "./components/QuickCapture";
@@ -50,6 +51,7 @@ export function MobileShell() {
   const { projects, loadProjects } = useProjectsStore();
   const { activeTab, setActiveTab, customView, setCustomView } = useTabBar();
   const { save: saveScroll, restore: restoreScroll } = useScrollPersistence();
+  const { palette, setPalette } = usePalette();
   const prevTabRef = useRef<string>(activeTab);
   const bottomSheet = useBottomSheet();
   const [captureOpen, setCaptureOpen] = useState(false);
@@ -230,7 +232,7 @@ export function MobileShell() {
   const screenProps = { todos, projects, user, onTodoClick: handleTodoClick, onToggleTodo: handleToggleTodo, onAvatarClick: handleAvatarClick, onSnoozeTodo: handleSnoozeTodo };
 
   return (
-    <div className="m-shell" data-density="normal">
+    <div className="m-shell" data-density="normal" data-palette={palette}>
       <div className="m-shell__content">
         {activeTab === "focus" && <FocusScreen {...screenProps} />}
         {activeTab === "today" && <TodayScreen {...screenProps} />}
@@ -250,6 +252,8 @@ export function MobileShell() {
         onChangeCustomView={setCustomView}
         onLogout={logout}
         onNavigate={(p) => setPage(p as "todos" | "ai" | "review" | "admin")}
+        palette={palette}
+        onChangePalette={setPalette}
       />
       <SnoozePicker open={!!snoozeTargetId} onClose={handleSnoozeClose} onSnooze={handleSnoozeConfirm} />
       <TabBar activeTab={activeTab} customView={customView} onTabChange={setActiveTab} onFabPress={() => setCaptureOpen(true)} />

--- a/client-react/src/mobile/components/CompletionBurst.tsx
+++ b/client-react/src/mobile/components/CompletionBurst.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  active: boolean;
+}
+
+export function CompletionBurst({ active }: Props) {
+  if (!active) return null;
+
+  return (
+    <div className="m-burst" aria-hidden="true">
+      {Array.from({ length: 8 }, (_, i) => (
+        <div
+          key={i}
+          className="m-burst__dot"
+          style={{
+            "--angle": `${i * 45}deg`,
+            animationDelay: `${i * 20}ms`,
+          } as React.CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client-react/src/mobile/components/ProfileSheet.tsx
+++ b/client-react/src/mobile/components/ProfileSheet.tsx
@@ -1,6 +1,7 @@
 import type { User } from "../../types";
 import type { WorkspaceView } from "../../components/projects/Sidebar";
 import { CUSTOM_TAB_OPTIONS } from "../hooks/useTabBar";
+import { PALETTES, type PaletteKey } from "../hooks/usePalette";
 
 interface Props {
   open: boolean;
@@ -12,6 +13,8 @@ interface Props {
   onChangeCustomView: (view: WorkspaceView) => void;
   onLogout: () => void;
   onNavigate: (page: string) => void;
+  palette: PaletteKey;
+  onChangePalette: (key: PaletteKey) => void;
 }
 
 function getUserInitial(user: User | null): string {
@@ -40,6 +43,8 @@ export function ProfileSheet({
   onChangeCustomView,
   onLogout,
   onNavigate,
+  palette,
+  onChangePalette,
 }: Props) {
   if (!open) return null;
 
@@ -76,6 +81,28 @@ export function ProfileSheet({
             >
               <span className="m-profile__toggle-knob" />
             </button>
+          </div>
+        </div>
+
+        <div className="m-profile__divider" />
+
+        {/* Theme section */}
+        <div className="m-profile__section">
+          <div className="m-profile__section-label">Theme</div>
+          <div className="m-profile__row">
+            <span className="m-profile__row-label">Color palette</span>
+            <div className="m-profile__palette-picker">
+              {PALETTES.map((p) => (
+                <button
+                  key={p.key}
+                  className={`m-profile__palette-dot${palette === p.key ? " m-profile__palette-dot--active" : ""}`}
+                  style={{ background: `linear-gradient(135deg, ${p.gradient[0]}, ${p.gradient[1]})` }}
+                  onClick={() => onChangePalette(p.key)}
+                  aria-label={p.label}
+                  aria-pressed={palette === p.key}
+                />
+              ))}
+            </div>
           </div>
         </div>
 

--- a/client-react/src/mobile/components/SwipeRow.tsx
+++ b/client-react/src/mobile/components/SwipeRow.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback, type ReactNode } from "react";
 import { useSwipeAction, SWIPE_THRESHOLD } from "../hooks/useSwipeAction";
+import { CompletionBurst } from "./CompletionBurst";
 
 interface Props {
   children: ReactNode;
@@ -40,6 +41,7 @@ export function SwipeRow({
 
   return (
     <div className={`m-swipe-row${completing ? " m-swipe-row--completing" : ""}`} ref={rowRef}>
+      <CompletionBurst active={completing} />
       <div
         className={`m-swipe-row__action m-swipe-row__action--right${isSwipingRight ? " m-swipe-row__action--visible" : ""}`}
         style={{ opacity: isSwipingRight ? progress : 0 }}

--- a/client-react/src/mobile/components/TabBar.tsx
+++ b/client-react/src/mobile/components/TabBar.tsx
@@ -1,3 +1,4 @@
+import { Sun, Calendar, FolderOpen, AlignJustify, Plus } from "lucide-react";
 import type { MobileTab } from "../hooks/useTabBar";
 import { CUSTOM_TAB_OPTIONS } from "../hooks/useTabBar";
 
@@ -12,6 +13,9 @@ function getCustomLabel(view: string): string {
   return CUSTOM_TAB_OPTIONS.find((o) => o.key === view)?.label ?? "More";
 }
 
+const ICON_SIZE = 22;
+const ICON_STROKE = 1.5;
+
 export function TabBar({ activeTab, customView, onTabChange, onFabPress }: Props) {
   return (
     <nav className="m-tab-bar" role="tablist" aria-label="Main navigation">
@@ -21,7 +25,7 @@ export function TabBar({ activeTab, customView, onTabChange, onFabPress }: Props
         aria-selected={activeTab === "focus"}
         onClick={() => onTabChange("focus")}
       >
-        <span className="m-tab-bar__icon" aria-hidden="true">◉</span>
+        <Sun size={ICON_SIZE} strokeWidth={ICON_STROKE} fill={activeTab === "focus" ? "currentColor" : "none"} />
         <span className="m-tab-bar__label">Focus</span>
       </button>
       <button
@@ -30,11 +34,15 @@ export function TabBar({ activeTab, customView, onTabChange, onFabPress }: Props
         aria-selected={activeTab === "today"}
         onClick={() => onTabChange("today")}
       >
-        <span className="m-tab-bar__icon" aria-hidden="true">☀</span>
+        <Calendar size={ICON_SIZE} strokeWidth={ICON_STROKE} fill={activeTab === "today" ? "currentColor" : "none"} />
         <span className="m-tab-bar__label">Today</span>
       </button>
-      <button className="m-tab-bar__fab" aria-label="Quick capture" onClick={() => { if (navigator.vibrate) navigator.vibrate(5); onFabPress(); }}>
-        <span className="m-tab-bar__fab-icon">+</span>
+      <button
+        className="m-tab-bar__fab"
+        aria-label="Quick capture"
+        onClick={() => { if (navigator.vibrate) navigator.vibrate(5); onFabPress(); }}
+      >
+        <Plus size={22} strokeWidth={2.5} color="white" />
       </button>
       <button
         className={`m-tab-bar__tab${activeTab === "projects" ? " m-tab-bar__tab--active" : ""}`}
@@ -42,7 +50,7 @@ export function TabBar({ activeTab, customView, onTabChange, onFabPress }: Props
         aria-selected={activeTab === "projects"}
         onClick={() => onTabChange("projects")}
       >
-        <span className="m-tab-bar__icon" aria-hidden="true">▤</span>
+        <FolderOpen size={ICON_SIZE} strokeWidth={ICON_STROKE} fill={activeTab === "projects" ? "currentColor" : "none"} />
         <span className="m-tab-bar__label">Projects</span>
       </button>
       <button
@@ -51,7 +59,7 @@ export function TabBar({ activeTab, customView, onTabChange, onFabPress }: Props
         aria-selected={activeTab === "custom"}
         onClick={() => onTabChange("custom")}
       >
-        <span className="m-tab-bar__icon" aria-hidden="true">≡</span>
+        <AlignJustify size={ICON_SIZE} strokeWidth={ICON_STROKE} fill={activeTab === "custom" ? "currentColor" : "none"} />
         <span className="m-tab-bar__label">{getCustomLabel(customView)}</span>
       </button>
     </nav>

--- a/client-react/src/mobile/hooks/useCountUp.test.ts
+++ b/client-react/src/mobile/hooks/useCountUp.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCountUp } from "./useCountUp";
+
+describe("useCountUp", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("starts at 0", () => {
+    const { result } = renderHook(() => useCountUp(42, 800));
+    expect(result.current).toBe(0);
+  });
+
+  it("reaches target after duration", () => {
+    const { result } = renderHook(() => useCountUp(10, 800));
+    act(() => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(result.current).toBe(10);
+  });
+
+  it("returns 0 when target is 0", () => {
+    const { result } = renderHook(() => useCountUp(0, 800));
+    expect(result.current).toBe(0);
+  });
+});

--- a/client-react/src/mobile/hooks/useCountUp.ts
+++ b/client-react/src/mobile/hooks/useCountUp.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, useRef } from "react";
+
+export function useCountUp(target: number, duration: number = 800): number {
+  const [value, setValue] = useState(0);
+  const startTime = useRef(0);
+  const tickRef = useRef<ReturnType<typeof setInterval>>();
+
+  useEffect(() => {
+    if (target === 0) { setValue(0); return; }
+    startTime.current = Date.now();
+
+    const tick = () => {
+      const elapsed = Date.now() - startTime.current;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - (1 - progress) * (1 - progress);
+      setValue(Math.round(eased * target));
+      if (progress >= 1) {
+        clearInterval(tickRef.current);
+      }
+    };
+
+    tickRef.current = setInterval(tick, 16);
+    tick();
+    return () => clearInterval(tickRef.current);
+  }, [target, duration]);
+
+  return value;
+}

--- a/client-react/src/mobile/hooks/useCountUp.ts
+++ b/client-react/src/mobile/hooks/useCountUp.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useRef } from "react";
 export function useCountUp(target: number, duration: number = 800): number {
   const [value, setValue] = useState(0);
   const startTime = useRef(0);
-  const tickRef = useRef<ReturnType<typeof setInterval>>();
+  const tickRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
   useEffect(() => {
     if (target === 0) { setValue(0); return; }

--- a/client-react/src/mobile/hooks/usePalette.test.ts
+++ b/client-react/src/mobile/hooks/usePalette.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePalette, PALETTES } from "./usePalette";
+
+const store: Record<string, string> = {};
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  vi.spyOn(Storage.prototype, "getItem").mockImplementation((k) => store[k] ?? null);
+  vi.spyOn(Storage.prototype, "setItem").mockImplementation((k, v) => { store[k] = v; });
+});
+
+describe("usePalette", () => {
+  it("defaults to amber", () => {
+    const { result } = renderHook(() => usePalette());
+    expect(result.current.palette).toBe("amber");
+  });
+
+  it("changes palette", () => {
+    const { result } = renderHook(() => usePalette());
+    act(() => result.current.setPalette("violet"));
+    expect(result.current.palette).toBe("violet");
+  });
+
+  it("persists to localStorage", () => {
+    const { result } = renderHook(() => usePalette());
+    act(() => result.current.setPalette("teal"));
+    expect(store["mobile:palette"]).toBe("teal");
+  });
+
+  it("restores from localStorage", () => {
+    store["mobile:palette"] = "coral";
+    const { result } = renderHook(() => usePalette());
+    expect(result.current.palette).toBe("coral");
+  });
+
+  it("falls back to amber for invalid stored value", () => {
+    store["mobile:palette"] = "invalid";
+    const { result } = renderHook(() => usePalette());
+    expect(result.current.palette).toBe("amber");
+  });
+
+  it("exports PALETTES metadata", () => {
+    expect(PALETTES).toHaveLength(4);
+    expect(PALETTES[0].key).toBe("amber");
+    expect(PALETTES[0].label).toBe("Sunset Amber");
+  });
+});

--- a/client-react/src/mobile/hooks/usePalette.ts
+++ b/client-react/src/mobile/hooks/usePalette.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback } from "react";
+
+export type PaletteKey = "amber" | "violet" | "teal" | "coral";
+
+export const PALETTES: { key: PaletteKey; label: string; gradient: [string, string] }[] = [
+  { key: "amber", label: "Sunset Amber", gradient: ["#FDCB6E", "#E17055"] },
+  { key: "violet", label: "Iris Violet", gradient: ["#A29BFE", "#6C5CE7"] },
+  { key: "teal", label: "Mint Teal", gradient: ["#00CEC9", "#00B894"] },
+  { key: "coral", label: "Coral Fire", gradient: ["#FF6B6B", "#EE5A24"] },
+];
+
+const STORAGE_KEY = "mobile:palette";
+
+function getStoredPalette(): PaletteKey {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored && PALETTES.some((p) => p.key === stored)) return stored as PaletteKey;
+  return "amber";
+}
+
+export function usePalette() {
+  const [palette, setPaletteState] = useState<PaletteKey>(getStoredPalette);
+
+  const setPalette = useCallback((key: PaletteKey) => {
+    setPaletteState(key);
+    localStorage.setItem(STORAGE_KEY, key);
+  }, []);
+
+  return { palette, setPalette };
+}

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1,14 +1,16 @@
+@import "./tokens-mobile.css";
+
 /* ===== Mobile Shell Styles ===== */
-/* Uses design tokens from tokens.css exclusively */
+/* Uses mobile tokens from tokens-mobile.css and shared tokens for spacing/typography */
 
 /* --- Shell layout --- */
 .m-shell {
   display: flex;
   flex-direction: column;
   min-height: 100dvh;
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font-sans);
+  background: var(--m-bg);
+  color: var(--m-text);
+  font-family: var(--m-font);
 }
 
 .m-shell__content {
@@ -43,14 +45,14 @@
 .m-header__title {
   font-size: var(--fs-xl);
   font-weight: var(--fw-bold);
-  color: var(--text-strong);
+  color: var(--m-text-strong);
   margin: 0;
   line-height: var(--lh-tight);
 }
 
 .m-header__subtitle {
   font-size: var(--fs-meta);
-  color: var(--muted);
+  color: var(--m-muted);
   margin: var(--s-0) 0 0;
 }
 
@@ -62,9 +64,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--accent-light);
-  color: var(--accent);
-  border-radius: var(--r-full);
+  background: var(--m-accent-light);
+  color: var(--m-accent);
+  border-radius: var(--m-r-full);
   border: none;
   font-size: var(--fs-meta);
   font-weight: var(--fw-semibold);
@@ -74,7 +76,7 @@
 .m-header__back {
   background: none;
   border: none;
-  color: var(--accent);
+  color: var(--m-accent);
   font-size: var(--fs-body);
   cursor: pointer;
   padding: var(--s-2);
@@ -90,8 +92,8 @@
   display: flex;
   align-items: flex-end;
   justify-content: space-around;
-  background: var(--surface);
-  border-top: 1px solid var(--border);
+  background: var(--m-surface);
+  border-top: 1px solid var(--m-border);
   padding: var(--s-2) 0;
   padding-bottom: calc(var(--s-2) + env(safe-area-inset-bottom, 0px));
   z-index: 100;
@@ -106,14 +108,14 @@
   min-height: 44px;
   background: none;
   border: none;
-  color: var(--muted);
+  color: var(--m-muted);
   cursor: pointer;
   padding: var(--s-1) 0;
   transition: color var(--dur-fast);
 }
 
 .m-tab-bar__tab--active {
-  color: var(--accent);
+  color: var(--m-accent);
 }
 
 .m-tab-bar__tab--active .m-tab-bar__label {
@@ -136,11 +138,11 @@
   justify-content: center;
   width: 52px;
   height: 52px;
-  background: linear-gradient(135deg, var(--accent), var(--accent-3));
-  border-radius: var(--r-full);
+  background: var(--m-gradient);
+  border-radius: var(--m-r-full);
   border: none;
   margin-top: -18px;
-  box-shadow: 0 4px 16px color-mix(in oklab, var(--accent) 40%, transparent);
+  box-shadow: var(--m-shadow-fab);
   cursor: pointer;
   transition: transform var(--dur-fast) var(--ease-out);
 }
@@ -174,17 +176,17 @@
 
 .m-swipe-row__action--right {
   left: 0;
-  background: color-mix(in oklab, var(--success) 15%, var(--surface));
+  background: color-mix(in oklab, var(--m-success) 15%, var(--m-surface));
   padding-left: var(--s-5);
-  color: var(--success);
+  color: var(--m-success);
 }
 
 .m-swipe-row__action--left {
   right: 0;
-  background: color-mix(in oklab, var(--accent) 15%, var(--surface));
+  background: color-mix(in oklab, var(--m-accent) 15%, var(--m-surface));
   justify-content: flex-end;
   padding-right: var(--s-5);
-  color: var(--accent);
+  color: var(--m-accent);
 }
 
 .m-swipe-row__action-label {
@@ -194,7 +196,7 @@
 
 .m-swipe-row__content {
   position: relative;
-  background: var(--surface);
+  background: var(--m-surface);
 }
 
 .m-swipe-row--completing .m-swipe-row__content {
@@ -211,7 +213,7 @@
 .m-bottom-sheet__backdrop {
   position: fixed;
   inset: 0;
-  background: var(--overlay);
+  background: rgba(0,0,0,0.5);
   z-index: 90;
   animation: m-fade-in var(--dur-base) var(--ease-out);
 }
@@ -221,12 +223,12 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background: var(--surface);
-  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  background: var(--m-surface);
+  border-radius: var(--m-r-xl) var(--m-r-xl) 0 0;
   z-index: 95;
   transition: height var(--dur-slow) var(--ease-spring);
   overflow-y: auto;
-  box-shadow: var(--shadow-xl);
+  box-shadow: var(--m-shadow-lg);
 }
 
 .m-bottom-sheet__handle {
@@ -240,8 +242,8 @@
 .m-bottom-sheet__handle-bar {
   width: 36px;
   height: 4px;
-  background: var(--muted-light);
-  border-radius: var(--r-full);
+  background: var(--m-muted-light);
+  border-radius: var(--m-r-full);
 }
 
 .m-bottom-sheet__body {
@@ -252,7 +254,7 @@
 .m-capture__backdrop {
   position: fixed;
   inset: 0;
-  background: var(--overlay);
+  background: rgba(0,0,0,0.5);
   z-index: 100;
 }
 
@@ -261,17 +263,17 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background: var(--surface);
-  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  background: var(--m-surface);
+  border-radius: var(--m-r-xl) var(--m-r-xl) 0 0;
   z-index: 105;
   padding: var(--s-3) var(--s-5) var(--s-6);
-  box-shadow: var(--shadow-xl);
+  box-shadow: var(--m-shadow-lg);
 }
 
 .m-capture__tabs {
   display: flex;
-  background: var(--surface-3);
-  border-radius: var(--r-sm);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-sm);
   padding: 3px;
   margin-bottom: var(--s-5);
 }
@@ -280,35 +282,35 @@
   flex: 1;
   text-align: center;
   padding: var(--s-2);
-  border-radius: var(--r-sm);
+  border-radius: var(--m-r-sm);
   border: none;
   background: none;
-  color: var(--muted);
+  color: var(--m-muted);
   font-size: var(--fs-meta);
   cursor: pointer;
 }
 
 .m-capture__tab--active {
-  background: var(--accent-light);
-  color: var(--accent);
+  background: var(--m-accent-light);
+  color: var(--m-accent);
   font-weight: var(--fw-semibold);
 }
 
 .m-capture__input {
   width: 100%;
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-3h) var(--s-4);
   border: none;
-  color: var(--text);
+  color: var(--m-text);
   font-size: var(--fs-body);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   margin-bottom: var(--s-3);
   box-sizing: border-box;
 }
 
 .m-capture__input::placeholder {
-  color: var(--muted-light);
+  color: var(--m-muted-light);
 }
 
 .m-capture__chips {
@@ -321,10 +323,10 @@
 .m-capture__chip {
   padding: var(--s-2) var(--s-3h);
   min-height: 36px;
-  background: var(--surface-3);
-  border-radius: var(--r-full);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-full);
   border: none;
-  color: var(--muted);
+  color: var(--m-muted);
   font-size: var(--fs-label);
   cursor: pointer;
   display: flex;
@@ -333,20 +335,20 @@
 }
 
 .m-capture__chip--set {
-  background: var(--accent-light);
-  color: var(--accent);
+  background: var(--m-accent-light);
+  color: var(--m-accent);
 }
 
 .m-capture__picker {
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-2);
   margin-bottom: var(--s-4);
 }
 
 .m-capture__picker-label {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
   padding: var(--s-1) var(--s-2) var(--s-2);
@@ -357,25 +359,25 @@
   width: 100%;
   text-align: left;
   padding: var(--s-2h) var(--s-3);
-  border-radius: var(--r-sm);
+  border-radius: var(--m-r-sm);
   border: none;
   background: none;
-  color: var(--muted);
+  color: var(--m-muted);
   font-size: var(--fs-meta);
   cursor: pointer;
 }
 
 .m-capture__picker-item--selected {
-  background: var(--accent-light);
-  color: var(--text);
+  background: var(--m-accent-light);
+  color: var(--m-text);
 }
 
 .m-capture__submit {
   width: 100%;
   padding: var(--s-3h);
-  background: linear-gradient(135deg, var(--accent), var(--accent-3));
+  background: var(--m-gradient);
   border: none;
-  border-radius: var(--r-md);
+  border-radius: var(--m-r-md);
   color: white;
   font-size: var(--fs-body);
   font-weight: var(--fw-semibold);
@@ -391,7 +393,7 @@
 .m-search {
   position: fixed;
   inset: 0;
-  background: var(--bg);
+  background: var(--m-bg);
   z-index: 110;
   display: flex;
   flex-direction: column;
@@ -406,23 +408,23 @@
 
 .m-search__input {
   flex: 1;
-  background: var(--surface-3);
-  border-radius: var(--r-sm);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-sm);
   padding: var(--s-2h) var(--s-3);
   border: none;
-  color: var(--text);
+  color: var(--m-text);
   font-size: var(--fs-body);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
 }
 
 .m-search__input::placeholder {
-  color: var(--muted-light);
+  color: var(--m-muted-light);
 }
 
 .m-search__cancel {
   background: none;
   border: none;
-  color: var(--accent);
+  color: var(--m-accent);
   font-size: var(--fs-meta);
   cursor: pointer;
 }
@@ -443,19 +445,19 @@
   width: 100%;
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--m-border);
   text-align: left;
-  color: var(--text);
+  color: var(--m-text);
   cursor: pointer;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
 }
 
 .m-search__result-check {
-  color: var(--muted);
+  color: var(--m-muted);
 }
 
 .m-search__result-check--done {
-  color: var(--success);
+  color: var(--m-success);
 }
 
 .m-search__result-title {
@@ -464,7 +466,7 @@
 
 .m-search__empty {
   text-align: center;
-  color: var(--muted);
+  color: var(--m-muted);
   padding: var(--s-8) var(--s-4);
 }
 
@@ -478,11 +480,11 @@
   width: 100%;
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--m-border);
   text-align: left;
-  color: var(--text);
+  color: var(--m-text);
   cursor: pointer;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
 }
 
 .m-todo-row:last-child {
@@ -492,15 +494,15 @@
 .m-todo-row__check {
   width: 20px;
   height: 20px;
-  border: 2px solid var(--muted-light);
-  border-radius: var(--r-xs);
+  border: 2px solid var(--m-muted-light);
+  border-radius: var(--m-r-sm);
   flex-shrink: 0;
   cursor: pointer;
 }
 
 .m-todo-row__check--done {
-  background: color-mix(in oklab, var(--success) 15%, transparent);
-  border-color: var(--success);
+  background: color-mix(in oklab, var(--m-success) 15%, transparent);
+  border-color: var(--m-success);
 }
 
 .m-todo-row__text {
@@ -510,7 +512,7 @@
 
 .m-todo-row__title {
   font-size: var(--fs-body);
-  color: var(--text);
+  color: var(--m-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -518,7 +520,7 @@
 
 .m-todo-row__meta {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-top: var(--s-0);
 }
 
@@ -530,20 +532,20 @@
 .m-focus__next-card {
   display: block;
   width: 100%;
-  background: var(--surface);
-  border-radius: var(--r-lg);
+  background: var(--m-surface);
+  border-radius: var(--m-r-lg);
   padding: var(--s-4);
-  border: 1px solid var(--border-light);
+  border: 1px solid var(--m-border);
   text-align: left;
   cursor: pointer;
   margin-bottom: var(--s-3);
-  font-family: var(--font-sans);
-  color: var(--text);
+  font-family: var(--m-font);
+  color: var(--m-text);
 }
 
 .m-focus__next-label {
   font-size: var(--fs-xs);
-  color: var(--accent);
+  color: var(--m-accent);
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
@@ -559,27 +561,27 @@
 .m-focus__check {
   width: 22px;
   height: 22px;
-  border: 2px solid var(--muted-light);
-  border-radius: var(--r-xs);
+  border: 2px solid var(--m-muted-light);
+  border-radius: var(--m-r-sm);
   flex-shrink: 0;
   margin-top: 1px;
   cursor: pointer;
 }
 
 .m-focus__check--done {
-  border-color: var(--success);
-  background: color-mix(in oklab, var(--success) 15%, transparent);
+  border-color: var(--m-success);
+  background: color-mix(in oklab, var(--m-success) 15%, transparent);
 }
 
 .m-focus__next-title {
   font-size: var(--fs-body);
   font-weight: var(--fw-medium);
-  color: var(--text-strong);
+  color: var(--m-text-strong);
 }
 
 .m-focus__next-meta {
   font-size: var(--fs-label);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-top: var(--s-1);
 }
 
@@ -589,7 +591,7 @@
 
 .m-focus__section-title {
   font-size: var(--fs-label);
-  color: var(--muted);
+  color: var(--m-muted);
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
@@ -598,9 +600,9 @@
 }
 
 .m-focus__list {
-  background: var(--surface);
-  border-radius: var(--r-lg);
-  border: 1px solid var(--border-light);
+  background: var(--m-surface);
+  border-radius: var(--m-r-lg);
+  border: 1px solid var(--m-border);
   overflow: hidden;
 }
 
@@ -612,11 +614,11 @@
   width: 100%;
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--m-border);
   text-align: left;
   cursor: pointer;
-  font-family: var(--font-sans);
-  color: var(--text);
+  font-family: var(--m-font);
+  color: var(--m-text);
 }
 
 .m-focus__list-row:last-child {
@@ -630,12 +632,12 @@
 
 .m-focus__list-title {
   font-size: var(--fs-body);
-  color: var(--text);
+  color: var(--m-text);
 }
 
 .m-focus__list-meta {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-top: var(--s-0);
 }
 
@@ -647,11 +649,11 @@
 
 .m-focus__stat {
   flex: 1;
-  background: var(--surface);
-  border-radius: var(--r-md);
+  background: var(--m-surface);
+  border-radius: var(--m-r-md);
   padding: var(--s-3h);
   text-align: center;
-  border: 1px solid var(--border-light);
+  border: 1px solid var(--m-border);
 }
 
 .m-focus__stat-value {
@@ -660,13 +662,13 @@
   line-height: 1;
 }
 
-.m-focus__stat-value--success { color: var(--success); }
-.m-focus__stat-value--warning { color: var(--warning); }
-.m-focus__stat-value--accent { color: var(--accent); }
+.m-focus__stat-value--success { color: var(--m-success); }
+.m-focus__stat-value--warning { color: var(--m-amber); }
+.m-focus__stat-value--accent { color: var(--m-accent); }
 
 .m-focus__stat-label {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-top: var(--s-0);
 }
 
@@ -677,7 +679,7 @@
 
 .m-today__pull-hint {
   text-align: center;
-  color: var(--muted-light);
+  color: var(--m-muted-light);
   font-size: var(--fs-xs);
   margin-bottom: var(--s-2);
 }
@@ -688,7 +690,7 @@
 
 .m-today__group-title {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
@@ -697,19 +699,19 @@
 }
 
 .m-today__group-title--overdue {
-  color: var(--danger);
+  color: var(--m-danger);
 }
 
 .m-today__group-list {
-  background: var(--surface);
-  border-radius: var(--r-lg);
-  border: 1px solid var(--border-light);
+  background: var(--m-surface);
+  border-radius: var(--m-r-lg);
+  border: 1px solid var(--m-border);
   overflow: hidden;
 }
 
 .m-today__empty {
   text-align: center;
-  color: var(--muted);
+  color: var(--m-muted);
   padding: var(--s-8) var(--s-4);
 }
 
@@ -724,7 +726,7 @@
 
 .m-projects__area-title {
   font-size: var(--fs-xs);
-  color: var(--accent);
+  color: var(--m-accent);
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
@@ -733,9 +735,9 @@
 }
 
 .m-projects__area-list {
-  background: var(--surface);
-  border-radius: var(--r-lg);
-  border: 1px solid var(--border-light);
+  background: var(--m-surface);
+  border-radius: var(--m-r-lg);
+  border: 1px solid var(--m-border);
   overflow: hidden;
 }
 
@@ -746,10 +748,10 @@
   width: 100%;
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--m-border);
   cursor: pointer;
-  font-family: var(--font-sans);
-  color: var(--text);
+  font-family: var(--m-font);
+  color: var(--m-text);
 }
 
 .m-projects__row:last-child {
@@ -764,12 +766,12 @@
 .m-projects__row-name {
   font-size: var(--fs-body);
   font-weight: var(--fw-medium);
-  color: var(--text);
+  color: var(--m-text);
 }
 
 .m-projects__row-counts {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-top: var(--s-0);
 }
 
@@ -782,19 +784,19 @@
 .m-projects__progress-bar {
   width: 40px;
   height: 4px;
-  background: var(--surface-3);
-  border-radius: var(--r-full);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-full);
   overflow: hidden;
 }
 
 .m-projects__progress-fill {
   height: 100%;
-  background: var(--success);
-  border-radius: var(--r-full);
+  background: var(--m-success);
+  border-radius: var(--m-r-full);
 }
 
 .m-projects__row-chevron {
-  color: var(--muted-light);
+  color: var(--m-muted-light);
   font-size: var(--fs-section);
 }
 
@@ -804,7 +806,7 @@
 
 .m-projects__empty {
   text-align: center;
-  color: var(--muted);
+  color: var(--m-muted);
   padding: var(--s-8) var(--s-4);
 }
 
@@ -814,15 +816,15 @@
 }
 
 .m-custom__list {
-  background: var(--surface);
-  border-radius: var(--r-lg);
-  border: 1px solid var(--border-light);
+  background: var(--m-surface);
+  border-radius: var(--m-r-lg);
+  border: 1px solid var(--m-border);
   overflow: hidden;
 }
 
 .m-custom__empty {
   text-align: center;
-  color: var(--muted);
+  color: var(--m-muted);
   padding: var(--s-8) var(--s-4);
 }
 
@@ -830,31 +832,31 @@
 .m-pill {
   display: inline-block;
   padding: var(--s-1) var(--s-3);
-  border-radius: var(--r-full);
+  border-radius: var(--m-r-full);
   font-size: var(--fs-label);
 }
 
 .m-pill--status {
-  background: var(--accent-light);
-  color: var(--accent);
+  background: var(--m-accent-light);
+  color: var(--m-accent);
 }
 
 .m-pill--due {
-  background: color-mix(in oklab, var(--warning) 12%, var(--surface));
-  color: var(--warning);
+  background: color-mix(in oklab, var(--m-amber) 12%, var(--m-surface));
+  color: var(--m-amber);
 }
 
 .m-pill--project {
-  background: color-mix(in oklab, var(--success) 12%, var(--surface));
-  color: var(--success);
+  background: color-mix(in oklab, var(--m-success) 12%, var(--m-surface));
+  color: var(--m-success);
 }
 
-.m-priority--urgent { color: var(--danger); }
-.m-priority--high { color: var(--warning); }
-.m-priority--medium { color: var(--accent); }
-.m-priority--low { color: var(--muted); }
+.m-priority--urgent { color: var(--m-danger); }
+.m-priority--high { color: var(--m-amber); }
+.m-priority--medium { color: var(--m-accent); }
+.m-priority--low { color: var(--m-muted); }
 
-.m-overdue { color: var(--danger); }
+.m-overdue { color: var(--m-danger); }
 
 /* --- Sheet half content --- */
 .m-sheet-half__header {
@@ -867,12 +869,12 @@
 .m-sheet-half__title {
   font-size: var(--fs-md);
   font-weight: var(--fw-semibold);
-  color: var(--text-strong);
+  color: var(--m-text-strong);
 }
 
 .m-sheet-half__desc {
   font-size: var(--fs-meta);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-top: var(--s-1);
 }
 
@@ -884,23 +886,23 @@
 }
 
 .m-sheet-half__subtasks {
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-3);
   margin-bottom: var(--s-4);
 }
 
 .m-sheet-half__subtasks-label {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   font-weight: var(--fw-semibold);
   margin-bottom: var(--s-2);
 }
 
 .m-sheet-half__subtask {
   padding: var(--s-2) 0;
-  border-bottom: 1px solid var(--border-light);
-  color: var(--text);
+  border-bottom: 1px solid var(--m-border);
+  color: var(--m-text);
   font-size: var(--fs-meta);
   background: none;
   border-top: none;
@@ -909,7 +911,7 @@
   width: 100%;
   text-align: left;
   cursor: pointer;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   min-height: 44px;
   display: flex;
   align-items: center;
@@ -921,7 +923,7 @@
 }
 
 .m-sheet-half__subtask--done {
-  color: var(--success);
+  color: var(--m-success);
   text-decoration: line-through;
   opacity: 0.6;
 }
@@ -933,22 +935,22 @@
 
 .m-sheet-half__action {
   flex: 1;
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-3);
   border: none;
   text-align: center;
-  color: var(--muted);
+  color: var(--m-muted);
   font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   cursor: pointer;
   min-height: 44px;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
 }
 
 .m-sheet-half__action--complete {
-  background: color-mix(in oklab, var(--success) 12%, var(--surface));
-  color: var(--success);
+  background: color-mix(in oklab, var(--m-success) 12%, var(--m-surface));
+  color: var(--m-success);
 }
 
 /* --- Sheet full content --- */
@@ -962,13 +964,13 @@
 .m-sheet-full__title {
   font-size: var(--fs-md);
   font-weight: var(--fw-semibold);
-  color: var(--text-strong);
+  color: var(--m-text-strong);
   flex: 1;
 }
 
 .m-sheet-full__desc {
   font-size: var(--fs-meta);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-bottom: var(--s-5);
   padding-left: 36px;
 }
@@ -981,20 +983,20 @@
 }
 
 .m-sheet-full__field {
-  background: var(--surface-3);
+  background: var(--m-surface-3);
   padding: var(--s-3);
-  border-radius: var(--r-sm);
+  border-radius: var(--m-r-sm);
 }
 
 .m-sheet-full__field-label {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   text-transform: uppercase;
   margin-bottom: var(--s-1);
 }
 
 .m-sheet-full__field-value {
-  color: var(--text);
+  color: var(--m-text);
   font-size: var(--fs-meta);
 }
 
@@ -1010,11 +1012,11 @@
 }
 
 .m-sheet-full__tag {
-  background: var(--surface-3);
+  background: var(--m-surface-3);
   padding: var(--s-1) var(--s-3);
-  border-radius: var(--r-full);
+  border-radius: var(--m-r-full);
   font-size: var(--fs-label);
-  color: var(--muted);
+  color: var(--m-muted);
 }
 
 .m-sheet-full__subtasks {
@@ -1023,9 +1025,9 @@
 
 .m-sheet-full__subtask {
   padding: var(--s-2h) 0;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--m-border);
   font-size: var(--fs-meta);
-  color: var(--text);
+  color: var(--m-text);
   background: none;
   border-top: none;
   border-left: none;
@@ -1033,7 +1035,7 @@
   width: 100%;
   text-align: left;
   cursor: pointer;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   min-height: 44px;
   display: flex;
   align-items: center;
@@ -1045,7 +1047,7 @@
 }
 
 .m-sheet-full__subtask--done {
-  color: var(--success);
+  color: var(--m-success);
   text-decoration: line-through;
   opacity: 0.6;
 }
@@ -1055,10 +1057,10 @@
 }
 
 .m-sheet-full__notes-text {
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-3h);
-  color: var(--muted);
+  color: var(--m-muted);
   font-size: var(--fs-meta);
   line-height: var(--lh-relaxed);
   margin-top: var(--s-2);
@@ -1066,22 +1068,22 @@
 
 .m-sheet-full__notes-input {
   width: 100%;
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-3h);
-  color: var(--text);
+  color: var(--m-text);
   font-size: var(--fs-meta);
   line-height: var(--lh-relaxed);
   border: none;
   resize: vertical;
   min-height: 80px;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   box-sizing: border-box;
   margin-top: var(--s-2);
 }
 
 .m-sheet-full__notes-input::placeholder {
-  color: var(--muted-light);
+  color: var(--m-muted-light);
 }
 
 .m-sheet-full__actions {
@@ -1092,8 +1094,8 @@
 
 .m-sheet-full__action {
   flex: 1;
-  background: var(--surface-3);
-  border-radius: var(--r-md);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-md);
   padding: var(--s-3);
   border: none;
   text-align: center;
@@ -1101,18 +1103,18 @@
   font-weight: var(--fw-medium);
   cursor: pointer;
   min-height: 44px;
-  font-family: var(--font-sans);
-  color: var(--muted);
+  font-family: var(--m-font);
+  color: var(--m-muted);
 }
 
 .m-sheet-full__action--complete {
-  background: color-mix(in oklab, var(--success) 12%, var(--surface));
-  color: var(--success);
+  background: color-mix(in oklab, var(--m-success) 12%, var(--m-surface));
+  color: var(--m-success);
 }
 
 .m-sheet-full__action--delete {
-  background: color-mix(in oklab, var(--danger) 12%, var(--surface));
-  color: var(--danger);
+  background: color-mix(in oklab, var(--m-danger) 12%, var(--m-surface));
+  color: var(--m-danger);
 }
 
 /* --- Profile sheet --- */
@@ -1121,10 +1123,10 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background: var(--surface);
-  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  background: var(--m-surface);
+  border-radius: var(--m-r-xl) var(--m-r-xl) 0 0;
   z-index: 105;
-  box-shadow: var(--shadow-xl);
+  box-shadow: var(--m-shadow-lg);
   padding-bottom: calc(var(--s-5) + env(safe-area-inset-bottom, 0px));
 }
 
@@ -1139,9 +1141,9 @@
   width: 48px;
   height: 48px;
   min-width: 48px;
-  background: var(--accent-light);
-  color: var(--accent);
-  border-radius: var(--r-full);
+  background: var(--m-accent-light);
+  color: var(--m-accent);
+  border-radius: var(--m-r-full);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1158,7 +1160,7 @@
 .m-profile__user-name {
   font-size: var(--fs-body);
   font-weight: var(--fw-semibold);
-  color: var(--text-strong);
+  color: var(--m-text-strong);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1166,7 +1168,7 @@
 
 .m-profile__user-email {
   font-size: var(--fs-meta);
-  color: var(--muted);
+  color: var(--m-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1174,7 +1176,7 @@
 
 .m-profile__user-plan {
   font-size: var(--fs-xs);
-  color: var(--accent);
+  color: var(--m-accent);
   font-weight: var(--fw-medium);
   text-transform: capitalize;
   margin-top: var(--s-0);
@@ -1182,7 +1184,7 @@
 
 .m-profile__divider {
   height: 1px;
-  background: var(--border-light);
+  background: var(--m-border);
   margin: 0 var(--s-5);
 }
 
@@ -1192,7 +1194,7 @@
 
 .m-profile__section-label {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   font-weight: var(--fw-semibold);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
@@ -1208,16 +1210,16 @@
 
 .m-profile__row-label {
   font-size: var(--fs-body);
-  color: var(--text);
+  color: var(--m-text);
 }
 
 /* Toggle switch */
 .m-profile__toggle {
   width: 48px;
   height: 28px;
-  border-radius: var(--r-full);
+  border-radius: var(--m-r-full);
   border: none;
-  background: var(--surface-3);
+  background: var(--m-surface-3);
   cursor: pointer;
   padding: 0;
   position: relative;
@@ -1226,7 +1228,7 @@
 }
 
 .m-profile__toggle--on {
-  background: var(--accent);
+  background: var(--m-accent);
 }
 
 .m-profile__toggle-knob {
@@ -1236,7 +1238,7 @@
   left: 3px;
   width: 22px;
   height: 22px;
-  border-radius: var(--r-full);
+  border-radius: var(--m-r-full);
   background: white;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   transition: transform var(--dur-fast) var(--ease-out);
@@ -1248,14 +1250,14 @@
 
 /* Custom view cycle button */
 .m-profile__cycle-btn {
-  background: var(--surface-3);
+  background: var(--m-surface-3);
   border: none;
-  border-radius: var(--r-sm);
+  border-radius: var(--m-r-sm);
   padding: var(--s-2) var(--s-3h);
-  color: var(--accent);
+  color: var(--m-accent);
   font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   cursor: pointer;
   min-height: 36px;
 }
@@ -1268,26 +1270,26 @@
 .m-profile__logout {
   width: 100%;
   padding: var(--s-3h);
-  background: color-mix(in oklab, var(--danger) 10%, var(--surface));
+  background: color-mix(in oklab, var(--m-danger) 10%, var(--m-surface));
   border: none;
-  border-radius: var(--r-md);
-  color: var(--danger);
+  border-radius: var(--m-r-md);
+  color: var(--m-danger);
   font-size: var(--fs-body);
   font-weight: var(--fw-semibold);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   cursor: pointer;
   min-height: 44px;
 }
 
 /* --- Field picker (inline expandable) --- */
 .m-field-picker {
-  background: var(--surface-3);
-  border-radius: var(--r-sm);
+  background: var(--m-surface-3);
+  border-radius: var(--m-r-sm);
   overflow: hidden;
 }
 
 .m-field-picker--open {
-  border: 1px solid var(--border);
+  border: 1px solid var(--m-border);
 }
 
 .m-field-picker__header {
@@ -1299,8 +1301,8 @@
   border: none;
   text-align: left;
   cursor: pointer;
-  font-family: var(--font-sans);
-  color: var(--text);
+  font-family: var(--m-font);
+  color: var(--m-text);
 }
 
 .m-field-picker__header--static {
@@ -1315,12 +1317,12 @@
 
 .m-field-picker__chevron {
   font-size: var(--fs-xs);
-  color: var(--muted-light);
+  color: var(--m-muted-light);
   margin-left: var(--s-1);
 }
 
 .m-field-picker__options {
-  border-top: 1px solid var(--border-light);
+  border-top: 1px solid var(--m-border);
   padding: var(--s-1) 0;
 }
 
@@ -1334,25 +1336,25 @@
   border: none;
   text-align: left;
   font-size: var(--fs-meta);
-  font-family: var(--font-sans);
-  color: var(--text);
+  font-family: var(--m-font);
+  color: var(--m-text);
   cursor: pointer;
   min-height: 44px;
 }
 
 .m-field-picker__option:active {
-  background: var(--surface);
+  background: var(--m-surface);
 }
 
 .m-field-picker__option--active {
-  background: var(--accent-light);
-  color: var(--accent);
+  background: var(--m-accent-light);
+  color: var(--m-accent);
   font-weight: var(--fw-medium);
 }
 
 .m-field-picker__option-check {
   font-size: var(--fs-xs);
-  color: var(--accent);
+  color: var(--m-accent);
   width: 14px;
   flex-shrink: 0;
 }
@@ -1363,11 +1365,11 @@
   padding: var(--s-2h) var(--s-3);
   background: none;
   border: none;
-  border-top: 1px solid var(--border-light);
+  border-top: 1px solid var(--m-border);
   text-align: left;
   font-size: var(--fs-meta);
-  font-family: var(--font-sans);
-  color: var(--muted);
+  font-family: var(--m-font);
+  color: var(--m-muted);
   cursor: pointer;
   min-height: 44px;
 }
@@ -1375,9 +1377,9 @@
 .m-field-picker__date {
   background: none;
   border: none;
-  color: var(--text);
+  color: var(--m-text);
   font-size: var(--fs-meta);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   padding: 0;
   margin-top: var(--s-1);
   width: 100%;
@@ -1393,7 +1395,7 @@
 .m-snooze__backdrop {
   position: fixed;
   inset: 0;
-  background: var(--overlay);
+  background: rgba(0,0,0,0.5);
   z-index: 100;
 }
 
@@ -1402,11 +1404,11 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background: var(--surface);
-  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  background: var(--m-surface);
+  border-radius: var(--m-r-xl) var(--m-r-xl) 0 0;
   z-index: 105;
   padding: var(--s-3) 0 var(--s-6);
-  box-shadow: var(--shadow-xl);
+  box-shadow: var(--m-shadow-lg);
   display: flex;
   flex-direction: column;
 }
@@ -1414,15 +1416,15 @@
 .m-snooze__handle-bar {
   width: 36px;
   height: 4px;
-  background: var(--muted-light);
-  border-radius: var(--r-full);
+  background: var(--m-muted-light);
+  border-radius: var(--m-r-full);
   margin: 0 auto var(--s-3);
 }
 
 .m-snooze__title {
   font-size: var(--fs-xs);
   font-weight: var(--fw-semibold);
-  color: var(--muted);
+  color: var(--m-muted);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
   padding: 0 var(--s-5) var(--s-2);
@@ -1437,10 +1439,10 @@
   padding: 0 var(--s-5);
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--m-border);
   text-align: left;
   cursor: pointer;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
 }
 
 .m-snooze__option:last-of-type {
@@ -1448,27 +1450,27 @@
 }
 
 .m-snooze__option:active {
-  background: var(--bg);
+  background: var(--m-bg);
 }
 
 .m-snooze__option-label {
   font-size: var(--fs-body);
-  color: var(--text);
+  color: var(--m-text);
   font-weight: var(--fw-medium);
 }
 
 .m-snooze__option-detail {
   font-size: var(--fs-meta);
-  color: var(--muted);
+  color: var(--m-muted);
 }
 
 .m-snooze__date {
   background: none;
-  border: 1px solid var(--border);
-  border-radius: var(--r-sm);
-  color: var(--text);
+  border: 1px solid var(--m-border);
+  border-radius: var(--m-r-sm);
+  color: var(--m-text);
   font-size: var(--fs-meta);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   padding: var(--s-1) var(--s-2);
   cursor: pointer;
 }
@@ -1483,13 +1485,13 @@
   width: calc(100% - 48px);
   margin: var(--s-3) var(--s-5) 0;
   padding: var(--s-3);
-  background: var(--accent);
+  background: var(--m-accent);
   color: white;
   border: none;
-  border-radius: var(--r-md);
+  border-radius: var(--m-r-md);
   font-size: var(--fs-body);
   font-weight: var(--fw-semibold);
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   cursor: pointer;
   text-align: center;
   min-height: 48px;
@@ -1512,11 +1514,11 @@
   padding: var(--s-3) var(--s-4);
   background: none;
   border: none;
-  border-bottom: 1px solid var(--border-light);
-  color: var(--text);
+  border-bottom: 1px solid var(--m-border);
+  color: var(--m-text);
   font-size: var(--fs-body);
   cursor: pointer;
-  font-family: var(--font-sans);
+  font-family: var(--m-font);
   min-height: 44px;
 }
 .m-profile__nav-link:last-child {
@@ -1527,7 +1529,7 @@
 .m-shell__page-overlay {
   position: fixed;
   inset: 0;
-  background: var(--bg);
+  background: var(--m-bg);
   z-index: 80;
   display: flex;
   flex-direction: column;
@@ -1556,19 +1558,19 @@
 
 .m-empty__title {
   font-size: var(--fs-body);
-  color: var(--text);
+  color: var(--m-text);
   font-weight: var(--fw-medium);
   margin-bottom: var(--s-1);
 }
 
 .m-empty__hint {
   font-size: var(--fs-meta);
-  color: var(--muted);
+  color: var(--m-muted);
 }
 
 /* --- Search result project name --- */
 .m-search__result-project {
   font-size: var(--fs-xs);
-  color: var(--muted);
+  color: var(--m-muted);
   margin-left: auto;
 }

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1574,3 +1574,74 @@
   color: var(--m-muted);
   margin-left: auto;
 }
+
+/* --- Completion burst particles --- */
+.m-burst {
+  position: absolute;
+  left: 32px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.m-burst__dot {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--m-r-full);
+  background: var(--m-accent);
+  animation: m-burst-fly 400ms var(--ease-out) forwards;
+}
+
+.m-burst__dot:nth-child(even) {
+  background: var(--m-amber);
+  width: 4px;
+  height: 4px;
+}
+
+.m-burst__dot:nth-child(1) { animation-delay: 0ms; }
+.m-burst__dot:nth-child(2) { animation-delay: 20ms; }
+.m-burst__dot:nth-child(3) { animation-delay: 40ms; }
+.m-burst__dot:nth-child(4) { animation-delay: 60ms; }
+.m-burst__dot:nth-child(5) { animation-delay: 80ms; }
+.m-burst__dot:nth-child(6) { animation-delay: 100ms; }
+.m-burst__dot:nth-child(7) { animation-delay: 120ms; }
+.m-burst__dot:nth-child(8) { animation-delay: 140ms; }
+
+@keyframes m-burst-fly {
+  0% { opacity: 1; transform: translate(0, 0) scale(1); }
+  100% { opacity: 0; transform: translate(var(--burst-x, 20px), var(--burst-y, -20px)) scale(0.3); }
+}
+
+.m-burst__dot:nth-child(1) { --burst-x: 24px; --burst-y: 0; }
+.m-burst__dot:nth-child(2) { --burst-x: 17px; --burst-y: -17px; }
+.m-burst__dot:nth-child(3) { --burst-x: 0; --burst-y: -24px; }
+.m-burst__dot:nth-child(4) { --burst-x: -17px; --burst-y: -17px; }
+.m-burst__dot:nth-child(5) { --burst-x: -24px; --burst-y: 0; }
+.m-burst__dot:nth-child(6) { --burst-x: -17px; --burst-y: 17px; }
+.m-burst__dot:nth-child(7) { --burst-x: 0; --burst-y: 24px; }
+
+/* --- Palette picker --- */
+.m-profile__palette-picker {
+  display: flex;
+  gap: var(--s-2);
+}
+
+.m-profile__palette-dot {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--m-r-full);
+  border: 2px solid transparent;
+  cursor: pointer;
+  padding: 0;
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
+.m-profile__palette-dot--active {
+  width: 32px;
+  height: 32px;
+  border-color: var(--m-text);
+  box-shadow: inset 0 0 0 2px var(--m-surface);
+}
+.m-burst__dot:nth-child(8) { --burst-x: 17px; --burst-y: 17px; }

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1645,3 +1645,80 @@
   box-shadow: inset 0 0 0 2px var(--m-surface);
 }
 .m-burst__dot:nth-child(8) { --burst-x: 17px; --burst-y: 17px; }
+
+/* --- Greeting animation --- */
+.m-header__title--animate {
+  animation: m-reveal 600ms var(--ease-out) both;
+}
+
+.m-header__subtitle--animate {
+  animation: m-fade-up 400ms var(--ease-out) 200ms both;
+}
+
+@keyframes m-reveal {
+  from { clip-path: inset(0 100% 0 0); }
+  to { clip-path: inset(0 0 0 0); }
+}
+
+@keyframes m-fade-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Confetti celebration --- */
+.m-confetti {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  pointer-events: none;
+}
+
+.m-confetti__piece {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  animation: m-confetti-fly var(--d, 500ms) var(--ease-out) forwards;
+}
+
+@keyframes m-confetti-fly {
+  0% { opacity: 1; transform: translate(0, 0) rotate(0deg) scale(1); }
+  100% { opacity: 0; transform: translate(var(--x, 0), var(--y, -100px)) rotate(var(--r, 180deg)) scale(0.3); }
+}
+
+.m-empty--celebrate {
+  position: relative;
+}
+
+.m-empty__title--bounce {
+  animation: m-bounce-in 600ms var(--ease-spring) 300ms both;
+}
+
+@keyframes m-bounce-in {
+  0% { opacity: 0; transform: scale(0.8); }
+  60% { opacity: 1; transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+/* --- FAB spring press --- */
+.m-tab-bar__fab:active {
+  animation: m-fab-press 250ms var(--ease-spring);
+}
+
+@keyframes m-fab-press {
+  0% { transform: scale(1); }
+  40% { transform: scale(0.9); }
+  70% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+/* --- Tab icon bounce on active --- */
+.m-tab-bar__tab--active svg {
+  animation: m-tab-bounce 200ms var(--ease-spring);
+}
+
+@keyframes m-tab-bounce {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}

--- a/client-react/src/mobile/screens/FocusScreen.tsx
+++ b/client-react/src/mobile/screens/FocusScreen.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import type { Todo, Project, User } from "../../types";
 import { MobileHeader } from "../MobileHeader";
+import { useCountUp } from "../hooks/useCountUp";
 
 interface Props {
   todos: Todo[];
@@ -51,14 +52,32 @@ export function FocusScreen({ todos, projects, user, onTodoClick, onToggleTodo, 
   const subtitle = `${todayCount} tasks today${overdueCount ? ` · ${overdueCount} overdue` : ""}`;
   const activeProjects = projects.filter((p) => p.status === "active").length;
 
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
+  const animDone = useCountUp(mounted ? completedThisWeek : 0, 800);
+  const animOpen = useCountUp(mounted ? openTodos.length : 0, 800);
+  const animProjects = useCountUp(mounted ? activeProjects : 0, 800);
+
   return (
     <div className="m-screen m-screen--focus">
-      <MobileHeader title={getGreeting()} subtitle={subtitle} user={user} onAvatarClick={onAvatarClick} />
+      <MobileHeader title={getGreeting()} subtitle={subtitle} user={user} onAvatarClick={onAvatarClick} animated={mounted} />
       <div className="m-focus__content">
         {openTodos.length === 0 && (
-          <div className="m-empty">
+          <div className="m-empty m-empty--celebrate">
+            <div className="m-confetti" aria-hidden="true">
+              {Array.from({ length: 20 }, (_, i) => (
+                <div key={i} className="m-confetti__piece" style={{
+                  "--x": `${(Math.random() - 0.5) * 200}px`,
+                  "--y": `${-Math.random() * 150 - 50}px`,
+                  "--r": `${Math.random() * 360}deg`,
+                  "--d": `${300 + Math.random() * 500}ms`,
+                  background: ["var(--m-amber)", "var(--m-accent)", "var(--m-success)", "var(--m-danger)"][i % 4],
+                } as React.CSSProperties} />
+              ))}
+            </div>
             <div className="m-empty__icon">🎉</div>
-            <div className="m-empty__title">All clear! No tasks right now.</div>
+            <div className="m-empty__title m-empty__title--bounce">All clear! No tasks right now.</div>
           </div>
         )}
         {topTask && (
@@ -100,15 +119,15 @@ export function FocusScreen({ todos, projects, user, onTodoClick, onToggleTodo, 
         )}
         <div className="m-focus__stats">
           <div className="m-focus__stat">
-            <div className="m-focus__stat-value m-focus__stat-value--success">{completedThisWeek}</div>
+            <div className="m-focus__stat-value m-focus__stat-value--success">{animDone}</div>
             <div className="m-focus__stat-label">done this week</div>
           </div>
           <div className="m-focus__stat">
-            <div className="m-focus__stat-value m-focus__stat-value--warning">{openTodos.length}</div>
+            <div className="m-focus__stat-value m-focus__stat-value--warning">{animOpen}</div>
             <div className="m-focus__stat-label">open tasks</div>
           </div>
           <div className="m-focus__stat">
-            <div className="m-focus__stat-value m-focus__stat-value--accent">{activeProjects}</div>
+            <div className="m-focus__stat-value m-focus__stat-value--accent">{animProjects}</div>
             <div className="m-focus__stat-label">projects</div>
           </div>
         </div>

--- a/client-react/src/mobile/tokens-mobile.css
+++ b/client-react/src/mobile/tokens-mobile.css
@@ -1,0 +1,243 @@
+/* ===== Mobile Token System ===== */
+/* Scoped to .m-shell — never pollutes desktop tokens */
+
+/* ------------------------------------------------------------------ */
+/* Sunset Amber (default) — light mode                                 */
+/* ------------------------------------------------------------------ */
+.m-shell {
+  /* Typography */
+  --m-font: "DM Sans", system-ui, -apple-system, sans-serif;
+
+  /* Backgrounds */
+  --m-bg:        #FFFCF5;
+  --m-surface:   #FFFFFF;
+  --m-surface-2: #FFF8EE;
+  --m-surface-3: #F5EDE3;
+
+  /* Text */
+  --m-text:        #2D1F1A;
+  --m-text-strong: #1A0F0A;
+  --m-muted:       #9A8C7F;
+  --m-muted-light: #C5B8AA;
+
+  /* Border */
+  --m-border: #F0EBE5;
+
+  /* Accent */
+  --m-accent:       #E17055;
+  --m-accent-light: #FFF0EB;
+  --m-amber:        #FDCB6E;
+  --m-amber-light:  #FEF9E7;
+
+  /* Gradient */
+  --m-gradient: linear-gradient(135deg, #FDCB6E, #E17055);
+
+  /* Semantic */
+  --m-success:     #2ECC71;
+  --m-danger:      #E05260;
+  --m-info:        #3498DB;
+  --m-focus-color: #9B59B6;
+
+  /* Radius */
+  --m-r-sm:   8px;
+  --m-r-md:   14px;
+  --m-r-lg:   16px;
+  --m-r-xl:   20px;
+  --m-r-full: 999px;
+
+  /* Shadows — warm brown-tinted */
+  --m-shadow-sm:  0 1px 4px rgba(45, 31, 26, 0.08);
+  --m-shadow-md:  0 4px 12px rgba(45, 31, 26, 0.12);
+  --m-shadow-lg:  0 8px 24px rgba(45, 31, 26, 0.16);
+  --m-shadow-fab: 0 4px 16px rgba(225, 112, 85, 0.40);
+}
+
+/* ------------------------------------------------------------------ */
+/* Sunset Amber — dark mode                                            */
+/* ------------------------------------------------------------------ */
+body.dark-mode .m-shell,
+body.dark-mode .m-shell[data-palette="amber"] {
+  --m-bg:        #1C1510;
+  --m-surface:   #2A1F18;
+  --m-surface-2: #362A20;
+  --m-surface-3: #4A3A2D;
+
+  --m-text:        #F5EFE8;
+  --m-text-strong: #FFFFFF;
+  --m-muted:       #8A7D70;
+  --m-muted-light: #5A4A3D;
+
+  --m-border: #3A2F25;
+
+  --m-accent:       #FDCB6E;
+  --m-accent-light: rgba(253, 203, 110, 0.12);
+
+  --m-gradient: linear-gradient(135deg, #FDCB6E, #E17055);
+
+  --m-shadow-sm:  0 1px 4px rgba(0, 0, 0, 0.30);
+  --m-shadow-md:  0 4px 12px rgba(0, 0, 0, 0.40);
+  --m-shadow-lg:  0 8px 24px rgba(0, 0, 0, 0.50);
+  --m-shadow-fab: 0 4px 16px rgba(253, 203, 110, 0.30);
+}
+
+/* ------------------------------------------------------------------ */
+/* Iris Violet — light mode                                            */
+/* ------------------------------------------------------------------ */
+.m-shell[data-palette="violet"] {
+  --m-bg:        #F8F7FF;
+  --m-surface:   #FFFFFF;
+  --m-surface-2: #F3F1FF;
+  --m-surface-3: #EAE7FF;
+
+  --m-text:        #1E1A3A;
+  --m-text-strong: #110D2A;
+  --m-muted:       #8B87A8;
+  --m-muted-light: #C2BEDD;
+
+  --m-border: #E8E4FF;
+
+  --m-accent:       #6C5CE7;
+  --m-accent-light: #EDE9FF;
+  --m-amber:        #FDCB6E;
+  --m-amber-light:  #FEF9E7;
+
+  --m-gradient: linear-gradient(135deg, #A29BFE, #6C5CE7);
+
+  --m-shadow-sm:  0 1px 4px rgba(108, 92, 231, 0.08);
+  --m-shadow-md:  0 4px 12px rgba(108, 92, 231, 0.12);
+  --m-shadow-lg:  0 8px 24px rgba(108, 92, 231, 0.16);
+  --m-shadow-fab: 0 4px 16px rgba(108, 92, 231, 0.40);
+}
+
+/* Iris Violet — dark mode */
+body.dark-mode .m-shell[data-palette="violet"] {
+  --m-bg:        #1A182E;
+  --m-surface:   #252240;
+  --m-surface-2: #302D52;
+  --m-surface-3: #3E3A68;
+
+  --m-text:        #E8E6FF;
+  --m-text-strong: #FFFFFF;
+  --m-muted:       #7A7699;
+  --m-muted-light: #4A4660;
+
+  --m-border: #38345A;
+
+  --m-accent:       #A29BFE;
+  --m-accent-light: rgba(162, 155, 254, 0.12);
+
+  --m-gradient: linear-gradient(135deg, #A29BFE, #6C5CE7);
+
+  --m-shadow-sm:  0 1px 4px rgba(0, 0, 0, 0.30);
+  --m-shadow-md:  0 4px 12px rgba(0, 0, 0, 0.40);
+  --m-shadow-lg:  0 8px 24px rgba(0, 0, 0, 0.50);
+  --m-shadow-fab: 0 4px 16px rgba(162, 155, 254, 0.30);
+}
+
+/* ------------------------------------------------------------------ */
+/* Mint Teal — light mode                                              */
+/* ------------------------------------------------------------------ */
+.m-shell[data-palette="teal"] {
+  --m-bg:        #F5FFFC;
+  --m-surface:   #FFFFFF;
+  --m-surface-2: #EDFAF6;
+  --m-surface-3: #DFF5EF;
+
+  --m-text:        #0D2420;
+  --m-text-strong: #061512;
+  --m-muted:       #7AA09A;
+  --m-muted-light: #B3D4CE;
+
+  --m-border: #D8F0EA;
+
+  --m-accent:       #00B894;
+  --m-accent-light: #D9F5EE;
+  --m-amber:        #FDCB6E;
+  --m-amber-light:  #FEF9E7;
+
+  --m-gradient: linear-gradient(135deg, #00CEC9, #00B894);
+
+  --m-shadow-sm:  0 1px 4px rgba(0, 184, 148, 0.08);
+  --m-shadow-md:  0 4px 12px rgba(0, 184, 148, 0.12);
+  --m-shadow-lg:  0 8px 24px rgba(0, 184, 148, 0.16);
+  --m-shadow-fab: 0 4px 16px rgba(0, 184, 148, 0.40);
+}
+
+/* Mint Teal — dark mode */
+body.dark-mode .m-shell[data-palette="teal"] {
+  --m-bg:        #101C1A;
+  --m-surface:   #162824;
+  --m-surface-2: #1E3530;
+  --m-surface-3: #284540;
+
+  --m-text:        #DFFAF4;
+  --m-text-strong: #FFFFFF;
+  --m-muted:       #5A8A82;
+  --m-muted-light: #354F4A;
+
+  --m-border: #254540;
+
+  --m-accent:       #00CEC9;
+  --m-accent-light: rgba(0, 206, 201, 0.12);
+
+  --m-gradient: linear-gradient(135deg, #00CEC9, #00B894);
+
+  --m-shadow-sm:  0 1px 4px rgba(0, 0, 0, 0.30);
+  --m-shadow-md:  0 4px 12px rgba(0, 0, 0, 0.40);
+  --m-shadow-lg:  0 8px 24px rgba(0, 0, 0, 0.50);
+  --m-shadow-fab: 0 4px 16px rgba(0, 206, 201, 0.30);
+}
+
+/* ------------------------------------------------------------------ */
+/* Coral Fire — light mode                                             */
+/* ------------------------------------------------------------------ */
+.m-shell[data-palette="coral"] {
+  --m-bg:        #FFFAF9;
+  --m-surface:   #FFFFFF;
+  --m-surface-2: #FFF2F0;
+  --m-surface-3: #FFE8E4;
+
+  --m-text:        #2A1210;
+  --m-text-strong: #1A0A08;
+  --m-muted:       #A08580;
+  --m-muted-light: #D4B8B4;
+
+  --m-border: #FFE0DA;
+
+  --m-accent:       #FF6B6B;
+  --m-accent-light: #FFEDED;
+  --m-amber:        #FDCB6E;
+  --m-amber-light:  #FEF9E7;
+
+  --m-gradient: linear-gradient(135deg, #FF6B6B, #EE5A24);
+
+  --m-shadow-sm:  0 1px 4px rgba(255, 107, 107, 0.08);
+  --m-shadow-md:  0 4px 12px rgba(255, 107, 107, 0.12);
+  --m-shadow-lg:  0 8px 24px rgba(255, 107, 107, 0.16);
+  --m-shadow-fab: 0 4px 16px rgba(255, 107, 107, 0.40);
+}
+
+/* Coral Fire — dark mode */
+body.dark-mode .m-shell[data-palette="coral"] {
+  --m-bg:        #1C1415;
+  --m-surface:   #2A1C1C;
+  --m-surface-2: #372525;
+  --m-surface-3: #4A3030;
+
+  --m-text:        #FFE8E4;
+  --m-text-strong: #FFFFFF;
+  --m-muted:       #8A6560;
+  --m-muted-light: #5A3D3A;
+
+  --m-border: #402A28;
+
+  --m-accent:       #FF8A8A;
+  --m-accent-light: rgba(255, 138, 138, 0.12);
+
+  --m-gradient: linear-gradient(135deg, #FF8A8A, #EE5A24);
+
+  --m-shadow-sm:  0 1px 4px rgba(0, 0, 0, 0.30);
+  --m-shadow-md:  0 4px 12px rgba(0, 0, 0, 0.40);
+  --m-shadow-lg:  0 8px 24px rgba(0, 0, 0, 0.50);
+  --m-shadow-fab: 0 4px 16px rgba(255, 138, 138, 0.30);
+}


### PR DESCRIPTION
## Summary

The visual language layer for the mobile shell — transforms it from a plain token-inherited layout into a distinctive, warm experience.

- **Sunset Amber palette** as default — warm cream backgrounds (#FFFCF5), coral/gold gradient accents, warm brown shadows
- **4 selectable themes** — Sunset Amber, Iris Violet, Mint Teal, Coral Fire. Picker in profile sheet. Stored in localStorage.
- **DM Sans typography** — warmer, more characterful than Inter. Loaded via Google Fonts.
- **Lucide SVG icons** — replaces text symbols (◉☀▤≡) with proper outlined/filled SVGs in tab bar. Active = filled, inactive = outlined.
- **Mobile token system** (`tokens-mobile.css`) — all `--m-*` scoped tokens. 4 palettes × 2 modes = 8 CSS combinations. Desktop completely unaffected.
- **6 micro-animations:**
  - Completion particle burst (8 amber/coral dots radiate from checkbox)
  - Greeting text reveal (clip-path left-to-right on Focus screen)
  - Stats count-up (numbers animate 0→target on mount)
  - Confetti celebration (20 particles when all tasks done)
  - FAB spring press (scale bounce on tap)
  - Tab icon bounce (subtle scale on active switch)

## New files
- `tokens-mobile.css` — 243 lines of palette/mode definitions
- `usePalette.ts` + test (6 tests) — palette selection hook
- `useCountUp.ts` + test (3 tests) — animated counting hook
- `CompletionBurst.tsx` — CSS-only particle animation

## Test plan
- [x] Typecheck passes
- [x] Production build passes (`npm run build:react`)
- [x] 9 new unit tests passing (usePalette + useCountUp)
- [ ] Manual: verify amber palette renders on mobile viewport
- [ ] Manual: palette picker switches themes live
- [ ] Manual: dark mode works with each palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)