### PR TITLE
fix(react): guard against undefined provenance in focus panels

### DIFF
--- a/client-react/src/components/home/CardBack.tsx
+++ b/client-react/src/components/home/CardBack.tsx
@@ -2,12 +2,26 @@ import type { ReactNode } from "react";
 import type { PanelProvenance } from "../../types/focusBrief";
 
 interface Props {
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
   pixelArt?: ReactNode;
 }
 
 export function CardBack({ provenance, reason, pixelArt }: Props) {
+  if (!provenance) {
+    return (
+      <div className="card-back">
+        <div className="card-back__header">How this was generated</div>
+        {pixelArt && <div className="card-back__art">{pixelArt}</div>}
+        <p className="card-back__section-text">Provenance data not available. Try refreshing.</p>
+        <div className="card-back__section">
+          <div className="card-back__section-label">Why this panel is showing</div>
+          <p className="card-back__section-text">{reason}</p>
+        </div>
+      </div>
+    );
+  }
+
   const isAi = provenance.source === "ai";
 
   return (

--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -21,7 +21,7 @@ function UnsortedPanel({
   onEditTodo,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
   onTaskClick: (id: string) => void;
   onEditTodo?: (id: string, updates: Record<string, unknown>) => void;
@@ -132,7 +132,7 @@ function DueSoonPanel({
   onTaskClick,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
   onTaskClick: (id: string) => void;
 }) {
@@ -215,7 +215,7 @@ function WhatNextPanel({
   onTaskClick,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
   onTaskClick: (id: string) => void;
 }) {
@@ -276,7 +276,7 @@ function BacklogHygienePanel({
   onTaskClick,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
   onTaskClick: (id: string) => void;
 }) {
@@ -336,7 +336,7 @@ function ProjectsToNudgePanel({
   onSelectProject,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
   onSelectProject: (id: string) => void;
 }) {
@@ -400,7 +400,7 @@ function TrackOverviewPanel({
   reason,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
 }) {
   const Art = PANEL_ART["trackOverview"];
@@ -451,7 +451,7 @@ function RescueModePanel({
   reason,
 }: {
   data: any;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   reason: string;
 }) {
   if (data.openCount <= 10 || data.overdueCount <= 3) return null;

--- a/client-react/src/components/home/RightNowPanel.tsx
+++ b/client-react/src/components/home/RightNowPanel.tsx
@@ -6,7 +6,7 @@ import type { RightNow, PanelProvenance } from "../../types/focusBrief";
 
 interface Props {
   data: RightNow;
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   onTaskClick: (id: string) => void;
 }
 

--- a/client-react/src/components/home/TodayAgendaPanel.tsx
+++ b/client-react/src/components/home/TodayAgendaPanel.tsx
@@ -6,7 +6,7 @@ import type { AgendaItem, PanelProvenance } from "../../types/focusBrief";
 
 interface Props {
   items: AgendaItem[];
-  provenance: PanelProvenance;
+  provenance?: PanelProvenance;
   onTaskClick: (id: string) => void;
   onToggle: (id: string, completed: boolean) => void;
 }

--- a/client-react/src/hooks/useFocusBrief.ts
+++ b/client-react/src/hooks/useFocusBrief.ts
@@ -7,7 +7,15 @@ const CACHE_KEY = "todos:focus-brief-cache";
 function readCache(): FocusBriefResponse | null {
   try {
     const raw = localStorage.getItem(CACHE_KEY);
-    if (raw) return JSON.parse(raw);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      // Invalidate stale cache missing provenance fields (pre-card-design format)
+      if (parsed.rankedPanels?.length > 0 && !parsed.rankedPanels[0].provenance) {
+        localStorage.removeItem(CACHE_KEY);
+        return null;
+      }
+      return parsed;
+    }
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary

Fixes "Cannot read properties of undefined (reading 'source')" error on the Focus dashboard.

**Root cause:** The localStorage cache contained a pre-provenance API response (from before PR #833). When the app loaded, it read the stale cached response which had no `provenance` field on panels, causing `CardBack` to crash when accessing `provenance.source`.

**Fixes:**
- `CardBack.tsx` — make `provenance` prop optional, render fallback message when undefined
- `useFocusBrief.ts` — invalidate stale localStorage cache if response lacks provenance fields
- `PanelRenderer.tsx`, `RightNowPanel.tsx`, `TodayAgendaPanel.tsx` — make `provenance` optional in all panel component props

🤖 Generated with [Claude Code](https://claude.com/claude-code)