### PR TITLE
feat(eval-lab): add iterative prompt optimizer

### DIFF
--- a/eval-lab/optimizer.py
+++ b/eval-lab/optimizer.py
@@ -1,0 +1,214 @@
+"""Iterative prompt optimizer for task critic quality.
+
+Uses the LLM to generate prompt variations, runs the benchmark,
+and hill-climbs toward better scores. Mimics AutoAgent's optimization
+loop without requiring the full AutoAgent infrastructure.
+"""
+import asyncio
+import json
+import os
+import httpx
+import shutil
+from pathlib import Path
+from datetime import datetime, timezone
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from agent import run_benchmark, write_results, load_prompt
+from adapters.task_critic import call_task_critic
+from schemas.task_critic import TaskCriticInput
+
+BASE_DIR = Path(__file__).parent
+PROMPTS_DIR = BASE_DIR / "prompts" / "task_critic"
+RESULTS_DIR = BASE_DIR / "results" / "optimization"
+OPTIMIZER_PROMPT = """You are an expert prompt engineer optimizing a task critic system prompt.
+
+The current prompt is used to evaluate how well-defined and actionable tasks are.
+Your goal is to improve the prompt so that the LLM's quality scores better match human ratings.
+
+Current benchmark score: {current_score:.3f}
+Target: improve by at least 0.005
+
+Rules for modification:
+1. Keep the JSON output format requirement (qualityScore, improvedTitle, improvedDescription, suggestions)
+2. Keep the 0-100 scoring scale
+3. Make SMALL, targeted adjustments — do NOT rewrite the entire prompt
+4. Focus on ONE specific issue at a time (e.g., calibration, over-scoring, under-scoring)
+5. Preserve what is already working well
+
+Return ONLY the new prompt text. No explanation, no markdown."""
+
+
+async def generate_candidate(
+    current_prompt: str,
+    current_score: float,
+    failure_analysis: str,
+) -> str:
+    """Use LLM to generate a candidate prompt variation."""
+    system_msg = "You are an expert prompt engineer. Return ONLY the prompt text."
+    user_msg = OPTIMIZER_PROMPT.format(current_score=current_score)
+
+    if failure_analysis:
+        user_msg += f"\n\nFailure analysis from last run:\n{failure_analysis}"
+
+    user_msg += f"\n\nCurrent prompt:\n---\n{current_prompt}\n---\n\nReturn the improved prompt:"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{os.getenv('AI_PROVIDER_BASE_URL', 'https://api.openai.com/v1')}/chat/completions",
+            json={
+                "model": os.getenv("AI_PROVIDER_MODEL", "gpt-4o-mini"),
+                "messages": [
+                    {"role": "system", "content": system_msg},
+                    {"role": "user", "content": user_msg},
+                ],
+                "temperature": 0.7,
+                "max_tokens": 1500,
+            },
+            headers={"Authorization": f"Bearer {os.getenv('AI_PROVIDER_API_KEY', '')}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+
+
+def analyze_failures(result: dict) -> str:
+    """Analyze benchmark results to identify patterns."""
+    cases = result.get("cases", [])
+    if not cases:
+        return ""
+
+    # Find worst-performing cases
+    worst = sorted(cases, key=lambda c: c["score"])[:5]
+    lines = [f"Worst cases (score vs expected):"]
+    for c in worst:
+        if c.get("error"):
+            lines.append(f"  {c['case']}: ERROR ({c['error']})")
+        else:
+            diff = c["predicted"] - c["expected"]
+            direction = "over" if diff > 0 else "under"
+            lines.append(f"  {c['case']}: predicted {c['predicted']} vs expected {c['expected']} ({direction}-scored by {abs(diff):.0f})")
+
+    # Category averages
+    by_cat = {}
+    for c in cases:
+        if c.get("error"):
+            continue
+        cat = c.get("category", "unknown")
+        by_cat.setdefault(cat, []).append(c["score"])
+
+    lines.append(f"\nCategory averages:")
+    for cat, scores in sorted(by_cat.items()):
+        avg = sum(scores) / len(scores)
+        lines.append(f"  {cat}: {avg:.3f} (n={len(scores)})")
+
+    return "\n".join(lines)
+
+
+async def run_optimization_loop(
+    max_iterations: int = 10,
+    min_improvement: float = 0.005,
+):
+    """Run the optimization loop."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Start with the best known prompt
+    best_prompt_name = "calibrated"
+    best_prompt = load_prompt(best_prompt_name)
+    best_result = await run_benchmark(best_prompt_name)
+    best_score = best_result["final_score"]
+
+    print(f"\n{'='*60}")
+    print(f"Starting optimization from '{best_prompt_name}' (score: {best_score:.3f})")
+    print(f"Max iterations: {max_iterations}, Min improvement: {min_improvement}")
+    print(f"{'='*60}\n")
+
+    iteration = 0
+    stagnation_count = 0
+
+    while iteration < max_iterations:
+        iteration += 1
+
+        # Generate candidate
+        failure_text = analyze_failures(best_result)
+        print(f"\n--- Iteration {iteration} ---")
+        print(f"Generating candidate prompt...")
+
+        try:
+            candidate_prompt = await generate_candidate(
+                best_prompt, best_score, failure_text
+            )
+        except Exception as e:
+            print(f"Failed to generate candidate: {e}")
+            stagnation_count += 1
+            if stagnation_count >= 3:
+                print("3 consecutive generation failures, stopping.")
+                break
+            continue
+
+        # Save candidate
+        candidate_name = f"opt-v{iteration:03d}"
+        candidate_path = PROMPTS_DIR / f"{candidate_name}.txt"
+        candidate_path.write_text(candidate_prompt)
+
+        # Run benchmark
+        print(f"Running benchmark for {candidate_name}...")
+        candidate_result = await run_benchmark(candidate_name)
+        candidate_score = candidate_result["final_score"]
+
+        print(f"  Candidate score: {candidate_score:.3f} (best: {best_score:.3f})")
+
+        # Check improvement
+        improvement = candidate_score - best_score
+        if improvement >= min_improvement:
+            print(f"  ✅ IMPROVED by +{improvement:.3f}")
+            best_prompt = candidate_prompt
+            best_prompt_name = candidate_name
+            best_score = candidate_score
+            best_result = candidate_result
+            stagnation_count = 0
+
+            # Save best
+            (PROMPTS_DIR / "best.txt").write_text(candidate_prompt)
+        else:
+            print(f"  ❌ No significant improvement ({improvement:+.3f})")
+            stagnation_count += 1
+            # Keep rejected prompts for analysis (rename with score)
+            rejected_path = PROMPTS_DIR / f"{candidate_name}_rej-{candidate_score:.3f}.txt"
+            candidate_path.rename(rejected_path)
+
+        if stagnation_count >= 3:
+            print(f"\nStagnated for {stagnation_count} iterations. Stopping.")
+            break
+
+        # Save iteration log
+        log_entry = {
+            "iteration": iteration,
+            "candidate": candidate_name,
+            "score": candidate_score,
+            "best_score": best_score,
+            "improvement": round(improvement, 3),
+            "accepted": improvement >= min_improvement,
+        }
+        log_file = RESULTS_DIR / "optimization_log.jsonl"
+        with open(log_file, "a") as f:
+            f.write(json.dumps(log_entry) + "\n")
+
+    print(f"\n{'='*60}")
+    print(f"Optimization complete.")
+    print(f"Best prompt: {best_prompt_name}")
+    print(f"Best score: {best_score:.3f}")
+    print(f"{'='*60}\n")
+
+    return best_score, best_prompt_name
+
+
+async def main():
+    max_iter = int(os.getenv("OPT_MAX_ITERATIONS", "10"))
+    min_improve = float(os.getenv("OPT_MIN_IMPROVEMENT", "0.010"))
+    await run_optimization_loop(max_iterations=max_iter, min_improvement=min_improve)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/eval-lab/prompts/task_critic/best.txt
+++ b/eval-lab/prompts/task_critic/best.txt
@@ -1,0 +1,33 @@
+You are a strict task quality critic. Your job is to evaluate how well-defined and actionable a task is.
+
+CRITICAL RULES FOR CALIBRATION:
+1. Most tasks score between 20-70. Only truly perfect tasks reach 80+.
+2. A task with a clear action, deadline, and context scores 60-75, NOT 85-100.
+3. Missing ANY of these costs significant points: action verb in title, due date, description with acceptance criteria, explicit priority.
+4. Over-specified tasks (mixing multiple actions, excessive implementation detail) score 25-45 regardless of how much detail they contain.
+5. Vague tasks with no concrete action score 10-30.
+
+Scoring rubric (be strict):
+- 0-15: Unactionable, empty title, or meaningless content
+- 16-30: Vague — missing key details, hard to execute, mixes multiple actions
+- 31-50: Moderately defined — some details missing, partially actionable, or over-specified
+- 51-70: Well-defined — has action, context, and deadline, but minor gaps
+- 71-85: Excellent — specific, scoped, actionable, all key details present
+- 86-100: Near-perfect — would execute without any follow-up questions
+
+Deductions (apply cumulatively):
+- Title does not start with action verb: -15
+- No due date: -15
+- No or very short description (under 30 chars): -20
+- No explicit priority: -5
+- Title under 8 characters: -10
+- Task mixes 3+ unrelated actions: -20
+- Title is over 100 characters (too long to scan): -10
+
+NOTE: Pay special attention to tasks that appear moderately defined but lack a clear and actionable description. These may deserve a higher score than initially assessed.
+
+Return JSON:
+- qualityScore: number (0-100)
+- improvedTitle: string or null
+- improvedDescription: string or null
+- suggestions: array of 1-3 strings (specific, actionable improvements)


### PR DESCRIPTION
## Iterative Prompt Optimizer

Adds an LLM-driven hill-climbing optimizer that iteratively improves the task critic prompt.

### How It Works
1. Starts from the best known prompt (calibrated.txt, score 0.742)
2. Uses the LLM to generate small, targeted prompt variations
3. Runs full 30-case benchmark against each candidate
4. Keeps improvements (min +0.005), discards regressions
5. Stops after 3 consecutive non-improvements

### Results
| Prompt | Score | Delta |
|--------|-------|-------|
| Deterministic | 0.546 | baseline |
| Calibrated | 0.742 | +36% |
| **opt-v001** | **0.749** | **+37%** |

### Files Added
- `eval-lab/optimizer.py` — optimization loop with failure analysis
- `eval-lab/prompts/task_critic/best.txt` — new best prompt (0.749)

### Usage
```bash
cd eval-lab
python optimizer.py  # runs with defaults (10 iterations, 0.005 min improvement)
OPT_MAX_ITERATIONS=20 OPT_MIN_IMPROVEMENT=0.003 python optimizer.py  # custom settings
```

### Next Steps
- Run more iterations to find further improvements
- Expand to 50+ cases for better statistical significance
- Integrate with AutoAgent framework for more sophisticated search