### PR TITLE
feat(react-mobile): abstract SVG illustrations for empty states and onboarding

### DIFF
--- a/client-react/src/mobile/MobileShell.tsx
+++ b/client-react/src/mobile/MobileShell.tsx
@@ -18,6 +18,7 @@ import { OfflineBanner } from "./components/OfflineBanner";
 import { SnoozePicker } from "./components/SnoozePicker";
 import { InstallBanner } from "./components/InstallBanner";
 import { Onboarding } from "./components/Onboarding";
+import { IllustrationConstruction } from "./components/Illustrations";
 import type { TodoStatus, Priority } from "../types";
 import { FocusScreen } from "./screens/FocusScreen";
 import { TodayScreen } from "./screens/TodayScreen";
@@ -280,7 +281,7 @@ export function MobileShell() {
           </header>
           <div className="m-shell__page-content">
             <div className="m-empty">
-              <div className="m-empty__icon">🚧</div>
+              <IllustrationConstruction />
               <div className="m-empty__title">Coming soon on mobile</div>
               <div className="m-empty__hint">Use the desktop app for full access</div>
             </div>

--- a/client-react/src/mobile/components/Illustrations.tsx
+++ b/client-react/src/mobile/components/Illustrations.tsx
@@ -1,0 +1,126 @@
+/** Celebration — overlapping circles bursting outward. For "All clear" empty state. */
+export function IllustrationCelebrate() {
+  return (
+    <svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <circle cx="70" cy="60" r="32" fill="var(--m-amber)" opacity="0.2" />
+      <circle cx="70" cy="60" r="20" fill="var(--m-amber)" opacity="0.35" />
+      <circle cx="45" cy="40" r="14" fill="var(--m-accent)" opacity="0.25" />
+      <circle cx="95" cy="40" r="10" fill="var(--m-success)" opacity="0.3" />
+      <circle cx="50" cy="80" r="8" fill="var(--m-accent)" opacity="0.2" />
+      <circle cx="100" cy="75" r="12" fill="var(--m-amber)" opacity="0.3" />
+      <circle cx="30" cy="60" r="6" fill="var(--m-success)" opacity="0.25" />
+      <circle cx="110" cy="55" r="7" fill="var(--m-accent)" opacity="0.2" />
+      {/* Sparkle accents */}
+      <path d="M70 30l2 6 6 2-6 2-2 6-2-6-6-2 6-2z" fill="var(--m-amber)" opacity="0.6" />
+      <path d="M105 90l1.5 4.5 4.5 1.5-4.5 1.5-1.5 4.5-1.5-4.5-4.5-1.5 4.5-1.5z" fill="var(--m-accent)" opacity="0.5" />
+      <path d="M25 45l1 3 3 1-3 1-1 3-1-3-3-1 3-1z" fill="var(--m-success)" opacity="0.4" />
+    </svg>
+  );
+}
+
+/** Sunny day — radiating lines from a warm circle. For "Nothing due today" empty state. */
+export function IllustrationSunny() {
+  return (
+    <svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      {/* Radiating soft lines */}
+      {Array.from({ length: 12 }, (_, i) => {
+        const angle = (i * 30 * Math.PI) / 180;
+        const x1 = 70 + Math.cos(angle) * 28;
+        const y1 = 60 + Math.sin(angle) * 28;
+        const x2 = 70 + Math.cos(angle) * 48;
+        const y2 = 60 + Math.sin(angle) * 48;
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="var(--m-amber)" strokeWidth="2" opacity={0.15 + (i % 3) * 0.1} strokeLinecap="round" />;
+      })}
+      <circle cx="70" cy="60" r="24" fill="var(--m-amber)" opacity="0.15" />
+      <circle cx="70" cy="60" r="16" fill="var(--m-amber)" opacity="0.25" />
+      <circle cx="70" cy="60" r="8" fill="var(--m-accent)" opacity="0.3" />
+    </svg>
+  );
+}
+
+/** Folder stack — overlapping rounded rectangles. For "No projects" empty state. */
+export function IllustrationFolders() {
+  return (
+    <svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect x="35" y="45" width="70" height="50" rx="10" fill="var(--m-amber)" opacity="0.12" />
+      <rect x="42" y="38" width="62" height="48" rx="9" fill="var(--m-amber)" opacity="0.18" />
+      <rect x="49" y="31" width="54" height="46" rx="8" fill="var(--m-accent)" opacity="0.15" />
+      <circle cx="76" cy="54" r="10" fill="var(--m-amber)" opacity="0.3" />
+      <path d="M72 54l3 3 5-6" stroke="var(--m-accent)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" opacity="0.5" />
+    </svg>
+  );
+}
+
+/** Flowing waves — abstract curves. For custom screen empty states. */
+export function IllustrationWaves() {
+  return (
+    <svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path d="M0 80 C30 65, 50 85, 70 70 S110 55, 140 70" stroke="var(--m-amber)" strokeWidth="2.5" opacity="0.2" fill="none" />
+      <path d="M0 90 C25 75, 55 95, 75 78 S115 65, 140 80" stroke="var(--m-accent)" strokeWidth="2" opacity="0.15" fill="none" />
+      <path d="M0 70 C35 58, 45 78, 65 62 S105 48, 140 60" stroke="var(--m-amber)" strokeWidth="1.5" opacity="0.12" fill="none" />
+      <circle cx="70" cy="45" r="18" fill="var(--m-amber)" opacity="0.1" />
+      <circle cx="70" cy="45" r="10" fill="var(--m-accent)" opacity="0.12" />
+    </svg>
+  );
+}
+
+/** Construction — geometric shapes suggesting work in progress. For "coming soon" state. */
+export function IllustrationConstruction() {
+  return (
+    <svg width="140" height="120" viewBox="0 0 140 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect x="40" y="50" width="60" height="40" rx="6" fill="var(--m-amber)" opacity="0.12" transform="rotate(-3 70 70)" />
+      <rect x="50" y="40" width="45" height="35" rx="5" fill="var(--m-accent)" opacity="0.12" transform="rotate(5 72 57)" />
+      <circle cx="70" cy="55" r="15" fill="var(--m-amber)" opacity="0.15" />
+      <path d="M63 55h14M70 48v14" stroke="var(--m-accent)" strokeWidth="2.5" strokeLinecap="round" opacity="0.3" />
+    </svg>
+  );
+}
+
+/** Swipe gesture — horizontal arrow with motion lines. For onboarding step 1. */
+export function IllustrationSwipe() {
+  return (
+    <svg width="160" height="120" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <rect x="20" y="40" width="120" height="40" rx="12" fill="var(--m-amber)" opacity="0.1" />
+      {/* Motion lines */}
+      <line x1="35" y1="55" x2="55" y2="55" stroke="var(--m-amber)" strokeWidth="2" strokeLinecap="round" opacity="0.2" />
+      <line x1="40" y1="60" x2="50" y2="60" stroke="var(--m-amber)" strokeWidth="1.5" strokeLinecap="round" opacity="0.15" />
+      <line x1="38" y1="65" x2="52" y2="65" stroke="var(--m-amber)" strokeWidth="1.5" strokeLinecap="round" opacity="0.15" />
+      {/* Arrow */}
+      <circle cx="100" cy="60" r="16" fill="var(--m-accent)" opacity="0.2" />
+      <path d="M93 60h18M105 54l6 6-6 6" stroke="var(--m-accent)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" opacity="0.5" />
+    </svg>
+  );
+}
+
+/** Plus burst — radiating from center plus. For onboarding step 2 (quick capture). */
+export function IllustrationCapture() {
+  return (
+    <svg width="160" height="120" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <circle cx="80" cy="60" r="30" fill="var(--m-amber)" opacity="0.1" />
+      <circle cx="80" cy="60" r="20" fill="var(--m-accent)" opacity="0.12" />
+      {/* Radiating dots */}
+      {Array.from({ length: 8 }, (_, i) => {
+        const angle = (i * 45 * Math.PI) / 180;
+        const cx = 80 + Math.cos(angle) * 40;
+        const cy = 60 + Math.sin(angle) * 40;
+        return <circle key={i} cx={cx} cy={cy} r={3 + (i % 3)} fill={i % 2 === 0 ? "var(--m-amber)" : "var(--m-accent)"} opacity={0.15 + (i % 3) * 0.08} />;
+      })}
+      <path d="M74 60h12M80 54v12" stroke="var(--m-accent)" strokeWidth="3" strokeLinecap="round" opacity="0.4" />
+    </svg>
+  );
+}
+
+/** Tap ripple — concentric circles with a finger tap point. For onboarding step 3 (details). */
+export function IllustrationTap() {
+  return (
+    <svg width="160" height="120" viewBox="0 0 160 120" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <circle cx="80" cy="55" r="40" fill="var(--m-amber)" opacity="0.06" />
+      <circle cx="80" cy="55" r="28" fill="var(--m-amber)" opacity="0.1" />
+      <circle cx="80" cy="55" r="16" fill="var(--m-accent)" opacity="0.12" />
+      <circle cx="80" cy="55" r="6" fill="var(--m-accent)" opacity="0.25" />
+      {/* Upward arrow suggesting drag-up */}
+      <path d="M80 85v16" stroke="var(--m-amber)" strokeWidth="2" strokeLinecap="round" opacity="0.2" />
+      <path d="M75 90l5-5 5 5" stroke="var(--m-amber)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" opacity="0.2" />
+    </svg>
+  );
+}

--- a/client-react/src/mobile/components/Onboarding.tsx
+++ b/client-react/src/mobile/components/Onboarding.tsx
@@ -1,17 +1,18 @@
 import { useState, useCallback } from "react";
+import { IllustrationSwipe, IllustrationCapture, IllustrationTap } from "./Illustrations";
 
 const ONBOARDING_KEY = "mobile:onboardingDone";
 
 interface Step {
-  icon: string;
+  icon: React.ReactNode;
   title: string;
   desc: string;
 }
 
 const STEPS: Step[] = [
-  { icon: "👆", title: "Swipe to act", desc: "Swipe right to complete a task. Swipe left to snooze." },
-  { icon: "✨", title: "Quick capture", desc: "Tap the + button to add a task in seconds." },
-  { icon: "📋", title: "Tap for details", desc: "Tap any task to see details. Drag up for more." },
+  { icon: <IllustrationSwipe />, title: "Swipe to act", desc: "Swipe right to complete a task. Swipe left to snooze." },
+  { icon: <IllustrationCapture />, title: "Quick capture", desc: "Tap the + button to add a task in seconds." },
+  { icon: <IllustrationTap />, title: "Tap for details", desc: "Tap any task to see details. Drag up for more." },
 ];
 
 export function Onboarding() {

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -541,6 +541,20 @@
   margin-bottom: var(--s-3);
   font-family: var(--m-font);
   color: var(--m-text);
+  position: relative;
+  overflow: hidden;
+}
+
+.m-focus__next-blob {
+  position: absolute;
+  top: -20px;
+  right: -20px;
+  width: 80px;
+  height: 80px;
+  border-radius: var(--m-r-full);
+  background: var(--m-gradient);
+  opacity: 0.06;
+  pointer-events: none;
 }
 
 .m-focus__next-label {
@@ -1863,8 +1877,9 @@
 }
 
 .m-onboarding__icon {
-  font-size: 48px;
   margin-bottom: var(--s-4);
+  display: flex;
+  justify-content: center;
 }
 
 .m-onboarding__title {

--- a/client-react/src/mobile/screens/CustomScreen.tsx
+++ b/client-react/src/mobile/screens/CustomScreen.tsx
@@ -4,6 +4,7 @@ import type { WorkspaceView } from "../../components/projects/Sidebar";
 import { MobileHeader } from "../MobileHeader";
 import { SwipeRow } from "../components/SwipeRow";
 import { CUSTOM_TAB_OPTIONS } from "../hooks/useTabBar";
+import { IllustrationWaves } from "../components/Illustrations";
 
 function getEmptyMessage(view: WorkspaceView): string {
   switch (view) {
@@ -78,6 +79,7 @@ export function CustomScreen({ view, todos, projects, user, onTodoClick, onToggl
           ))}
           {filteredTodos.length === 0 && (
             <div className="m-empty">
+              <IllustrationWaves />
               <div className="m-empty__title">{getEmptyMessage(view)}</div>
             </div>
           )}

--- a/client-react/src/mobile/screens/FocusScreen.tsx
+++ b/client-react/src/mobile/screens/FocusScreen.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useEffect } from "react";
 import type { Todo, Project, User } from "../../types";
 import { MobileHeader } from "../MobileHeader";
 import { useCountUp } from "../hooks/useCountUp";
+import { IllustrationCelebrate } from "../components/Illustrations";
 
 interface Props {
   todos: Todo[];
@@ -76,12 +77,13 @@ export function FocusScreen({ todos, projects, user, onTodoClick, onToggleTodo, 
                 } as React.CSSProperties} />
               ))}
             </div>
-            <div className="m-empty__icon">🎉</div>
+            <IllustrationCelebrate />
             <div className="m-empty__title m-empty__title--bounce">All clear! No tasks right now.</div>
           </div>
         )}
         {topTask && (
           <button className="m-focus__next-card" onClick={() => onTodoClick(topTask.id)}>
+            <div className="m-focus__next-blob" aria-hidden="true" />
             <div className="m-focus__next-label">✦ What Next</div>
             <div className="m-focus__next-row">
               <span className={`m-focus__check${topTask.completed ? " m-focus__check--done" : ""}`}

--- a/client-react/src/mobile/screens/ProjectsScreen.tsx
+++ b/client-react/src/mobile/screens/ProjectsScreen.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import type { Todo, Project, User } from "../../types";
 import { MobileHeader } from "../MobileHeader";
 import { SwipeRow } from "../components/SwipeRow";
+import { IllustrationFolders } from "../components/Illustrations";
 
 interface Props {
   todos: Todo[];
@@ -71,6 +72,7 @@ export function ProjectsScreen({ todos, projects, user, onTodoClick, onToggleTod
         <div className="m-today__pull-hint">↓ pull to search</div>
         {groups.length === 0 && (
           <div className="m-empty">
+            <IllustrationFolders />
             <div className="m-empty__title">No active projects yet</div>
             <div className="m-empty__hint">Tap + to create one</div>
           </div>

--- a/client-react/src/mobile/screens/TodayScreen.tsx
+++ b/client-react/src/mobile/screens/TodayScreen.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { Todo, Project, User } from "../../types";
 import { MobileHeader } from "../MobileHeader";
 import { SwipeRow } from "../components/SwipeRow";
+import { IllustrationSunny } from "../components/Illustrations";
 
 interface Props {
   todos: Todo[];
@@ -93,7 +94,7 @@ export function TodayScreen({ todos, projects, user, onTodoClick, onToggleTodo, 
         {renderGroup("Scheduled", groups.scheduled)}
         {openTodos.length === 0 && (
           <div className="m-empty">
-            <div className="m-empty__icon">☀️</div>
+            <IllustrationSunny />
             <div className="m-empty__title">Nothing due today. Enjoy your day!</div>
             <div className="m-empty__hint">Tasks with today&apos;s due date will appear here</div>
           </div>


### PR DESCRIPTION
## Summary

Replaces emoji icons with palette-aware abstract SVG illustrations across the mobile shell:

- **8 inline SVG components** in `Illustrations.tsx` — no external assets, all use `var(--m-*)` tokens so they adapt to palette and dark mode
- **Empty states**: celebration (overlapping circles + sparkles), sunny day (radiating lines), folder stack, flowing waves, construction shapes
- **Onboarding steps**: swipe gesture arrow, capture plus-burst, tap ripple rings
- **Focus card**: subtle gradient blob decoration behind "What Next" card

**Design language**: warm geometric shapes — circles, curves, gradients. Nothing figurative. Feels like sunlight on paper.

## Files
- New: `Illustrations.tsx` (8 SVG components)
- Modified: FocusScreen, TodayScreen, ProjectsScreen, CustomScreen, MobileShell, Onboarding, mobile.css

## Test plan
- [x] Typecheck passes
- [ ] Manual: empty states show SVG illustrations instead of emoji
- [ ] Manual: illustrations adapt to palette changes (violet, teal, coral)
- [ ] Manual: onboarding shows gesture diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)