### PR TITLE
fix: provenance source mismatch + fixed card height + hero pinned cards

### DIFF
--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -3074,6 +3074,27 @@ body {
   padding: var(--s-4);
 }
 
+.flip-card__front {
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+}
+
+.flip-card__back {
+  min-height: 240px;
+}
+
+/* Hero pinned cards — larger and more prominent */
+.home-dashboard__pinned .flip-card__front,
+.home-dashboard__pinned .flip-card__back {
+  min-height: 300px;
+  padding: var(--s-5);
+}
+
+.home-dashboard__pinned .flip-card__front {
+  border-top: 3px solid var(--accent);
+}
+
 .flip-card:hover .flip-card__front {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), 0 8px 24px rgba(0, 0, 0, 0.08);
   transform: translateY(-1px);

--- a/src/routes/focusBriefRouter.ts
+++ b/src/routes/focusBriefRouter.ts
@@ -106,7 +106,7 @@ function buildLlmProvenance(
   projectCount: number,
 ): PanelProvenance {
   return {
-    source: "llm",
+    source: "ai",
     model: config.aiProviderModel,
     temperature: 0.3,
     maxTokens: 1500,

--- a/src/types/focusBrief.ts
+++ b/src/types/focusBrief.ts
@@ -104,7 +104,7 @@ export type PanelData =
 export type PanelType = PanelData["type"];
 
 export interface PanelProvenance {
-  source: "llm" | "deterministic";
+  source: "ai" | "deterministic";
   model?: string;
   temperature?: number;
   maxTokens?: number;


### PR DESCRIPTION
## Summary

Three fixes for the Focus dashboard cards:

1. **Provenance all showing "Deterministic"** — backend sent `source: "llm"` but frontend checked for `source === "ai"`. Fixed backend type and value to use `"ai"`. Now Right Now and What Next correctly show "AI-generated" with model/temperature/prompt on the card back.

2. **Fixed card height** — cards now have `min-height: 240px` so they maintain a consistent card-like form factor regardless of content amount. No more cards collapsing to a single line.

3. **Hero pinned cards** — Right Now and Today's Agenda get special treatment: taller (300px min), more padding, and an accent-colored top border to visually distinguish them from the competing panels below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)