### PR TITLE
style: format adaptation service files

### DIFF
--- a/src/adaptation.api.integration.test.ts
+++ b/src/adaptation.api.integration.test.ts
@@ -135,7 +135,9 @@ describe("Adaptation API Integration", () => {
         .expect(200);
 
       expect(getResponse.body.confidence).toBe(computeResponse.body.confidence);
-      expect(getResponse.body.eligibility).toBe(computeResponse.body.eligibility);
+      expect(getResponse.body.eligibility).toBe(
+        computeResponse.body.eligibility,
+      );
     });
   });
 
@@ -148,7 +150,9 @@ describe("Adaptation API Integration", () => {
 
     it("returns 404 for non-existent project", async () => {
       const response = await request(app)
-        .get("/adaptation/projects/00000000-0000-0000-0000-000000000001/soft-inference")
+        .get(
+          "/adaptation/projects/00000000-0000-0000-0000-000000000001/soft-inference",
+        )
         .set("Authorization", `Bearer ${authToken}`)
         .expect(404);
 

--- a/src/routes/adaptationRouter.ts
+++ b/src/routes/adaptationRouter.ts
@@ -169,7 +169,8 @@ export function createAdaptationRouter({
         ]);
 
         // Check behavioral confidence — only use LLM when low
-        const profileResult = await adaptationService.getOrCreateProfile(userId);
+        const profileResult =
+          await adaptationService.getOrCreateProfile(userId);
         if (profileResult.profile.confidence >= 0.4) {
           // Behavioral data is sufficient — don't use LLM
           return res.json({

--- a/src/services/adaptationFlags.ts
+++ b/src/services/adaptationFlags.ts
@@ -115,7 +115,10 @@ function parseEnvInt(key: string, fallback: number): number {
 function parseEnvAllowlist(key: string): string[] | undefined {
   const val = process.env[key];
   if (!val) return undefined;
-  return val.split(",").map((s) => s.trim()).filter(Boolean);
+  return val
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 /** Simple deterministic hash for rollout. */

--- a/src/services/adaptationLlmInference.test.ts
+++ b/src/services/adaptationLlmInference.test.ts
@@ -12,8 +12,11 @@ jest.mock("./llmService", () => ({
   },
 }));
 
-const mockCallLlm = llmService.callLlm as jest.MockedFunction<typeof llmService.callLlm>;
-const MockLlmProviderNotConfiguredError = llmService.LlmProviderNotConfiguredError;
+const mockCallLlm = llmService.callLlm as jest.MockedFunction<
+  typeof llmService.callLlm
+>;
+const MockLlmProviderNotConfiguredError =
+  llmService.LlmProviderNotConfiguredError;
 
 describe("AdaptationLlmInferenceService", () => {
   let service: AdaptationLlmInferenceService;
@@ -25,12 +28,14 @@ describe("AdaptationLlmInferenceService", () => {
 
   describe("inferProjectIntent", () => {
     it("returns parsed inference from valid LLM response", async () => {
-      mockCallLlm.mockResolvedValue(JSON.stringify({
-        inferredProjectType: "trip planning",
-        suggestedSections: ["Flights", "Accommodation", "Itinerary"],
-        recommendedHintStyle: "structured",
-        confidence: 0.85,
-      }));
+      mockCallLlm.mockResolvedValue(
+        JSON.stringify({
+          inferredProjectType: "trip planning",
+          suggestedSections: ["Flights", "Accommodation", "Itinerary"],
+          recommendedHintStyle: "structured",
+          confidence: 0.85,
+        }),
+      );
 
       const result = await service.inferProjectIntent({
         projectName: "Japan Trip",
@@ -41,7 +46,11 @@ describe("AdaptationLlmInferenceService", () => {
 
       expect(result).not.toBeNull();
       expect(result!.inferredProjectType).toBe("trip planning");
-      expect(result!.suggestedSections).toEqual(["Flights", "Accommodation", "Itinerary"]);
+      expect(result!.suggestedSections).toEqual([
+        "Flights",
+        "Accommodation",
+        "Itinerary",
+      ]);
       expect(result!.recommendedHintStyle).toBe("structured");
       expect(result!.confidence).toBe(0.85);
     });
@@ -99,12 +108,14 @@ describe("AdaptationLlmInferenceService", () => {
     });
 
     it("clamps confidence to [0, 1]", async () => {
-      mockCallLlm.mockResolvedValue(JSON.stringify({
-        inferredProjectType: "test",
-        suggestedSections: [],
-        recommendedHintStyle: "minimal",
-        confidence: 1.5,
-      }));
+      mockCallLlm.mockResolvedValue(
+        JSON.stringify({
+          inferredProjectType: "test",
+          suggestedSections: [],
+          recommendedHintStyle: "minimal",
+          confidence: 1.5,
+        }),
+      );
 
       const result = await service.inferProjectIntent({
         projectName: "Test",
@@ -116,9 +127,11 @@ describe("AdaptationLlmInferenceService", () => {
     });
 
     it("handles missing optional fields gracefully", async () => {
-      mockCallLlm.mockResolvedValue(JSON.stringify({
-        confidence: 0.5,
-      }));
+      mockCallLlm.mockResolvedValue(
+        JSON.stringify({
+          confidence: 0.5,
+        }),
+      );
 
       const result = await service.inferProjectIntent({
         projectName: "Test",
@@ -133,9 +146,11 @@ describe("AdaptationLlmInferenceService", () => {
     });
 
     it("limits task titles in prompt to 15", async () => {
-      mockCallLlm.mockResolvedValue(JSON.stringify({
-        confidence: 0.5,
-      }));
+      mockCallLlm.mockResolvedValue(
+        JSON.stringify({
+          confidence: 0.5,
+        }),
+      );
 
       const taskTitles = Array.from({ length: 20 }, (_, i) => `Task ${i + 1}`);
       await service.inferProjectIntent({
@@ -153,7 +168,9 @@ describe("AdaptationLlmInferenceService", () => {
 
   describe("suggestStarterSections", () => {
     it("returns parsed sections from valid LLM response", async () => {
-      mockCallLlm.mockResolvedValue(JSON.stringify(["Planning", "Execution", "Review"]));
+      mockCallLlm.mockResolvedValue(
+        JSON.stringify(["Planning", "Execution", "Review"]),
+      );
 
       const result = await service.suggestStarterSections({
         projectName: "New Project",
@@ -188,9 +205,7 @@ describe("AdaptationLlmInferenceService", () => {
     });
 
     it("limits sections to 5 from plain text", async () => {
-      mockCallLlm.mockResolvedValue(
-        "- A\n- B\n- C\n- D\n- E\n- F\n- G",
-      );
+      mockCallLlm.mockResolvedValue("- A\n- B\n- C\n- D\n- E\n- F\n- G");
 
       const result = await service.suggestStarterSections({
         projectName: "Test",

--- a/src/services/surfacePolicy.test.ts
+++ b/src/services/surfacePolicy.test.ts
@@ -1,11 +1,5 @@
-import {
-  deriveSurfacePolicy,
-  buildProjectContext,
-} from "./surfacePolicy";
-import type {
-  UserAdaptationProfile,
-  ProjectContext,
-} from "../types";
+import { deriveSurfacePolicy, buildProjectContext } from "./surfacePolicy";
+import type { UserAdaptationProfile, ProjectContext } from "../types";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -105,11 +99,7 @@ describe("deriveSurfacePolicy — cold start", () => {
     const profile = baseProfile();
     profile.eligibility = "none";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "rich",
-      richContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "rich", richContext());
 
     expect(policy.defaultOverviewMode).toBe("balanced");
     expect(policy.showSectionsPreview).toBe(true);
@@ -148,11 +138,7 @@ describe("deriveSurfacePolicy — simple projects", () => {
     profile.guidanceNeed = "high";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "simple",
-      sparseContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "simple", sparseContext());
 
     expect(policy.showSetupGuidance).toBe(true);
     expect(policy.setupGuidanceStyle).toBe("light");
@@ -164,11 +150,7 @@ describe("deriveSurfacePolicy — simple projects", () => {
     profile.dateDiscipline = "high";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "simple",
-      sparseContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "simple", sparseContext());
 
     expect(policy.suggestDates).toBe(true);
   });
@@ -179,11 +161,7 @@ describe("deriveSurfacePolicy — simple projects", () => {
     profile.dateDiscipline = "medium";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "simple",
-      sparseContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "simple", sparseContext());
 
     expect(policy.defaultOverviewMode).toBe("minimal");
     expect(policy.showDatesProminently).toBe(true);
@@ -196,11 +174,7 @@ describe("deriveSurfacePolicy — simple projects", () => {
     profile.insightAffinity = "high";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "simple",
-      sparseContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "simple", sparseContext());
 
     expect(policy.showInsightsDisclosure).toBe(true);
   });
@@ -210,11 +184,7 @@ describe("deriveSurfacePolicy — simple projects", () => {
     profile.structureAppetite = "planner";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "simple",
-      sparseContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "simple", sparseContext());
 
     expect(policy.defaultOverviewMode).toBe("balanced");
     expect(policy.showDatesProminently).toBe(true);
@@ -258,11 +228,7 @@ describe("deriveSurfacePolicy — guided projects", () => {
     profile.structureAppetite = "lightweight";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "guided",
-      guidedContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "guided", guidedContext());
 
     expect(policy.defaultOverviewMode).toBe("balanced");
     expect(policy.showSectionsPreview).toBe(true);
@@ -289,11 +255,7 @@ describe("deriveSurfacePolicy — guided projects", () => {
     profile.structureAppetite = "balanced";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "guided",
-      guidedContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "guided", guidedContext());
 
     expect(policy.showSectionsPreview).toBe(true);
     expect(policy.showTaskPreview).toBe(false);
@@ -320,11 +282,7 @@ describe("deriveSurfacePolicy — guided projects", () => {
     profile.confidence = 0.75;
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "guided",
-      guidedContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "guided", guidedContext());
 
     expect(policy.showDatesProminently).toBe(true);
     expect(policy.showInsightsDisclosure).toBe(true);
@@ -337,11 +295,7 @@ describe("deriveSurfacePolicy — guided projects", () => {
     profile.confidence = 0.8;
     profile.eligibility = "full";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "guided",
-      guidedContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "guided", guidedContext());
 
     expect(policy.autoExpandInsights).toBe(true);
   });
@@ -355,11 +309,7 @@ describe("deriveSurfacePolicy — rich projects", () => {
     profile.structureAppetite = "lightweight";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "rich",
-      richContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "rich", richContext());
 
     expect(policy.defaultOverviewMode).toBe("balanced");
     expect(policy.suggestSections).toBe(false);
@@ -373,11 +323,7 @@ describe("deriveSurfacePolicy — rich projects", () => {
     profile.structureAppetite = "balanced";
     profile.eligibility = "standard";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "rich",
-      richContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "rich", richContext());
 
     expect(policy.defaultOverviewMode).toBe("detailed");
     expect(policy.showInsightsDisclosure).toBe(true);
@@ -390,11 +336,7 @@ describe("deriveSurfacePolicy — rich projects", () => {
     profile.confidence = 0.75;
     profile.eligibility = "full";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "rich",
-      richContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "rich", richContext());
 
     expect(policy.autoExpandInsights).toBe(true);
   });
@@ -406,11 +348,7 @@ describe("deriveSurfacePolicy — rich projects", () => {
     profile.insightAffinity = "medium";
     profile.eligibility = "full";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "rich",
-      richContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "rich", richContext());
 
     expect(policy.defaultOverviewMode).toBe("detailed");
     expect(policy.autoExpandInsights).toBe(true);
@@ -423,11 +361,7 @@ describe("deriveSurfacePolicy — rich projects", () => {
     profile.insightAffinity = "low";
     profile.eligibility = "full";
 
-    const { policy } = deriveSurfacePolicy(
-      profile,
-      "rich",
-      richContext(),
-    );
+    const { policy } = deriveSurfacePolicy(profile, "rich", richContext());
 
     expect(policy.autoExpandInsights).toBe(false);
   });
@@ -509,9 +443,7 @@ describe("policy guardrails", () => {
     for (const complexity of complexities) {
       for (const ctx of contexts) {
         const { policy } = deriveSurfacePolicy(profile, complexity, ctx);
-        expect(
-          policy.showTaskPreview || policy.showSectionsPreview,
-        ).toBe(true);
+        expect(policy.showTaskPreview || policy.showSectionsPreview).toBe(true);
       }
     }
   });

--- a/src/services/surfacePolicy.ts
+++ b/src/services/surfacePolicy.ts
@@ -20,10 +20,7 @@ export interface DerivePolicyResult {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function capByEligibility<T extends string>(
-  value: T,
-  allowed: T[],
-): T {
+function capByEligibility<T extends string>(value: T, allowed: T[]): T {
   return allowed.includes(value) ? value : allowed[allowed.length - 1];
 }
 
@@ -48,7 +45,8 @@ function deriveSimplePolicy(
   } = profile;
 
   // Base: simple projects stay minimal
-  let defaultOverviewMode: ProjectSurfacePolicy["defaultOverviewMode"] = "minimal";
+  let defaultOverviewMode: ProjectSurfacePolicy["defaultOverviewMode"] =
+    "minimal";
   let showSectionsPreview = false;
   let showTaskPreview = true;
   let showDatesProminently = false;
@@ -157,7 +155,8 @@ function deriveGuidedPolicy(
     eligibility,
   } = profile;
 
-  let defaultOverviewMode: ProjectSurfacePolicy["defaultOverviewMode"] = "balanced";
+  let defaultOverviewMode: ProjectSurfacePolicy["defaultOverviewMode"] =
+    "balanced";
   let showSectionsPreview = false;
   let showTaskPreview = false;
   let showDatesProminently = false;
@@ -286,7 +285,8 @@ function deriveRichPolicy(
     eligibility,
   } = profile;
 
-  let defaultOverviewMode: ProjectSurfacePolicy["defaultOverviewMode"] = "balanced";
+  let defaultOverviewMode: ProjectSurfacePolicy["defaultOverviewMode"] =
+    "balanced";
   let showSectionsPreview = true;
   let showTaskPreview = false;
   let showDatesProminently = true;
@@ -361,7 +361,8 @@ export function deriveSurfacePolicy(
   if (profile.eligibility === "none") {
     return {
       policy: {
-        defaultOverviewMode: projectComplexity === "rich" ? "balanced" : "minimal",
+        defaultOverviewMode:
+          projectComplexity === "rich" ? "balanced" : "minimal",
         personalizationLevel: "none",
         showSectionsPreview: projectComplexity !== "simple",
         showTaskPreview: projectComplexity === "simple",

--- a/src/services/userAdaptationScoring.ts
+++ b/src/services/userAdaptationScoring.ts
@@ -32,9 +32,7 @@ function normalize(value: number, maxRange: number): number {
 }
 
 /** Weighted average of percentage inputs. */
-function weightedScore(
-  inputs: { value: number; weight: number }[],
-): number {
+function weightedScore(inputs: { value: number; weight: number }[]): number {
   const totalWeight = inputs.reduce((sum, i) => sum + i.weight, 0);
   if (totalWeight === 0) return 0;
   const weighted = inputs.reduce((sum, i) => sum + i.value * i.weight, 0);
@@ -56,7 +54,7 @@ export function computeStructureUsageScore(
     { value: signals.pctProjectsWithSections, weight: 0.35 },
     {
       value: normalize(signals.avgSectionsPerProject, 8),
-      weight: 0.20,
+      weight: 0.2,
     },
     { value: signals.sectionCreationRate, weight: 0.15 },
     { value: signals.sectionReorganizationRate, weight: 0.15 },
@@ -72,7 +70,7 @@ export function computeStructureUsageScore(
 export function computeDateUsageScore(signals: UserBehaviorSignals): number {
   return weightedScore([
     { value: signals.pctProjectsWithDueDates, weight: 0.35 },
-    { value: signals.pctTasksWithDueDates, weight: 0.20 },
+    { value: signals.pctTasksWithDueDates, weight: 0.2 },
     { value: signals.pctProjectsWithTargetDates, weight: 0.15 },
     { value: signals.dueDateEditRate, weight: 0.15 },
     { value: signals.overdueResolutionRate, weight: 0.15 },
@@ -94,8 +92,8 @@ export function computeInsightEngagementScore(
 
   return weightedScore([
     { value: signals.insightsOpenRate, weight: 0.45 },
-    { value: signals.insightsActionRate, weight: 0.30 },
-    { value: signals.expandAdvancedPanelsRate, weight: 0.10 },
+    { value: signals.insightsActionRate, weight: 0.3 },
+    { value: signals.expandAdvancedPanelsRate, weight: 0.1 },
     {
       value: 100 - signals.collapseAdvancedPanelsRate,
       weight: 0.15,
@@ -129,9 +127,9 @@ export function computeSectionsFirstScore(
   signals: UserBehaviorSignals,
 ): number {
   return weightedScore([
-    { value: signals.pctProjectsWithSections, weight: 0.40 },
+    { value: signals.pctProjectsWithSections, weight: 0.4 },
     { value: signals.revisitViaSectionViewRate, weight: 0.25 },
-    { value: signals.sectionCreationRate, weight: 0.20 },
+    { value: signals.sectionCreationRate, weight: 0.2 },
     { value: signals.sectionReorganizationRate, weight: 0.15 },
   ]);
 }
@@ -146,15 +144,16 @@ export function computeGuidanceRelianceScore(
   signals: UserBehaviorSignals,
 ): number {
   return weightedScore([
-    { value: signals.avgProjectStartSparsity, weight: 0.30 },
-    { value: signals.suggestionAcceptRate, weight: 0.20 },
+    { value: signals.avgProjectStartSparsity, weight: 0.3 },
+    { value: signals.suggestionAcceptRate, weight: 0.2 },
     {
-      value: signals.avgTimeToSecondMeaningfulEditHours !== null
-        ? normalize(signals.avgTimeToSecondMeaningfulEditHours, 72)
-        : 50,
+      value:
+        signals.avgTimeToSecondMeaningfulEditHours !== null
+          ? normalize(signals.avgTimeToSecondMeaningfulEditHours, 72)
+          : 50,
       weight: 0.15,
     },
-    { value: 100 - signals.sectionCreationRate, weight: 0.20 },
+    { value: 100 - signals.sectionCreationRate, weight: 0.2 },
     { value: 100 - signals.pctProjectsWithDueDates, weight: 0.15 },
   ]);
 }
@@ -184,7 +183,9 @@ export function classifyOrganizationStyle(
   sectionsFirstScore: number,
 ): OrganizationStyle {
   if (Math.abs(tasksFirstScore - sectionsFirstScore) < 10) return "mixed";
-  return tasksFirstScore > sectionsFirstScore ? "tasks_first" : "sections_first";
+  return tasksFirstScore > sectionsFirstScore
+    ? "tasks_first"
+    : "sections_first";
 }
 
 export function classifyGuidanceNeed(score: number): GuidanceNeed {
@@ -238,11 +239,9 @@ export function computeConfidence(
   const sessionsNorm = normalize(totalMeaningfulSessions, 20);
   const signalsNorm = normalize(signalsWithSufficientData, 5);
 
-  const confidence = clamp(
-    0.4 * projectsNorm + 0.3 * sessionsNorm + 0.3 * signalsNorm,
-    0,
-    100,
-  ) / 100;
+  const confidence =
+    clamp(0.4 * projectsNorm + 0.3 * sessionsNorm + 0.3 * signalsNorm, 0, 100) /
+    100;
 
   const roundedConfidence = Math.round(confidence * 100) / 100;
 
@@ -269,12 +268,21 @@ export interface EligibilityInput {
  * - "standard": full surface emphasis tuning
  * - "full": maximum personalization with auto-expand insights
  */
-export function computeEligibility(input: EligibilityInput): PersonalizationEligibility {
-  const { projectsCreated, meaningfulSessions, daysActive, confidence, hasRecentActivity } = input;
+export function computeEligibility(
+  input: EligibilityInput,
+): PersonalizationEligibility {
+  const {
+    projectsCreated,
+    meaningfulSessions,
+    daysActive,
+    confidence,
+    hasRecentActivity,
+  } = input;
 
   if (confidence >= 0.7 && hasRecentActivity) return "full";
   if (projectsCreated >= 5 || meaningfulSessions >= 20) return "standard";
-  if (projectsCreated < 3 && meaningfulSessions < 10 && daysActive < 14) return "none";
+  if (projectsCreated < 3 && meaningfulSessions < 10 && daysActive < 14)
+    return "none";
   return "light";
 }
 
@@ -295,7 +303,14 @@ export interface BuildProfileInput {
 export function buildUserProfile(
   input: BuildProfileInput,
 ): UserAdaptationProfile {
-  const { signals, scores, projectsCreated, meaningfulSessions, daysActive, hasRecentActivity } = input;
+  const {
+    signals,
+    scores,
+    projectsCreated,
+    meaningfulSessions,
+    daysActive,
+    hasRecentActivity,
+  } = input;
 
   const { confidence, reason: confidenceReason } = computeConfidence(
     projectsCreated,

--- a/src/services/userAdaptationService.ts
+++ b/src/services/userAdaptationService.ts
@@ -117,31 +117,29 @@ export class UserAdaptationService {
     });
 
     // Fetch project-level aggregates
-    const [
-      projectsCreated,
-      projectsCompleted,
-      allProjects,
-    ] = await Promise.all([
-      this.prisma.project.count({
-        where: { userId, createdAt: { gte: windowStart } },
-      }),
-      this.prisma.project.count({
-        where: {
-          userId,
-          status: "completed",
-          updatedAt: { gte: windowStart },
-        },
-      }),
-      this.prisma.project.findMany({
-        where: { userId, archived: false },
-        select: {
-          id: true,
-          targetDate: true,
-          createdAt: true,
-          _count: { select: { todos: true, headings: true } },
-        },
-      }),
-    ]);
+    const [projectsCreated, projectsCompleted, allProjects] = await Promise.all(
+      [
+        this.prisma.project.count({
+          where: { userId, createdAt: { gte: windowStart } },
+        }),
+        this.prisma.project.count({
+          where: {
+            userId,
+            status: "completed",
+            updatedAt: { gte: windowStart },
+          },
+        }),
+        this.prisma.project.findMany({
+          where: { userId, archived: false },
+          select: {
+            id: true,
+            targetDate: true,
+            createdAt: true,
+            _count: { select: { todos: true, headings: true } },
+          },
+        }),
+      ],
+    );
 
     // Fetch task-level aggregates across all projects
     const allTodos = await this.prisma.todo.findMany({
@@ -157,13 +155,13 @@ export class UserAdaptationService {
     });
 
     // Apply decay weight to each event
-    const weightedEventCount = (
-      type: ActivityEventType,
-    ): number => {
+    const weightedEventCount = (type: ActivityEventType): number => {
       const matching = events.filter((e) => e.eventType === type);
       return matching.reduce((sum, e) => {
-        const age = (now.getTime() - e.createdAt.getTime()) / (1000 * 60 * 60 * 24);
-        const weight = age <= DECAY_RECENT_DAYS ? DECAY_RECENT_WEIGHT : DECAY_OLDER_WEIGHT;
+        const age =
+          (now.getTime() - e.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+        const weight =
+          age <= DECAY_RECENT_DAYS ? DECAY_RECENT_WEIGHT : DECAY_OLDER_WEIGHT;
         return sum + weight;
       }, 0);
     };
@@ -174,9 +172,7 @@ export class UserAdaptationService {
       (p) => p._count.headings > 0,
     ).length;
     const projectsWithDueDates = allProjects.filter((p) =>
-      allTodos.some(
-        (t) => t.dueDate != null,
-      ),
+      allTodos.some((t) => t.dueDate != null),
     ).length;
     const projectsWithTargetDates = allProjects.filter(
       (p) => p.targetDate != null,
@@ -185,7 +181,9 @@ export class UserAdaptationService {
     // Task-level percentages
     const taskCount = allTodos.length || 1;
     const tasksWithDueDates = allTodos.filter((t) => t.dueDate != null).length;
-    const tasksWithPriority = allTodos.filter((t) => t.priority != null && t.priority !== "medium").length;
+    const tasksWithPriority = allTodos.filter(
+      (t) => t.priority != null && t.priority !== "medium",
+    ).length;
 
     // Sections per project average
     const totalSections = allProjects.reduce(
@@ -199,67 +197,79 @@ export class UserAdaptationService {
       .filter((e) => e.eventType === "section_created")
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-    const avgDaysToFirstSection = sectionCreatedEvents.length > 0
-      ? (sectionCreatedEvents[0].createdAt.getTime() -
-          new Date(Math.min(...allProjects.map((p) => p.createdAt.getTime())))
-            .getTime()) /
-        (1000 * 60 * 60 * 24)
-      : null;
+    const avgDaysToFirstSection =
+      sectionCreatedEvents.length > 0
+        ? (sectionCreatedEvents[0].createdAt.getTime() -
+            new Date(
+              Math.min(...allProjects.map((p) => p.createdAt.getTime())),
+            ).getTime()) /
+          (1000 * 60 * 60 * 24)
+        : null;
 
     // Insight engagement metrics
     const insightsOpenCount = weightedEventCount("insights_open");
-    const insightOpportunityCount = weightedEventCount("insight_opportunity_shown");
+    const insightOpportunityCount = weightedEventCount(
+      "insight_opportunity_shown",
+    );
     const insightsDismissCount = weightedEventCount("insights_dismissed");
 
-    const insightsOpenRate = insightOpportunityCount > 0
-      ? (insightsOpenCount / insightOpportunityCount) * 100
-      : 0;
-    const insightsDismissRate = insightOpportunityCount > 0
-      ? (insightsDismissCount / insightOpportunityCount) * 100
-      : 0;
+    const insightsOpenRate =
+      insightOpportunityCount > 0
+        ? (insightsOpenCount / insightOpportunityCount) * 100
+        : 0;
+    const insightsDismissRate =
+      insightOpportunityCount > 0
+        ? (insightsDismissCount / insightOpportunityCount) * 100
+        : 0;
     // Action rate: opens that led to some subsequent task edit within the session
     // Approximated as open rate * 0.5 for now (refined when task-level session data available)
     const insightsActionRate = insightsOpenRate * 0.5;
 
     // Section creation / reorganization rates (per project)
-    const sectionCreationRate = projectCount > 0
-      ? (weightedEventCount("section_created") / projectCount) * 100
-      : 0;
-    const sectionReorganizationRate = projectCount > 0
-      ? (weightedEventCount("section_reorganized") / projectCount) * 100
-      : 0;
+    const sectionCreationRate =
+      projectCount > 0
+        ? (weightedEventCount("section_created") / projectCount) * 100
+        : 0;
+    const sectionReorganizationRate =
+      projectCount > 0
+        ? (weightedEventCount("section_reorganized") / projectCount) * 100
+        : 0;
 
     // Task first action rate: tasks edited before sections created
-    const taskFirstActionRate = taskCount > 0
-      ? ((weightedEventCount("task_created") + weightedEventCount("task_updated")) /
-          (weightedEventCount("task_created") +
-            weightedEventCount("task_updated") +
-            weightedEventCount("section_created") +
-            1)) *
-        100
-      : 0;
+    const taskFirstActionRate =
+      taskCount > 0
+        ? ((weightedEventCount("task_created") +
+            weightedEventCount("task_updated")) /
+            (weightedEventCount("task_created") +
+              weightedEventCount("task_updated") +
+              weightedEventCount("section_created") +
+              1)) *
+          100
+        : 0;
 
     // Suggestion rates
     const suggestionAcceptCount = weightedEventCount("suggestion_accepted");
     const suggestionDismissCount = weightedEventCount("suggestion_dismissed");
     const totalSuggestions = suggestionAcceptCount + suggestionDismissCount;
-    const suggestionAcceptRate = totalSuggestions > 0
-      ? (suggestionAcceptCount / totalSuggestions) * 100
-      : 0;
-    const suggestionDismissRate = totalSuggestions > 0
-      ? (suggestionDismissCount / totalSuggestions) * 100
-      : 0;
+    const suggestionAcceptRate =
+      totalSuggestions > 0
+        ? (suggestionAcceptCount / totalSuggestions) * 100
+        : 0;
+    const suggestionDismissRate =
+      totalSuggestions > 0
+        ? (suggestionDismissCount / totalSuggestions) * 100
+        : 0;
 
     // Panel expand/collapse rates
     const panelExpandCount = weightedEventCount("panel_expanded");
     const panelCollapseCount = weightedEventCount("panel_collapsed");
     const totalPanelActions = panelExpandCount + panelCollapseCount;
-    const expandAdvancedPanelsRate = totalPanelActions > 0
-      ? (panelExpandCount / totalPanelActions) * 100
-      : 0;
-    const collapseAdvancedPanelsRate = totalPanelActions > 0
-      ? (panelCollapseCount / totalPanelActions) * 100
-      : 0;
+    const expandAdvancedPanelsRate =
+      totalPanelActions > 0 ? (panelExpandCount / totalPanelActions) * 100 : 0;
+    const collapseAdvancedPanelsRate =
+      totalPanelActions > 0
+        ? (panelCollapseCount / totalPanelActions) * 100
+        : 0;
 
     // Project revisit metrics
     const projectOpenedCount = weightedEventCount("project_opened");
@@ -268,31 +278,34 @@ export class UserAdaptationService {
       "project_revisited_after_idle",
     );
 
-    const revisitViaTaskListRate = projectOpenedCount > 0
-      ? ((weightedEventCount("task_updated") + weightedEventCount("task_completed")) /
-          (projectOpenedCount + 1)) *
-        50
-      : 0;
-    const revisitViaSectionViewRate = projectOpenedCount > 0
-      ? (weightedEventCount("section_reorganized") / (projectOpenedCount + 1)) *
-        100
-      : 0;
+    const revisitViaTaskListRate =
+      projectOpenedCount > 0
+        ? ((weightedEventCount("task_updated") +
+            weightedEventCount("task_completed")) /
+            (projectOpenedCount + 1)) *
+          50
+        : 0;
+    const revisitViaSectionViewRate =
+      projectOpenedCount > 0
+        ? (weightedEventCount("section_reorganized") /
+            (projectOpenedCount + 1)) *
+          100
+        : 0;
 
     // Due date edit rate (approximate from task updates on dated tasks)
-    const dueDateEditRate = tasksWithDueDates > 0
-      ? (weightedEventCount("task_updated") / tasksWithDueDates) * 50
-      : 0;
+    const dueDateEditRate =
+      tasksWithDueDates > 0
+        ? (weightedEventCount("task_updated") / tasksWithDueDates) * 50
+        : 0;
 
     // Overdue resolution rate (approximate)
     const overdueTasks = allTodos.filter(
-      (t) =>
-        t.dueDate != null &&
-        !t.completed &&
-        new Date(t.dueDate) < now,
+      (t) => t.dueDate != null && !t.completed && new Date(t.dueDate) < now,
     ).length;
-    const overdueResolutionRate = overdueTasks > 0
-      ? ((weightedEventCount("task_completed") / overdueTasks) * 100)
-      : 100;
+    const overdueResolutionRate =
+      overdueTasks > 0
+        ? (weightedEventCount("task_completed") / overdueTasks) * 100
+        : 100;
 
     // Project start sparsity: projects with <= 2 tasks in first week
     const sparseProjects = allProjects.filter((p) => {
@@ -303,9 +316,8 @@ export class UserAdaptationService {
       ).length;
       return tasksInFirstWeek <= 2;
     }).length;
-    const avgProjectStartSparsity = projectCount > 0
-      ? (sparseProjects / projectCount) * 100
-      : 0;
+    const avgProjectStartSparsity =
+      projectCount > 0 ? (sparseProjects / projectCount) * 100 : 0;
 
     // Avg time to second meaningful edit (approximate)
     const avgTimeToSecondMeaningfulEditHours = null; // Requires session-level tracking
@@ -343,7 +355,9 @@ export class UserAdaptationService {
       expandAdvancedPanelsRate: Math.min(expandAdvancedPanelsRate, 100),
       projectOpenedCount: Math.round(projectOpenedCount),
       projectResumedCount: Math.round(projectResumedCount),
-      projectRevisitedAfterIdleCount: Math.round(projectRevisitedAfterIdleCount),
+      projectRevisitedAfterIdleCount: Math.round(
+        projectRevisitedAfterIdleCount,
+      ),
       revisitViaTaskListRate: Math.min(revisitViaTaskListRate, 100),
       revisitViaSectionViewRate: Math.min(revisitViaSectionViewRate, 100),
     };
@@ -458,33 +472,36 @@ export class UserAdaptationService {
     }
   }
 
-  private _mapStoredToProfile(
-    stored: {
-      id: string;
-      userId: string;
-      profileVersion: number;
-      policyVersion: number;
-      eligibility: string;
-      structureAppetite: string;
-      insightAffinity: string;
-      dateDiscipline: string;
-      organizationStyle: string;
-      guidanceNeed: string;
-      confidence: number;
-      confidenceReason: string | null;
-      signalsSnapshot: unknown;
-      scoresSnapshot: unknown;
-      signalsWindowDays: number;
-      computedAt: Date;
-      updatedAt: Date;
-    },
-  ): ProfileWithMetadata {
+  private _mapStoredToProfile(stored: {
+    id: string;
+    userId: string;
+    profileVersion: number;
+    policyVersion: number;
+    eligibility: string;
+    structureAppetite: string;
+    insightAffinity: string;
+    dateDiscipline: string;
+    organizationStyle: string;
+    guidanceNeed: string;
+    confidence: number;
+    confidenceReason: string | null;
+    signalsSnapshot: unknown;
+    scoresSnapshot: unknown;
+    signalsWindowDays: number;
+    computedAt: Date;
+    updatedAt: Date;
+  }): ProfileWithMetadata {
     let profile: UserAdaptationProfile = {
-      structureAppetite: stored.structureAppetite as UserAdaptationProfile["structureAppetite"],
-      insightAffinity: stored.insightAffinity as UserAdaptationProfile["insightAffinity"],
-      dateDiscipline: stored.dateDiscipline as UserAdaptationProfile["dateDiscipline"],
-      organizationStyle: stored.organizationStyle as UserAdaptationProfile["organizationStyle"],
-      guidanceNeed: stored.guidanceNeed as UserAdaptationProfile["guidanceNeed"],
+      structureAppetite:
+        stored.structureAppetite as UserAdaptationProfile["structureAppetite"],
+      insightAffinity:
+        stored.insightAffinity as UserAdaptationProfile["insightAffinity"],
+      dateDiscipline:
+        stored.dateDiscipline as UserAdaptationProfile["dateDiscipline"],
+      organizationStyle:
+        stored.organizationStyle as UserAdaptationProfile["organizationStyle"],
+      guidanceNeed:
+        stored.guidanceNeed as UserAdaptationProfile["guidanceNeed"],
       confidence: stored.confidence,
       confidenceReason: stored.confidenceReason ?? "",
       eligibility: stored.eligibility as UserAdaptationProfile["eligibility"],
@@ -521,7 +538,10 @@ export class UserAdaptationService {
     }
 
     // Scale decay factor by how long since compute (caps at 2x the base factor)
-    const decayMultiplier = Math.min(2, hoursSinceCompute / PROFILE_DECAY_HOURS);
+    const decayMultiplier = Math.min(
+      2,
+      hoursSinceCompute / PROFILE_DECAY_HOURS,
+    );
     const effectiveDecay = PROFILE_DECAY_FACTOR * decayMultiplier;
 
     // Decay confidence toward zero


### PR DESCRIPTION
## Summary

Fixes the pre-existing `format:check` CI failure that's been blocking every PR.

8 files in the adaptation service (from PRs #785, #786) had Prettier violations. This runs `prettier --write` on them.

No logic changes — formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)