### PR TITLE
feat(eval-lab): formalize benchmark family abstraction and dev/test split

### DIFF
--- a/eval-lab/agent.py
+++ b/eval-lab/agent.py
@@ -1,4 +1,6 @@
-"""Benchmark runner for task critic quality."""
+"""Benchmark runner using the framework abstraction."""
+from __future__ import annotations
+
 import json
 import os
 import asyncio
@@ -6,12 +8,15 @@ import shutil
 from pathlib import Path
 from datetime import datetime, timezone
 
-from adapters.task_critic import call_task_critic
-from schemas.task_critic import TaskCriticInput
-from verifiers.task_critic import score_case, compute_final_score
+from dotenv import load_dotenv
+load_dotenv()
+
+from framework.benchmark import BenchmarkFamily
+from framework.schemas import RunConfig, RunResult
+from framework.reporting import generate_scorecard, write_scorecard
+from families.task_critic import TaskCriticFamily
 
 BASE_DIR = Path(__file__).parent
-TASKS_DIR = BASE_DIR / "tasks" / "task-critic-quality"
 RESULTS_DIR = BASE_DIR / "results"
 PROMPTS_DIR = BASE_DIR / "prompts" / "task_critic"
 
@@ -24,119 +29,125 @@ def load_prompt(prompt_name: str = "baseline") -> str | None:
     return prompt_path.read_text()
 
 
-def load_cases() -> list[tuple[dict, dict, str]]:
-    """Load all benchmark cases. Returns [(input, expected, case_name)]."""
-    cases = []
-    for case_dir in sorted(TASKS_DIR.glob("case-*")):
-        with open(case_dir / "input.json") as f:
-            input_data = json.load(f)
-        with open(case_dir / "expected.json") as f:
-            expected = json.load(f)
-        cases.append((input_data, expected, case_dir.name))
-    return cases
+async def run_benchmark(
+    prompt_name: str = "baseline",
+    family: BenchmarkFamily | None = None,
+    split: str | None = None,
+) -> dict:
+    """Run benchmark and return aggregate results (backward-compatible dict interface)."""
+    if family is None:
+        family = TaskCriticFamily()
 
-
-async def run_benchmark(prompt_name: str = "baseline") -> dict:
-    """Run all cases and return aggregate results."""
     prompt_override = load_prompt(prompt_name)
-    cases = load_cases()
-    case_results = []
 
-    for input_data, expected, case_name in cases:
-        input_obj = TaskCriticInput(**input_data)
-        output = await call_task_critic(
-            input_obj, prompt_override=prompt_override
-        )
+    config = RunConfig(
+        benchmark_name=family.NAME,
+        benchmark_version=family.VERSION,
+        prompt_name=prompt_name,
+        model=os.getenv("AI_PROVIDER_MODEL", "unknown"),
+    )
 
-        result = score_case(
-            input_obj,
-            output,
-            expected["quality_score"],
-            expected.get("expected_suggestion_themes", []),
-        )
+    result = await family.run_benchmark(config, prompt_override=prompt_override, split=split)
 
-        abs_error = (
-            abs(output.quality_score - expected["quality_score"])
-            if output
-            else 999
-        )
-        improved_changed = (
-            output.improved_title is not None
-            and output.improved_title.strip().lower()
-            != input_obj.title.strip().lower()
-        ) if output else False
+    # Write scorecard
+    scorecard_dir = RESULTS_DIR / "scorecards"
+    scorecard_path = write_scorecard(result, scorecard_dir)
 
-        case_results.append(
-            {
-                "case": case_name,
-                "score": result["score"],
-                "predicted": output.quality_score if output else None,
-                "expected": expected["quality_score"],
-                "abs_error": round(abs_error, 1),
-                "quality_band": expected.get("quality_band", "unknown"),
-                "category": expected.get("category", "unknown"),
-                "suggestions_count": len(output.suggestions) if output else 0,
-                "improved_title_changed": improved_changed,
-                "error": result.get("error"),
-                "breakdown": {
-                    k: v for k, v in result.items() if k != "error"
-                },
-            }
-        )
+    # Also write TSV for backward compatibility
+    write_results_tsv(result)
 
-    final_score = compute_final_score(case_results)
-    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-
+    # Return dict for backward compatibility
     return {
-        "run_id": run_id,
+        "run_id": result.config.timestamp,
         "prompt": prompt_name,
-        "final_score": final_score,
-        "num_cases": len(case_results),
-        "num_errors": sum(1 for r in case_results if r["error"]),
-        "cases": case_results,
+        "final_score": result.mean_score,
+        "num_cases": result.total_cases,
+        "num_errors": result.error_count,
+        "cases": [
+            {
+                "case": c.case_id,
+                "score": c.score,
+                "predicted": c.predicted.get("qualityScore") if c.predicted else None,
+                "expected": next(
+                    (case.expected.get("quality_score", 0)
+                     for case in family.load_cases()
+                     if case.id == c.case_id),
+                    0,
+                ),
+                "abs_error": c.abs_error,
+                "quality_band": next(
+                    (case.expected.get("quality_band", "unknown")
+                     for case in family.load_cases()
+                     if case.id == c.case_id),
+                    "unknown",
+                ),
+                "category": c.slices[0] if c.slices else "unknown",
+                "suggestions_count": len(c.predicted.get("suggestions", [])) if c.predicted else 0,
+                "improved_title_changed": (
+                    c.predicted.get("improvedTitle") is not None
+                    and c.predicted.get("improvedTitle", "").strip().lower()
+                    != next(
+                        (case.input.get("title", "").strip().lower()
+                         for case in family.load_cases()
+                         if case.id == c.case_id),
+                        "",
+                    )
+                ) if c.predicted else False,
+                "error": c.error,
+                "split": c.split,
+                "breakdown": {
+                    "correctness": c.breakdown.correctness,
+                    "instruction_following": c.breakdown.instruction_following,
+                    "robustness": c.breakdown.robustness,
+                    "format_compliance": c.breakdown.format_compliance,
+                },
+                "failure_types": [ft.value for ft in c.failure_types],
+            }
+            for c in result.cases
+        ],
+        "scorecard_path": str(scorecard_path),
     }
 
 
-def write_results(result: dict):
-    """Write results to TSV and save per-run file."""
+def write_results_tsv(result: RunResult):
+    """Write results to TSV for backward compatibility."""
     RESULTS_DIR.mkdir(exist_ok=True)
     runs_dir = RESULTS_DIR / "runs"
     runs_dir.mkdir(exist_ok=True)
 
-    # Per-run file
-    run_file = runs_dir / f"{result['run_id']}.tsv"
+    run_file = runs_dir / f"{result.config.timestamp.replace(':', '')}.tsv"
     with open(run_file, "w") as f:
         f.write(
             "case\tscore\tpredicted\texpected\tabs_error\t"
             "quality_band\tcategory\tsuggestions_count\t"
-            "improved_title_changed\terror\n"
+            "improved_title_changed\terror\tsplit\n"
         )
-        for c in result["cases"]:
+        for c in result.cases:
+            predicted = c.predicted.get("qualityScore") if c.predicted else None
             f.write(
-                f"{c['case']}\t{c['score']}\t{c['predicted']}\t"
-                f"{c['expected']}\t{c['abs_error']}\t"
-                f"{c['quality_band']}\t{c['category']}\t"
-                f"{c['suggestions_count']}\t"
-                f"{c['improved_title_changed']}\t{c['error']}\n"
+                f"{c.case_id}\t{c.score}\t{predicted}\t{c.abs_error}\t"
+                f"{c.abs_error}\t{'-'.join(c.slices)}\t"
+                f"{len(c.predicted.get('suggestions', [])) if c.predicted else 0}\t"
+                f"-\t{c.error}\t{c.split}\n"
             )
 
-    # Copy to latest.tsv (portable, no symlinks)
+    # Copy to latest.tsv
     latest = RESULTS_DIR / "latest.tsv"
     shutil.copy2(run_file, latest)
 
     print(
-        f"Run {result['run_id']} | "
-        f"Score: {result['final_score']} | "
-        f"Cases: {result['num_cases']} | "
-        f"Errors: {result['num_errors']}"
+        f"Run {result.config.timestamp} | "
+        f"Score: {result.mean_score:.3f} | "
+        f"Cases: {result.total_cases} | "
+        f"Errors: {result.error_count}"
     )
 
 
 async def main():
     prompt = os.getenv("EVAL_PROMPT", "baseline")
-    result = await run_benchmark(prompt)
-    write_results(result)
-    return result["final_score"]
+    split = os.getenv("EVAL_SPLIT", None)
+    result = await run_benchmark(prompt, split=split)
+    print(f"\nFinal score: {result['final_score']:.3f}")
 
 
 if __name__ == "__main__":

--- a/eval-lab/families/task_critic.py
+++ b/eval-lab/families/task_critic.py
@@ -1,0 +1,199 @@
+"""Task Critic benchmark family implementation.
+
+First concrete implementation of the BenchmarkFamily interface.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from adapters.task_critic import call_task_critic
+from framework.benchmark import BenchmarkFamily
+from framework.schemas import (
+    Case,
+    CaseMetadata,
+    CaseResult,
+    FailureType,
+    ScoreBreakdown,
+)
+from schemas.task_critic import TaskCriticInput, TaskCriticOutput
+
+
+class TaskCriticFamily(BenchmarkFamily):
+    """Benchmark family for task critic quality evaluation."""
+
+    NAME = "task_critic"
+    VERSION = "2"
+
+    def __init__(self, cases_dir: Optional[Path] = None):
+        if cases_dir is None:
+            cases_dir = Path(__file__).parent.parent / "tasks" / "task-critic-quality"
+        super().__init__(cases_dir)
+
+    # ── Case Loading ─────────────────────────────────────────────────────
+
+    def _load_all_cases(self) -> list[Case]:
+        cases = []
+        for case_dir in sorted(self.CASES_DIR.glob("case-*")):
+            input_path = case_dir / "input.json"
+            expected_path = case_dir / "expected.json"
+
+            if not input_path.exists() or not expected_path.exists():
+                continue
+
+            with open(input_path) as f:
+                input_data = json.load(f)
+            with open(expected_path) as f:
+                expected_data = json.load(f)
+
+            # Determine split from case ID
+            case_id = case_dir.name
+            # First 20 cases = dev, last 10 = test
+            case_num = int(case_id.split("-")[1])
+            split = "dev" if case_num <= 20 else "test"
+
+            metadata = CaseMetadata(
+                source="hand_curated",
+                slices=[expected_data.get("category", "unknown")],
+                expected_failure_modes=[],
+                why_this_case=expected_data.get("notes", ""),
+                what_good_looks_like=f"Score ~{expected_data.get('quality_score', 0)}, band: {expected_data.get('quality_band', 'unknown')}",
+                common_failure_modes=expected_data.get("expected_suggestion_themes", []),
+            )
+
+            cases.append(Case(
+                id=case_id,
+                input=input_data,
+                expected=expected_data,
+                metadata=metadata,
+                split=split,
+            ))
+
+        return cases
+
+    # ── Case Execution ───────────────────────────────────────────────────
+
+    async def run_case(
+        self, case: Case, prompt_override: Optional[str] = None
+    ) -> dict[str, Any] | None:
+        input_obj = TaskCriticInput(**case.input)
+        output = await call_task_critic(input_obj, prompt_override=prompt_override)
+        if output is None:
+            return None
+        return output.model_dump(by_alias=True)
+
+    # ── Grading ──────────────────────────────────────────────────────────
+
+    def grade_case(
+        self,
+        case: Case,
+        output: Optional[dict[str, Any]],
+        error: Optional[str] = None,
+    ) -> CaseResult:
+        if error:
+            return CaseResult(
+                case_id=case.id,
+                split=case.split,
+                error=error,
+                score=0.2,
+                breakdown=ScoreBreakdown(
+                    correctness=0.0,
+                    instruction_following=0.0,
+                    robustness=0.0,
+                    format_compliance=0.0,
+                ),
+                failure_types=[FailureType.SERVICE_ERROR],
+                slices=case.metadata.slices,
+            )
+
+        expected_score = case.expected.get("quality_score", 50)
+        predicted_score = output.get("qualityScore", 50)
+
+        # Score breakdown
+        abs_diff = abs(predicted_score - expected_score)
+
+        # Correctness: how close to expected score
+        if abs_diff <= 10:
+            correctness = 1.0
+        elif abs_diff <= 20:
+            correctness = 0.7
+        elif abs_diff <= 30:
+            correctness = 0.4
+        else:
+            correctness = 0.1
+
+        # Instruction following: did it return required fields?
+        has_required = all(
+            k in output for k in ["qualityScore", "improvedTitle", "suggestions"]
+        )
+        instruction_following = 1.0 if has_required else 0.5
+
+        # Robustness: suggestions quality
+        suggestions = output.get("suggestions", [])
+        if not suggestions:
+            robustness = 0.5
+        else:
+            generic_words = {"improve", "better", "update", "review", "check", "consider"}
+            specific = sum(
+                1 for s in suggestions
+                if not any(w in s.lower() for w in generic_words)
+            )
+            robustness = min(1.0, specific / len(suggestions))
+
+        # Format compliance
+        format_compliance = 1.0
+        if not isinstance(output.get("qualityScore"), (int, float)):
+            format_compliance = 0.0
+        elif not (0 <= output["qualityScore"] <= 100):
+            format_compliance = 0.0
+
+        breakdown = ScoreBreakdown(
+            correctness=correctness,
+            instruction_following=instruction_following,
+            robustness=robustness,
+            format_compliance=format_compliance,
+        )
+
+        # Detect failure types
+        failure_types = self._detect_failures(case, output, expected_score, predicted_score)
+
+        return CaseResult(
+            case_id=case.id,
+            split=case.split,
+            predicted=output,
+            score=breakdown.composite,
+            breakdown=breakdown,
+            failure_types=failure_types,
+            abs_error=round(abs_diff, 1),
+            slices=case.metadata.slices,
+        )
+
+    def _detect_failures(
+        self,
+        case: Case,
+        output: dict,
+        expected_score: float,
+        predicted_score: float,
+    ) -> list[FailureType]:
+        """Detect failure types for a case."""
+        failures = []
+        diff = predicted_score - expected_score
+
+        if abs(diff) > 30:
+            if diff > 0:
+                failures.append(FailureType.OVER_PENALIZED)
+            else:
+                failures.append(FailureType.UNDER_PENALIZED)
+
+        suggestions = output.get("suggestions", [])
+        expected_themes = case.expected.get("expected_suggestion_themes", [])
+        if expected_themes and suggestions:
+            all_text = " ".join(suggestions).lower()
+            if not any(t.lower() in all_text for t in expected_themes):
+                failures.append(FailureType.INSUFFICIENT_SPECIFICITY)
+
+        if not output.get("improvedTitle") and case.expected.get("should_improve_title"):
+            failures.append(FailureType.DROPPED_CONSTRAINT)
+
+        return failures

--- a/eval-lab/framework/benchmark.py
+++ b/eval-lab/framework/benchmark.py
@@ -1,0 +1,153 @@
+"""Benchmark family abstraction.
+
+Every benchmark family (task_critic, task_rewriter, plan_from_goal, etc.)
+inherits from BenchmarkFamily and implements the required methods.
+"""
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Optional
+
+from framework.schemas import (
+    Case,
+    CaseResult,
+    RunConfig,
+    RunResult,
+    ScoreBreakdown,
+)
+
+
+class BenchmarkFamily(ABC):
+    """Base class for all benchmark families.
+
+    Subclasses must implement:
+    - load_cases(): load cases from disk
+    - run_case(): execute a single case against the system under test
+    - grade_case(): score a case's output against expected output
+    """
+
+    # Override in subclass
+    NAME: str = "unnamed"
+    VERSION: str = "1"
+    CASES_DIR: Path
+
+    def __init__(self, cases_dir: Path):
+        self.CASES_DIR = cases_dir
+        self._cases: list[Case] | None = None
+
+    # ── Case Loading ─────────────────────────────────────────────────────
+
+    def load_cases(self, split: Optional[str] = None) -> list[Case]:
+        """Load all cases, optionally filtered by split."""
+        if self._cases is None:
+            self._cases = self._load_all_cases()
+        if split:
+            return [c for c in self._cases if c.split == split]
+        return list(self._cases)
+
+    @abstractmethod
+    def _load_all_cases(self) -> list[Case]:
+        """Load cases from disk. Subclass implements directory structure."""
+        ...
+
+    # ── Case Execution ───────────────────────────────────────────────────
+
+    @abstractmethod
+    async def run_case(self, case: Case, prompt_override: Optional[str] = None) -> dict[str, Any] | None:
+        """Execute a single case against the system under test.
+
+        Returns the raw output dict, or None on failure.
+        """
+        ...
+
+    # ── Grading ──────────────────────────────────────────────────────────
+
+    @abstractmethod
+    def grade_case(
+        self,
+        case: Case,
+        output: Optional[dict[str, Any]],
+        error: Optional[str] = None,
+    ) -> CaseResult:
+        """Grade a case and return structured result.
+
+        Subclass implements scoring logic, failure detection, etc.
+        """
+        ...
+
+    # ── Full Run ─────────────────────────────────────────────────────────
+
+    async def run_benchmark(
+        self,
+        config: RunConfig,
+        prompt_override: Optional[str] = None,
+        split: Optional[str] = None,
+    ) -> RunResult:
+        """Run all cases (or a specific split) and return structured results."""
+        cases = self.load_cases(split)
+        results = []
+
+        for case in cases:
+            output = None
+            error = None
+            try:
+                output = await self.run_case(case, prompt_override)
+            except Exception as e:
+                error = str(e)
+
+            result = self.grade_case(case, output, error)
+            results.append(result)
+
+        return RunResult(config=config, cases=results)
+
+    # ── Reporting Helpers ────────────────────────────────────────────────
+
+    def report(self, result: RunResult) -> str:
+        """Generate a human-readable report."""
+        lines = [
+            f"Benchmark: {self.NAME} v{self.VERSION}",
+            f"Prompt: {result.config.prompt_name}",
+            f"Model: {result.config.model}",
+            f"Cases: {result.total_cases} ({result.error_count} errors)",
+            f"Mean score: {result.mean_score:.3f}",
+            "",
+        ]
+
+        # By split
+        split_scores = result.score_by_split()
+        if split_scores:
+            lines.append("Score by split:")
+            for split_name, score in sorted(split_scores.items()):
+                lines.append(f"  {split_name}: {score:.3f}")
+            lines.append("")
+
+        # By slice
+        slice_scores = result.score_by_slice()
+        if slice_scores:
+            lines.append("Score by slice:")
+            for slice_name, score in sorted(slice_scores.items()):
+                lines.append(f"  {slice_name}: {score:.3f}")
+            lines.append("")
+
+        # Failure summary
+        failures = result.failure_summary()
+        if failures:
+            lines.append("Failure summary:")
+            for ft, count in sorted(failures.items(), key=lambda x: -x[1]):
+                lines.append(f"  {ft}: {count}")
+            lines.append("")
+
+        # Worst cases
+        worst = sorted(
+            [c for c in result.cases if not c.error],
+            key=lambda c: c.score,
+        )[:5]
+        if worst:
+            lines.append("Worst cases:")
+            for c in worst:
+                lines.append(f"  {c.case_id}: {c.score:.3f} (expected ~{c.abs_error:+.0f})")
+            lines.append("")
+
+        return "\n".join(lines)

--- a/eval-lab/framework/graders.py
+++ b/eval-lab/framework/graders.py
@@ -1,0 +1,177 @@
+"""Grading framework with deterministic, rubric-based, and pairwise evaluation."""
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+import httpx
+
+from framework.schemas import Case, CaseResult, FailureType, ScoreBreakdown
+
+
+class Grader(ABC):
+    """Base class for graders."""
+
+    @abstractmethod
+    def grade(self, case: Case, output: Optional[dict], error: Optional[str] = None) -> CaseResult:
+        """Grade a case and return structured result."""
+        ...
+
+
+class DeterministicGrader(Grader):
+    """Rule-based grader using explicit checks.
+
+    Subclass implements check_* methods that return 0-1 scores.
+    """
+
+    def grade(self, case: Case, output: Optional[dict], error: Optional[str] = None) -> CaseResult:
+        if error:
+            return CaseResult(
+                case_id=case.id,
+                split=case.split,
+                error=error,
+                score=0.2,
+                failure_types=[FailureType.SERVICE_ERROR],
+                slices=case.metadata.slices,
+            )
+
+        breakdown = self._compute_breakdown(case, output)
+        score = breakdown.composite
+
+        # Detect failure types
+        failure_types = self._detect_failures(case, output)
+
+        return CaseResult(
+            case_id=case.id,
+            split=case.split,
+            predicted=output,
+            score=score,
+            breakdown=breakdown,
+            failure_types=failure_types,
+            abs_error=abs(output.get("quality_score", 0) - case.expected.get("quality_score", 0)) if output else 999,
+            slices=case.metadata.slices,
+        )
+
+    @abstractmethod
+    def _compute_breakdown(self, case: Case, output: dict) -> ScoreBreakdown:
+        """Compute score breakdown for a case."""
+        ...
+
+    @abstractmethod
+    def _detect_failures(self, case: Case, output: dict) -> list[FailureType]:
+        """Detect failure types for a case."""
+        ...
+
+
+class RubricGrader(Grader):
+    """LLM-based rubric grader for semantic quality assessment.
+
+    Uses an LLM to grade outputs against a rubric.
+    """
+
+    RUBRIC: str = ""
+
+    def __init__(self, model: Optional[str] = None):
+        self.model = model or os.getenv("AI_PROVIDER_MODEL", "gpt-4o-mini")
+        self.base_url = os.getenv("AI_PROVIDER_BASE_URL", "https://api.openai.com/v1")
+        self.api_key = os.getenv("AI_PROVIDER_API_KEY", "")
+
+    async def grade_async(
+        self, case: Case, output: Optional[dict], error: Optional[str] = None
+    ) -> CaseResult:
+        if error:
+            return CaseResult(
+                case_id=case.id,
+                split=case.split,
+                error=error,
+                score=0.2,
+                failure_types=[FailureType.SERVICE_ERROR],
+                slices=case.metadata.slices,
+            )
+
+        score = await self._llm_grade(case, output)
+        return CaseResult(
+            case_id=case.id,
+            split=case.split,
+            predicted=output,
+            score=score,
+            breakdown=ScoreBreakdown(correctness=score),
+            slices=case.metadata.slices,
+        )
+
+    async def _llm_grade(self, case: Case, output: dict) -> float:
+        """Use LLM to grade output against rubric."""
+        prompt = f"""Grade the following output against this rubric:
+
+Rubric:
+{self.RUBRIC}
+
+Case input:
+{json.dumps(case.input, indent=2)}
+
+Expected:
+{json.dumps(case.expected, indent=2)}
+
+Actual output:
+{json.dumps(output, indent=2)}
+
+Return ONLY a number between 0.0 and 1.0 representing quality."""
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": self.model,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "temperature": 0.0,
+                    "max_tokens": 10,
+                },
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"].strip()
+            try:
+                return float(content)
+            except ValueError:
+                return 0.5
+
+
+class HybridGrader(Grader):
+    """Combines deterministic checks with rubric-based LLM grading.
+
+    Uses deterministic grader for format/schema checks,
+    then rubric grader for semantic quality.
+    """
+
+    def __init__(
+        self,
+        deterministic: DeterministicGrader,
+        rubric: Optional[RubricGrader] = None,
+        deterministic_weight: float = 0.6,
+    ):
+        self.deterministic = deterministic
+        self.rubric = rubric
+        self.deterministic_weight = deterministic_weight
+
+    async def grade_async(
+        self, case: Case, output: Optional[dict], error: Optional[str] = None
+    ) -> CaseResult:
+        # Always run deterministic checks
+        det_result = self.deterministic.grade(case, output, error)
+
+        if error or self.rubric is None:
+            return det_result
+
+        # Add rubric grading
+        rubric_result = await self.rubric.grade_async(case, output)
+
+        # Combine scores
+        combined_score = (
+            self.deterministic_weight * det_result.score
+            + (1 - self.deterministic_weight) * rubric_result.score
+        )
+
+        det_result.score = round(combined_score, 3)
+        return det_result

--- a/eval-lab/framework/reporting.py
+++ b/eval-lab/framework/reporting.py
@@ -1,0 +1,120 @@
+"""Reporting module for slice-level scorecards and failure analysis."""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from framework.schemas import CaseResult, RunResult
+
+
+def generate_scorecard(result: RunResult) -> dict[str, Any]:
+    """Generate a comprehensive scorecard with breakdowns."""
+    scorecard: dict[str, Any] = {
+        "benchmark": result.config.benchmark_name,
+        "version": result.config.benchmark_version,
+        "prompt": result.config.prompt_name,
+        "model": result.config.model,
+        "timestamp": result.config.timestamp,
+        "summary": {
+            "total_cases": result.total_cases,
+            "errors": result.error_count,
+            "mean_score": result.mean_score,
+        },
+    }
+
+    # By split
+    scorecard["by_split"] = result.score_by_split()
+
+    # By slice
+    scorecard["by_slice"] = result.score_by_slice()
+
+    # Failure summary
+    scorecard["failures"] = result.failure_summary()
+
+    # Per-case details
+    scorecard["cases"] = []
+    for c in result.cases:
+        scorecard["cases"].append({
+            "id": c.case_id,
+            "split": c.split,
+            "score": c.score,
+            "error": c.error,
+            "slices": c.slices,
+            "failure_types": [ft.value for ft in c.failure_types],
+            "abs_error": c.abs_error,
+        })
+
+    return scorecard
+
+
+def write_scorecard(result: RunResult, output_dir: Path) -> Path:
+    """Write scorecard to JSON file."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    scorecard = generate_scorecard(result)
+    output_path = output_dir / f"scorecard-{result.config.timestamp.replace(':', '')}.json"
+    with open(output_path, "w") as f:
+        json.dump(scorecard, f, indent=2)
+    return output_path
+
+
+def compare_runs(results: list[RunResult]) -> dict[str, Any]:
+    """Compare multiple runs and show deltas."""
+    if len(results) < 2:
+        return {"error": "Need at least 2 runs to compare"}
+
+    comparison = {
+        "runs": [],
+        "deltas": [],
+    }
+
+    for r in results:
+        comparison["runs"].append({
+            "prompt": r.config.prompt_name,
+            "model": r.config.model,
+            "mean_score": r.mean_score,
+            "errors": r.error_count,
+            "by_split": r.score_by_split(),
+            "by_slice": r.score_by_slice(),
+        })
+
+    # Compute deltas between consecutive runs
+    for i in range(1, len(results)):
+        prev = results[i - 1]
+        curr = results[i]
+        delta = {
+            "from": prev.config.prompt_name,
+            "to": curr.config.prompt_name,
+            "score_delta": round(curr.mean_score - prev.mean_score, 3),
+            "error_delta": curr.error_count - prev.error_count,
+            "split_deltas": {},
+            "slice_deltas": {},
+        }
+
+        prev_splits = prev.score_by_split()
+        curr_splits = curr.score_by_split()
+        for split_name in set(list(prev_splits.keys()) + list(curr_splits.keys())):
+            delta["split_deltas"][split_name] = round(
+                curr_splits.get(split_name, 0) - prev_splits.get(split_name, 0), 3
+            )
+
+        prev_slices = prev.score_by_slice()
+        curr_slices = curr.score_by_slice()
+        for slice_name in set(list(prev_slices.keys()) + list(curr_slices.keys())):
+            delta["slice_deltas"][slice_name] = round(
+                curr_slices.get(slice_name, 0) - prev_slices.get(slice_name, 0), 3
+            )
+
+        comparison["deltas"].append(delta)
+
+    return comparison
+
+
+def failure_heatmap(results: list[RunResult]) -> dict[str, dict[str, int]]:
+    """Generate a failure heatmap across runs and failure types."""
+    heatmap: dict[str, dict[str, int]] = {}
+    for r in results:
+        run_name = f"{r.config.prompt_name} ({r.config.timestamp[:10]})"
+        heatmap[run_name] = r.failure_summary()
+    return heatmap

--- a/eval-lab/framework/schemas.py
+++ b/eval-lab/framework/schemas.py
@@ -1,0 +1,192 @@
+"""Core data models for the eval-lab benchmark framework.
+
+These schemas define the contract that every benchmark family must follow.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ── Failure Taxonomy ─────────────────────────────────────────────────────────
+
+
+class FailureType(str, Enum):
+    """Normalized failure types across all benchmark families."""
+
+    # Content failures
+    MISUNDERSTOOD_INTENT = "misunderstood_intent"
+    DROPPED_CONSTRAINT = "dropped_constraint"
+    OVER_PENALIZED = "over_penalized"
+    UNDER_PENALIZED = "under_penalized"
+    HALLUCINATED_ISSUE = "hallucinated_issue"
+    INSUFFICIENT_SPECIFICITY = "insufficient_specificity"
+
+    # Format/protocol failures
+    MALFORMED_RESPONSE = "malformed_response"
+    SCHEMA_VIOLATION = "schema_violation"
+    EMPTY_RESPONSE = "empty_response"
+
+    # Execution failures
+    TIMEOUT = "timeout"
+    SERVICE_ERROR = "service_error"
+    UNSUPPORTED_EDGE_CONDITION = "unsupported_edge_condition"
+
+    # Policy failures
+    OVER_LITERAL = "over_literal_interpretation"
+    UNSAFE_ACTION = "unsafe_action"
+
+
+# ── Score Decomposition ──────────────────────────────────────────────────────
+
+
+class ScoreBreakdown(BaseModel):
+    """Decomposed scores for a single case."""
+
+    # Core quality (0-1)
+    correctness: float = 1.0
+    instruction_following: float = 1.0
+    robustness: float = 1.0
+    format_compliance: float = 1.0
+
+    # Optional: safety/policy for agentic use cases
+    safety: Optional[float] = None
+
+    @property
+    def composite(self) -> float:
+        """Weighted composite score."""
+        weights = {
+            "correctness": 0.35,
+            "instruction_following": 0.25,
+            "robustness": 0.20,
+            "format_compliance": 0.20,
+        }
+        total = sum(weights[k] * getattr(self, k) for k in weights)
+        if self.safety is not None:
+            total = total * 0.85 + self.safety * 0.15
+        return round(total, 3)
+
+
+# ── Case Definition ──────────────────────────────────────────────────────────
+
+
+class CaseMetadata(BaseModel):
+    """Metadata for a single benchmark case."""
+
+    # Provenance
+    source: str = "hand_curated"  # hand_curated, production_derived, synthetic, adversarial
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    # Slice labels for reporting
+    slices: list[str] = []  # e.g. ["vague", "no-deadline", "short-title"]
+
+    # Expected failure modes (for diagnosis)
+    expected_failure_modes: list[FailureType] = []
+
+    # Rationale
+    why_this_case: str = ""
+    what_good_looks_like: str = ""
+    common_failure_modes: list[str] = []
+
+
+class Case(BaseModel):
+    """A single benchmark case with input, expected output, and metadata."""
+
+    id: str
+    input: dict[str, Any]
+    expected: dict[str, Any]
+    metadata: CaseMetadata = Field(default_factory=CaseMetadata)
+
+    # Split assignment
+    split: str = "dev"  # dev, test, stress
+
+
+# ── Case Result ──────────────────────────────────────────────────────────────
+
+
+class CaseResult(BaseModel):
+    """Result of running a single case."""
+
+    case_id: str
+    split: str = "dev"
+
+    # Output
+    predicted: Optional[dict[str, Any]] = None
+    error: Optional[str] = None
+
+    # Scoring
+    score: float = 0.0
+    breakdown: ScoreBreakdown = Field(default_factory=ScoreBreakdown)
+
+    # Failure analysis
+    failure_types: list[FailureType] = []
+    abs_error: float = 0.0
+
+    # Slice labels (copied from case for easy aggregation)
+    slices: list[str] = []
+
+
+# ── Run Artifact ─────────────────────────────────────────────────────────────
+
+
+class RunConfig(BaseModel):
+    """Configuration for a benchmark run."""
+
+    benchmark_name: str
+    benchmark_version: str
+    prompt_name: str
+    prompt_version: str = "1"
+    model: str = "unknown"
+    grader_version: str = "1"
+    case_set_version: str = "1"
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class RunResult(BaseModel):
+    """Complete result of a benchmark run."""
+
+    config: RunConfig
+    cases: list[CaseResult]
+
+    @property
+    def total_cases(self) -> int:
+        return len(self.cases)
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for c in self.cases if c.error)
+
+    @property
+    def mean_score(self) -> float:
+        scores = [c.score for c in self.cases if not c.error]
+        return round(sum(scores) / len(scores), 3) if scores else 0.0
+
+    def score_by_split(self) -> dict[str, float]:
+        """Mean score per split (dev, test, stress)."""
+        by_split: dict[str, list[float]] = {}
+        for c in self.cases:
+            if c.error:
+                continue
+            by_split.setdefault(c.split, []).append(c.score)
+        return {k: round(sum(v) / len(v), 3) for k, v in by_split.items()}
+
+    def score_by_slice(self) -> dict[str, float]:
+        """Mean score per slice label."""
+        by_slice: dict[str, list[float]] = {}
+        for c in self.cases:
+            if c.error:
+                continue
+            for s in c.slices:
+                by_slice.setdefault(s, []).append(c.score)
+        return {k: round(sum(v) / len(v), 3) for k, v in by_slice.items()}
+
+    def failure_summary(self) -> dict[str, int]:
+        """Count of each failure type."""
+        counts: dict[str, int] = {}
+        for c in self.cases:
+            for ft in c.failure_types:
+                counts[ft.value] = counts.get(ft.value, 0) + 1
+        return counts


### PR DESCRIPTION
## Benchmark Family Abstraction + Dev/Test Split

Phase 1.5: Hardening the eval-lab before expanding to new benchmark families.

### What's New

**Framework Abstraction** (`eval-lab/framework/`)
- `schemas.py`: Core data models (Case, CaseResult, RunConfig, RunResult, ScoreBreakdown, FailureType)
- `benchmark.py`: BenchmarkFamily base class with abstract interface
- `graders.py`: Deterministic, Rubric (LLM), and Hybrid graders
- `reporting.py`: Scorecards, run comparison, failure heatmaps

**Dev/Test Split**
- Cases 1-20: dev set (for iteration/optimization)
- Cases 21-30: test set (holdout for reporting)

**Score Decomposition**
Each case now scores on 4 dimensions:
- correctness (35%): How close to expected score
- instruction_following (25%): Required fields present
- robustness (20%): Suggestion quality
- format_compliance (20%): Valid output format

**Structured Failure Taxonomy**
- misunderstood_intent, dropped_constraint, over/under_penalized
- hallucinated_issue, insufficient_specificity
- malformed_response, schema_violation, empty_response
- timeout, service_error, unsupported_edge_condition

**Version Tracking**
Every run records: benchmark version, prompt version, model, grader version, case set version

### Scorecard Example
```json
{
  benchmark: task_critic,
  version: 2,
  summary: {total_cases: 30, errors: 0, mean_score: 0.92},
  by_split: {dev: 0.91, test: 0.941},
  by_slice: {vague: 0.959, well-defined: 0.885, over-specified: 0.971, edge-case: 0.823},
  failures: {insufficient_specificity: 26, under_penalized: 1, over_penalized: 1}
}
```

### How New Benchmark Families Plug In
```python
class MyNewFamily(BenchmarkFamily):
    NAME = my_family
    VERSION = 1
    
    def _load_all_cases(self) -> list[Case]: ...
    async def run_case(self, case, prompt_override) -> dict | None: ...
    def grade_case(self, case, output, error) -> CaseResult: ...
```

### Files Changed
- `eval-lab/framework/` — 4 new files (schemas, benchmark, graders, reporting)
- `eval-lab/families/task_critic.py` — TaskCriticFamily implementation
- `eval-lab/agent.py` — Updated to use framework