### PR TITLE
fix(eval-lab): send prompt override in body instead of HTTP header

### DIFF
--- a/eval-lab/adapters/task_critic.py
+++ b/eval-lab/adapters/task_critic.py
@@ -19,8 +19,9 @@ async def call_task_critic(
     payload = input.model_dump(by_alias=True, exclude_none=True)
 
     headers = {"Authorization": f"Bearer {API_TOKEN}"}
+    # Send prompt override in body, not header (headers can't contain newlines)
     if prompt_override:
-        headers["X-Eval-Prompt-Override"] = prompt_override
+        payload["__evalPromptOverride"] = prompt_override
 
     for attempt in range(MAX_RETRIES + 1):
         try:

--- a/eval-lab/prompts/task_critic/baseline.txt
+++ b/eval-lab/prompts/task_critic/baseline.txt
@@ -5,7 +5,7 @@ Score the task on a scale of 0-100:
 - 21-40: Vague, missing key details, hard to execute
 - 41-60: Moderately defined, some details missing, partially actionable
 - 61-80: Well-defined, mostly actionable, minor improvements possible
-- 81-100: Excellent — specific, scoped, actionable, well-contextualized
+- 81-100: Excellent - specific, scoped, actionable, well-contextualized
 
 Consider:
 - Does the title clearly state what needs to be done?

--- a/src/routes/aiRouter.ts
+++ b/src/routes/aiRouter.ts
@@ -303,9 +303,10 @@ export function createAiRouter({
         const feedbackContext = await quotaService.getFeedbackContext(userId);
 
         // Eval prompt override — only enabled via env flag
+        // Read from body field, not header (headers can't contain newlines)
         const promptOverride =
           config.enableEvalPromptOverride === true
-            ? (req.headers["x-eval-prompt-override"] as string | undefined)
+            ? (req.body.__evalPromptOverride as string | undefined)
             : undefined;
 
         const result = await runtimeAiPlannerService.critiqueTask(


### PR DESCRIPTION
Fix two issues with the eval-lab prompt override mechanism:\n\n1. **HTTP header cannot contain newlines** — the prompt text was being sent as a header value, causing `UnicodeEncodeError` and `LocalProtocolError`. Now sent in the JSON body as `__evalPromptOverride`.\n\n2. **Em-dash encoding error** — the baseline prompt contained an em-dash (—) that failed ASCII encoding. Replaced with regular dash.\n\n### Baseline Results\nWith the fix, the benchmark runs successfully:\n- **Score: 0.546** (deterministic scorer, no LLM provider)\n- 10 cases, 2 service errors (JSON parsing failures on edge cases)\n- Main finding: deterministic scorer over-scores vague and over-specified tasks\n\n### Next Steps\n- Configure an LLM provider (`AI_PROVIDER_ENABLED=true`) to enable prompt optimization\n- The eval lab will then iterate on `prompts/task_critic/candidate.txt` to improve scores