### PR TITLE
fix(api): serialize provenance dataBreakdown as strings

### DIFF
--- a/src/routes/focusBriefRouter.ts
+++ b/src/routes/focusBriefRouter.ts
@@ -129,14 +129,17 @@ function buildDeterministicProvenance(
   itemsShown: number,
 ): PanelProvenance {
   const staticInfo = DETERMINISTIC_PROVENANCE[key];
+  const breakdownStr = Object.entries(dataBreakdown)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join(" · ");
   return {
     source: "deterministic",
     generatedAt,
     cacheStatus,
     cacheExpiresAt,
     freshness,
-    dataBreakdown,
-    itemsShown,
+    dataBreakdown: breakdownStr,
+    itemsShown: `${itemsShown}`,
     ...staticInfo,
   };
 }

--- a/src/types/focusBrief.ts
+++ b/src/types/focusBrief.ts
@@ -115,8 +115,8 @@ export interface PanelProvenance {
   method?: string;
   freshness?: "fresh" | "stale" | "cached";
   filter?: string;
-  dataBreakdown?: Record<string, number>;
-  itemsShown?: number;
+  dataBreakdown?: string;
+  itemsShown?: string;
   logic?: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes React error #31 ("Objects are not valid as a React child") on the Focus dashboard.

**Root cause:** `buildDeterministicProvenance` was setting `dataBreakdown` to `Record<string, number>` (an object like `{ items: 5 }`) and `itemsShown` to a raw `number`. When `CardBack` rendered `{provenance.dataBreakdown}` as JSX text content, React threw because it received an object instead of a string.

**Fix:**
- `focusBriefRouter.ts` — serialize `dataBreakdown` object to a string (`"items: 5"`) and `itemsShown` to a string (`"5"`)
- `src/types/focusBrief.ts` — change `dataBreakdown` from `Record<string, number>` to `string`, `itemsShown` from `number` to `string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)