### PR TITLE
fix(react): 2-column card grid layout with stronger elevation for Focus panels

### DIFF
--- a/client-react/src/components/layout/HomeDashboard.tsx
+++ b/client-react/src/components/layout/HomeDashboard.tsx
@@ -46,51 +46,53 @@ export function HomeDashboard({ onTodoClick, onToggleTodo, onSelectProject, onEd
 
   return (
     <div data-testid="home-dashboard" className="home-dashboard">
-      <RightNowPanel
-        data={brief.pinned.rightNow}
-        provenance={brief.pinned.rightNowProvenance}
-        onTaskClick={onTodoClick}
-      />
-      <TodayAgendaPanel
-        items={brief.pinned.todayAgenda}
-        provenance={brief.pinned.todayAgendaProvenance}
-        onTaskClick={onTodoClick}
-        onToggle={onToggleTodo}
-      />
+      <div className="home-dashboard__pinned">
+        <RightNowPanel
+          data={brief.pinned.rightNow}
+          provenance={brief.pinned.rightNowProvenance}
+          onTaskClick={onTodoClick}
+        />
+        <TodayAgendaPanel
+          items={brief.pinned.todayAgenda}
+          provenance={brief.pinned.todayAgendaProvenance}
+          onTaskClick={onTodoClick}
+          onToggle={onToggleTodo}
+        />
+      </div>
 
       {brief.rankedPanels.length > 0 && (
         <>
           <div className="focus-divider">Surfaced for you</div>
-          {brief.rankedPanels.slice(0, 3).map((panel) => (
-            <PanelRenderer
-              key={panel.type}
-              panel={panel}
-              onTaskClick={onTodoClick}
-              onSelectProject={onSelectProject}
-              onEditTodo={onEditTodo}
-            />
-          ))}
+          <div className="home-dashboard__ranked">
+            {brief.rankedPanels.slice(0, 3).map((panel) => (
+              <PanelRenderer
+                key={panel.type}
+                panel={panel}
+                onTaskClick={onTodoClick}
+                onSelectProject={onSelectProject}
+                onEditTodo={onEditTodo}
+              />
+            ))}
+            {showMore &&
+              brief.rankedPanels.slice(3).map((panel) => (
+                <PanelRenderer
+                  key={panel.type}
+                  panel={panel}
+                  onTaskClick={onTodoClick}
+                  onSelectProject={onSelectProject}
+                  onEditTodo={onEditTodo}
+                />
+              ))}
+          </div>
           {brief.rankedPanels.length > 3 && (
-            <>
-              {showMore &&
-                brief.rankedPanels.slice(3).map((panel) => (
-                  <PanelRenderer
-                    key={panel.type}
-                    panel={panel}
-                    onTaskClick={onTodoClick}
-                    onSelectProject={onSelectProject}
-                    onEditTodo={onEditTodo}
-                  />
-                ))}
-              <button
-                className="focus-disclosure"
-                onClick={() => setShowMore((s) => !s)}
-              >
-                {showMore
-                  ? "Show less ▴"
-                  : `Show ${brief.rankedPanels.length - 3} more panels ▾`}
-              </button>
-            </>
+            <button
+              className="focus-disclosure"
+              onClick={() => setShowMore((s) => !s)}
+            >
+              {showMore
+                ? "Show less ▴"
+                : `Show ${brief.rankedPanels.length - 3} more panels ▾`}
+            </button>
           )}
         </>
       )}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2763,7 +2763,29 @@ body {
 /* --- Home dashboard (classic Focus — pixel-matched) --- */
 .home-dashboard {
   display: grid;
-  gap: 12px;
+  gap: var(--s-4);
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--s-4);
+}
+
+.home-dashboard__pinned {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-4);
+}
+
+.home-dashboard__ranked {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-4);
+}
+
+@media (max-width: 768px) {
+  .home-dashboard__pinned,
+  .home-dashboard__ranked {
+    grid-template-columns: 1fr;
+  }
 }
 
 .home-dashboard__hero-grid {
@@ -3046,9 +3068,16 @@ body {
 .flip-card__back {
   backface-visibility: hidden;
   border-radius: var(--r-lg);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 4px 16px rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--border-light);
   background: var(--surface);
   padding: var(--s-4);
+}
+
+.flip-card:hover .flip-card__front {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), 0 8px 24px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .flip-card__back {


### PR DESCRIPTION
## Summary

Focus dashboard panels were stretching full-width, making them feel like sections rather than cards. This was a significant visual gap between the brainstorm mockups and the shipped result.

**Changes:**
- **2-column grid layout** — pinned panels (Right Now + Today's Agenda) sit side by side; competing panels also use a 2-column grid. Falls back to single column on mobile (<768px)
- **Max-width constraint** — dashboard capped at 960px, centered
- **Stronger card elevation** — increased shadow depth (2px/8px + 4px/16px), added subtle border, hover lifts the card slightly
- **Grid wrappers** — new `.home-dashboard__pinned` and `.home-dashboard__ranked` CSS classes; `HomeDashboard.tsx` wraps panels in these grid containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)