### PR TITLE
feat: Right Now panel uses narrative prose instead of urgent item list

### DIFF
--- a/client-react/src/components/home/RightNowPanel.tsx
+++ b/client-react/src/components/home/RightNowPanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
-  if (data.urgentItems.length === 0 && !data.topRecommendation) {
+  if (!data.narrative && data.urgentItems.length === 0 && !data.topRecommendation) {
     return null;
   }
 
@@ -22,17 +22,9 @@ export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
         <span className="panel-right-now__title">Right Now</span>
       </div>
 
-      {data.urgentItems.map((item, i) => (
-        <div key={i} className="focus-urgent-banner">
-          <span className="focus-urgent-banner__dot" />
-          <div>
-            <strong>
-              {item.dueDate} — {item.title}.
-            </strong>{" "}
-            <span className="focus-urgent-banner__reason">{item.reason}</span>
-          </div>
-        </div>
-      ))}
+      {data.narrative && (
+        <p className="panel-right-now__narrative">{data.narrative}</p>
+      )}
 
       {data.topRecommendation && (
         <button

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -10818,6 +10818,13 @@ body.dark-mode {
   color: var(--text);
 }
 
+.panel-right-now__narrative {
+  font-size: var(--fs-body);
+  line-height: 1.6;
+  color: var(--text);
+  margin: 0 0 var(--s-3);
+}
+
 /* ==========================================================================
    Today Agenda Panel
    ========================================================================== */

--- a/client-react/src/types/focusBrief.ts
+++ b/client-react/src/types/focusBrief.ts
@@ -26,7 +26,8 @@ export interface TopRecommendation {
 }
 
 export interface RightNow {
-  urgentItems: UrgentItem[];
+  narrative: string; // 2-3 sentence prose summary
+  urgentItems: UrgentItem[]; // kept for card back transparency
   topRecommendation: TopRecommendation | null;
 }
 

--- a/src/routes/focusBriefRouter.ts
+++ b/src/routes/focusBriefRouter.ts
@@ -151,6 +151,7 @@ Analyze the user's open tasks and projects and return a JSON object (no markdown
 
 {
   "rightNow": {
+    "narrative": "2-3 sentence paragraph summarizing the user's most urgent situation. Weave in task names, deadlines, and stakes. Write as prose, not a list. Example: 'Your contractor quote for the todo app is overdue — this blocks the project timeline. The AWS study plan and garage sort are both due April 10th, but the contractor call is the bottleneck.'",
     "urgentItems": [
       { "title": "task title", "dueDate": "YYYY-MM-DD", "reason": "one sentence" }
     ],
@@ -175,7 +176,8 @@ Analyze the user's open tasks and projects and return a JSON object (no markdown
 }
 
 Rules:
-- urgentItems: tasks that are overdue OR have priority=urgent AND due within 7 days. Max 3. Omit if none.
+- narrative: 2-3 sentence paragraph synthesizing the urgency situation. Mention actual task names and dates. Write as prose — do NOT list tasks. If nothing is urgent, write something encouraging like "No fires today. Good time to get ahead on..."
+- urgentItems: tasks that are overdue OR have priority=urgent AND due within 7 days. Max 3. These are metadata for transparency, not displayed as a list.
 - topRecommendation: the single most impactful task. Omit (null) if no open tasks.
 - whatNext: 3-5 high-impact task recommendations ordered by impact. Use actual task ids and titles.
 - panelRanking: ordered list of all panel types relevant to the user's situation. Include "whatNext" as a panel type.
@@ -434,6 +436,7 @@ function assembleBrief(
   return {
     pinned: {
       rightNow: llmOutput.rightNow ?? {
+        narrative: "",
         urgentItems: [],
         topRecommendation: null,
       },

--- a/src/types/focusBrief.ts
+++ b/src/types/focusBrief.ts
@@ -26,7 +26,8 @@ export interface TopRecommendation {
 }
 
 export interface RightNow {
-  urgentItems: UrgentItem[];
+  narrative: string; // 2-3 sentence prose summary
+  urgentItems: UrgentItem[]; // kept for card back transparency
   topRecommendation: TopRecommendation | null;
 }
 


### PR DESCRIPTION
## Summary

The Right Now panel was rendering urgent items as a bulleted list of banners — identical to a task list. The design intent was a **narrative paragraph** that synthesizes the urgency situation as prose.

**Before:** Three red-dot banners listing each urgent item with dates
**After:** One 2-3 sentence paragraph weaving task names, deadlines, and stakes into natural prose

**Changes:**
- `RightNow` type — added `narrative: string` field
- LLM prompt — instructs the model to write a prose paragraph summarizing urgency, not list items
- `urgentItems` array kept in the response for card-back transparency, but no longer rendered on the front
- `RightNowPanel.tsx` — renders `<p>` narrative + recommendation card (no more banner list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)