### PR TITLE
feat(react): add inline project editing to workspace header

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from "../../hooks/useIsMobile";
 import { IconMoon, IconSun, IconMenu } from "../shared/Icons";
 import { useIcsExport } from "../../hooks/useIcsExport";
 import { captureInboxItem } from "../../api/inbox";
+import { apiCall } from "../../api/client";
 import { Sidebar, type WorkspaceView } from "../projects/Sidebar";
 import { SortableTodoList } from "../todos/SortableTodoList";
 import { TodoDrawer } from "../todos/TodoDrawer";
@@ -1291,6 +1292,28 @@ export function AppShell() {
                     }}
                     onDeferTask={handleProjectTaskDefer}
                     onReplaceNext={handleReplaceNextTask}
+                    onRenameProject={async (id, newName) => {
+                      await apiCall(`/projects/${id}`, {
+                        method: "PUT",
+                        body: JSON.stringify({ name: newName }),
+                      });
+                      loadProjects();
+                    }}
+                    onArchiveProject={async (id) => {
+                      await apiCall(`/projects/${id}`, {
+                        method: "PUT",
+                        body: JSON.stringify({ archived: true }),
+                      });
+                      handleSelectProject(null);
+                      loadProjects();
+                    }}
+                    onDeleteProject={async (id) => {
+                      await apiCall(`/projects/${id}?taskDisposition=unsorted`, {
+                        method: "DELETE",
+                      });
+                      handleSelectProject(null);
+                      loadProjects();
+                    }}
                   />
                 </ViewRoute>
               )}

--- a/client-react/src/components/projects/EditableTitle.test.tsx
+++ b/client-react/src/components/projects/EditableTitle.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { EditableTitle } from "./EditableTitle";
+
+describe("EditableTitle", () => {
+  it("renders title text by default", () => {
+    render(<EditableTitle value="My Project" onSave={vi.fn()} />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("My Project");
+  });
+
+  it("enters edit mode on click", () => {
+    render(<EditableTitle value="My Project" onSave={vi.fn()} />);
+    fireEvent.click(screen.getByRole("heading", { level: 1 }));
+    expect(screen.getByRole("textbox")).toHaveValue("My Project");
+  });
+
+  it("saves on Enter", () => {
+    const onSave = vi.fn();
+    render(<EditableTitle value="My Project" onSave={onSave} />);
+    fireEvent.click(screen.getByRole("heading", { level: 1 }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Renamed" } });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    expect(onSave).toHaveBeenCalledWith("Renamed");
+  });
+
+  it("cancels on Escape", () => {
+    const onSave = vi.fn();
+    render(<EditableTitle value="My Project" onSave={onSave} />);
+    fireEvent.click(screen.getByRole("heading", { level: 1 }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Renamed" } });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("My Project");
+  });
+
+  it("saves on blur", () => {
+    const onSave = vi.fn();
+    render(<EditableTitle value="My Project" onSave={onSave} />);
+    fireEvent.click(screen.getByRole("heading", { level: 1 }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Renamed" } });
+    fireEvent.blur(screen.getByRole("textbox"));
+    expect(onSave).toHaveBeenCalledWith("Renamed");
+  });
+
+  it("does not save empty name", () => {
+    const onSave = vi.fn();
+    render(<EditableTitle value="My Project" onSave={onSave} />);
+    fireEvent.click(screen.getByRole("heading", { level: 1 }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("supports controlled editing prop", () => {
+    render(<EditableTitle value="My Project" onSave={vi.fn()} editing={true} />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+});

--- a/client-react/src/components/projects/EditableTitle.tsx
+++ b/client-react/src/components/projects/EditableTitle.tsx
@@ -1,0 +1,80 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+
+interface Props {
+  value: string;
+  onSave: (newValue: string) => void;
+  editing?: boolean;
+  onEditingChange?: (editing: boolean) => void;
+  className?: string;
+}
+
+export function EditableTitle({ value, onSave, editing: externalEditing, onEditingChange, className }: Props) {
+  const [internalEditing, setInternalEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const isEditing = externalEditing ?? internalEditing;
+  const setIsEditing = useCallback(
+    (val: boolean) => {
+      if (onEditingChange) onEditingChange(val);
+      else setInternalEditing(val);
+    },
+    [onEditingChange],
+  );
+
+  useEffect(() => {
+    if (isEditing) {
+      setDraft(value);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    }
+  }, [isEditing, value]);
+
+  const handleSave = useCallback(() => {
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== value) {
+      onSave(trimmed);
+    }
+    setIsEditing(false);
+  }, [draft, value, onSave, setIsEditing]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setDraft(value);
+        setIsEditing(false);
+      }
+    },
+    [handleSave, value, setIsEditing],
+  );
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        className={`${className || "project-workspace__title"} project-workspace__title--editing`}
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleSave}
+        aria-label="Project name"
+      />
+    );
+  }
+
+  return (
+    <h1
+      className={`${className || "project-workspace__title"} project-workspace__title--editable`}
+      onClick={() => setIsEditing(true)}
+    >
+      {value}
+    </h1>
+  );
+}

--- a/client-react/src/components/projects/ProjectKebabMenu.test.tsx
+++ b/client-react/src/components/projects/ProjectKebabMenu.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ProjectKebabMenu } from "./ProjectKebabMenu";
+
+const defaultProps = {
+  onRename: vi.fn(),
+  onArchive: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe("ProjectKebabMenu", () => {
+  it("renders kebab trigger button", () => {
+    render(<ProjectKebabMenu {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /project actions/i })).toBeInTheDocument();
+  });
+
+  it("opens menu on click", () => {
+    render(<ProjectKebabMenu {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    expect(screen.getByRole("menuitem", { name: /rename/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /archive/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it("closes on Escape", () => {
+    render(<ProjectKebabMenu {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menuitem", { name: /rename/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onRename and closes", () => {
+    const onRename = vi.fn();
+    render(<ProjectKebabMenu {...defaultProps} onRename={onRename} />);
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /rename/i }));
+    expect(onRename).toHaveBeenCalled();
+    expect(screen.queryByRole("menuitem", { name: /rename/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onArchive and closes", () => {
+    const onArchive = vi.fn();
+    render(<ProjectKebabMenu {...defaultProps} onArchive={onArchive} />);
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /archive/i }));
+    expect(onArchive).toHaveBeenCalled();
+  });
+
+  it("shows confirmation on delete click", () => {
+    const onDelete = vi.fn();
+    render(<ProjectKebabMenu {...defaultProps} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.getByText(/tasks will become unsorted/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm delete/i })).toBeInTheDocument();
+  });
+
+  it("calls onDelete after confirmation", () => {
+    const onDelete = vi.fn();
+    render(<ProjectKebabMenu {...defaultProps} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole("button", { name: /project actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /delete/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/client-react/src/components/projects/ProjectKebabMenu.tsx
+++ b/client-react/src/components/projects/ProjectKebabMenu.tsx
@@ -1,0 +1,116 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { IconKebab } from "../shared/Icons";
+
+interface Props {
+  onRename: () => void;
+  onArchive: () => void;
+  onDelete: () => void;
+}
+
+export function ProjectKebabMenu({ onRename, onArchive, onDelete }: Props) {
+  const [open, setOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setConfirmingDelete(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
+      ) {
+        close();
+      }
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open, close]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        close();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, close]);
+
+  return (
+    <div className="project-kebab" ref={panelRef}>
+      <button
+        ref={triggerRef}
+        className="project-kebab__trigger"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Project actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <IconKebab size={16} />
+      </button>
+      {open && (
+        <div className="project-kebab__menu" role="menu">
+          <button
+            className="project-kebab__item"
+            role="menuitem"
+            onClick={() => {
+              onRename();
+              close();
+            }}
+            aria-label="Rename"
+          >
+            Rename
+          </button>
+          <button
+            className="project-kebab__item"
+            role="menuitem"
+            onClick={() => {
+              onArchive();
+              close();
+            }}
+            aria-label="Archive"
+          >
+            Archive
+          </button>
+          {!confirmingDelete ? (
+            <button
+              className="project-kebab__item project-kebab__item--danger"
+              role="menuitem"
+              onClick={() => setConfirmingDelete(true)}
+              aria-label="Delete"
+            >
+              Delete
+            </button>
+          ) : (
+            <div className="project-kebab__confirm">
+              <p className="project-kebab__confirm-text">
+                Delete project? Tasks will become unsorted.
+              </p>
+              <button
+                className="project-kebab__confirm-btn"
+                onClick={() => {
+                  onDelete();
+                  close();
+                }}
+                aria-label="Confirm delete"
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-react/src/components/projects/ProjectWorkspaceView.test.tsx
+++ b/client-react/src/components/projects/ProjectWorkspaceView.test.tsx
@@ -142,6 +142,9 @@ function renderWorkspace({
       sortBy="order"
       sortOrder="asc"
       onSortChange={vi.fn()}
+      onRenameProject={vi.fn()}
+      onArchiveProject={vi.fn()}
+      onDeleteProject={vi.fn()}
     />,
   );
 }

--- a/client-react/src/components/projects/ProjectWorkspaceView.tsx
+++ b/client-react/src/components/projects/ProjectWorkspaceView.tsx
@@ -24,6 +24,8 @@ import { QuickEntry } from "../todos/QuickEntry";
 import { BulkToolbar } from "../todos/BulkToolbar";
 import { FilterPanel, type ActiveFilters } from "../todos/FilterPanel";
 import { ProjectHeadings } from "./ProjectHeadings";
+import { EditableTitle } from "./EditableTitle";
+import { ProjectKebabMenu } from "./ProjectKebabMenu";
 import { SortableTodoList } from "../todos/SortableTodoList";
 import { useGroupBy } from "../../hooks/useGroupBy";
 import { useDensity } from "../../hooks/useDensity";
@@ -113,6 +115,9 @@ interface Props {
   onSortChange: (field: SortField, order: SortOrder) => void;
   onDeferTask?: (todo: Todo) => Promise<void>;
   onReplaceNext?: () => void;
+  onRenameProject: (id: string, newName: string) => void;
+  onArchiveProject: (id: string) => void;
+  onDeleteProject: (id: string) => void;
 }
 
 function formatSectionName(name: string) {
@@ -323,9 +328,13 @@ export function ProjectWorkspaceView({
   onSortChange,
   onDeferTask,
   onReplaceNext,
+  onRenameProject,
+  onArchiveProject,
+  onDeleteProject,
 }: Props) {
   const [workspaceMode, setWorkspaceMode] = useState<WorkspaceMode>("overview");
   const [insightsOpen, setInsightsOpen] = useState(false);
+  const [titleEditing, setTitleEditing] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { groupBy, setGroupBy } = useGroupBy();
   const { density, setDensity } = useDensity();
@@ -561,7 +570,12 @@ export function ProjectWorkspaceView({
           <div className="project-workspace__hero-copy">
             <span className="project-workspace__eyebrow">Project</span>
             <div className="project-workspace__title-row">
-              <h1 className="project-workspace__title">{project.name}</h1>
+              <EditableTitle
+                value={project.name}
+                onSave={(newName) => onRenameProject(project.id, newName)}
+                editing={titleEditing}
+                onEditingChange={setTitleEditing}
+              />
               <div
                 className="project-complexity-badge"
                 style={{
@@ -574,6 +588,11 @@ export function ProjectWorkspaceView({
                   {COMPLEXITY_LABELS[overviewProfile.mode]}
                 </span>
               </div>
+              <ProjectKebabMenu
+                onRename={() => setTitleEditing(true)}
+                onArchive={() => onArchiveProject(project.id)}
+                onDelete={() => onDeleteProject(project.id)}
+              />
             </div>
             <p className="project-workspace__summary">
               {project.description?.trim() ||

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -3809,6 +3809,129 @@ body {
   color: var(--text-strong);
 }
 
+/* ── Project Editable Title ────────────────── */
+
+.project-workspace__title--editable {
+  cursor: text;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--dur-fast) ease;
+}
+
+.project-workspace__title--editable:hover {
+  border-bottom-color: var(--border);
+}
+
+.project-workspace__title--editing {
+  font-size: inherit;
+  font-weight: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  color: inherit;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid var(--accent);
+  outline: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+
+/* ── Project Kebab Menu ────────────────────── */
+
+.project-kebab {
+  position: relative;
+}
+
+.project-kebab__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s-1h);
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--dur-fast) ease, background var(--dur-fast) ease;
+}
+
+.project-workspace__title-row:hover .project-kebab__trigger,
+.project-kebab__trigger:focus-visible,
+.project-kebab__trigger[aria-expanded="true"] {
+  opacity: 1;
+}
+
+.project-kebab__trigger:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.project-kebab__menu {
+  position: absolute;
+  top: calc(100% + var(--s-1));
+  right: 0;
+  min-width: 160px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-elevated);
+  z-index: 200;
+  overflow: hidden;
+  animation: viewMenuIn var(--dur-base) var(--ease-spring);
+}
+
+.project-kebab__item {
+  display: block;
+  width: 100%;
+  padding: var(--s-2) var(--s-3);
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: var(--fs-label);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.project-kebab__item:hover {
+  background: var(--surface-2);
+}
+
+.project-kebab__item--danger {
+  color: var(--danger);
+}
+
+.project-kebab__item--danger:hover {
+  background: color-mix(in oklab, var(--danger) 8%, transparent);
+}
+
+.project-kebab__confirm {
+  padding: var(--s-2) var(--s-3);
+  border-top: 1px solid var(--border-light);
+}
+
+.project-kebab__confirm-text {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin: 0 0 var(--s-2);
+}
+
+.project-kebab__confirm-btn {
+  padding: var(--s-1) var(--s-3);
+  border: none;
+  border-radius: var(--r-sm);
+  background: var(--danger);
+  color: white;
+  font-size: var(--fs-label);
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.project-kebab__confirm-btn:hover {
+  opacity: 0.9;
+}
+
 .project-workspace__summary {
   font-size: var(--fs-body-lg);
   color: color-mix(in oklab, var(--text) 84%, var(--surface));


### PR DESCRIPTION
## Summary

- Adds **click-to-edit project title** — click the `<h1>` to rename inline (Enter saves, Escape cancels, blur saves)
- Adds **kebab menu (⋯)** in the project header with Rename, Archive, and Delete actions
- Delete shows **inline confirmation** before executing ("Tasks will become unsorted")
- After archive/delete, navigates back to workspace view and refreshes sidebar

## What changed

**New components:**
- `EditableTitle.tsx` — reusable click-to-edit heading with controlled/uncontrolled mode (7 tests)
- `ProjectKebabMenu.tsx` — dropdown with rename/archive/delete + delete confirmation (7 tests)

**Modified:**
- `ProjectWorkspaceView.tsx` — replaced static `<h1>` with `EditableTitle`, added `ProjectKebabMenu` in title row, new props for rename/archive/delete callbacks
- `AppShell.tsx` — threads rename (PUT), archive (PUT), delete (DELETE) API handlers to ProjectWorkspaceView, calls `loadProjects()` after each action

**Styles:** Editable title hover cues (cursor: text, underline), kebab trigger hidden-until-hover, dropdown menu, danger styling for delete, inline confirmation

## Test plan

- [x] 14 new unit tests (EditableTitle: 7, ProjectKebabMenu: 7)
- [x] 121 UI tests pass (0 failures)
- [x] Typecheck, format, architecture, CSS lint all pass
- [ ] Manual: click project title → input appears, type new name, Enter saves
- [ ] Manual: click ⋯ → Rename/Archive/Delete menu appears
- [ ] Manual: Delete → confirmation → executes and navigates back
- [ ] Manual: Archive → navigates back, project removed from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)