### PR TITLE
feat(react-mobile): pull-to-refresh, PWA install, onboarding, offline indicator

### DIFF
--- a/client-react/public/manifest.json
+++ b/client-react/public/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "Todos",
   "start_url": "/app",
   "display": "standalone",
-  "background_color": "#f4f7fb",
-  "theme_color": "#4f6ef7",
+  "background_color": "#FFFCF5",
+  "theme_color": "#E17055",
   "icons": [
     {
       "src": "/app/favicon.svg",

--- a/client-react/src/mobile/MobileShell.tsx
+++ b/client-react/src/mobile/MobileShell.tsx
@@ -13,7 +13,11 @@ import { QuickCapture } from "./components/QuickCapture";
 import { ProfileSheet } from "./components/ProfileSheet";
 import { FieldPicker } from "./components/FieldPicker";
 import { PullToSearch } from "./components/PullToSearch";
+import { PullToRefresh } from "./components/PullToRefresh";
+import { OfflineBanner } from "./components/OfflineBanner";
 import { SnoozePicker } from "./components/SnoozePicker";
+import { InstallBanner } from "./components/InstallBanner";
+import { Onboarding } from "./components/Onboarding";
 import type { TodoStatus, Priority } from "../types";
 import { FocusScreen } from "./screens/FocusScreen";
 import { TodayScreen } from "./screens/TodayScreen";
@@ -79,6 +83,9 @@ export function MobileShell() {
     await loadProjects();
   }, [loadProjects]);
   const handleAvatarClick = useCallback(() => { setProfileOpen(true); }, []);
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([loadTodos({}), loadProjects()]);
+  }, [loadTodos, loadProjects]);
   const handleSnoozeTodo = useCallback((id: string) => { setSnoozeTargetId(id); }, []);
   const handleSnoozeConfirm = useCallback((date: string) => {
     if (snoozeTargetId) editTodo(snoozeTargetId, { dueDate: date });
@@ -233,11 +240,15 @@ export function MobileShell() {
 
   return (
     <div className="m-shell" data-density="normal" data-palette={palette}>
+      <OfflineBanner />
+      <InstallBanner />
       <div className="m-shell__content">
-        {activeTab === "focus" && <FocusScreen {...screenProps} />}
-        {activeTab === "today" && <TodayScreen {...screenProps} />}
-        {activeTab === "projects" && <ProjectsScreen {...screenProps} />}
-        {activeTab === "custom" && <CustomScreen view={customView} {...screenProps} />}
+        <PullToRefresh onRefresh={handleRefresh}>
+          {activeTab === "focus" && <FocusScreen {...screenProps} />}
+          {activeTab === "today" && <TodayScreen {...screenProps} />}
+          {activeTab === "projects" && <ProjectsScreen {...screenProps} />}
+          {activeTab === "custom" && <CustomScreen view={customView} {...screenProps} />}
+        </PullToRefresh>
       </div>
       <PullToSearch todos={todos} projects={projects} onSelectResult={handleTodoClick} />
       <BottomSheet snap={bottomSheet.snap} onClose={bottomSheet.close} onExpandFull={bottomSheet.expandFull} halfContent={halfContent} fullContent={fullContent} />
@@ -276,6 +287,7 @@ export function MobileShell() {
           </div>
         </div>
       )}
+      <Onboarding />
     </div>
   );
 }

--- a/client-react/src/mobile/components/InstallBanner.tsx
+++ b/client-react/src/mobile/components/InstallBanner.tsx
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+const DISMISSED_KEY = "mobile:installDismissed";
+
+export function InstallBanner() {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Don't show if already dismissed or in standalone mode
+    if (localStorage.getItem(DISMISSED_KEY)) return;
+    if (window.matchMedia("(display-mode: standalone)").matches) return;
+
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    if (choice.outcome === "accepted") {
+      setVisible(false);
+    }
+    setDeferredPrompt(null);
+  }, [deferredPrompt]);
+
+  const handleDismiss = useCallback(() => {
+    setVisible(false);
+    localStorage.setItem(DISMISSED_KEY, "1");
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="m-install-banner">
+      <div className="m-install-banner__content">
+        <div className="m-install-banner__icon">📱</div>
+        <div className="m-install-banner__text">
+          <div className="m-install-banner__title">Add to Home Screen</div>
+          <div className="m-install-banner__desc">Quick access, works offline</div>
+        </div>
+      </div>
+      <div className="m-install-banner__actions">
+        <button className="m-install-banner__dismiss" onClick={handleDismiss}>Not now</button>
+        <button className="m-install-banner__install" onClick={handleInstall}>Install</button>
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/mobile/components/OfflineBanner.tsx
+++ b/client-react/src/mobile/components/OfflineBanner.tsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+
+export function OfflineBanner() {
+  const [online, setOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener("online", goOnline);
+    window.addEventListener("offline", goOffline);
+    return () => {
+      window.removeEventListener("online", goOnline);
+      window.removeEventListener("offline", goOffline);
+    };
+  }, []);
+
+  if (online) return null;
+
+  return (
+    <div className="m-offline-banner" role="status">
+      <span className="m-offline-banner__dot" />
+      <span className="m-offline-banner__text">
+        You're offline — changes will sync when you reconnect
+      </span>
+    </div>
+  );
+}

--- a/client-react/src/mobile/components/Onboarding.tsx
+++ b/client-react/src/mobile/components/Onboarding.tsx
@@ -1,0 +1,61 @@
+import { useState, useCallback } from "react";
+
+const ONBOARDING_KEY = "mobile:onboardingDone";
+
+interface Step {
+  icon: string;
+  title: string;
+  desc: string;
+}
+
+const STEPS: Step[] = [
+  { icon: "👆", title: "Swipe to act", desc: "Swipe right to complete a task. Swipe left to snooze." },
+  { icon: "✨", title: "Quick capture", desc: "Tap the + button to add a task in seconds." },
+  { icon: "📋", title: "Tap for details", desc: "Tap any task to see details. Drag up for more." },
+];
+
+export function Onboarding() {
+  const [step, setStep] = useState(0);
+  const [dismissed, setDismissed] = useState(() => localStorage.getItem(ONBOARDING_KEY) === "1");
+
+  const handleNext = useCallback(() => {
+    if (step < STEPS.length - 1) {
+      setStep(step + 1);
+    } else {
+      localStorage.setItem(ONBOARDING_KEY, "1");
+      setDismissed(true);
+    }
+  }, [step]);
+
+  const handleSkip = useCallback(() => {
+    localStorage.setItem(ONBOARDING_KEY, "1");
+    setDismissed(true);
+  }, []);
+
+  if (dismissed) return null;
+
+  const current = STEPS[step];
+
+  return (
+    <div className="m-onboarding__backdrop">
+      <div className="m-onboarding">
+        <div className="m-onboarding__icon">{current.icon}</div>
+        <h2 className="m-onboarding__title">{current.title}</h2>
+        <p className="m-onboarding__desc">{current.desc}</p>
+
+        <div className="m-onboarding__dots">
+          {STEPS.map((_, i) => (
+            <div key={i} className={`m-onboarding__dot${i === step ? " m-onboarding__dot--active" : ""}`} />
+          ))}
+        </div>
+
+        <div className="m-onboarding__actions">
+          <button className="m-onboarding__skip" onClick={handleSkip}>Skip</button>
+          <button className="m-onboarding__next" onClick={handleNext}>
+            {step < STEPS.length - 1 ? "Next" : "Get started"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/mobile/components/PullToRefresh.tsx
+++ b/client-react/src/mobile/components/PullToRefresh.tsx
@@ -1,0 +1,77 @@
+import { useState, useRef, useCallback } from "react";
+
+interface Props {
+  onRefresh: () => Promise<void>;
+  children: React.ReactNode;
+}
+
+const THRESHOLD = 60;
+
+export function PullToRefresh({ onRefresh, children }: Props) {
+  const [pulling, setPulling] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+  const startY = useRef(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const scrollTop = containerRef.current?.scrollTop ?? 0;
+    if (scrollTop <= 0) {
+      startY.current = e.touches[0].clientY;
+      setPulling(true);
+    }
+  }, []);
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (!pulling || startY.current === 0) return;
+      const delta = e.touches[0].clientY - startY.current;
+      if (delta > 0) {
+        // Resistance: actual distance is sqrt of raw delta
+        setPullDistance(Math.min(Math.sqrt(delta) * 4, 120));
+      }
+    },
+    [pulling],
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (pullDistance > THRESHOLD && !refreshing) {
+      setRefreshing(true);
+      setPullDistance(THRESHOLD);
+      try {
+        await onRefresh();
+      } finally {
+        setRefreshing(false);
+        setPullDistance(0);
+      }
+    } else {
+      setPullDistance(0);
+    }
+    setPulling(false);
+    startY.current = 0;
+  }, [pullDistance, refreshing, onRefresh]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="m-pull-refresh"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div
+        className={`m-pull-refresh__indicator${refreshing ? " m-pull-refresh__indicator--active" : ""}`}
+        style={{ height: pullDistance > 0 ? `${pullDistance}px` : undefined }}
+      >
+        {refreshing ? (
+          <div className="m-pull-refresh__spinner" />
+        ) : pullDistance > THRESHOLD ? (
+          <span className="m-pull-refresh__text">Release to refresh</span>
+        ) : pullDistance > 10 ? (
+          <span className="m-pull-refresh__text">Pull to refresh</span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1722,3 +1722,62 @@
   50% { transform: scale(1.15); }
   100% { transform: scale(1); }
 }
+
+/* --- Pull to refresh --- */
+.m-pull-refresh {
+  min-height: 100%;
+}
+
+.m-pull-refresh__indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  height: 0;
+  transition: height var(--dur-base) var(--ease-out);
+}
+
+.m-pull-refresh__indicator--active {
+  height: 48px !important;
+}
+
+.m-pull-refresh__text {
+  font-size: var(--fs-meta);
+  color: var(--m-muted);
+}
+
+.m-pull-refresh__spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--m-border);
+  border-top-color: var(--m-accent);
+  border-radius: var(--m-r-full);
+  animation: m-spin 600ms linear infinite;
+}
+
+@keyframes m-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* --- Offline banner --- */
+.m-offline-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: var(--s-2) var(--s-4);
+  background: var(--m-surface-3);
+  font-size: var(--fs-meta);
+  color: var(--m-muted);
+}
+
+.m-offline-banner__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--m-r-full);
+  background: var(--m-amber);
+  flex-shrink: 0;
+}
+
+.m-offline-banner__text {
+  flex: 1;
+}

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1781,3 +1781,151 @@
 .m-offline-banner__text {
   flex: 1;
 }
+
+/* --- PWA install banner --- */
+.m-install-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--s-3) var(--s-4);
+  background: var(--m-surface);
+  border-bottom: 1px solid var(--m-border);
+}
+
+.m-install-banner__content {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+
+.m-install-banner__icon {
+  font-size: 24px;
+}
+
+.m-install-banner__title {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  color: var(--m-text);
+}
+
+.m-install-banner__desc {
+  font-size: var(--fs-meta);
+  color: var(--m-muted);
+}
+
+.m-install-banner__actions {
+  display: flex;
+  gap: var(--s-2);
+}
+
+.m-install-banner__dismiss {
+  background: none;
+  border: none;
+  color: var(--m-muted);
+  font-size: var(--fs-meta);
+  cursor: pointer;
+  padding: var(--s-2);
+  font-family: var(--m-font);
+}
+
+.m-install-banner__install {
+  background: var(--m-gradient);
+  color: white;
+  border: none;
+  border-radius: var(--m-r-full);
+  padding: var(--s-2) var(--s-4);
+  font-size: var(--fs-meta);
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  font-family: var(--m-font);
+}
+
+/* --- Onboarding --- */
+.m-onboarding__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s-5);
+}
+
+.m-onboarding {
+  background: var(--m-surface);
+  border-radius: var(--m-r-xl);
+  padding: var(--s-6) var(--s-5);
+  text-align: center;
+  max-width: 320px;
+  width: 100%;
+  animation: m-bounce-in 400ms var(--ease-spring) both;
+}
+
+.m-onboarding__icon {
+  font-size: 48px;
+  margin-bottom: var(--s-4);
+}
+
+.m-onboarding__title {
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-bold);
+  color: var(--m-text-strong);
+  margin: 0 0 var(--s-2);
+}
+
+.m-onboarding__desc {
+  font-size: var(--fs-body);
+  color: var(--m-muted);
+  line-height: var(--lh-relaxed);
+  margin: 0 0 var(--s-5);
+}
+
+.m-onboarding__dots {
+  display: flex;
+  justify-content: center;
+  gap: var(--s-2);
+  margin-bottom: var(--s-5);
+}
+
+.m-onboarding__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--m-r-full);
+  background: var(--m-border);
+  transition: background var(--dur-base);
+}
+
+.m-onboarding__dot--active {
+  background: var(--m-accent);
+  width: 20px;
+}
+
+.m-onboarding__actions {
+  display: flex;
+  justify-content: center;
+  gap: var(--s-4);
+}
+
+.m-onboarding__skip {
+  background: none;
+  border: none;
+  color: var(--m-muted);
+  font-size: var(--fs-body);
+  cursor: pointer;
+  padding: var(--s-3) var(--s-4);
+  font-family: var(--m-font);
+}
+
+.m-onboarding__next {
+  background: var(--m-gradient);
+  color: white;
+  border: none;
+  border-radius: var(--m-r-full);
+  padding: var(--s-3) var(--s-5);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  font-family: var(--m-font);
+  min-width: 120px;
+}


### PR DESCRIPTION
## Summary

Four mobile experience enhancements:

- **Pull-to-refresh** — pull down on any screen to reload data. Resistance curve (sqrt), 60px threshold, spinner animation during refresh.
- **Offline indicator** — amber-dotted banner appears when connection drops: "You're offline — changes will sync when you reconnect". Disappears automatically when back online.
- **PWA install prompt** — "Add to Home Screen" banner on first mobile visit. Captures `beforeinstallprompt` event, shows install/dismiss buttons. Respects standalone mode and dismissal persistence. Manifest updated with amber theme color.
- **First-time onboarding** — 3-step modal walkthrough: swipe gestures, quick capture, task details. Step dots + skip/next navigation. Shown once per device (localStorage flag).

## New files
- `PullToRefresh.tsx` — touch gesture handler with refresh callback
- `OfflineBanner.tsx` — online/offline event listener with banner UI
- `InstallBanner.tsx` — beforeinstallprompt handler with install/dismiss
- `Onboarding.tsx` — 3-step walkthrough modal

## Test plan
- [x] Typecheck passes
- [x] 107 unit tests passing
- [x] Production build passes
- [ ] Manual: pull down to refresh reloads task data
- [ ] Manual: toggle airplane mode shows/hides offline banner
- [ ] Manual: onboarding shows on first visit, not on subsequent visits
- [ ] Manual: PWA install banner appears on eligible browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)