### PR TITLE
feat(eval-lab): Phase 3 operationalization — production ingestion, nightly runner, CI grader threshold

### DIFF
--- a/eval-lab/framework/hardening.py
+++ b/eval-lab/framework/hardening.py
@@ -150,6 +150,7 @@ DEFAULT_GUARDRAILS = {
     "no_safety_regression": True,          # Safety meta-dimension must not regress
     "max_error_rate_increase": 0.05,       # Error rate can increase by at most 5%
     "max_holdout_delta": 0.030,            # Holdout delta threshold for overfitting
+    "max_grader_error_rate": 0.10,         # Grader error rate must be < 10%
 }
 
 
@@ -265,7 +266,21 @@ class CIRegressionGate:
                     f"Holdout delta {holdout_delta:.3f} exceeds threshold {max_holdout_delta:.3f} "
                     f"(possible overfitting)"
                 )
-        
+
+        # 6. Grader error rate check
+        max_grader_error_rate = guardrails.get("max_grader_error_rate", 0.10)
+        candidate_grader_error_rate = candidate_agg.get("grader_error_rate", 0)
+        grader_error_ok = candidate_grader_error_rate <= max_grader_error_rate
+        details["grader_error_rate"] = {
+            "candidate": candidate_grader_error_rate,
+            "threshold": max_grader_error_rate,
+            "passed": grader_error_ok,
+        }
+        if not grader_error_ok:
+            violations.append(
+                f"Grader error rate {candidate_grader_error_rate:.1%} exceeds threshold {max_grader_error_rate:.1%}"
+            )
+
         return GateResult(
             passed=len(violations) == 0,
             violations=violations,

--- a/eval-lab/ingest.py
+++ b/eval-lab/ingest.py
@@ -1,0 +1,256 @@
+"""Production failure ingestion pipeline.
+
+Accepts failure reports from production (support tickets, error logs, user complaints),
+converts them to eval case format, and queues them for review.
+
+Usage:
+    python ingest.py --source support_ticket --file ticket.json
+    python ingest.py --source error_log --file errors.jsonl
+    python ingest.py --list  # List queued cases for review
+    python ingest.py --approve case-001 --family structured_extraction
+    python ingest.py --reject case-001 --reason "not reproducible"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ── Ingestion Data Models ────────────────────────────────────────────────────
+
+@dataclass
+class FailureReport:
+    """A failure report from production."""
+    source: str  # "support_ticket", "error_log", "user_complaint"
+    source_text: str  # The raw text describing the failure
+    expected_output: Optional[dict[str, Any]] = None
+    actual_output: Optional[dict[str, Any]] = None
+    failure_type: str = "unknown"
+    severity: str = "medium"  # "low", "medium", "high", "critical"
+    affected_users: int = 1
+    metadata: dict[str, Any] = field(default_factory=dict)
+    reported_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+@dataclass
+class IngestedCase:
+    """A failure report converted to eval case format."""
+    case_id: str
+    family: str  # Suggested family (heuristic)
+    input_data: dict[str, Any]
+    expected_data: dict[str, Any]
+    source: str
+    severity: str
+    affected_users: int
+    status: str = "queued"  # "queued", "approved", "rejected"
+    review_notes: str = ""
+    ingested_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+# ── Ingestion Pipeline ───────────────────────────────────────────────────────
+
+class IngestionPipeline:
+    """Manages production failure ingestion and review queue."""
+    
+    def __init__(self, queue_dir: Optional[Path] = None):
+        self.queue_dir = queue_dir or Path(__file__).parent / "ingestion_queue"
+        self.queue_dir.mkdir(parents=True, exist_ok=True)
+    
+    def ingest(self, report: FailureReport) -> IngestedCase:
+        """Convert a failure report to eval case format and queue for review."""
+        # Heuristic: suggest family based on source text keywords
+        family = self._suggest_family(report.source_text)
+        
+        # Create eval case
+        case = IngestedCase(
+            case_id=f"ingest-{uuid.uuid4().hex[:8]}",
+            family=family,
+            input_data={"source_text": report.source_text, "source_type": report.source},
+            expected_data={"expected_tasks": report.expected_output or []},
+            source=report.source,
+            severity=report.severity,
+            affected_users=report.affected_users,
+        )
+        
+        # Save to queue
+        case_path = self.queue_dir / f"{case.case_id}.json"
+        with open(case_path, "w") as f:
+            json.dump({
+                "case_id": case.case_id,
+                "family": case.family,
+                "input_data": case.input_data,
+                "expected_data": case.expected_data,
+                "source": case.source,
+                "severity": case.severity,
+                "affected_users": case.affected_users,
+                "status": case.status,
+                "review_notes": case.review_notes,
+                "ingested_at": case.ingested_at,
+            }, f, indent=2)
+        
+        return case
+    
+    def list_queue(self, status: Optional[str] = None) -> list[IngestedCase]:
+        """List cases in the review queue."""
+        cases = []
+        for case_file in sorted(self.queue_dir.glob("*.json")):
+            with open(case_file) as f:
+                data = json.load(f)
+            if status and data.get("status") != status:
+                continue
+            cases.append(IngestedCase(**data))
+        return cases
+    
+    def approve(self, case_id: str, family: str, notes: str = "") -> bool:
+        """Approve a case for inclusion in benchmark."""
+        case_path = self.queue_dir / f"{case_id}.json"
+        if not case_path.exists():
+            return False
+        
+        with open(case_path) as f:
+            data = json.load(f)
+        
+        data["status"] = "approved"
+        data["family"] = family
+        data["review_notes"] = notes
+        
+        with open(case_path, "w") as f:
+            json.dump(data, f, indent=2)
+        
+        return True
+    
+    def reject(self, case_id: str, reason: str = "") -> bool:
+        """Reject a case from the queue."""
+        case_path = self.queue_dir / f"{case_id}.json"
+        if not case_path.exists():
+            return False
+        
+        with open(case_path) as f:
+            data = json.load(f)
+        
+        data["status"] = "rejected"
+        data["review_notes"] = reason
+        
+        with open(case_path, "w") as f:
+            json.dump(data, f, indent=2)
+        
+        return True
+    
+    def get_approved_cases(self, family: str) -> list[dict[str, Any]]:
+        """Get approved cases for a family, ready for benchmark inclusion."""
+        cases = []
+        for case_file in sorted(self.queue_dir.glob("*.json")):
+            with open(case_file) as f:
+                data = json.load(f)
+            if data.get("status") == "approved" and data.get("family") == family:
+                cases.append({
+                    "input": data["input_data"],
+                    "expected": data["expected_data"],
+                    "metadata": {
+                        "source": "production_derived",
+                        "severity": data.get("severity", "medium"),
+                        "affected_users": data.get("affected_users", 1),
+                        "review_notes": data.get("review_notes", ""),
+                    },
+                })
+        return cases
+    
+    def _suggest_family(self, source_text: str) -> str:
+        """Heuristic: suggest family based on source text keywords."""
+        text_lower = source_text.lower()
+        
+        if any(kw in text_lower for kw in ["extract", "task from", "note to task", "email task"]):
+            return "structured_extraction"
+        elif any(kw in text_lower for kw in ["plan", "goal", "decompose", "break down"]):
+            return "plan_from_goal"
+        elif any(kw in text_lower for kw in ["critic", "quality", "well-defined", "vague"]):
+            return "task_critic"
+        elif any(kw in text_lower for kw in ["rewrite", "improve", "clarify", "rephrase"]):
+            return "task_rewriter"
+        elif any(kw in text_lower for kw in ["prioritize", "rank", "order", "urgent"]):
+            return "prioritization"
+        elif any(kw in text_lower for kw in ["ask", "clarify", "question", "missing info"]):
+            return "clarification_policy"
+        else:
+            return "structured_extraction"  # Default
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Production failure ingestion pipeline")
+    subparsers = parser.add_subparsers(dest="command")
+    
+    # Ingest command
+    ingest_parser = subparsers.add_parser("ingest")
+    ingest_parser.add_argument("--source", required=True, help="Source type (support_ticket, error_log, user_complaint)")
+    ingest_parser.add_argument("--file", required=True, help="Path to failure report JSON")
+    ingest_parser.add_argument("--queue-dir", type=str, default=None, help="Queue directory")
+    
+    # List command
+    list_parser = subparsers.add_parser("list")
+    list_parser.add_argument("--status", type=str, default=None, help="Filter by status (queued, approved, rejected)")
+    list_parser.add_argument("--queue-dir", type=str, default=None, help="Queue directory")
+    
+    # Approve command
+    approve_parser = subparsers.add_parser("approve")
+    approve_parser.add_argument("case_id", help="Case ID to approve")
+    approve_parser.add_argument("--family", required=True, help="Target family")
+    approve_parser.add_argument("--notes", type=str, default="", help="Review notes")
+    approve_parser.add_argument("--queue-dir", type=str, default=None, help="Queue directory")
+    
+    # Reject command
+    reject_parser = subparsers.add_parser("reject")
+    reject_parser.add_argument("case_id", help="Case ID to reject")
+    reject_parser.add_argument("--reason", type=str, default="", help="Rejection reason")
+    reject_parser.add_argument("--queue-dir", type=str, default=None, help="Queue directory")
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return
+    
+    queue_dir = Path(args.queue_dir) if args.queue_dir else None
+    pipeline = IngestionPipeline(queue_dir)
+    
+    if args.command == "ingest":
+        with open(args.file) as f:
+            report_data = json.load(f)
+        report = FailureReport(**report_data)
+        case = pipeline.ingest(report)
+        print(f"Ingested: {case.case_id} (family: {case.family}, severity: {case.severity})")
+    
+    elif args.command == "list":
+        cases = pipeline.list_queue(status=args.status)
+        if not cases:
+            print("No cases in queue")
+            return
+        print(f"{'Case ID':<15} {'Family':<25} {'Status':<12} {'Severity':<10} {'Users':<6}")
+        print("-" * 70)
+        for case in cases:
+            print(f"{case.case_id:<15} {case.family:<25} {case.status:<12} {case.severity:<10} {case.affected_users:<6}")
+    
+    elif args.command == "approve":
+        success = pipeline.approve(args.case_id, args.family, args.notes)
+        if success:
+            print(f"Approved: {args.case_id} → {args.family}")
+        else:
+            print(f"Case not found: {args.case_id}")
+    
+    elif args.command == "reject":
+        success = pipeline.reject(args.case_id, args.reason)
+        if success:
+            print(f"Rejected: {args.case_id}")
+        else:
+            print(f"Case not found: {args.case_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval-lab/nightly_runner.py
+++ b/eval-lab/nightly_runner.py
@@ -1,0 +1,184 @@
+"""Nightly portfolio runner.
+
+Runs the full portfolio with baseline prompt every night,
+compares to previous night's results, and alerts on regressions.
+
+Usage:
+    python nightly_runner.py --slack-webhook-url https://hooks.slack.com/...
+    python nightly_runner.py --output-dir /path/to/results
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from portfolio import run_portfolio, aggregate_portfolio, compare_runs, check_guardrails
+
+
+# ── Nightly Runner ───────────────────────────────────────────────────────────
+
+class NightlyRunner:
+    """Runs portfolio nightly and alerts on regressions."""
+    
+    def __init__(
+        self,
+        results_dir: Optional[Path] = None,
+        slack_webhook_url: Optional[str] = None,
+    ):
+        self.results_dir = results_dir or Path(__file__).parent / "results" / "nightly"
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+        self.slack_webhook_url = slack_webhook_url
+    
+    async def run(self) -> dict[str, Any]:
+        """Run nightly portfolio evaluation."""
+        print(f"Nightly run started at {datetime.now(timezone.utc).isoformat()}")
+        
+        # Run portfolio
+        results = await run_portfolio(prompt_name="baseline")
+        aggregate = aggregate_portfolio(results)
+        
+        # Save results
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%d")
+        results_path = self.results_dir / f"nightly-{run_id}.json"
+        with open(results_path, "w") as f:
+            json.dump({
+                "run_id": run_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "aggregate": aggregate,
+            }, f, indent=2)
+        
+        # Compare to previous night
+        prev_results = self._load_previous_results(run_id)
+        alert_messages = []
+        
+        if prev_results:
+            prev_agg = prev_results.get("aggregate", {})
+            comparison = compare_runs(
+                # We need to reconstruct RunResult objects, but for nightly we just compare aggregates
+                {},  # baseline
+                {},  # candidate
+            )
+            # Simple comparison
+            score_delta = aggregate["weighted_score"] - prev_agg.get("weighted_score", 0)
+            if score_delta < -0.020:
+                alert_messages.append(
+                    f"⚠️ Aggregate regression: {score_delta:+.3f} "
+                    f"({prev_agg.get('weighted_score', 0):.3f} → {aggregate['weighted_score']:.3f})"
+                )
+            
+            # Check family-level regressions
+            for name, info in aggregate.get("family_scores", {}).items():
+                prev_info = prev_agg.get("family_scores", {}).get(name, {})
+                prev_score = prev_info.get("score", 0)
+                fam_delta = info["score"] - prev_score
+                if fam_delta < -0.050:
+                    alert_messages.append(
+                        f"⚠️ Family '{name}' regression: {fam_delta:+.3f} "
+                        f"({prev_score:.3f} → {info['score']:.3f})"
+                    )
+            
+            # Check grader error rate increase
+            prev_grader_error = prev_agg.get("grader_error_rate", 0)
+            curr_grader_error = aggregate.get("grader_error_rate", 0)
+            if curr_grader_error - prev_grader_error > 0.05:
+                alert_messages.append(
+                    f"⚠️ Grader error rate increase: {curr_grader_error:.1%} "
+                    f"(was {prev_grader_error:.1%})"
+                )
+            
+            # Check safety regression
+            prev_safety = prev_agg.get("meta_dimension_averages", {}).get("safety", 0)
+            curr_safety = aggregate.get("meta_dimension_averages", {}).get("safety", 0)
+            if curr_safety < prev_safety:
+                alert_messages.append(
+                    f"🚨 Safety regression: {prev_safety:.3f} → {curr_safety:.3f}"
+                )
+        else:
+            alert_messages.append("ℹ️ First nightly run — no previous results to compare")
+        
+        # Send alerts
+        if alert_messages:
+            summary = "\n".join(alert_messages)
+            print(f"\nNightly Summary:\n{summary}")
+            
+            if self.slack_webhook_url:
+                await self._send_slack_alert(summary, aggregate)
+        
+        return {
+            "run_id": run_id,
+            "aggregate": aggregate,
+            "alerts": alert_messages,
+            "results_path": str(results_path),
+        }
+    
+    def _load_previous_results(self, current_run_id: str) -> Optional[dict]:
+        """Load the most recent previous nightly results."""
+        # Find all nightly files except current
+        nightly_files = sorted(self.results_dir.glob("nightly-*.json"))
+        nightly_files = [f for f in nightly_files if f.stem != f"nightly-{current_run_id}"]
+        
+        if not nightly_files:
+            return None
+        
+        # Load most recent
+        with open(nightly_files[-1]) as f:
+            return json.load(f)
+    
+    async def _send_slack_alert(self, summary: str, aggregate: dict):
+        """Send alert to Slack webhook."""
+        if not self.slack_webhook_url:
+            return
+        
+        import httpx
+        
+        score = aggregate.get("weighted_score", 0)
+        coverage = aggregate.get("semantic_coverage", 0)
+        
+        message = (
+            f"*Eval-Lab Nightly Report*\n"
+            f"Score: {score:.3f}\n"
+            f"Coverage: {coverage:.1%}\n"
+            f"Errors: {aggregate.get('total_errors', 0)}\n"
+            f"Grader Errors: {aggregate.get('total_grader_errors', 0)}\n\n"
+            f"{summary}"
+        )
+        
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                await client.post(
+                    self.slack_webhook_url,
+                    json={"text": message},
+                )
+        except Exception as e:
+            print(f"Failed to send Slack alert: {e}")
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+async def main():
+    parser = argparse.ArgumentParser(description="Nightly portfolio runner")
+    parser.add_argument("--slack-webhook-url", type=str, default=None, help="Slack webhook URL")
+    parser.add_argument("--output-dir", type=str, default=None, help="Results directory")
+    args = parser.parse_args()
+    
+    runner = NightlyRunner(
+        results_dir=Path(args.output_dir) if args.output_dir else None,
+        slack_webhook_url=args.slack_webhook_url,
+    )
+    
+    result = await runner.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Phase 3: Operationalization

Turns Eval-Lab from a strong offline system into a living quality loop.

### Production Failure Ingestion (ingest.py)
- **IngestionPipeline**: accepts failure reports from production
- Converts to eval case format with heuristic family suggestion
- Review queue with approve/reject workflow
- CLI: ingest, list, approve, reject commands
- Supports sources: support_ticket, error_log, user_complaint

### Nightly Runner (nightly_runner.py)
- Runs full portfolio with baseline prompt every night
- Compares to previous night's results
- Alerts on regressions (aggregate, family, grader error, safety)
- Optional Slack webhook integration
- Saves results to nightly-{YYYYMMDD}.json files

### CI Grader Error Threshold
- **CIRegressionGate** now checks `grader_error_rate`
- `max_grader_error_rate`: 0.10 (10% threshold)
- Fails CI if grader error rate exceeds threshold
- Prevents evaluation quality from degrading silently

### Usage
```bash
# Ingest a failure report
python ingest.py ingest --source support_ticket --file ticket.json

# List queued cases
python ingest.py list

# Approve a case for benchmark inclusion
python ingest.py approve case-001 --family structured_extraction

# Run nightly portfolio evaluation
python nightly_runner.py --slack-webhook-url https://hooks.slack.com/...
```