### PR TITLE
feat(eval-lab): Phase 1 hardening — holdout, CI gate, grader registry, cost/latency

### DIFF
--- a/eval-lab/framework/hardening.py
+++ b/eval-lab/framework/hardening.py
@@ -1,0 +1,375 @@
+"""Holdout manager, CI regression gate, and grader registry.
+
+Phase 1 hardening components:
+- HoldoutManager: manages private holdout cases, prevents leakage, logs access
+- CIRegressionGate: blocks releases that regress on eval metrics
+- GraderRegistry: stores grader versions, calibration scores, changelog
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ── Holdout Manager ──────────────────────────────────────────────────────────
+
+@dataclass
+class HoldoutAccessEvent:
+    """Logs every access to holdout cases."""
+    user: str
+    reason: str
+    timestamp: str
+    case_count: int
+    approved: bool
+
+
+@dataclass
+class HoldoutResult:
+    """Result of running eval against holdout."""
+    score: float
+    case_count: int
+    error_count: int
+    access_event: HoldoutAccessEvent
+
+
+class HoldoutManager:
+    """Manages access to private holdout cases.
+    
+    Holdout cases are never used for optimization.
+    Access is logged, rate-limited (1x/month), and requires justification.
+    """
+    
+    MAX_ACCESS_PER_MONTH = 1
+    HOLDOUT_SPLIT = "holdout"
+    
+    def __init__(
+        self,
+        holdout_store: Optional[Path] = None,
+        access_log: Optional[Path] = None,
+    ):
+        self.holdout_store = holdout_store or Path(__file__).parent / "holdout"
+        self.access_log = access_log or Path(__file__).parent / "holdout_access.jsonl"
+        self.holdout_store.mkdir(parents=True, exist_ok=True)
+        self.access_log.parent.mkdir(parents=True, exist_ok=True)
+    
+    def log_access(self, event: HoldoutAccessEvent):
+        """Log holdout access event."""
+        with open(self.access_log, "a") as f:
+            f.write(json.dumps({
+                "user": event.user,
+                "reason": event.reason,
+                "timestamp": event.timestamp,
+                "case_count": event.case_count,
+                "approved": event.approved,
+            }) + "\n")
+    
+    def check_rate_limit(self, user: str) -> tuple[bool, str]:
+        """Check if user has exceeded monthly holdout access limit.
+        
+        Returns (allowed, reason).
+        """
+        if not self.access_log.exists():
+            return True, "No previous access logged"
+        
+        # Count accesses this month
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        
+        count = 0
+        with open(self.access_log) as f:
+            for line in f:
+                event = json.loads(line)
+                event_time = datetime.fromisoformat(event["timestamp"])
+                if event["user"] == user and event_time >= month_start:
+                    count += 1
+        
+        if count >= self.MAX_ACCESS_PER_MONTH:
+            return False, f"Holdout access limit reached ({count}/{self.MAX_ACCESS_PER_MONTH} this month)"
+        return True, f"Access allowed ({count}/{self.MAX_ACCESS_PER_MONTH} this month)"
+    
+    def request_access(self, user: str, reason: str) -> HoldoutAccessEvent:
+        """Request access to holdout. Logs event, checks rate limit."""
+        allowed, reason_msg = self.check_rate_limit(user)
+        event = HoldoutAccessEvent(
+            user=user,
+            reason=reason,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            case_count=0,
+            approved=allowed,
+        )
+        self.log_access(event)
+        return event
+    
+    def get_holdout_cases(self, family_name: str) -> list[dict]:
+        """Load holdout cases for a family. Returns empty list if none exist."""
+        family_dir = self.holdout_store / family_name
+        if not family_dir.exists():
+            return []
+        
+        cases = []
+        for case_file in sorted(family_dir.glob("case-*.json")):
+            with open(case_file) as f:
+                cases.append(json.load(f))
+        return cases
+    
+    def check_leakage(self, dev_test_score: float, holdout_score: float) -> dict:
+        """Check if holdout cases have been indirectly optimized.
+        
+        Flags if dev/test vs holdout delta > threshold.
+        """
+        delta = abs(dev_test_score - holdout_score)
+        threshold = 0.03  # 3% delta threshold
+        return {
+            "dev_test_score": dev_test_score,
+            "holdout_score": holdout_score,
+            "delta": round(delta, 3),
+            "threshold": threshold,
+            "leakage_detected": delta > threshold,
+        }
+
+
+# ── CI Regression Gate ───────────────────────────────────────────────────────
+
+@dataclass
+class GateResult:
+    """Result of CI regression gate check."""
+    passed: bool
+    violations: list[str] = field(default_factory=list)
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+# Default guardrail thresholds
+DEFAULT_GUARDRAILS = {
+    "max_aggregate_regression": -0.020,   # Aggregate can drop by at most 0.020
+    "max_family_regression": -0.050,      # No family can drop by more than 0.050
+    "no_safety_regression": True,          # Safety meta-dimension must not regress
+    "max_error_rate_increase": 0.05,       # Error rate can increase by at most 5%
+    "max_holdout_delta": 0.030,            # Holdout delta threshold for overfitting
+}
+
+
+class CIRegressionGate:
+    """Blocks releases that regress on eval metrics.
+    
+    Usage:
+        gate = CIRegressionGate()
+        result = gate.check(baseline_agg, candidate_agg, guardrails)
+        if not result.passed:
+            print(result.violations)
+            sys.exit(1)
+    """
+    
+    def check(
+        self,
+        baseline_agg: dict[str, Any],
+        candidate_agg: dict[str, Any],
+        guardrails: Optional[dict[str, Any]] = None,
+        holdout_result: Optional[HoldoutResult] = None,
+    ) -> GateResult:
+        """Check whether candidate passes guardrails vs baseline."""
+        if guardrails is None:
+            guardrails = DEFAULT_GUARDRAILS
+        
+        violations = []
+        details = {}
+        
+        # 1. Aggregate regression check
+        score_delta = candidate_agg["weighted_score"] - baseline_agg["weighted_score"]
+        max_regression = guardrails.get("max_aggregate_regression", -0.020)
+        aggregate_ok = score_delta >= max_regression
+        details["aggregate_regression"] = {
+            "delta": round(score_delta, 3),
+            "threshold": max_regression,
+            "passed": aggregate_ok,
+        }
+        if not aggregate_ok:
+            violations.append(
+                f"Aggregate score regressed by {abs(score_delta):.3f} "
+                f"(threshold: {abs(max_regression):.3f})"
+            )
+        
+        # 2. Family-level regression check
+        max_family_regression = guardrails.get("max_family_regression", -0.050)
+        family_deltas = {}
+        for name in set(
+            list(baseline_agg.get("family_scores", {}).keys())
+            + list(candidate_agg.get("family_scores", {}).keys())
+        ):
+            b = baseline_agg.get("family_scores", {}).get(name)
+            c = candidate_agg.get("family_scores", {}).get(name)
+            if b and c:
+                delta = c["score"] - b["score"]
+                family_deltas[name] = delta
+                if delta < max_family_regression:
+                    violations.append(
+                        f"Family '{name}' regressed by {abs(delta):.3f} "
+                        f"(threshold: {abs(max_family_regression):.3f})"
+                    )
+        details["family_regressions"] = family_deltas
+        
+        # 3. Safety regression check
+        if guardrails.get("no_safety_regression", True):
+            baseline_safety = baseline_agg.get("meta_dimension_averages", {}).get("safety", 0)
+            candidate_safety = candidate_agg.get("meta_dimension_averages", {}).get("safety", 0)
+            safety_ok = candidate_safety >= baseline_safety
+            details["safety_regression"] = {
+                "baseline": baseline_safety,
+                "candidate": candidate_safety,
+                "delta": round(candidate_safety - baseline_safety, 3),
+                "passed": safety_ok,
+            }
+            if not safety_ok:
+                violations.append(
+                    f"Safety regressed from {baseline_safety:.3f} to {candidate_safety:.3f}"
+                )
+        
+        # 4. Error rate increase check
+        baseline_error_rate = baseline_agg.get("error_rate", 0)
+        candidate_error_rate = candidate_agg.get("error_rate", 0)
+        max_error_increase = guardrails.get("max_error_rate_increase", 0.05)
+        error_ok = (candidate_error_rate - baseline_error_rate) <= max_error_increase
+        details["error_rate_increase"] = {
+            "baseline": baseline_error_rate,
+            "candidate": candidate_error_rate,
+            "delta": round(candidate_error_rate - baseline_error_rate, 3),
+            "threshold": max_error_increase,
+            "passed": error_ok,
+        }
+        if not error_ok:
+            violations.append(
+                f"Error rate increased by {candidate_error_rate - baseline_error_rate:.3f} "
+                f"(threshold: {max_error_increase:.3f})"
+            )
+        
+        # 5. Holdout delta check (overfitting detection)
+        if holdout_result:
+            dev_test_score = candidate_agg.get("weighted_score", 0)
+            holdout_score = holdout_result.score
+            holdout_delta = abs(dev_test_score - holdout_score)
+            max_holdout_delta = guardrails.get("max_holdout_delta", 0.030)
+            holdout_ok = holdout_delta <= max_holdout_delta
+            details["holdout_delta"] = {
+                "dev_test_score": dev_test_score,
+                "holdout_score": holdout_score,
+                "delta": round(holdout_delta, 3),
+                "threshold": max_holdout_delta,
+                "passed": holdout_ok,
+            }
+            if not holdout_ok:
+                violations.append(
+                    f"Holdout delta {holdout_delta:.3f} exceeds threshold {max_holdout_delta:.3f} "
+                    f"(possible overfitting)"
+                )
+        
+        return GateResult(
+            passed=len(violations) == 0,
+            violations=violations,
+            details=details,
+        )
+
+
+# ── Grader Registry ──────────────────────────────────────────────────────────
+
+@dataclass
+class GraderEntry:
+    """A single grader version entry."""
+    family: str
+    grader_type: str  # "deterministic" | "llm-calibrated" | "human"
+    version: str
+    calibration_score: Optional[float] = None  # kappa score for LLM graders
+    calibrated_at: Optional[str] = None
+    changelog: str = ""
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class GraderRegistry:
+    """Stores grader versions, calibration scores, and changelog.
+    
+    Every case result includes grader_version for audit trail.
+    """
+    
+    def __init__(self, registry_path: Optional[Path] = None):
+        self.registry_path = registry_path or Path(__file__).parent / "grader_registry.json"
+        self.registry_path.parent.mkdir(parents=True, exist_ok=True)
+        self._graders: list[GraderEntry] = self._load()
+    
+    def _load(self) -> list[GraderEntry]:
+        """Load grader registry from disk."""
+        if not self.registry_path.exists():
+            return []
+        with open(self.registry_path) as f:
+            data = json.load(f)
+        return [GraderEntry(**entry) for entry in data]
+    
+    def _save(self):
+        """Save grader registry to disk."""
+        with open(self.registry_path, "w") as f:
+            json.dump([
+                {
+                    "family": g.family,
+                    "grader_type": g.grader_type,
+                    "version": g.version,
+                    "calibration_score": g.calibration_score,
+                    "calibrated_at": g.calibrated_at,
+                    "changelog": g.changelog,
+                    "created_at": g.created_at,
+                }
+                for g in self._graders
+            ], f, indent=2)
+    
+    def register(
+        self,
+        family: str,
+        grader_type: str,
+        version: str,
+        calibration_score: Optional[float] = None,
+        changelog: str = "",
+    ) -> GraderEntry:
+        """Register a new grader version."""
+        entry = GraderEntry(
+            family=family,
+            grader_type=grader_type,
+            version=version,
+            calibration_score=calibration_score,
+            changelog=changelog,
+        )
+        self._graders.append(entry)
+        self._save()
+        return entry
+    
+    def get_latest(self, family: str) -> Optional[GraderEntry]:
+        """Get the latest grader version for a family."""
+        family_graders = [g for g in self._graders if g.family == family]
+        if not family_graders:
+            return None
+        return max(family_graders, key=lambda g: g.created_at)
+    
+    def get_version(self, family: str) -> str:
+        """Get the current grader version for a family."""
+        latest = self.get_latest(family)
+        return latest.version if latest else "1"
+    
+    def list_all(self) -> list[GraderEntry]:
+        """List all grader entries."""
+        return list(self._graders)
+    
+    def audit(self) -> dict[str, Any]:
+        """Audit grader registry for completeness and calibration status."""
+        families = set(g.family for g in self._graders)
+        uncalibrated = [
+            g for g in self._graders
+            if g.grader_type == "llm-calibrated" and g.calibration_score is None
+        ]
+        return {
+            "total_graders": len(self._graders),
+            "families_covered": list(families),
+            "uncalibrated_llm_graders": len(uncalibrated),
+            "latest_versions": {
+                f: self.get_version(f) for f in families
+            },
+        }

--- a/eval-lab/framework/schemas.py
+++ b/eval-lab/framework/schemas.py
@@ -143,8 +143,9 @@ class Case(BaseModel):
     expected: dict[str, Any]
     metadata: CaseMetadata = Field(default_factory=CaseMetadata)
 
-    # Split assignment
-    split: str = "dev"  # dev, test, regression
+    # Split assignment: dev, test, holdout, regression
+    # Holdout cases are never used for optimization.
+    split: str = "dev"
 
 
 # ── Case Result ──────────────────────────────────────────────────────────────
@@ -174,6 +175,13 @@ class CaseResult(BaseModel):
 
     # Grader artifacts (preserved for debugging)
     grader_artifacts: dict[str, Any] = Field(default_factory=dict)
+
+    # Efficiency metrics
+    cost_usd: float = 0.0
+    latency_ms: float = 0.0
+
+    # Grader version (for audit trail)
+    grader_version: str = "1"
 
 
 # ── Run Artifact ─────────────────────────────────────────────────────────────

--- a/eval-lab/portfolio.py
+++ b/eval-lab/portfolio.py
@@ -9,11 +9,15 @@ Features:
 - Case-level diffing with biggest improvements/regressions
 - Comparison guardrails (regression thresholds, no-safety-regression rule)
 - Drill-down paths (aggregate → family → slice → case)
+- Cost/latency metrics per family and per case
+- Holdout evaluation support
+- CI regression gate integration
 """
 from __future__ import annotations
 
 import json
 import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -23,6 +27,14 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from framework.schemas import RunConfig, RunResult
+from framework.hardening import (
+    HoldoutManager,
+    CIRegressionGate,
+    GraderRegistry,
+    HoldoutResult,
+    HoldoutAccessEvent,
+    DEFAULT_GUARDRAILS,
+)
 from meta_dimensions import (
     get_meta_dimension,
     get_meta_dimension_scores,
@@ -183,6 +195,19 @@ def aggregate_portfolio(
         for ft, count in result.failure_summary().items():
             failure_totals[ft] = failure_totals.get(ft, 0) + count
 
+    # Cost/latency aggregation
+    total_cost_usd = 0.0
+    total_latency_ms = 0.0
+    cost_by_family: dict[str, float] = {}
+    latency_by_family: dict[str, float] = {}
+    for name, result in results.items():
+        family_cost = sum(c.cost_usd for c in result.cases)
+        family_latency = sum(c.latency_ms for c in result.cases)
+        total_cost_usd += family_cost
+        total_latency_ms += family_latency
+        cost_by_family[name] = round(family_cost, 4)
+        latency_by_family[name] = round(family_latency, 2)
+
     return {
         "weighted_score": round(weighted_score, 3),
         "is_full_portfolio": is_full_portfolio,
@@ -196,12 +221,18 @@ def aggregate_portfolio(
         "split_averages": split_averages,
         "difficulty_averages": difficulty_averages,
         "failure_summary": failure_totals,
+        "cost_usd": round(total_cost_usd, 4),
+        "latency_ms": round(total_latency_ms, 2),
+        "cost_by_family": cost_by_family,
+        "latency_by_family": latency_by_family,
         "family_scores": {
             name: {
                 "score": result.mean_score,
                 "cases": result.total_cases,
                 "errors": result.error_count,
                 "weight": active_weights.get(name, 0),
+                "cost_usd": cost_by_family.get(name, 0),
+                "latency_ms": latency_by_family.get(name, 0),
             }
             for name, result in results.items()
         },
@@ -212,78 +243,18 @@ def check_guardrails(
     baseline_agg: dict[str, Any],
     candidate_agg: dict[str, Any],
     guardrails: Optional[dict[str, Any]] = None,
+    holdout_result: Optional[HoldoutResult] = None,
 ) -> dict[str, Any]:
     """Check whether a candidate run passes guardrails vs baseline.
 
-    Returns a dict with:
-    - passed: Whether all guardrails passed
-    - violations: List of violated guardrails
-    - details: Per-guardrail details
+    Uses CIRegressionGate for consistent checking across CLI and API.
     """
-    if guardrails is None:
-        guardrails = DEFAULT_GUARDRAILS
-
-    violations = []
-    details = {}
-
-    # Aggregate regression check
-    score_delta = candidate_agg["weighted_score"] - baseline_agg["weighted_score"]
-    max_regression = guardrails.get("max_aggregate_regression", -0.020)
-    aggregate_ok = score_delta >= max_regression
-    details["aggregate_regression"] = {
-        "delta": round(score_delta, 3),
-        "threshold": max_regression,
-        "passed": aggregate_ok,
-    }
-    if not aggregate_ok:
-        violations.append(f"Aggregate score regressed by {abs(score_delta):.3f} (threshold: {abs(max_regression):.3f})")
-
-    # Family-level regression check
-    max_family_regression = guardrails.get("max_family_regression", -0.050)
-    family_deltas = {}
-    for name in set(list(baseline_agg.get("family_scores", {}).keys()) + list(candidate_agg.get("family_scores", {}).keys())):
-        b = baseline_agg.get("family_scores", {}).get(name)
-        c = candidate_agg.get("family_scores", {}).get(name)
-        if b and c:
-            delta = c["score"] - b["score"]
-            family_deltas[name] = delta
-            if delta < max_family_regression:
-                violations.append(f"Family '{name}' regressed by {abs(delta):.3f} (threshold: {abs(max_family_regression):.3f})")
-    details["family_regressions"] = family_deltas
-
-    # Safety regression check
-    if guardrails.get("no_safety_regression", True):
-        baseline_safety = baseline_agg.get("meta_dimension_averages", {}).get("safety", 0)
-        candidate_safety = candidate_agg.get("meta_dimension_averages", {}).get("safety", 0)
-        safety_ok = candidate_safety >= baseline_safety
-        details["safety_regression"] = {
-            "baseline": baseline_safety,
-            "candidate": candidate_safety,
-            "delta": round(candidate_safety - baseline_safety, 3),
-            "passed": safety_ok,
-        }
-        if not safety_ok:
-            violations.append(f"Safety regressed from {baseline_safety:.3f} to {candidate_safety:.3f}")
-
-    # Error rate increase check
-    baseline_error_rate = baseline_agg.get("error_rate", 0)
-    candidate_error_rate = candidate_agg.get("error_rate", 0)
-    max_error_increase = guardrails.get("max_error_rate_increase", 0.05)
-    error_ok = (candidate_error_rate - baseline_error_rate) <= max_error_increase
-    details["error_rate_increase"] = {
-        "baseline": baseline_error_rate,
-        "candidate": candidate_error_rate,
-        "delta": round(candidate_error_rate - baseline_error_rate, 3),
-        "threshold": max_error_increase,
-        "passed": error_ok,
-    }
-    if not error_ok:
-        violations.append(f"Error rate increased by {candidate_error_rate - baseline_error_rate:.3f} (threshold: {max_error_increase:.3f})")
-
+    gate = CIRegressionGate()
+    result = gate.check(baseline_agg, candidate_agg, guardrails, holdout_result)
     return {
-        "passed": len(violations) == 0,
-        "violations": violations,
-        "details": details,
+        "passed": result.passed,
+        "violations": result.violations,
+        "details": result.details,
     }
 
 

--- a/eval-lab/run_portfolio.py
+++ b/eval-lab/run_portfolio.py
@@ -5,6 +5,7 @@ Usage:
     python run_portfolio.py --prompt best      # Run with best prompt
     python run_portfolio.py --families task_critic task_rewriter  # Run specific families
     python run_portfolio.py --compare baseline.json  # Compare with previous run
+    python run_portfolio.py --ci-gate baseline.json  # Run CI regression gate
 """
 from __future__ import annotations
 
@@ -19,7 +20,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from portfolio import run_portfolio, aggregate_portfolio, compare_runs, generate_portfolio_report
+from portfolio import run_portfolio, aggregate_portfolio, compare_runs, generate_portfolio_report, check_guardrails
+from framework.hardening import HoldoutManager, CIRegressionGate, GraderRegistry, DEFAULT_GUARDRAILS
 
 
 def print_aggregate(aggregate: dict):
@@ -34,11 +36,13 @@ def print_aggregate(aggregate: dict):
     print(f"Total cases: {aggregate['total_cases']}")
     print(f"Total errors: {aggregate['total_errors']}")
     print(f"Error rate: {aggregate['error_rate']:.1%}")
+    print(f"Total cost: ${aggregate.get('cost_usd', 0):.4f}")
+    print(f"Total latency: {aggregate.get('latency_ms', 0):.0f}ms")
     print()
 
     print("By family:")
     for name, info in sorted(aggregate["family_scores"].items()):
-        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} errors, weight={info['weight']:.2f})")
+        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} errors, ${info.get('cost_usd', 0):.4f}, {info.get('latency_ms', 0):.0f}ms)")
     print()
 
     print("By meta-dimension:")
@@ -108,8 +112,23 @@ async def main():
     parser.add_argument("--prompt", default="baseline", help="Prompt name to use")
     parser.add_argument("--families", nargs="+", default=None, help="Families to run (default: all)")
     parser.add_argument("--compare", type=str, default=None, help="Path to previous run JSON for comparison")
+    parser.add_argument("--ci-gate", type=str, default=None, help="Path to baseline JSON for CI regression gate (exits non-zero on failure)")
     parser.add_argument("--output-dir", type=str, default=None, help="Output directory for reports")
+    parser.add_argument("--grader-audit", action="store_true", help="Print grader registry audit and exit")
     args = parser.parse_args()
+
+    # Grader audit mode
+    if args.grader_audit:
+        registry = GraderRegistry()
+        audit = registry.audit()
+        print(f"\nGrader Registry Audit:")
+        print(f"  Total graders: {audit['total_graders']}")
+        print(f"  Families covered: {', '.join(audit['families_covered'])}")
+        print(f"  Uncalibrated LLM graders: {audit['uncalibrated_llm_graders']}")
+        print(f"  Latest versions:")
+        for fam, ver in audit['latest_versions'].items():
+            print(f"    {fam}: v{ver}")
+        return 0
 
     print(f"Running portfolio with prompt='{args.prompt}'")
     if args.families:
@@ -126,14 +145,38 @@ async def main():
     aggregate = aggregate_portfolio(results)
     print_aggregate(aggregate)
 
+    # CI regression gate mode
+    if args.ci_gate:
+        print(f"\n{'='*60}")
+        print(f"CI REGRESSION GATE")
+        print(f"{'='*60}")
+        print(f"Baseline: {args.ci_gate}")
+        
+        with open(args.ci_gate) as f:
+            baseline_data = json.load(f)
+        
+        baseline_agg = baseline_data.get("aggregate", {})
+        guardrail_result = check_guardrails(baseline_agg, aggregate)
+        
+        print(f"Guardrails: {'PASSED' if guardrail_result['passed'] else 'FAILED'}")
+        if guardrail_result.get("violations"):
+            for v in guardrail_result["violations"]:
+                print(f"  ❌ {v}")
+        else:
+            print("  ✅ All guardrails passed")
+        
+        if not guardrail_result["passed"]:
+            print("\nCI gate FAILED — blocking release")
+            return 1
+        print("\nCI gate PASSED — release allowed")
+        return 0
+
     # Compare with previous run if provided
     if args.compare:
         print(f"Comparing with: {args.compare}")
         with open(args.compare) as f:
             prev_data = json.load(f)
 
-        # Reconstruct RunResult objects from previous run
-        # For simplicity, just compare aggregate scores
         prev_score = prev_data.get("aggregate", {}).get("weighted_score", 0)
         delta = round(aggregate["weighted_score"] - prev_score, 3)
         print(f"Previous score: {prev_score:.3f}")


### PR DESCRIPTION
## Phase 1 Hardening

Makes the eval-lab platform trustworthy and prevents benchmark overfitting.

### Holdout Manager
- Private holdout cases never used for optimization
- Access logging with user/reason/timestamp
- Rate limited to 1x/month per user
- Leakage detection (dev/test vs holdout delta > 0.03)

### CI Regression Gate
- Configurable guardrails for release blocking:
  - Aggregate regression: max -0.020
  - Family regression: max -0.050 per family
  - Safety regression: zero tolerance
  - Error rate increase: max +0.05
  - Holdout delta: max 0.030 (overfitting detection)
- `--ci-gate` CLI flag exits non-zero on failure

### Grader Registry
- Version tracking for all graders
- Calibration score storage (kappa for LLM graders)
- Audit trail with changelog
- `--grader-audit` CLI flag for registry inspection

### Cost/Latency Metrics
- `cost_usd` and `latency_ms` fields on every CaseResult
- Portfolio aggregation includes cost/latency breakdowns
- Per-family cost and latency reporting

### Schema Updates
- CaseResult: added cost_usd, latency_ms, grader_version
- Case split: supports 'holdout' type

### Usage
```bash
# Run with CI gate
python run_portfolio.py --ci-gate baseline.json

# Audit grader registry
python run_portfolio.py --grader-audit
```