### PR TITLE
feat(eval-lab): framework refinements for multi-family readiness

### DIFF
--- a/eval-lab/agent.py
+++ b/eval-lab/agent.py
@@ -95,12 +95,9 @@ async def run_benchmark(
                 ) if c.predicted else False,
                 "error": c.error,
                 "split": c.split,
-                "breakdown": {
-                    "correctness": c.breakdown.correctness,
-                    "instruction_following": c.breakdown.instruction_following,
-                    "robustness": c.breakdown.robustness,
-                    "format_compliance": c.breakdown.format_compliance,
-                },
+                "breakdown": c.breakdown.dimensions,
+                "grader_rationale": c.breakdown.grader_rationale,
+                "borderline": c.breakdown.borderline,
                 "failure_types": [ft.value for ft in c.failure_types],
             }
             for c in result.cases

--- a/eval-lab/families/task_critic.py
+++ b/eval-lab/families/task_critic.py
@@ -12,24 +12,60 @@ from adapters.task_critic import call_task_critic
 from framework.benchmark import BenchmarkFamily
 from framework.schemas import (
     Case,
+    CaseDifficulty,
     CaseMetadata,
     CaseResult,
     FailureType,
     ScoreBreakdown,
+    ScoreDimension,
 )
 from schemas.task_critic import TaskCriticInput, TaskCriticOutput
+
+
+# ── Task Critic Score Dimensions ─────────────────────────────────────────────
+
+TASK_CRITIC_DIMENSIONS = [
+    ScoreDimension(
+        name="correctness",
+        weight=0.40,
+        description="How close predicted score is to expected score",
+    ),
+    ScoreDimension(
+        name="instruction_following",
+        weight=0.25,
+        description="Required fields present (qualityScore, improvedTitle, suggestions)",
+    ),
+    ScoreDimension(
+        name="suggestion_quality",
+        weight=0.20,
+        description="Suggestions are specific, actionable, and non-generic",
+    ),
+    ScoreDimension(
+        name="format_compliance",
+        weight=0.15,
+        description="Valid output format and score range",
+    ),
+]
 
 
 class TaskCriticFamily(BenchmarkFamily):
     """Benchmark family for task critic quality evaluation."""
 
     NAME = "task_critic"
-    VERSION = "2"
+    VERSION = "3"  # Bumped for family-specific dimensions + stratified split
 
     def __init__(self, cases_dir: Optional[Path] = None):
         if cases_dir is None:
             cases_dir = Path(__file__).parent.parent / "tasks" / "task-critic-quality"
         super().__init__(cases_dir)
+
+    # ── Score Dimensions ─────────────────────────────────────────────────
+
+    def score_dimensions(self) -> list[ScoreDimension]:
+        return TASK_CRITIC_DIMENSIONS
+
+    def score_weights(self) -> dict[str, float]:
+        return {d.name: d.weight for d in TASK_CRITIC_DIMENSIONS}
 
     # ── Case Loading ─────────────────────────────────────────────────────
 
@@ -47,29 +83,42 @@ class TaskCriticFamily(BenchmarkFamily):
             with open(expected_path) as f:
                 expected_data = json.load(f)
 
-            # Determine split from case ID
-            case_id = case_dir.name
-            # First 20 cases = dev, last 10 = test
-            case_num = int(case_id.split("-")[1])
-            split = "dev" if case_num <= 20 else "test"
+            category = expected_data.get("category", "unknown")
+            quality_score = expected_data.get("quality_score", 50)
+
+            # Determine difficulty from expected score range and category
+            if category == "edge-case":
+                difficulty = CaseDifficulty.ADVERSARIAL
+            elif category == "over-specified":
+                difficulty = CaseDifficulty.HARD
+            elif quality_score < 30:
+                difficulty = CaseDifficulty.EASY  # Easy for LLM to identify as bad
+            elif quality_score > 75:
+                difficulty = CaseDifficulty.EASY  # Easy for LLM to identify as good
+            else:
+                difficulty = CaseDifficulty.MEDIUM
 
             metadata = CaseMetadata(
                 source="hand_curated",
-                slices=[expected_data.get("category", "unknown")],
+                slices=[category],
+                difficulty=difficulty,
                 expected_failure_modes=[],
                 why_this_case=expected_data.get("notes", ""),
-                what_good_looks_like=f"Score ~{expected_data.get('quality_score', 0)}, band: {expected_data.get('quality_band', 'unknown')}",
+                what_good_looks_like=f"Score ~{quality_score}, band: {expected_data.get('quality_band', 'unknown')}",
                 common_failure_modes=expected_data.get("expected_suggestion_themes", []),
+                acceptable_variation="±10 points on quality score is acceptable",
             )
 
             cases.append(Case(
-                id=case_id,
+                id=case_dir.name,
                 input=input_data,
                 expected=expected_data,
                 metadata=metadata,
-                split=split,
+                split="dev",  # Will be reassigned by stratified split
             ))
 
+        # Apply stratified split
+        cases = self.assign_stratified_split(cases, dev_ratio=0.67)
         return cases
 
     # ── Case Execution ───────────────────────────────────────────────────
@@ -98,19 +147,18 @@ class TaskCriticFamily(BenchmarkFamily):
                 error=error,
                 score=0.2,
                 breakdown=ScoreBreakdown(
-                    correctness=0.0,
-                    instruction_following=0.0,
-                    robustness=0.0,
-                    format_compliance=0.0,
+                    dimensions={d.name: 0.0 for d in TASK_CRITIC_DIMENSIONS},
+                    grader_rationale=f"Service error: {error}",
                 ),
                 failure_types=[FailureType.SERVICE_ERROR],
                 slices=case.metadata.slices,
+                difficulty=case.metadata.difficulty.value,
             )
 
         expected_score = case.expected.get("quality_score", 50)
         predicted_score = output.get("qualityScore", 50)
 
-        # Score breakdown
+        # Score breakdown using family-specific dimensions
         abs_diff = abs(predicted_score - expected_score)
 
         # Correctness: how close to expected score
@@ -129,17 +177,25 @@ class TaskCriticFamily(BenchmarkFamily):
         )
         instruction_following = 1.0 if has_required else 0.5
 
-        # Robustness: suggestions quality
+        # Suggestion quality: specific, actionable, non-generic
         suggestions = output.get("suggestions", [])
+        expected_themes = case.expected.get("expected_suggestion_themes", [])
         if not suggestions:
-            robustness = 0.5
+            suggestion_quality = 0.5
         else:
             generic_words = {"improve", "better", "update", "review", "check", "consider"}
             specific = sum(
                 1 for s in suggestions
                 if not any(w in s.lower() for w in generic_words)
             )
-            robustness = min(1.0, specific / len(suggestions))
+            suggestion_quality = min(1.0, specific / len(suggestions))
+
+            # Bonus for hitting expected themes
+            if expected_themes:
+                all_text = " ".join(suggestions).lower()
+                theme_hits = sum(1 for t in expected_themes if t.lower() in all_text)
+                theme_bonus = theme_hits / len(expected_themes)
+                suggestion_quality = min(1.0, suggestion_quality * 0.7 + theme_bonus * 0.3)
 
         # Format compliance
         format_compliance = 1.0
@@ -148,11 +204,17 @@ class TaskCriticFamily(BenchmarkFamily):
         elif not (0 <= output["qualityScore"] <= 100):
             format_compliance = 0.0
 
+        dimensions = {
+            "correctness": correctness,
+            "instruction_following": instruction_following,
+            "suggestion_quality": suggestion_quality,
+            "format_compliance": format_compliance,
+        }
+
         breakdown = ScoreBreakdown(
-            correctness=correctness,
-            instruction_following=instruction_following,
-            robustness=robustness,
-            format_compliance=format_compliance,
+            dimensions=dimensions,
+            grader_rationale=f"correctness={correctness:.2f} (diff={abs_diff:.0f}), instr={instruction_following:.2f}, sugg={suggestion_quality:.2f}, fmt={format_compliance:.2f}",
+            borderline=15 <= abs_diff <= 25,  # Near decision boundary
         )
 
         # Detect failure types
@@ -162,11 +224,13 @@ class TaskCriticFamily(BenchmarkFamily):
             case_id=case.id,
             split=case.split,
             predicted=output,
-            score=breakdown.composite,
+            score=breakdown.composite(self.score_weights()),
             breakdown=breakdown,
             failure_types=failure_types,
             abs_error=round(abs_diff, 1),
             slices=case.metadata.slices,
+            difficulty=case.metadata.difficulty.value,
+            grader_artifacts={"grader_type": "deterministic", "dimensions": dimensions},
         )
 
     def _detect_failures(

--- a/eval-lab/framework/benchmark.py
+++ b/eval-lab/framework/benchmark.py
@@ -6,16 +6,20 @@ inherits from BenchmarkFamily and implements the required methods.
 from __future__ import annotations
 
 import json
+import random
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Optional
 
 from framework.schemas import (
     Case,
+    CaseDifficulty,
+    CaseMetadata,
     CaseResult,
     RunConfig,
     RunResult,
     ScoreBreakdown,
+    ScoreDimension,
 )
 
 
@@ -26,16 +30,37 @@ class BenchmarkFamily(ABC):
     - load_cases(): load cases from disk
     - run_case(): execute a single case against the system under test
     - grade_case(): score a case's output against expected output
+
+    Subclasses should override:
+    - score_dimensions(): define family-specific scoring dimensions + weights
     """
 
     # Override in subclass
     NAME: str = "unnamed"
     VERSION: str = "1"
-    CASES_DIR: Path
 
     def __init__(self, cases_dir: Path):
         self.CASES_DIR = cases_dir
         self._cases: list[Case] | None = None
+
+    # ── Score Dimensions ─────────────────────────────────────────────────
+
+    def score_dimensions(self) -> list[ScoreDimension]:
+        """Define family-specific scoring dimensions and weights.
+
+        Override in subclass to define custom dimensions.
+        Default provides equal-weighted generic dimensions.
+        """
+        return [
+            ScoreDimension(name="correctness", weight=0.35, description="How close to expected output"),
+            ScoreDimension(name="instruction_following", weight=0.25, description="Required fields present"),
+            ScoreDimension(name="robustness", weight=0.20, description="Output quality under variation"),
+            ScoreDimension(name="format_compliance", weight=0.20, description="Valid output format"),
+        ]
+
+    def score_weights(self) -> dict[str, float]:
+        """Return weight mapping for composite score computation."""
+        return {d.name: d.weight for d in self.score_dimensions()}
 
     # ── Case Loading ─────────────────────────────────────────────────────
 
@@ -51,6 +76,39 @@ class BenchmarkFamily(ABC):
     def _load_all_cases(self) -> list[Case]:
         """Load cases from disk. Subclass implements directory structure."""
         ...
+
+    # ── Stratified Split Assignment ──────────────────────────────────────
+
+    @staticmethod
+    def assign_stratified_split(
+        cases: list[Case],
+        dev_ratio: float = 0.67,
+        seed: int = 42,
+    ) -> list[Case]:
+        """Assign dev/test splits stratified by slice and difficulty.
+
+        Ensures each slice/difficulty combination is proportionally
+        represented in both splits.
+        """
+        # Group cases by (slice, difficulty)
+        groups: dict[tuple, list[Case]] = {}
+        for case in cases:
+            # Use first slice as primary stratification key
+            primary_slice = case.metadata.slices[0] if case.metadata.slices else "default"
+            key = (primary_slice, case.metadata.difficulty)
+            groups.setdefault(key, []).append(case)
+
+        # Split each group proportionally
+        rng = random.Random(seed)
+        result = []
+        for key, group in groups.items():
+            rng.shuffle(group)
+            dev_count = max(1, int(len(group) * dev_ratio))
+            for i, case in enumerate(group):
+                case.split = "dev" if i < dev_count else "test"
+                result.append(case)
+
+        return result
 
     # ── Case Execution ───────────────────────────────────────────────────
 
@@ -74,6 +132,7 @@ class BenchmarkFamily(ABC):
         """Grade a case and return structured result.
 
         Subclass implements scoring logic, failure detection, etc.
+        Should use self.score_weights() for composite computation.
         """
         ...
 
@@ -131,12 +190,28 @@ class BenchmarkFamily(ABC):
                 lines.append(f"  {slice_name}: {score:.3f}")
             lines.append("")
 
-        # Failure summary
-        failures = result.failure_summary()
-        if failures:
-            lines.append("Failure summary:")
-            for ft, count in sorted(failures.items(), key=lambda x: -x[1]):
-                lines.append(f"  {ft}: {count}")
+        # By difficulty
+        diff_scores = result.score_by_difficulty()
+        if diff_scores:
+            lines.append("Score by difficulty:")
+            for diff_name, score in sorted(diff_scores.items()):
+                lines.append(f"  {diff_name}: {score:.3f}")
+            lines.append("")
+
+        # Dimension averages
+        dim_avgs = result.dimension_averages()
+        if dim_avgs:
+            lines.append("Dimension averages:")
+            for dim_name, avg in sorted(dim_avgs.items()):
+                lines.append(f"  {dim_name}: {avg:.3f}")
+            lines.append("")
+
+        # Failure summary (rates, not raw counts)
+        failure_rates = result.failure_rate()
+        if failure_rates:
+            lines.append("Failure rates:")
+            for ft, rate in sorted(failure_rates.items(), key=lambda x: -x[1]):
+                lines.append(f"  {ft}: {rate:.1%}")
             lines.append("")
 
         # Worst cases
@@ -147,7 +222,7 @@ class BenchmarkFamily(ABC):
         if worst:
             lines.append("Worst cases:")
             for c in worst:
-                lines.append(f"  {c.case_id}: {c.score:.3f} (expected ~{c.abs_error:+.0f})")
+                lines.append(f"  {c.case_id}: {c.score:.3f} [{c.difficulty}] slices={c.slices}")
             lines.append("")
 
         return "\n".join(lines)

--- a/eval-lab/framework/graders.py
+++ b/eval-lab/framework/graders.py
@@ -32,12 +32,18 @@ class DeterministicGrader(Grader):
                 split=case.split,
                 error=error,
                 score=0.2,
+                breakdown=ScoreBreakdown(
+                    dimensions={"correctness": 0.0, "instruction_following": 0.0, "robustness": 0.0, "format_compliance": 0.0},
+                    grader_rationale=f"Service error: {error}",
+                ),
                 failure_types=[FailureType.SERVICE_ERROR],
                 slices=case.metadata.slices,
+                difficulty=case.metadata.difficulty.value,
             )
 
         breakdown = self._compute_breakdown(case, output)
-        score = breakdown.composite
+        weights = getattr(self, "_weights", None)
+        score = breakdown.composite(weights)
 
         # Detect failure types
         failure_types = self._detect_failures(case, output)
@@ -51,6 +57,8 @@ class DeterministicGrader(Grader):
             failure_types=failure_types,
             abs_error=abs(output.get("quality_score", 0) - case.expected.get("quality_score", 0)) if output else 999,
             slices=case.metadata.slices,
+            difficulty=case.metadata.difficulty.value,
+            grader_artifacts={"grader_type": "deterministic"},
         )
 
     @abstractmethod
@@ -71,6 +79,7 @@ class RubricGrader(Grader):
     """
 
     RUBRIC: str = ""
+    DIMENSIONS: list[str] = ["quality"]
 
     def __init__(self, model: Optional[str] = None):
         self.model = model or os.getenv("AI_PROVIDER_MODEL", "gpt-4o-mini")
@@ -86,22 +95,33 @@ class RubricGrader(Grader):
                 split=case.split,
                 error=error,
                 score=0.2,
+                breakdown=ScoreBreakdown(
+                    dimensions={d: 0.0 for d in self.DIMENSIONS},
+                    grader_rationale=f"Service error: {error}",
+                ),
                 failure_types=[FailureType.SERVICE_ERROR],
                 slices=case.metadata.slices,
+                difficulty=case.metadata.difficulty.value,
             )
 
-        score = await self._llm_grade(case, output)
+        dimensions, rationale, borderline = await self._llm_grade(case, output)
         return CaseResult(
             case_id=case.id,
             split=case.split,
             predicted=output,
-            score=score,
-            breakdown=ScoreBreakdown(correctness=score),
+            score=breakdown.composite() if (breakdown := ScoreBreakdown(dimensions=dimensions, grader_rationale=rationale, borderline=borderline)) else 0.5,
+            breakdown=ScoreBreakdown(dimensions=dimensions, grader_rationale=rationale, borderline=borderline),
             slices=case.metadata.slices,
+            difficulty=case.metadata.difficulty.value,
+            grader_artifacts={"grader_type": "rubric", "model": self.model},
         )
 
-    async def _llm_grade(self, case: Case, output: dict) -> float:
-        """Use LLM to grade output against rubric."""
+    async def _llm_grade(self, case: Case, output: dict) -> tuple[dict[str, float], str, bool]:
+        """Use LLM to grade output against rubric.
+
+        Returns (dimensions, rationale, borderline).
+        """
+        dims_json = ", ".join(f'"{d}": <0.0-1.0>' for d in self.DIMENSIONS)
         prompt = f"""Grade the following output against this rubric:
 
 Rubric:
@@ -116,7 +136,10 @@ Expected:
 Actual output:
 {json.dumps(output, indent=2)}
 
-Return ONLY a number between 0.0 and 1.0 representing quality."""
+Return ONLY a JSON object with:
+- {dims_json}
+- "rationale": "<brief explanation>"
+- "borderline": <true if score is near a decision boundary>"""
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
@@ -125,7 +148,8 @@ Return ONLY a number between 0.0 and 1.0 representing quality."""
                     "model": self.model,
                     "messages": [{"role": "user", "content": prompt}],
                     "temperature": 0.0,
-                    "max_tokens": 10,
+                    "max_tokens": 300,
+                    "response_format": {"type": "json_object"},
                 },
                 headers={"Authorization": f"Bearer {self.api_key}"},
             )
@@ -133,9 +157,13 @@ Return ONLY a number between 0.0 and 1.0 representing quality."""
             data = resp.json()
             content = data["choices"][0]["message"]["content"].strip()
             try:
-                return float(content)
-            except ValueError:
-                return 0.5
+                parsed = json.loads(content)
+                dimensions = {d: float(parsed.get(d, 0.5)) for d in self.DIMENSIONS}
+                rationale = parsed.get("rationale", "")
+                borderline = parsed.get("borderline", False)
+                return dimensions, rationale, borderline
+            except (json.JSONDecodeError, ValueError):
+                return {d: 0.5 for d in self.DIMENSIONS}, f"Failed to parse LLM response: {content[:100]}", False
 
 
 class HybridGrader(Grader):
@@ -174,4 +202,10 @@ class HybridGrader(Grader):
         )
 
         det_result.score = round(combined_score, 3)
+        det_result.grader_artifacts = {
+            "grader_type": "hybrid",
+            "deterministic_score": det_result.score,
+            "rubric_score": rubric_result.score,
+            "deterministic_weight": self.deterministic_weight,
+        }
         return det_result

--- a/eval-lab/framework/regression.py
+++ b/eval-lab/framework/regression.py
@@ -1,0 +1,101 @@
+"""Regression suite support.
+
+Manages a separate set of cases that track specific bugs/failures.
+Regression cases are distinct from benchmark/dev/test cases — they are
+added whenever a new failure mode is discovered and fixed.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from framework.schemas import Case, CaseMetadata
+
+
+class RegressionSuite:
+    """Manages regression test cases.
+
+    Regression cases are stored separately from benchmark cases.
+    They track specific bugs/failures that should not recur.
+    """
+
+    def __init__(self, regression_dir: Path):
+        self.REGRESSION_DIR = regression_dir
+        self.REGRESSION_DIR.mkdir(parents=True, exist_ok=True)
+        self._cases: list[Case] | None = None
+
+    def load_cases(self) -> list[Case]:
+        """Load all regression cases."""
+        if self._cases is not None:
+            return list(self._cases)
+
+        cases = []
+        for case_file in sorted(self.REGRESSION_DIR.glob("regression-*.json")):
+            with open(case_file) as f:
+                data = json.load(f)
+            cases.append(Case(**data))
+
+        self._cases = cases
+        return cases
+
+    def add_regression_case(
+        self,
+        case_id: str,
+        input_data: dict[str, Any],
+        expected_data: dict[str, Any],
+        bug_description: str,
+        fix_description: str,
+        slices: list[str] | None = None,
+        source: str = "production_derived",
+    ) -> Case:
+        """Add a new regression case.
+
+        Args:
+            case_id: Unique identifier (e.g. "reg-001")
+            input_data: Case input
+            expected_data: Expected output
+            bug_description: What bug this case covers
+            fix_description: How the bug was fixed
+            slices: Slice labels for this case
+            source: Provenance source
+        """
+        metadata = CaseMetadata(
+            source=source,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            slices=slices or [],
+            why_this_case=f"Regression for bug: {bug_description}",
+            what_good_looks_like=fix_description,
+            regression_for_bug=bug_description,
+        )
+
+        case = Case(
+            id=case_id,
+            input=input_data,
+            expected=expected_data,
+            metadata=metadata,
+            split="regression",
+        )
+
+        # Save to disk
+        case_file = self.REGRESSION_DIR / f"{case_id}.json"
+        with open(case_file, "w") as f:
+            json.dump(case.model_dump(), f, indent=2)
+
+        # Invalidate cache
+        self._cases = None
+        return case
+
+    def list_regressions(self) -> list[dict[str, str]]:
+        """List all regression cases with their bug descriptions."""
+        cases = self.load_cases()
+        return [
+            {
+                "id": c.id,
+                "bug": c.metadata.regression_for_bug,
+                "slices": c.metadata.slices,
+                "created_at": c.metadata.created_at,
+            }
+            for c in cases
+        ]

--- a/eval-lab/framework/reporting.py
+++ b/eval-lab/framework/reporting.py
@@ -30,7 +30,16 @@ def generate_scorecard(result: RunResult) -> dict[str, Any]:
     # By slice
     scorecard["by_slice"] = result.score_by_slice()
 
-    # Failure summary
+    # By difficulty
+    scorecard["by_difficulty"] = result.score_by_difficulty()
+
+    # Dimension averages
+    scorecard["dimension_averages"] = result.dimension_averages()
+
+    # Failure rates (normalized)
+    scorecard["failure_rates"] = result.failure_rate()
+
+    # Failure summary (raw counts)
     scorecard["failures"] = result.failure_summary()
 
     # Per-case details
@@ -39,11 +48,15 @@ def generate_scorecard(result: RunResult) -> dict[str, Any]:
         scorecard["cases"].append({
             "id": c.case_id,
             "split": c.split,
+            "difficulty": c.difficulty,
             "score": c.score,
             "error": c.error,
             "slices": c.slices,
             "failure_types": [ft.value for ft in c.failure_types],
             "abs_error": c.abs_error,
+            "dimensions": c.breakdown.dimensions,
+            "grader_rationale": c.breakdown.grader_rationale,
+            "borderline": c.breakdown.borderline,
         })
 
     return scorecard
@@ -77,6 +90,8 @@ def compare_runs(results: list[RunResult]) -> dict[str, Any]:
             "errors": r.error_count,
             "by_split": r.score_by_split(),
             "by_slice": r.score_by_slice(),
+            "by_difficulty": r.score_by_difficulty(),
+            "dimension_averages": r.dimension_averages(),
         })
 
     # Compute deltas between consecutive runs
@@ -90,6 +105,8 @@ def compare_runs(results: list[RunResult]) -> dict[str, Any]:
             "error_delta": curr.error_count - prev.error_count,
             "split_deltas": {},
             "slice_deltas": {},
+            "difficulty_deltas": {},
+            "dimension_deltas": {},
         }
 
         prev_splits = prev.score_by_split()
@@ -106,15 +123,29 @@ def compare_runs(results: list[RunResult]) -> dict[str, Any]:
                 curr_slices.get(slice_name, 0) - prev_slices.get(slice_name, 0), 3
             )
 
+        prev_diffs = prev.score_by_difficulty()
+        curr_diffs = curr.score_by_difficulty()
+        for diff_name in set(list(prev_diffs.keys()) + list(curr_diffs.keys())):
+            delta["difficulty_deltas"][diff_name] = round(
+                curr_diffs.get(diff_name, 0) - prev_diffs.get(diff_name, 0), 3
+            )
+
+        prev_dims = prev.dimension_averages()
+        curr_dims = curr.dimension_averages()
+        for dim_name in set(list(prev_dims.keys()) + list(curr_dims.keys())):
+            delta["dimension_deltas"][dim_name] = round(
+                curr_dims.get(dim_name, 0) - prev_dims.get(dim_name, 0), 3
+            )
+
         comparison["deltas"].append(delta)
 
     return comparison
 
 
-def failure_heatmap(results: list[RunResult]) -> dict[str, dict[str, int]]:
-    """Generate a failure heatmap across runs and failure types."""
-    heatmap: dict[str, dict[str, int]] = {}
+def failure_heatmap(results: list[RunResult]) -> dict[str, dict[str, float]]:
+    """Generate a failure heatmap across runs and failure types (normalized rates)."""
+    heatmap: dict[str, dict[str, float]] = {}
     for r in results:
         run_name = f"{r.config.prompt_name} ({r.config.timestamp[:10]})"
-        heatmap[run_name] = r.failure_summary()
+        heatmap[run_name] = r.failure_rate()
     return heatmap

--- a/eval-lab/framework/schemas.py
+++ b/eval-lab/framework/schemas.py
@@ -24,6 +24,8 @@ class FailureType(str, Enum):
     UNDER_PENALIZED = "under_penalized"
     HALLUCINATED_ISSUE = "hallucinated_issue"
     INSUFFICIENT_SPECIFICITY = "insufficient_specificity"
+    OVER_EDITED = "over_edited"  # For rewriter: changed too much
+    INTENT_DRIFT = "intent_drift"  # For rewriter: changed meaning
 
     # Format/protocol failures
     MALFORMED_RESPONSE = "malformed_response"
@@ -40,56 +42,97 @@ class FailureType(str, Enum):
     UNSAFE_ACTION = "unsafe_action"
 
 
-# ── Score Decomposition ──────────────────────────────────────────────────────
+# ── Score Dimensions ─────────────────────────────────────────────────────────
+
+
+class ScoreDimension(BaseModel):
+    """A single scoring dimension with weight."""
+
+    name: str
+    weight: float  # 0-1, weights should sum to 1.0
+    description: str = ""
 
 
 class ScoreBreakdown(BaseModel):
-    """Decomposed scores for a single case."""
+    """Decomposed scores for a single case.
 
-    # Core quality (0-1)
-    correctness: float = 1.0
-    instruction_following: float = 1.0
-    robustness: float = 1.0
-    format_compliance: float = 1.0
+    Families define their own dimensions via ScoreDimension list.
+    This model stores arbitrary dimension scores + computes weighted composite.
+    """
+
+    # Arbitrary dimension scores (0-1 each)
+    dimensions: dict[str, float] = Field(default_factory=dict)
 
     # Optional: safety/policy for agentic use cases
     safety: Optional[float] = None
 
-    @property
-    def composite(self) -> float:
-        """Weighted composite score."""
-        weights = {
-            "correctness": 0.35,
-            "instruction_following": 0.25,
-            "robustness": 0.20,
-            "format_compliance": 0.20,
-        }
-        total = sum(weights[k] * getattr(self, k) for k in weights)
+    # Grader artifacts (for debugging score disagreements)
+    grader_rationale: str = ""
+    grader_prompt_version: str = ""
+    borderline: bool = False  # True if score is near a decision boundary
+
+    def composite(self, weights: Optional[dict[str, float]] = None) -> float:
+        """Weighted composite score.
+
+        If weights provided, uses them. Otherwise equal-weights all dimensions.
+        """
+        if not self.dimensions:
+            return 0.0
+
+        if weights:
+            # Use provided weights, normalize if needed
+            total_weight = sum(weights.get(k, 0) for k in self.dimensions)
+            if total_weight == 0:
+                return 0.0
+            score = sum(
+                weights.get(k, 0) * v for k, v in self.dimensions.items()
+            ) / total_weight
+        else:
+            # Equal weights
+            score = sum(self.dimensions.values()) / len(self.dimensions)
+
         if self.safety is not None:
-            total = total * 0.85 + self.safety * 0.15
-        return round(total, 3)
+            score = score * 0.85 + self.safety * 0.15
+
+        return round(score, 3)
 
 
 # ── Case Definition ──────────────────────────────────────────────────────────
+
+
+class CaseDifficulty(str, Enum):
+    """Difficulty levels for benchmark cases."""
+
+    EASY = "easy"
+    MEDIUM = "medium"
+    HARD = "hard"
+    ADVERSARIAL = "adversarial"
 
 
 class CaseMetadata(BaseModel):
     """Metadata for a single benchmark case."""
 
     # Provenance
-    source: str = "hand_curated"  # hand_curated, production_derived, synthetic, adversarial
+    source: str = "hand_curated"  # hand_curated, production_derived, synthetic, adversarial, regression
     created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
     # Slice labels for reporting
     slices: list[str] = []  # e.g. ["vague", "no-deadline", "short-title"]
 
+    # Difficulty
+    difficulty: CaseDifficulty = CaseDifficulty.MEDIUM
+
     # Expected failure modes (for diagnosis)
     expected_failure_modes: list[FailureType] = []
 
-    # Rationale
+    # Rationale (gold rationale fields)
     why_this_case: str = ""
     what_good_looks_like: str = ""
     common_failure_modes: list[str] = []
+    acceptable_variation: str = ""  # What outputs are acceptable even if different from expected
+
+    # Regression tracking
+    regression_for_bug: str = ""  # If this case is a regression, what bug does it cover?
 
 
 class Case(BaseModel):
@@ -101,7 +144,7 @@ class Case(BaseModel):
     metadata: CaseMetadata = Field(default_factory=CaseMetadata)
 
     # Split assignment
-    split: str = "dev"  # dev, test, stress
+    split: str = "dev"  # dev, test, regression
 
 
 # ── Case Result ──────────────────────────────────────────────────────────────
@@ -127,6 +170,10 @@ class CaseResult(BaseModel):
 
     # Slice labels (copied from case for easy aggregation)
     slices: list[str] = []
+    difficulty: str = "medium"
+
+    # Grader artifacts (preserved for debugging)
+    grader_artifacts: dict[str, Any] = Field(default_factory=dict)
 
 
 # ── Run Artifact ─────────────────────────────────────────────────────────────
@@ -165,7 +212,7 @@ class RunResult(BaseModel):
         return round(sum(scores) / len(scores), 3) if scores else 0.0
 
     def score_by_split(self) -> dict[str, float]:
-        """Mean score per split (dev, test, stress)."""
+        """Mean score per split (dev, test, regression)."""
         by_split: dict[str, list[float]] = {}
         for c in self.cases:
             if c.error:
@@ -183,6 +230,15 @@ class RunResult(BaseModel):
                 by_slice.setdefault(s, []).append(c.score)
         return {k: round(sum(v) / len(v), 3) for k, v in by_slice.items()}
 
+    def score_by_difficulty(self) -> dict[str, float]:
+        """Mean score per difficulty level."""
+        by_diff: dict[str, list[float]] = {}
+        for c in self.cases:
+            if c.error:
+                continue
+            by_diff.setdefault(c.difficulty, []).append(c.score)
+        return {k: round(sum(v) / len(v), 3) for k, v in by_diff.items()}
+
     def failure_summary(self) -> dict[str, int]:
         """Count of each failure type."""
         counts: dict[str, int] = {}
@@ -190,3 +246,21 @@ class RunResult(BaseModel):
             for ft in c.failure_types:
                 counts[ft.value] = counts.get(ft.value, 0) + 1
         return counts
+
+    def failure_rate(self) -> dict[str, float]:
+        """Failure rate per type (normalized by total non-error cases)."""
+        total = sum(1 for c in self.cases if not c.error)
+        if total == 0:
+            return {}
+        counts = self.failure_summary()
+        return {k: round(v / total, 3) for k, v in counts.items()}
+
+    def dimension_averages(self) -> dict[str, float]:
+        """Average score per dimension across all cases."""
+        dim_totals: dict[str, list[float]] = {}
+        for c in self.cases:
+            if c.error:
+                continue
+            for dim, val in c.breakdown.dimensions.items():
+                dim_totals.setdefault(dim, []).append(val)
+        return {k: round(sum(v) / len(v), 3) for k, v in dim_totals.items()}


### PR DESCRIPTION
## Framework Refinements

Phase 1.5b: Hardening the framework before adding new benchmark families.

### What Changed

**Family-Specific Score Dimensions**
- ScoreDimension model with name, weight, description
- ScoreBreakdown uses arbitrary dimensions dict instead of fixed fields
- BenchmarkFamily.score_dimensions() override point
- TaskCriticFamily: correctness(40%), instruction_following(25%), suggestion_quality(20%), format_compliance(15%)

**Stratified Split Generation**
- assign_stratified_split() ensures each slice/difficulty combination is proportionally represented
- Dev: 19 cases, Test: 11 cases (67/33 split)
- Both splits have proportional vague/well-defined/over-specified/edge-case coverage

**Case Rationale Metadata**
- why_this_case, what_good_looks_like, acceptable_variation
- regression_for_bug tracking
- difficulty tags (easy/medium/hard/adversarial)

**Saved Grader Artifacts**
- grader_rationale, grader_prompt_version, borderline flags
- grader_artifacts dict for debugging score disagreements

**Regression Suite Support**
- framework/regression.py: RegressionSuite class
- Separate storage from benchmark cases
- add_regression_case() with bug/fix tracking

**Reporting Enhancements**
- score_by_difficulty() breakdown
- dimension_averages() across all cases
- failure_rate() (normalized, not raw counts)
- Run comparison includes difficulty and dimension deltas

### Results (best prompt, 30 cases)
| Metric | Value |
|--------|-------|
| Mean | 0.867 |
| Dev | 0.868 |
| Test | 0.864 |
| Easy | 0.894 |
| Medium | 0.815 |
| Hard | 0.923 |
| Adversarial | 0.746 |

**Weakest dimension**: suggestion_quality (0.653)
**Dominant failure**: insufficient_specificity (83.3%)