### PR TITLE
fix(react): header layout — popover z-index, filter popover, right-align buttons

### DIFF
--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -1,3 +1,4 @@
+import { useRef, type CSSProperties } from "react";
 import type { Todo, User, CreateTodoDto } from "../../types";
 import { IconMoon, IconSun, IconMenu } from "../shared/Icons";
 import { Breadcrumb } from "../shared/Breadcrumb";
@@ -156,6 +157,7 @@ export function ListViewHeader({
   viewMenuOpen,
   onViewMenuOpenChange,
 }: ListViewHeaderProps) {
+  const filtersButtonRef = useRef<HTMLButtonElement>(null);
   const activeCount = visibleTodos.filter((t) => !t.completed).length;
   const showHorizonSegments =
     activeView === "horizon" &&
@@ -264,21 +266,43 @@ export function ListViewHeader({
             externalOpen={viewMenuOpen}
             onOpenChange={onViewMenuOpenChange}
           />
-          <Tooltip content="Filters" shortcut="f">
-            <button
-              id="moreFiltersToggle"
-              className={`btn${filtersOpen ? " btn--active" : ""}`}
-              onClick={onToggleFilters}
-              style={{ fontSize: "var(--fs-label)" }}
-            >
-              Filters
-              {(activeFilters.dateFilter !== "all" ||
-                activeFilters.priority ||
-                activeFilters.status) && (
-                <span className="filter-badge">●</span>
-              )}
-            </button>
-          </Tooltip>
+          <div className="filter-menu">
+            <Tooltip content="Filters" shortcut="f">
+              <button
+                id="moreFiltersToggle"
+                ref={filtersButtonRef}
+                className={`btn${filtersOpen ? " btn--active" : ""}`}
+                onClick={onToggleFilters}
+                style={{ fontSize: "var(--fs-label)" }}
+              >
+                Filters
+                {(activeFilters.dateFilter !== "all" ||
+                  activeFilters.priority ||
+                  activeFilters.status) && (
+                  <span className="filter-badge">●</span>
+                )}
+              </button>
+            </Tooltip>
+            {filtersOpen && filtersButtonRef.current && (() => {
+              const rect = filtersButtonRef.current!.getBoundingClientRect();
+              return (
+                <div
+                  className="filter-menu__panel"
+                  style={{
+                    position: "fixed",
+                    top: rect.bottom + 8,
+                    right: window.innerWidth - rect.right,
+                  } as CSSProperties}
+                >
+                  <FilterPanel
+                    filters={activeFilters}
+                    onChange={onFilterChange}
+                    onClose={onToggleFilters}
+                  />
+                </div>
+              );
+            })()}
+          </div>
           <Tooltip content={dark ? "Light mode" : "Dark mode"}>
             <button
               className="btn"
@@ -353,15 +377,6 @@ export function ListViewHeader({
             </div>
           ) : null;
         })()}
-
-      {/* Filter panel */}
-      {filtersOpen && (
-        <FilterPanel
-          filters={activeFilters}
-          onChange={onFilterChange}
-          onClose={onToggleFilters}
-        />
-      )}
 
       {/* Bulk actions toolbar */}
       {bulkMode && (

--- a/client-react/src/components/layout/ViewMenu.tsx
+++ b/client-react/src/components/layout/ViewMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, type CSSProperties } from "react";
 import type { SortField, SortOrder, ViewMode } from "../../types/viewTypes";
 import type { Density } from "../../hooks/useDensity";
 import type { GroupBy } from "../../utils/groupTodos";
@@ -71,15 +71,25 @@ export function ViewMenu({
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const [focusedSection, setFocusedSection] = useState(0);
+  const [panelPos, setPanelPos] = useState<{ top: number; right: number } | null>(null);
 
   const closeMenu = useCallback(() => {
     setIsOpen(false);
     triggerRef.current?.focus();
   }, [setIsOpen]);
 
-  // Reset focused section when opening
+  // Reset focused section when opening; compute fixed panel position
   useEffect(() => {
-    if (isOpen) setFocusedSection(0);
+    if (isOpen) {
+      setFocusedSection(0);
+      if (triggerRef.current) {
+        const rect = triggerRef.current.getBoundingClientRect();
+        setPanelPos({
+          top: rect.bottom + 8,
+          right: window.innerWidth - rect.right,
+        });
+      }
+    }
   }, [isOpen]);
 
   // Close on click outside
@@ -172,8 +182,12 @@ export function ViewMenu({
         </button>
       </Tooltip>
 
-      {isOpen && (
-        <div className="view-menu__panel" role="menu">
+      {isOpen && panelPos && (
+        <div
+          className="view-menu__panel"
+          role="menu"
+          style={{ position: "fixed", top: panelPos.top, right: panelPos.right } as CSSProperties}
+        >
           {/* Layout */}
           <div className={`view-menu__section${focusedSection === 0 ? " view-menu__section--focused" : ""}`}>
             <div className="view-menu__label">Layout</div>

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -278,7 +278,6 @@ body {
   font-weight: var(--fw-semibold);
   letter-spacing: var(--tracking-tight);
   color: var(--text-strong);
-  flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -293,6 +292,8 @@ body {
 .app-header__title-group {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-width: 0;
 }
 
 .app-header__title-row {

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2180,6 +2180,22 @@ body {
   white-space: nowrap;
 }
 
+/* ── Filter Menu ───────────────────────────── */
+
+.filter-menu {
+  position: relative;
+}
+
+.filter-menu__panel {
+  z-index: 200;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-elevated);
+  animation: viewMenuIn var(--dur-base) var(--ease-spring);
+  overflow: hidden;
+}
+
 /* ── View Menu ─────────────────────────────── */
 
 .view-menu {

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2187,9 +2187,6 @@ body {
 }
 
 .view-menu__panel {
-  position: absolute;
-  top: calc(100% + var(--s-2));
-  right: 0;
   width: 320px;
   background: var(--surface);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Three header UI fixes:

- **View popover z-index** — switched from `position: absolute` to `position: fixed` with computed coordinates from trigger button's bounding rect. Prevents clipping by ancestor `overflow: hidden` on `.app-shell`
- **Filters as popover** — converted inline FilterPanel (pushed content down) to a fixed-position popover matching the View menu pattern. Added `.filter-menu__panel` with same shadow/animation
- **Right-align action buttons** — added `flex: 1` to `.app-header__title-group` so title fills available space, pushing View/Filters/dark mode/Logout to the right

## Test plan

- [x] 121 UI tests pass
- [x] Typecheck, CSS lint pass
- [ ] Manual: View popover no longer hidden behind sidebar
- [ ] Manual: Filters opens as popover overlay, not inline push
- [ ] Manual: Action buttons right-aligned in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)