### PR TITLE
feat(eval-lab): Phase 2 trust completion — trusted_for_gating, explicit thresholds, grader coverage

### DIFF
--- a/eval-lab/calibrate.py
+++ b/eval-lab/calibrate.py
@@ -31,6 +31,19 @@ from framework.schemas import Case
 from portfolio import load_family
 
 
+# ── Calibration Thresholds ───────────────────────────────────────────────────
+
+# Explicit, machine-readable thresholds for trust assignment
+CALIBRATION_THRESHOLDS = {
+    "min_human_reviewers": 2,
+    "min_reviewed_cases": 10,
+    "min_human_agreement_kappa": 0.4,  # Tolerance-based reviewer agreement
+    "min_llm_vs_human_agreement": 0.6,  # Correlation between LLM and human scores
+    "max_grader_error_rate": 0.10,  # 10% max grader errors
+    "max_grader_error_rate_for_gating": 0.05,  # 5% max for gating trust
+}
+
+
 # ── Calibration Report ───────────────────────────────────────────────────────
 
 def generate_calibration_report(
@@ -39,12 +52,16 @@ def generate_calibration_report(
     llm_scores: list[dict[str, float]],
     llm_errors: list[Optional[str]],
     human_scores: list[dict[str, float]],
+    thresholds: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Generate a calibration report comparing LLM vs human grading."""
+    if thresholds is None:
+        thresholds = CALIBRATION_THRESHOLDS
+
     # Compute human agreement (tolerance-based)
     reviewers = set(a.reviewer for a in review_set.assignments if a.completed)
     reviewer_list = sorted(reviewers)
-    
+
     agreements = {}
     if len(reviewer_list) >= 2:
         for i in range(len(reviewer_list)):
@@ -52,52 +69,88 @@ def generate_calibration_report(
                 r1, r2 = reviewer_list[i], reviewer_list[j]
                 kappa = review_set.compute_kappa(r1, r2)
                 agreements[f"{r1}_vs_{r2}"] = kappa
-    
-    # Compare LLM vs human average
+
+    # Compare LLM vs human average and compute agreement
     llm_averages = {}
     human_averages = {}
+    llm_vs_human_agreement = 0.0
     if llm_scores and human_scores:
         # Average across all dimensions
         all_dims = set()
         for s in llm_scores + human_scores:
             all_dims.update(s.keys())
-        
+
         for dim in all_dims:
             llm_vals = [s.get(dim, 0) for s in llm_scores]
             human_vals = [s.get(dim, 0) for s in human_scores]
             llm_averages[dim] = round(sum(llm_vals) / len(llm_vals), 3) if llm_vals else 0
             human_averages[dim] = round(sum(human_vals) / len(human_vals), 3) if human_vals else 0
-    
+
+        # Compute LLM vs human agreement (tolerance-based: within 0.15)
+        total_comparisons = 0
+        agreements_count = 0
+        for llm_s, human_s in zip(llm_scores, human_scores):
+            for dim in all_dims:
+                llm_v = llm_s.get(dim, 0)
+                human_v = human_s.get(dim, 0)
+                total_comparisons += 1
+                if abs(llm_v - human_v) <= 0.15:
+                    agreements_count += 1
+        llm_vs_human_agreement = agreements_count / total_comparisons if total_comparisons > 0 else 0
+
     # LLM error rate
     llm_error_count = sum(1 for e in llm_errors if e is not None)
     llm_error_rate = llm_error_count / len(llm_errors) if llm_errors else 0
-    
-    # Trust recommendation
-    human_agreement_ok = all(v >= 0.4 for v in agreements.values()) if agreements else False
-    llm_error_rate_ok = llm_error_rate < 0.1  # Less than 10% grader errors
-    
-    if human_agreement_ok and llm_error_rate_ok:
+
+    # Trust recommendation with explicit thresholds
+    min_human_agreement = thresholds.get("min_human_agreement_kappa", 0.4)
+    min_llm_vs_human = thresholds.get("min_llm_vs_human_agreement", 0.6)
+    max_grader_error = thresholds.get("max_grader_error_rate", 0.10)
+    max_grader_error_gating = thresholds.get("max_grader_error_rate_for_gating", 0.05)
+    min_reviewed = thresholds.get("min_reviewed_cases", 10)
+
+    human_agreement_ok = all(v >= min_human_agreement for v in agreements.values()) if agreements else False
+    llm_vs_human_ok = llm_vs_human_agreement >= min_llm_vs_human
+    llm_error_rate_ok = llm_error_rate < max_grader_error
+    llm_error_rate_gating_ok = llm_error_rate < max_grader_error_gating
+    enough_reviews = len(review_set.get_reviewed_cases()) >= min_reviewed
+
+    # Trust progression:
+    # not_trusted → trusted_for_reporting → trusted_for_gating
+    if human_agreement_ok and llm_vs_human_ok and llm_error_rate_gating_ok and enough_reviews:
+        trust_level = "trusted_for_gating"
+    elif human_agreement_ok and llm_vs_human_ok and llm_error_rate_ok and enough_reviews:
         trust_level = "trusted_for_reporting"
     elif llm_error_rate_ok:
         trust_level = "not_yet_trusted"
     else:
         trust_level = "not_trusted"
-    
+
     return {
         "family": family_name,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "case_count": len(review_set.assignments),
+        "reviewed_cases": len(review_set.get_reviewed_cases()),
         "reviewers": reviewer_list,
         "human_agreement": agreements,
         "human_agreement_ok": human_agreement_ok,
+        "human_agreement_threshold": min_human_agreement,
+        "llm_vs_human_agreement": round(llm_vs_human_agreement, 3),
+        "llm_vs_human_agreement_ok": llm_vs_human_ok,
+        "llm_vs_human_threshold": min_llm_vs_human,
         "llm_error_rate": round(llm_error_rate, 3),
         "llm_error_rate_ok": llm_error_rate_ok,
+        "llm_error_rate_gating_ok": llm_error_rate_gating_ok,
+        "max_grader_error_rate": max_grader_error,
+        "max_grader_error_rate_for_gating": max_grader_error_gating,
         "llm_averages": llm_averages,
         "human_averages": human_averages,
         "trust_level": trust_level,
+        "thresholds_used": thresholds,
         "recommendation": (
             f"LLM grader is {trust_level.replace('_', ' ')} for {family_name}. "
             f"Human agreement: {agreements}. "
+            f"LLM vs human agreement: {llm_vs_human_agreement:.1%}. "
             f"LLM error rate: {llm_error_rate:.1%}."
         ),
     }

--- a/eval-lab/portfolio.py
+++ b/eval-lab/portfolio.py
@@ -208,13 +208,22 @@ def aggregate_portfolio(
     total_latency_ms = 0.0
     cost_by_family: dict[str, float] = {}
     latency_by_family: dict[str, float] = {}
+    coverage_by_family: dict[str, float] = {}
     for name, result in results.items():
         family_cost = sum(c.cost_usd for c in result.cases)
         family_latency = sum(c.latency_ms for c in result.cases)
+        family_grader_errors = sum(1 for c in result.cases if c.grader_error)
         total_cost_usd += family_cost
         total_latency_ms += family_latency
         cost_by_family[name] = round(family_cost, 4)
         latency_by_family[name] = round(family_latency, 2)
+        # Semantic coverage: % of cases successfully graded (no execution or grader errors)
+        valid_cases = sum(1 for c in result.cases if not c.error and not c.grader_error)
+        coverage_by_family[name] = round(valid_cases / result.total_cases, 3) if result.total_cases > 0 else 0.0
+
+    # Overall semantic coverage
+    total_valid_cases = total_cases - total_errors - total_grader_errors
+    semantic_coverage = round(total_valid_cases / total_cases, 3) if total_cases > 0 else 0.0
 
     return {
         "weighted_score": round(weighted_score, 3),
@@ -224,6 +233,7 @@ def aggregate_portfolio(
         "total_cases": total_cases,
         "total_errors": total_errors,
         "total_grader_errors": total_grader_errors,
+        "semantic_coverage": semantic_coverage,
         "error_rate": round(total_errors / total_cases, 3) if total_cases > 0 else 0.0,
         "grader_error_rate": round(total_grader_errors / total_cases, 3) if total_cases > 0 else 0.0,
         "meta_dimension_averages": meta_averages,
@@ -235,11 +245,14 @@ def aggregate_portfolio(
         "latency_ms": round(total_latency_ms, 2),
         "cost_by_family": cost_by_family,
         "latency_by_family": latency_by_family,
+        "coverage_by_family": coverage_by_family,
         "family_scores": {
             name: {
                 "score": result.mean_score,
                 "cases": result.total_cases,
                 "errors": result.error_count,
+                "grader_errors": sum(1 for c in result.cases if c.grader_error),
+                "coverage": coverage_by_family.get(name, 0),
                 "weight": active_weights.get(name, 0),
                 "cost_usd": cost_by_family.get(name, 0),
                 "latency_ms": latency_by_family.get(name, 0),

--- a/eval-lab/run_portfolio.py
+++ b/eval-lab/run_portfolio.py
@@ -35,14 +35,17 @@ def print_aggregate(aggregate: dict):
     print(f"Weighted score: {aggregate['weighted_score']:.3f}")
     print(f"Total cases: {aggregate['total_cases']}")
     print(f"Total errors: {aggregate['total_errors']}")
+    print(f"Grader errors: {aggregate.get('total_grader_errors', 0)}")
+    print(f"Semantic coverage: {aggregate.get('semantic_coverage', 0):.1%}")
     print(f"Error rate: {aggregate['error_rate']:.1%}")
+    print(f"Grader error rate: {aggregate.get('grader_error_rate', 0):.1%}")
     print(f"Total cost: ${aggregate.get('cost_usd', 0):.4f}")
     print(f"Total latency: {aggregate.get('latency_ms', 0):.0f}ms")
     print()
 
     print("By family:")
     for name, info in sorted(aggregate["family_scores"].items()):
-        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} errors, ${info.get('cost_usd', 0):.4f}, {info.get('latency_ms', 0):.0f}ms)")
+        print(f"  {name}: {info['score']:.3f} ({info['cases']} cases, {info['errors']} exec errors, {info.get('grader_errors', 0)} grader errors, {info.get('coverage', 0):.1%} coverage, ${info.get('cost_usd', 0):.4f}, {info.get('latency_ms', 0):.0f}ms)")
     print()
 
     print("By meta-dimension:")


### PR DESCRIPTION
## Phase 2 Trust Completion

Completes the evaluator trustworthiness layer with explicit thresholds and coverage tracking.

### Trust Level Improvements
- **trusted_for_gating**: New distinct trust level (stricter than trusted_for_reporting)
- **Trust progression**: not_trusted → not_yet_trusted → trusted_for_reporting → trusted_for_gating
- **Explicit thresholds**: Machine-readable calibration thresholds in `CALIBRATION_THRESHOLDS` dict
- **LLM vs human agreement**: New metric (tolerance-based: within 0.15)
- **Auditable**: All thresholds documented in calibration reports

### Grader Coverage Metrics
- **semantic_coverage**: % of cases successfully graded (no execution or grader errors)
- **coverage_by_family**: Per-family coverage breakdown
- **family_scores**: Now include grader_errors and coverage fields
- **CLI display**: Shows exec errors, grader errors, coverage % per family

### Key Thresholds
| Threshold | Value | Purpose |
|-----------|-------|---------|
| min_human_agreement_kappa | 0.4 | Tolerance-based reviewer agreement |
| min_llm_vs_human_agreement | 0.6 | LLM vs human score agreement |
| max_grader_error_rate | 0.10 | 10% max for reporting trust |
| max_grader_error_rate_for_gating | 0.05 | 5% max for gating trust |
| min_reviewed_cases | 10 | Minimum cases for trust assignment |

### Usage
```bash
# Calibration report now includes all thresholds and agreement metrics
python calibrate.py --family structured_extraction --reviewers alice bob --sample-size 10

# Portfolio output includes semantic_coverage and coverage_by_family
python run_portfolio.py
```