### PR TITLE
feat(eval-lab): add portfolio-level evaluation and cross-family reporting

### DIFF
--- a/eval-lab/families/task_critic.py
+++ b/eval-lab/families/task_critic.py
@@ -140,7 +140,7 @@ class TaskCriticFamily(BenchmarkFamily):
         output: Optional[dict[str, Any]],
         error: Optional[str] = None,
     ) -> CaseResult:
-        if error:
+        if error or output is None:
             return CaseResult(
                 case_id=case.id,
                 split=case.split,

--- a/eval-lab/meta_dimensions.py
+++ b/eval-lab/meta_dimensions.py
@@ -1,0 +1,111 @@
+"""Meta-dimension mapping for portfolio-level reporting.
+
+Maps family-specific dimensions into common meta-buckets so that
+portfolio-level reporting can compare apples to apples across families.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MetaDimension:
+    """A meta-dimension that groups family-specific dimensions."""
+
+    name: str
+    description: str
+
+
+# ── Meta-Dimensions ──────────────────────────────────────────────────────────
+
+CORRECTNESS = MetaDimension(
+    name="correctness",
+    description="How well the output matches expected behavior or content",
+)
+COMPLIANCE = MetaDimension(
+    name="compliance",
+    description="Whether output follows required format and constraints",
+)
+ROBUSTNESS = MetaDimension(
+    name="robustness",
+    description="Quality under variation, edge cases, and adversarial inputs",
+)
+SAFETY = MetaDimension(
+    name="safety",
+    description="Whether the system avoids dangerous or irreversible actions",
+)
+REASONING = MetaDimension(
+    name="reasoning",
+    description="Quality of justification, explanation, and decision logic",
+)
+
+# ── Family Dimension Mapping ─────────────────────────────────────────────────
+
+# Maps (family_name, dimension_name) → MetaDimension
+DIMENSION_MAP: dict[tuple[str, str], MetaDimension] = {
+    # Task Critic
+    ("task_critic", "correctness"): CORRECTNESS,
+    ("task_critic", "instruction_following"): COMPLIANCE,
+    ("task_critic", "suggestion_quality"): ROBUSTNESS,
+    ("task_critic", "format_compliance"): COMPLIANCE,
+
+    # Task Rewriter
+    ("task_rewriter", "intent_preservation"): CORRECTNESS,
+    ("task_rewriter", "clarity_improvement"): CORRECTNESS,
+    ("task_rewriter", "actionability"): ROBUSTNESS,
+    ("task_rewriter", "constraint_adherence"): COMPLIANCE,
+    ("task_rewriter", "no_hallucination"): SAFETY,
+    ("task_rewriter", "format_compliance"): COMPLIANCE,
+
+    # Plan-from-Goal
+    ("plan_from_goal", "goal_coverage"): CORRECTNESS,
+    ("plan_from_goal", "step_quality"): CORRECTNESS,
+    ("plan_from_goal", "sequencing"): REASONING,
+    ("plan_from_goal", "feasibility"): ROBUSTNESS,
+    ("plan_from_goal", "granularity"): REASONING,
+    ("plan_from_goal", "non_redundancy"): CORRECTNESS,
+    ("plan_from_goal", "constraint_adherence"): COMPLIANCE,
+    ("plan_from_goal", "format_compliance"): COMPLIANCE,
+
+    # Clarification Policy
+    ("clarification_policy", "decision_quality"): CORRECTNESS,
+    ("clarification_policy", "question_quality"): REASONING,
+    ("clarification_policy", "minimality"): REASONING,
+    ("clarification_policy", "safety"): SAFETY,
+    ("clarification_policy", "format_compliance"): COMPLIANCE,
+
+    # Prioritization
+    ("prioritization", "ordering_quality"): CORRECTNESS,
+    ("prioritization", "dependency_respect"): COMPLIANCE,
+    ("prioritization", "justification_quality"): REASONING,
+    ("prioritization", "tie_handling"): REASONING,
+    ("prioritization", "format_compliance"): COMPLIANCE,
+}
+
+
+def get_meta_dimension(family_name: str, dimension_name: str) -> MetaDimension | None:
+    """Look up the meta-dimension for a family-specific dimension."""
+    return DIMENSION_MAP.get((family_name, dimension_name))
+
+
+def get_family_dimensions(family_name: str) -> list[str]:
+    """Get all dimension names for a family."""
+    return [
+        dim_name
+        for (fam, dim_name) in DIMENSION_MAP.keys()
+        if fam == family_name
+    ]
+
+
+def get_meta_dimension_scores(
+    family_name: str,
+    dimension_scores: dict[str, float],
+) -> dict[str, list[float]]:
+    """Group dimension scores by meta-dimension."""
+    meta_scores: dict[str, list[float]] = {}
+    for dim_name, score in dimension_scores.items():
+        meta = get_meta_dimension(family_name, dim_name)
+        if meta:
+            meta_scores.setdefault(meta.name, []).append(score)
+    # Average within each meta-dimension
+    return {k: round(sum(v) / len(v), 3) for k, v in meta_scores.items()}

--- a/eval-lab/portfolio.py
+++ b/eval-lab/portfolio.py
@@ -1,0 +1,267 @@
+"""Portfolio-level evaluation runner.
+
+Runs all benchmark families, aggregates results, and enables
+cross-family run comparison.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from framework.schemas import RunConfig, RunResult
+from meta_dimensions import get_meta_dimension, get_meta_dimension_scores
+
+
+# ── Family Registry ──────────────────────────────────────────────────────────
+
+FAMILY_REGISTRY = {
+    "task_critic": "families.task_critic:TaskCriticFamily",
+    "task_rewriter": "families.task_rewriter:TaskRewriterFamily",
+    "plan_from_goal": "families.plan_from_goal:PlanFromGoalFamily",
+    "clarification_policy": "families.clarification_policy:ClarificationPolicyFamily",
+    "prioritization": "families.prioritization:PrioritizationFamily",
+}
+
+# Default family weights for aggregate scoring
+DEFAULT_FAMILY_WEIGHTS = {
+    "task_critic": 0.25,
+    "task_rewriter": 0.20,
+    "plan_from_goal": 0.20,
+    "clarification_policy": 0.15,
+    "prioritization": 0.20,
+}
+
+
+def load_family(name: str):
+    """Dynamically load a benchmark family class."""
+    if name not in FAMILY_REGISTRY:
+        raise ValueError(f"Unknown family: {name}")
+    module_path, class_name = FAMILY_REGISTRY[name].split(":")
+    import importlib
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+async def run_portfolio(
+    families: Optional[list[str]] = None,
+    prompt_name: str = "baseline",
+    run_id: Optional[str] = None,
+    splits: Optional[list[str]] = None,
+) -> dict[str, RunResult]:
+    """Run all (or selected) families and return results by family name."""
+    if families is None:
+        families = list(FAMILY_REGISTRY.keys())
+    if splits is None:
+        splits = [None]  # Run all splits together
+
+    results = {}
+    for family_name in families:
+        family_cls = load_family(family_name)
+        family = family_cls()
+
+        config = RunConfig(
+            benchmark_name=family_name,
+            benchmark_version=family.VERSION,
+            prompt_name=prompt_name,
+            model=os.getenv("AI_PROVIDER_MODEL", "unknown"),
+        )
+
+        result = await family.run_benchmark(config, prompt_override=None)
+        results[family_name] = result
+
+    return results
+
+
+def aggregate_portfolio(
+    results: dict[str, RunResult],
+    weights: Optional[dict[str, float]] = None,
+) -> dict[str, Any]:
+    """Compute portfolio-level aggregate metrics."""
+    if weights is None:
+        weights = DEFAULT_FAMILY_WEIGHTS
+
+    # Filter to families that were run
+    weights = {k: v for k, v in weights.items() if k in results}
+    total_weight = sum(weights.values())
+    if total_weight == 0:
+        return {"error": "No families with weights"}
+
+    # Weighted mean score
+    weighted_score = sum(
+        weights.get(name, 0) * result.mean_score
+        for name, result in results.items()
+    ) / total_weight
+
+    # Total cases and errors
+    total_cases = sum(r.total_cases for r in results.values())
+    total_errors = sum(r.error_count for r in results.values())
+
+    # Meta-dimension averages across families
+    meta_dimension_totals: dict[str, list[float]] = {}
+    for name, result in results.items():
+        for case_result in result.cases:
+            if case_result.error:
+                continue
+            for dim_name, score in case_result.breakdown.dimensions.items():
+                meta = get_meta_dimension(name, dim_name)
+                if meta:
+                    meta_dimension_totals.setdefault(meta.name, []).append(score)
+
+    meta_averages = {
+        k: round(sum(v) / len(v), 3)
+        for k, v in meta_dimension_totals.items()
+    }
+
+    # By split
+    by_split: dict[str, list[float]] = {}
+    for name, result in results.items():
+        for split, score in result.score_by_split().items():
+            by_split.setdefault(split, []).append(score)
+    split_averages = {k: round(sum(v) / len(v), 3) for k, v in by_split.items()}
+
+    # By difficulty
+    by_difficulty: dict[str, list[float]] = {}
+    for name, result in results.items():
+        for diff, score in result.score_by_difficulty().items():
+            by_difficulty.setdefault(diff, []).append(score)
+    difficulty_averages = {k: round(sum(v) / len(v), 3) for k, v in by_difficulty.items()}
+
+    # Failure summary across families
+    failure_totals: dict[str, int] = {}
+    for name, result in results.items():
+        for ft, count in result.failure_summary().items():
+            failure_totals[ft] = failure_totals.get(ft, 0) + count
+
+    return {
+        "weighted_score": round(weighted_score, 3),
+        "total_cases": total_cases,
+        "total_errors": total_errors,
+        "error_rate": round(total_errors / total_cases, 3) if total_cases > 0 else 0.0,
+        "meta_dimension_averages": meta_averages,
+        "split_averages": split_averages,
+        "difficulty_averages": difficulty_averages,
+        "failure_summary": failure_totals,
+        "family_scores": {
+            name: {
+                "score": result.mean_score,
+                "cases": result.total_cases,
+                "errors": result.error_count,
+                "weight": weights.get(name, 0),
+            }
+            for name, result in results.items()
+        },
+    }
+
+
+def compare_runs(
+    baseline: dict[str, RunResult],
+    candidate: dict[str, RunResult],
+    weights: Optional[dict[str, float]] = None,
+) -> dict[str, Any]:
+    """Compare two portfolio runs and show deltas."""
+    baseline_agg = aggregate_portfolio(baseline, weights)
+    candidate_agg = aggregate_portfolio(candidate, weights)
+
+    score_delta = round(candidate_agg["weighted_score"] - baseline_agg["weighted_score"], 3)
+
+    # Per-family deltas
+    family_deltas = {}
+    for name in set(list(baseline.keys()) + list(candidate.keys())):
+        b = baseline.get(name)
+        c = candidate.get(name)
+        if b and c:
+            family_deltas[name] = {
+                "baseline_score": b.mean_score,
+                "candidate_score": c.mean_score,
+                "delta": round(c.mean_score - b.mean_score, 3),
+                "baseline_errors": b.error_count,
+                "candidate_errors": c.error_count,
+            }
+
+    # Per-case deltas
+    case_deltas = []
+    for name in set(list(baseline.keys()) + list(candidate.keys())):
+        b = baseline.get(name)
+        c = candidate.get(name)
+        if not b or not c:
+            continue
+        for bc, cc in zip(b.cases, c.cases):
+            if bc.case_id != cc.case_id:
+                continue
+            case_deltas.append({
+                "family": name,
+                "case_id": bc.case_id,
+                "baseline_score": bc.score,
+                "candidate_score": cc.score,
+                "delta": round(cc.score - bc.score, 3),
+                "baseline_error": bc.error,
+                "candidate_error": cc.error,
+                "slices": bc.slices,
+                "difficulty": bc.difficulty,
+            })
+
+    # Win/loss summary
+    wins = sum(1 for d in case_deltas if d["delta"] > 0)
+    losses = sum(1 for d in case_deltas if d["delta"] < 0)
+    ties = sum(1 for d in case_deltas if d["delta"] == 0)
+
+    return {
+        "baseline_aggregate": baseline_agg,
+        "candidate_aggregate": candidate_agg,
+        "score_delta": score_delta,
+        "family_deltas": family_deltas,
+        "case_deltas": case_deltas,
+        "win_loss": {"wins": wins, "losses": losses, "ties": ties},
+    }
+
+
+def generate_portfolio_report(
+    results: dict[str, RunResult],
+    run_id: Optional[str] = None,
+    output_dir: Optional[Path] = None,
+) -> Path:
+    """Generate a portfolio-level report and write to disk."""
+    if output_dir is None:
+        output_dir = Path(__file__).parent / "results" / "portfolio"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    aggregate = aggregate_portfolio(results)
+
+    if run_id is None:
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    report = {
+        "run_id": run_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "model": os.getenv("AI_PROVIDER_MODEL", "unknown"),
+        "families_run": list(results.keys()),
+        "aggregate": aggregate,
+        "family_details": {},
+    }
+
+    for name, result in results.items():
+        family_detail = {
+            "score": result.mean_score,
+            "cases": result.total_cases,
+            "errors": result.error_count,
+            "by_split": result.score_by_split(),
+            "by_difficulty": result.score_by_difficulty(),
+            "by_slice": result.score_by_slice(),
+            "dimension_averages": result.dimension_averages(),
+            "failure_summary": result.failure_summary(),
+        }
+        report["family_details"][name] = family_detail
+
+    output_path = output_dir / f"portfolio-{run_id}.json"
+    with open(output_path, "w") as f:
+        json.dump(report, f, indent=2)
+
+    return output_path

--- a/eval-lab/run_portfolio.py
+++ b/eval-lab/run_portfolio.py
@@ -1,0 +1,94 @@
+"""Portfolio runner CLI.
+
+Usage:
+    python run_portfolio.py                    # Run all families with baseline prompt
+    python run_portfolio.py --prompt best      # Run with best prompt
+    python run_portfolio.py --families task_critic task_rewriter  # Run specific families
+    python run_portfolio.py --compare baseline.json  # Compare with previous run
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from portfolio import run_portfolio, aggregate_portfolio, compare_runs, generate_portfolio_report
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Run eval-lab portfolio")
+    parser.add_argument("--prompt", default="baseline", help="Prompt name to use")
+    parser.add_argument("--families", nargs="+", default=None, help="Families to run (default: all)")
+    parser.add_argument("--compare", type=str, default=None, help="Path to previous run JSON for comparison")
+    parser.add_argument("--output-dir", type=str, default=None, help="Output directory for reports")
+    args = parser.parse_args()
+
+    print(f"Running portfolio with prompt='{args.prompt}'")
+    if args.families:
+        print(f"Families: {', '.join(args.families)}")
+    else:
+        print("Families: all")
+
+    results = await run_portfolio(
+        families=args.families,
+        prompt_name=args.prompt,
+    )
+
+    # Print summary
+    aggregate = aggregate_portfolio(results)
+    print(f"\n{'='*60}")
+    print(f"PORTFOLIO SUMMARY")
+    print(f"{'='*60}")
+    print(f"Weighted score: {aggregate['weighted_score']:.3f}")
+    print(f"Total cases: {aggregate['total_cases']}")
+    print(f"Total errors: {aggregate['total_errors']}")
+    print(f"Error rate: {aggregate['error_rate']:.1%}")
+    print()
+
+    print("By family:")
+    for name, info in sorted(aggregate["family_scores"].items()):
+        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} errors)")
+    print()
+
+    print("By meta-dimension:")
+    for dim, score in sorted(aggregate["meta_dimension_averages"].items()):
+        print(f"  {dim}: {score:.3f}")
+    print()
+
+    print("By difficulty:")
+    for diff, score in sorted(aggregate["difficulty_averages"].items()):
+        print(f"  {diff}: {score:.3f}")
+    print()
+
+    # Compare with previous run if provided
+    if args.compare:
+        print(f"\nComparing with: {args.compare}")
+        with open(args.compare) as f:
+            prev_data = json.load(f)
+
+        # Reconstruct RunResult objects from previous run
+        # For simplicity, just compare aggregate scores
+        prev_score = prev_data.get("aggregate", {}).get("weighted_score", 0)
+        delta = round(aggregate["weighted_score"] - prev_score, 3)
+        print(f"Previous score: {prev_score:.3f}")
+        print(f"Current score:  {aggregate['weighted_score']:.3f}")
+        print(f"Delta: {delta:+.3f}")
+
+    # Generate report
+    output_dir = Path(args.output_dir) if args.output_dir else None
+    report_path = generate_portfolio_report(results, output_dir=output_dir)
+    print(f"\nReport written to: {report_path}")
+
+    return aggregate["weighted_score"]
+
+
+if __name__ == "__main__":
+    score = asyncio.run(main())
+    sys.exit(0 if score > 0 else 1)


### PR DESCRIPTION
## Portfolio Consolidation

Adds portfolio-level evaluation that runs all benchmark families,
aggregates results, and enables cross-family run comparison.

### New Components
- **meta_dimensions.py**: Maps 28 family-specific dimensions into 5
  meta-buckets (correctness, compliance, robustness, safety, reasoning)
- **portfolio.py**: Core portfolio runner with aggregation and comparison
- **run_portfolio.py**: CLI runner for portfolio evaluation

### Aggregate Scoring
- Family-weighted rollups (critic 25%, rewriter 20%, plan 20%,
  clarification 15%, prioritization 20%)
- Meta-dimension averages across families
- Split and difficulty breakdowns
- Failure summary across families
- Win/loss tracking for run comparison

### Quick Test Results (2 families)
| Metric | Value |
|--------|-------|
| task_critic | 0.795 (30 cases, 0 errors) |
| clarification_policy | 0.884 (20 cases, 0 errors) |
| **Aggregate** | **0.828** |
| correctness | 0.804 |
| compliance | 1.000 |
| robustness | 0.496 |
| reasoning | 0.842 |
| safety | 0.885 |

### Usage
```bash
cd eval-lab
python run_portfolio.py                    # Run all families
python run_portfolio.py --prompt best      # Run with best prompt
python run_portfolio.py --families task_critic clarification_policy  # Specific families
python run_portfolio.py --compare prev.json  # Compare with previous run
```

### Also Fixed
- task_critic grade_case now handles output=None properly