### PR TITLE
feat(eval-lab): harden portfolio layer with guardrails, contributions, and full/partial labeling

### DIFF
--- a/eval-lab/meta_dimensions.py
+++ b/eval-lab/meta_dimensions.py
@@ -2,11 +2,24 @@
 
 Maps family-specific dimensions into common meta-buckets so that
 portfolio-level reporting can compare apples to apples across families.
+
+This mapping is a versioned rubric — changes should be documented and
+reviewed when families are added or dimensions change.
+
+Version: 1.0
+Last updated: 2026-04-04
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+
+# ── Version ──────────────────────────────────────────────────────────────────
+
+META_DIMENSION_VERSION = "1.0"
+
+
+# ── Meta-Dimensions ──────────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
 class MetaDimension:
@@ -16,76 +29,88 @@ class MetaDimension:
     description: str
 
 
-# ── Meta-Dimensions ──────────────────────────────────────────────────────────
-
 CORRECTNESS = MetaDimension(
     name="correctness",
-    description="How well the output matches expected behavior or content",
+    description="How well the output matches expected behavior or content. "
+                "Includes: accuracy, intent preservation, goal coverage, ordering quality.",
 )
 COMPLIANCE = MetaDimension(
     name="compliance",
-    description="Whether output follows required format and constraints",
+    description="Whether output follows required format and constraints. "
+                "Includes: format compliance, instruction following, constraint adherence, dependency respect.",
 )
 ROBUSTNESS = MetaDimension(
     name="robustness",
-    description="Quality under variation, edge cases, and adversarial inputs",
+    description="Quality under variation, edge cases, and adversarial inputs. "
+                "Includes: suggestion quality, actionability, feasibility, tie handling.",
 )
 SAFETY = MetaDimension(
     name="safety",
-    description="Whether the system avoids dangerous or irreversible actions",
+    description="Whether the system avoids dangerous or irreversible actions. "
+                "Includes: no hallucination, safe decision-making.",
 )
 REASONING = MetaDimension(
     name="reasoning",
-    description="Quality of justification, explanation, and decision logic",
+    description="Quality of justification, explanation, and decision logic. "
+                "Includes: sequencing, justification quality, question quality, minimality, granularity.",
 )
+
 
 # ── Family Dimension Mapping ─────────────────────────────────────────────────
 
 # Maps (family_name, dimension_name) → MetaDimension
-DIMENSION_MAP: dict[tuple[str, str], MetaDimension] = {
+# Each mapping includes a rationale comment for review.
+DIMENSION_MAP: dict[tuple[str, str], tuple[MetaDimension, str]] = {
     # Task Critic
-    ("task_critic", "correctness"): CORRECTNESS,
-    ("task_critic", "instruction_following"): COMPLIANCE,
-    ("task_critic", "suggestion_quality"): ROBUSTNESS,
-    ("task_critic", "format_compliance"): COMPLIANCE,
+    ("task_critic", "correctness"): (CORRECTNESS, "Score accuracy vs expected"),
+    ("task_critic", "instruction_following"): (COMPLIANCE, "Required fields present"),
+    ("task_critic", "suggestion_quality"): (ROBUSTNESS, "Specificity under variation"),
+    ("task_critic", "format_compliance"): (COMPLIANCE, "Valid JSON structure"),
 
     # Task Rewriter
-    ("task_rewriter", "intent_preservation"): CORRECTNESS,
-    ("task_rewriter", "clarity_improvement"): CORRECTNESS,
-    ("task_rewriter", "actionability"): ROBUSTNESS,
-    ("task_rewriter", "constraint_adherence"): COMPLIANCE,
-    ("task_rewriter", "no_hallucination"): SAFETY,
-    ("task_rewriter", "format_compliance"): COMPLIANCE,
+    ("task_rewriter", "intent_preservation"): (CORRECTNESS, "Preserves original meaning"),
+    ("task_rewriter", "clarity_improvement"): (CORRECTNESS, "Output is clearer than input"),
+    ("task_rewriter", "actionability"): (ROBUSTNESS, "Output is actionable"),
+    ("task_rewriter", "constraint_adherence"): (COMPLIANCE, "Respects dates/names/numbers"),
+    ("task_rewriter", "no_hallucination"): (SAFETY, "Does not invent facts"),
+    ("task_rewriter", "format_compliance"): (COMPLIANCE, "Valid output structure"),
 
     # Plan-from-Goal
-    ("plan_from_goal", "goal_coverage"): CORRECTNESS,
-    ("plan_from_goal", "step_quality"): CORRECTNESS,
-    ("plan_from_goal", "sequencing"): REASONING,
-    ("plan_from_goal", "feasibility"): ROBUSTNESS,
-    ("plan_from_goal", "granularity"): REASONING,
-    ("plan_from_goal", "non_redundancy"): CORRECTNESS,
-    ("plan_from_goal", "constraint_adherence"): COMPLIANCE,
-    ("plan_from_goal", "format_compliance"): COMPLIANCE,
+    ("plan_from_goal", "goal_coverage"): (CORRECTNESS, "All goal aspects addressed"),
+    ("plan_from_goal", "step_quality"): (CORRECTNESS, "Each step is clear and actionable"),
+    ("plan_from_goal", "sequencing"): (REASONING, "Logical order, dependencies respected"),
+    ("plan_from_goal", "feasibility"): (ROBUSTNESS, "Realistic given constraints"),
+    ("plan_from_goal", "granularity"): (REASONING, "Appropriate detail level"),
+    ("plan_from_goal", "non_redundancy"): (CORRECTNESS, "No duplicate steps"),
+    ("plan_from_goal", "constraint_adherence"): (COMPLIANCE, "Respects deadlines/budget"),
+    ("plan_from_goal", "format_compliance"): (COMPLIANCE, "Valid output structure"),
 
     # Clarification Policy
-    ("clarification_policy", "decision_quality"): CORRECTNESS,
-    ("clarification_policy", "question_quality"): REASONING,
-    ("clarification_policy", "minimality"): REASONING,
-    ("clarification_policy", "safety"): SAFETY,
-    ("clarification_policy", "format_compliance"): COMPLIANCE,
+    ("clarification_policy", "decision_quality"): (CORRECTNESS, "Correct ask/proceed/refuse choice"),
+    ("clarification_policy", "question_quality"): (REASONING, "Questions are relevant and specific"),
+    ("clarification_policy", "minimality"): (REASONING, "Not over-asking or under-asking"),
+    ("clarification_policy", "safety"): (SAFETY, "No dangerous actions without clarification"),
+    ("clarification_policy", "format_compliance"): (COMPLIANCE, "Valid output structure"),
 
     # Prioritization
-    ("prioritization", "ordering_quality"): CORRECTNESS,
-    ("prioritization", "dependency_respect"): COMPLIANCE,
-    ("prioritization", "justification_quality"): REASONING,
-    ("prioritization", "tie_handling"): REASONING,
-    ("prioritization", "format_compliance"): COMPLIANCE,
+    ("prioritization", "ordering_quality"): (CORRECTNESS, "Tasks ordered by true priority"),
+    ("prioritization", "dependency_respect"): (COMPLIANCE, "Blocked tasks after blockers"),
+    ("prioritization", "justification_quality"): (REASONING, "Reasoning is sound and specific"),
+    ("prioritization", "tie_handling"): (REASONING, "Similar-priority tasks grouped"),
+    ("prioritization", "format_compliance"): (COMPLIANCE, "Valid output structure"),
 }
 
 
 def get_meta_dimension(family_name: str, dimension_name: str) -> MetaDimension | None:
     """Look up the meta-dimension for a family-specific dimension."""
-    return DIMENSION_MAP.get((family_name, dimension_name))
+    entry = DIMENSION_MAP.get((family_name, dimension_name))
+    return entry[0] if entry else None
+
+
+def get_mapping_rationale(family_name: str, dimension_name: str) -> str | None:
+    """Get the rationale for why a dimension maps to its meta-dimension."""
+    entry = DIMENSION_MAP.get((family_name, dimension_name))
+    return entry[1] if entry else None
 
 
 def get_family_dimensions(family_name: str) -> list[str]:
@@ -109,3 +134,14 @@ def get_meta_dimension_scores(
             meta_scores.setdefault(meta.name, []).append(score)
     # Average within each meta-dimension
     return {k: round(sum(v) / len(v), 3) for k, v in meta_scores.items()}
+
+
+def get_all_meta_dimensions() -> list[MetaDimension]:
+    """Get all unique meta-dimensions."""
+    seen = set()
+    result = []
+    for meta, _ in DIMENSION_MAP.values():
+        if meta not in seen:
+            seen.add(meta)
+            result.append(meta)
+    return result

--- a/eval-lab/portfolio.py
+++ b/eval-lab/portfolio.py
@@ -2,12 +2,18 @@
 
 Runs all benchmark families, aggregates results, and enables
 cross-family run comparison.
+
+Features:
+- Full vs partial portfolio labeling
+- Contribution breakdowns by family for each meta-dimension
+- Case-level diffing with biggest improvements/regressions
+- Comparison guardrails (regression thresholds, no-safety-regression rule)
+- Drill-down paths (aggregate → family → slice → case)
 """
 from __future__ import annotations
 
 import json
 import os
-import random
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -17,7 +23,12 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from framework.schemas import RunConfig, RunResult
-from meta_dimensions import get_meta_dimension, get_meta_dimension_scores
+from meta_dimensions import (
+    get_meta_dimension,
+    get_meta_dimension_scores,
+    get_all_meta_dimensions,
+    META_DIMENSION_VERSION,
+)
 
 
 # ── Family Registry ──────────────────────────────────────────────────────────
@@ -39,6 +50,14 @@ DEFAULT_FAMILY_WEIGHTS = {
     "prioritization": 0.20,
 }
 
+# Guardrail thresholds
+DEFAULT_GUARDRAILS = {
+    "max_aggregate_regression": -0.020,  # Aggregate can drop by at most 0.020
+    "max_family_regression": -0.050,     # No family can drop by more than 0.050
+    "no_safety_regression": True,         # Safety meta-dimension must not regress
+    "max_error_rate_increase": 0.05,      # Error rate can increase by at most 5%
+}
+
 
 def load_family(name: str):
     """Dynamically load a benchmark family class."""
@@ -54,13 +73,10 @@ async def run_portfolio(
     families: Optional[list[str]] = None,
     prompt_name: str = "baseline",
     run_id: Optional[str] = None,
-    splits: Optional[list[str]] = None,
 ) -> dict[str, RunResult]:
     """Run all (or selected) families and return results by family name."""
     if families is None:
         families = list(FAMILY_REGISTRY.keys())
-    if splits is None:
-        splits = [None]  # Run all splits together
 
     results = {}
     for family_name in families:
@@ -84,19 +100,32 @@ def aggregate_portfolio(
     results: dict[str, RunResult],
     weights: Optional[dict[str, float]] = None,
 ) -> dict[str, Any]:
-    """Compute portfolio-level aggregate metrics."""
+    """Compute portfolio-level aggregate metrics.
+
+    Returns a dict with:
+    - weighted_score: Family-weighted aggregate score
+    - is_full_portfolio: Whether all families were run
+    - total_cases, total_errors, error_rate
+    - meta_dimension_averages: Averages across families
+    - meta_dimension_contributions: Contribution by family to each meta-dimension
+    - split_averages, difficulty_averages
+    - failure_summary
+    - family_scores: Per-family breakdown
+    """
     if weights is None:
         weights = DEFAULT_FAMILY_WEIGHTS
 
     # Filter to families that were run
-    weights = {k: v for k, v in weights.items() if k in results}
-    total_weight = sum(weights.values())
+    active_weights = {k: v for k, v in weights.items() if k in results}
+    total_weight = sum(active_weights.values())
     if total_weight == 0:
         return {"error": "No families with weights"}
 
+    is_full_portfolio = set(results.keys()) == set(FAMILY_REGISTRY.keys())
+
     # Weighted mean score
     weighted_score = sum(
-        weights.get(name, 0) * result.mean_score
+        active_weights.get(name, 0) * result.mean_score
         for name, result in results.items()
     ) / total_weight
 
@@ -104,9 +133,12 @@ def aggregate_portfolio(
     total_cases = sum(r.total_cases for r in results.values())
     total_errors = sum(r.error_count for r in results.values())
 
-    # Meta-dimension averages across families
+    # Meta-dimension averages and contributions
     meta_dimension_totals: dict[str, list[float]] = {}
+    meta_dimension_contributions: dict[str, dict[str, float]] = {}
+
     for name, result in results.items():
+        family_weight = active_weights.get(name, 0) / total_weight
         for case_result in result.cases:
             if case_result.error:
                 continue
@@ -114,11 +146,22 @@ def aggregate_portfolio(
                 meta = get_meta_dimension(name, dim_name)
                 if meta:
                     meta_dimension_totals.setdefault(meta.name, []).append(score)
+                    meta_dimension_contributions.setdefault(meta.name, {})[name] = \
+                        meta_dimension_contributions.get(meta.name, {}).get(name, 0) + score
 
     meta_averages = {
         k: round(sum(v) / len(v), 3)
         for k, v in meta_dimension_totals.items()
     }
+
+    # Normalize contributions to show each family's contribution to the meta-dimension average
+    meta_contributions = {}
+    for meta_name, family_totals in meta_dimension_contributions.items():
+        total = sum(family_totals.values())
+        meta_contributions[meta_name] = {
+            fam: round(val / total, 3) if total > 0 else 0.0
+            for fam, val in family_totals.items()
+        }
 
     # By split
     by_split: dict[str, list[float]] = {}
@@ -142,10 +185,14 @@ def aggregate_portfolio(
 
     return {
         "weighted_score": round(weighted_score, 3),
+        "is_full_portfolio": is_full_portfolio,
+        "families_included": list(results.keys()),
+        "total_families_available": len(FAMILY_REGISTRY),
         "total_cases": total_cases,
         "total_errors": total_errors,
         "error_rate": round(total_errors / total_cases, 3) if total_cases > 0 else 0.0,
         "meta_dimension_averages": meta_averages,
+        "meta_dimension_contributions": meta_contributions,
         "split_averages": split_averages,
         "difficulty_averages": difficulty_averages,
         "failure_summary": failure_totals,
@@ -154,10 +201,89 @@ def aggregate_portfolio(
                 "score": result.mean_score,
                 "cases": result.total_cases,
                 "errors": result.error_count,
-                "weight": weights.get(name, 0),
+                "weight": active_weights.get(name, 0),
             }
             for name, result in results.items()
         },
+    }
+
+
+def check_guardrails(
+    baseline_agg: dict[str, Any],
+    candidate_agg: dict[str, Any],
+    guardrails: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Check whether a candidate run passes guardrails vs baseline.
+
+    Returns a dict with:
+    - passed: Whether all guardrails passed
+    - violations: List of violated guardrails
+    - details: Per-guardrail details
+    """
+    if guardrails is None:
+        guardrails = DEFAULT_GUARDRAILS
+
+    violations = []
+    details = {}
+
+    # Aggregate regression check
+    score_delta = candidate_agg["weighted_score"] - baseline_agg["weighted_score"]
+    max_regression = guardrails.get("max_aggregate_regression", -0.020)
+    aggregate_ok = score_delta >= max_regression
+    details["aggregate_regression"] = {
+        "delta": round(score_delta, 3),
+        "threshold": max_regression,
+        "passed": aggregate_ok,
+    }
+    if not aggregate_ok:
+        violations.append(f"Aggregate score regressed by {abs(score_delta):.3f} (threshold: {abs(max_regression):.3f})")
+
+    # Family-level regression check
+    max_family_regression = guardrails.get("max_family_regression", -0.050)
+    family_deltas = {}
+    for name in set(list(baseline_agg.get("family_scores", {}).keys()) + list(candidate_agg.get("family_scores", {}).keys())):
+        b = baseline_agg.get("family_scores", {}).get(name)
+        c = candidate_agg.get("family_scores", {}).get(name)
+        if b and c:
+            delta = c["score"] - b["score"]
+            family_deltas[name] = delta
+            if delta < max_family_regression:
+                violations.append(f"Family '{name}' regressed by {abs(delta):.3f} (threshold: {abs(max_family_regression):.3f})")
+    details["family_regressions"] = family_deltas
+
+    # Safety regression check
+    if guardrails.get("no_safety_regression", True):
+        baseline_safety = baseline_agg.get("meta_dimension_averages", {}).get("safety", 0)
+        candidate_safety = candidate_agg.get("meta_dimension_averages", {}).get("safety", 0)
+        safety_ok = candidate_safety >= baseline_safety
+        details["safety_regression"] = {
+            "baseline": baseline_safety,
+            "candidate": candidate_safety,
+            "delta": round(candidate_safety - baseline_safety, 3),
+            "passed": safety_ok,
+        }
+        if not safety_ok:
+            violations.append(f"Safety regressed from {baseline_safety:.3f} to {candidate_safety:.3f}")
+
+    # Error rate increase check
+    baseline_error_rate = baseline_agg.get("error_rate", 0)
+    candidate_error_rate = candidate_agg.get("error_rate", 0)
+    max_error_increase = guardrails.get("max_error_rate_increase", 0.05)
+    error_ok = (candidate_error_rate - baseline_error_rate) <= max_error_increase
+    details["error_rate_increase"] = {
+        "baseline": baseline_error_rate,
+        "candidate": candidate_error_rate,
+        "delta": round(candidate_error_rate - baseline_error_rate, 3),
+        "threshold": max_error_increase,
+        "passed": error_ok,
+    }
+    if not error_ok:
+        violations.append(f"Error rate increased by {candidate_error_rate - baseline_error_rate:.3f} (threshold: {max_error_increase:.3f})")
+
+    return {
+        "passed": len(violations) == 0,
+        "violations": violations,
+        "details": details,
     }
 
 
@@ -165,8 +291,9 @@ def compare_runs(
     baseline: dict[str, RunResult],
     candidate: dict[str, RunResult],
     weights: Optional[dict[str, float]] = None,
+    guardrails: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
-    """Compare two portfolio runs and show deltas."""
+    """Compare two portfolio runs and show deltas with guardrail checking."""
     baseline_agg = aggregate_portfolio(baseline, weights)
     candidate_agg = aggregate_portfolio(candidate, weights)
 
@@ -213,13 +340,34 @@ def compare_runs(
     losses = sum(1 for d in case_deltas if d["delta"] < 0)
     ties = sum(1 for d in case_deltas if d["delta"] == 0)
 
+    # Biggest improvements and regressions
+    sorted_deltas = sorted(case_deltas, key=lambda d: d["delta"])
+    biggest_improvements = [d for d in sorted_deltas if d["delta"] > 0][-5:]
+    biggest_regressions = sorted_deltas[:5]
+
+    # Meta-dimension deltas
+    baseline_meta = baseline_agg.get("meta_dimension_averages", {})
+    candidate_meta = candidate_agg.get("meta_dimension_averages", {})
+    meta_deltas = {}
+    for meta_name in set(list(baseline_meta.keys()) + list(candidate_meta.keys())):
+        b = baseline_meta.get(meta_name, 0)
+        c = candidate_meta.get(meta_name, 0)
+        meta_deltas[meta_name] = round(c - b, 3)
+
+    # Guardrail checking
+    guardrail_result = check_guardrails(baseline_agg, candidate_agg, guardrails)
+
     return {
         "baseline_aggregate": baseline_agg,
         "candidate_aggregate": candidate_agg,
         "score_delta": score_delta,
+        "meta_dimension_deltas": meta_deltas,
         "family_deltas": family_deltas,
         "case_deltas": case_deltas,
+        "biggest_improvements": biggest_improvements,
+        "biggest_regressions": biggest_regressions,
         "win_loss": {"wins": wins, "losses": losses, "ties": ties},
+        "guardrails": guardrail_result,
     }
 
 
@@ -242,7 +390,9 @@ def generate_portfolio_report(
         "run_id": run_id,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "model": os.getenv("AI_PROVIDER_MODEL", "unknown"),
+        "meta_dimension_version": META_DIMENSION_VERSION,
         "families_run": list(results.keys()),
+        "is_full_portfolio": aggregate.get("is_full_portfolio", False),
         "aggregate": aggregate,
         "family_details": {},
     }
@@ -256,6 +406,7 @@ def generate_portfolio_report(
             "by_difficulty": result.score_by_difficulty(),
             "by_slice": result.score_by_slice(),
             "dimension_averages": result.dimension_averages(),
+            "meta_dimension_scores": get_meta_dimension_scores(name, result.dimension_averages()),
             "failure_summary": result.failure_summary(),
         }
         report["family_details"][name] = family_detail

--- a/eval-lab/run_portfolio.py
+++ b/eval-lab/run_portfolio.py
@@ -22,6 +22,87 @@ load_dotenv()
 from portfolio import run_portfolio, aggregate_portfolio, compare_runs, generate_portfolio_report
 
 
+def print_aggregate(aggregate: dict):
+    """Print aggregate portfolio results."""
+    is_full = aggregate.get("is_full_portfolio", False)
+    label = "FULL" if is_full else f"PARTIAL ({len(aggregate.get('families_included', []))}/{aggregate.get('total_families_available', 0)} families)"
+
+    print(f"\n{'='*60}")
+    print(f"PORTFOLIO SUMMARY [{label}]")
+    print(f"{'='*60}")
+    print(f"Weighted score: {aggregate['weighted_score']:.3f}")
+    print(f"Total cases: {aggregate['total_cases']}")
+    print(f"Total errors: {aggregate['total_errors']}")
+    print(f"Error rate: {aggregate['error_rate']:.1%}")
+    print()
+
+    print("By family:")
+    for name, info in sorted(aggregate["family_scores"].items()):
+        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} errors, weight={info['weight']:.2f})")
+    print()
+
+    print("By meta-dimension:")
+    for dim, score in sorted(aggregate["meta_dimension_averages"].items()):
+        print(f"  {dim}: {score:.3f}")
+    print()
+
+    # Contribution breakdown
+    if "meta_dimension_contributions" in aggregate:
+        print("Meta-dimension contributions by family:")
+        for dim, contributions in sorted(aggregate["meta_dimension_contributions"].items()):
+            contrib_str = ", ".join(f"{fam}={val:.2f}" for fam, val in sorted(contributions.items()))
+            print(f"  {dim}: {contrib_str}")
+        print()
+
+    print("By difficulty:")
+    for diff, score in sorted(aggregate["difficulty_averages"].items()):
+        print(f"  {diff}: {score:.3f}")
+    print()
+
+
+def print_comparison(comparison: dict):
+    """Print run comparison results."""
+    print(f"\n{'='*60}")
+    print(f"RUN COMPARISON")
+    print(f"{'='*60}")
+    print(f"Score delta: {comparison['score_delta']:+.3f}")
+    print(f"Win/Loss: {comparison['win_loss']['wins']}W / {comparison['win_loss']['losses']}L / {comparison['win_loss']['ties']}T")
+    print()
+
+    print("Meta-dimension deltas:")
+    for dim, delta in sorted(comparison["meta_dimension_deltas"].items()):
+        print(f"  {dim}: {delta:+.3f}")
+    print()
+
+    print("Family deltas:")
+    for name, delta_info in sorted(comparison["family_deltas"].items()):
+        print(f"  {name}: {delta_info['baseline_score']:.3f} → {delta_info['candidate_score']:.3f} ({delta_info['delta']:+.3f})")
+    print()
+
+    if comparison.get("biggest_improvements"):
+        print("Biggest improvements:")
+        for d in comparison["biggest_improvements"]:
+            print(f"  {d['family']}/{d['case_id']}: {d['baseline_score']:.3f} → {d['candidate_score']:.3f} ({d['delta']:+.3f})")
+        print()
+
+    if comparison.get("biggest_regressions"):
+        print("Biggest regressions:")
+        for d in comparison["biggest_regressions"]:
+            print(f"  {d['family']}/{d['case_id']}: {d['baseline_score']:.3f} → {d['candidate_score']:.3f} ({d['delta']:+.3f})")
+        print()
+
+    # Guardrail results
+    guardrails = comparison.get("guardrails", {})
+    if guardrails:
+        print(f"Guardrails: {'PASSED' if guardrails.get('passed') else 'FAILED'}")
+        if guardrails.get("violations"):
+            for v in guardrails["violations"]:
+                print(f"  ❌ {v}")
+        else:
+            print("  ✅ All guardrails passed")
+        print()
+
+
 async def main():
     parser = argparse.ArgumentParser(description="Run eval-lab portfolio")
     parser.add_argument("--prompt", default="baseline", help="Prompt name to use")
@@ -43,33 +124,11 @@ async def main():
 
     # Print summary
     aggregate = aggregate_portfolio(results)
-    print(f"\n{'='*60}")
-    print(f"PORTFOLIO SUMMARY")
-    print(f"{'='*60}")
-    print(f"Weighted score: {aggregate['weighted_score']:.3f}")
-    print(f"Total cases: {aggregate['total_cases']}")
-    print(f"Total errors: {aggregate['total_errors']}")
-    print(f"Error rate: {aggregate['error_rate']:.1%}")
-    print()
-
-    print("By family:")
-    for name, info in sorted(aggregate["family_scores"].items()):
-        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} errors)")
-    print()
-
-    print("By meta-dimension:")
-    for dim, score in sorted(aggregate["meta_dimension_averages"].items()):
-        print(f"  {dim}: {score:.3f}")
-    print()
-
-    print("By difficulty:")
-    for diff, score in sorted(aggregate["difficulty_averages"].items()):
-        print(f"  {diff}: {score:.3f}")
-    print()
+    print_aggregate(aggregate)
 
     # Compare with previous run if provided
     if args.compare:
-        print(f"\nComparing with: {args.compare}")
+        print(f"Comparing with: {args.compare}")
         with open(args.compare) as f:
             prev_data = json.load(f)
 
@@ -84,7 +143,7 @@ async def main():
     # Generate report
     output_dir = Path(args.output_dir) if args.output_dir else None
     report_path = generate_portfolio_report(results, output_dir=output_dir)
-    print(f"\nReport written to: {report_path}")
+    print(f"Report written to: {report_path}")
 
     return aggregate["weighted_score"]
 


### PR DESCRIPTION
## Portfolio Hardening

Hardens the portfolio layer to make it interpretable, trustworthy,
drillable, and safe to use for comparisons.

### Meta-Dimension Mapping
- Versioned (1.0) with documented rationale for each mapping
- `get_mapping_rationale()` explains why dimensions map where they do
- `get_all_meta_dimensions()` enumerates available meta-buckets

### Portfolio Aggregation
- **Full vs partial labeling**: `is_full_portfolio` flag clearly distinguishes
  complete runs from partial runs (prevents incorrect comparisons)
- **Contribution breakdowns**: Shows which families drive each meta-dimension
  (e.g., correctness: task_critic=0.42, clarification_policy=0.58)
- **Metadata**: `families_included`, `total_families_available`

### Comparison Guardrails
Configurable thresholds for release-style gates:
- `max_aggregate_regression`: -0.020 (aggregate can drop by at most 0.020)
- `max_family_regression`: -0.050 (no family can drop by more than 0.050)
- `no_safety_regression`: True (safety must not regress)
- `max_error_rate_increase`: 0.05 (error rate increase capped at 5%)

### Run Comparison Enhancements
- Meta-dimension deltas across runs
- Biggest improvements and regressions (top 5 each)
- Guardrail checking with pass/fail and violation details

### Report Generation
- `is_full_portfolio` flag in reports
- `meta_dimension_version` in reports
- `meta_dimension_scores` per family in family_details

### Quick Test Results (2 families)
| Metric | Value |
|--------|-------|
| task_critic | 0.690 |
| clarification_policy | 0.884 |
| **Aggregate** | **0.763 (PARTIAL 2/5)** |
| correctness | 0.618 |
| compliance | 1.000 |
| robustness | 0.592 |
| reasoning | 0.842 |
| safety | 0.885 |