### PR TITLE
feat(react): real card feel — fixed dimensions, watermark art, geometric borders, hero gradients

### DIFF
--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -30,7 +30,10 @@ function UnsortedPanel({
   const topItem = data.items[0];
 
   const front = (
-    <div className="panel-unsorted">
+    <div className="panel-unsorted" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-unsorted__header">
         <Art size={18} />
         <span className="panel-unsorted__title">Unsorted Items</span>
@@ -144,7 +147,10 @@ function DueSoonPanel({
   const maxCount = Math.max(...data.groups.map((g: any) => g.items.length), 1);
 
   const front = (
-    <div className="panel-due-soon">
+    <div className="panel-due-soon" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-due-soon__header">
         <Art size={18} />
         <span className="panel-due-soon__title">Due Soon</span>
@@ -222,7 +228,10 @@ function WhatNextPanel({
   const Art = PANEL_ART["whatNext"];
 
   const front = (
-    <div className="panel-what-next">
+    <div className="panel-what-next" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-what-next__header">
         <Art size={18} />
         <span className="panel-what-next__title">What Next</span>
@@ -283,7 +292,10 @@ function BacklogHygienePanel({
   const Art = PANEL_ART["backlogHygiene"];
 
   const front = (
-    <div className="panel-backlog">
+    <div className="panel-backlog" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-backlog__header">
         <Art size={18} />
         <span className="panel-backlog__title">Backlog Hygiene</span>
@@ -343,7 +355,10 @@ function ProjectsToNudgePanel({
   const Art = PANEL_ART["projectsToNudge"];
 
   const front = (
-    <div className="panel-nudge">
+    <div className="panel-nudge" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-nudge__header">
         <Art size={18} />
         <span className="panel-nudge__title">Projects to Nudge</span>
@@ -406,7 +421,10 @@ function TrackOverviewPanel({
   const Art = PANEL_ART["trackOverview"];
 
   const front = (
-    <div className="panel-track">
+    <div className="panel-track" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-track__header">
         <Art size={18} />
         <span className="panel-track__title">Task Timeline</span>
@@ -459,7 +477,10 @@ function RescueModePanel({
   const Art = PANEL_ART["rescueMode"];
 
   const front = (
-    <div className="panel-rescue">
+    <div className="panel-rescue" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <Art size={120} />
+      </div>
       <div className="panel-rescue__header">
         <Art size={18} />
         <span className="panel-rescue__title">Rescue Mode</span>

--- a/client-react/src/components/home/RightNowPanel.tsx
+++ b/client-react/src/components/home/RightNowPanel.tsx
@@ -16,7 +16,10 @@ export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
   }
 
   const front = (
-    <div className="panel-right-now">
+    <div className="panel-right-now" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <FlameArt size={120} />
+      </div>
       <div className="panel-right-now__header">
         <FlameArt size={18} />
         <span className="panel-right-now__title">Right Now</span>

--- a/client-react/src/components/home/TodayAgendaPanel.tsx
+++ b/client-react/src/components/home/TodayAgendaPanel.tsx
@@ -28,7 +28,10 @@ export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle }: P
 
   if (items.length === 0) {
     const front = (
-      <div className="panel-today-agenda">
+      <div className="panel-today-agenda" style={{ position: "relative" }}>
+        <div className="card-watermark">
+          <SunriseArt size={120} />
+        </div>
         <div className="panel-today-agenda__header">
           <SunriseArt size={18} />
           <span className="panel-today-agenda__title">Today's Agenda</span>
@@ -40,7 +43,10 @@ export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle }: P
   }
 
   const front = (
-    <div className="panel-today-agenda">
+    <div className="panel-today-agenda" style={{ position: "relative" }}>
+      <div className="card-watermark">
+        <SunriseArt size={120} />
+      </div>
       <div className="panel-today-agenda__header">
         <SunriseArt size={18} />
         <span className="panel-today-agenda__title">Today's Agenda</span>
@@ -73,6 +79,10 @@ export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle }: P
           </div>
         ))}
       </div>
+
+      {items.length <= 2 && items.length > 0 && (
+        <p className="panel-today-agenda__light-day">Light day — room to get ahead.</p>
+      )}
     </div>
   );
 

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2773,12 +2773,14 @@ body {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--s-4);
+  align-items: stretch;
 }
 
 .home-dashboard__ranked {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--s-4);
+  align-items: stretch;
 }
 
 @media (max-width: 768px) {
@@ -3075,24 +3077,147 @@ body {
 }
 
 .flip-card__front {
-  min-height: 240px;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
-.flip-card__back {
-  min-height: 240px;
+/* Geometric inner border frame — collectible card feel */
+.flip-card__front::before {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border: 1px solid color-mix(in oklab, var(--muted) 10%, transparent);
+  border-radius: calc(var(--r-lg) - 6px);
+  pointer-events: none;
 }
 
-/* Hero pinned cards — larger and more prominent */
+/* ── Competing (ranked) cards — fixed 280px ── */
+
+.home-dashboard__ranked .flip-card__inner {
+  height: 280px;
+}
+
+.home-dashboard__ranked .flip-card__front {
+  height: 280px;
+  overflow: hidden;
+}
+
+/* Fade-out gradient at bottom if content overflows */
+.home-dashboard__ranked .flip-card__front::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
+  background: linear-gradient(transparent, var(--surface));
+  pointer-events: none;
+}
+
+.home-dashboard__ranked .flip-card__back {
+  height: 280px;
+  overflow-y: auto;
+}
+
+/* ── Hero pinned cards — fixed 340px ── */
+
+.home-dashboard__pinned .flip-card__inner {
+  height: 340px;
+}
+
 .home-dashboard__pinned .flip-card__front,
 .home-dashboard__pinned .flip-card__back {
-  min-height: 300px;
   padding: var(--s-5);
 }
 
 .home-dashboard__pinned .flip-card__front {
-  border-top: 3px solid var(--accent);
+  height: 340px;
+  overflow: hidden;
+}
+
+.home-dashboard__pinned .flip-card__front::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
+  background: linear-gradient(transparent, var(--surface));
+  pointer-events: none;
+}
+
+.home-dashboard__pinned .flip-card__back {
+  height: 340px;
+  overflow-y: auto;
+}
+
+/* Hero inner border frame — accent tinted */
+.home-dashboard__pinned .flip-card__front::before {
+  border-color: color-mix(in oklab, var(--accent) 15%, transparent);
+  inset: 10px;
+}
+
+/* Hero gradient backgrounds instead of thin top border */
+.home-dashboard__pinned .flip-card:first-child .flip-card__front {
+  background: linear-gradient(135deg, var(--surface), color-mix(in oklab, var(--danger) 3%, var(--surface)));
+}
+
+.home-dashboard__pinned .flip-card:nth-child(2) .flip-card__front {
+  background: linear-gradient(135deg, var(--surface), color-mix(in oklab, var(--accent) 3%, var(--surface)));
+}
+
+/* ── Card accent colors per panel type ── */
+
+.panel-right-now { --card-accent: var(--danger); }
+.panel-today-agenda { --card-accent: var(--accent); }
+.panel-due-soon { --card-accent: var(--danger); }
+.panel-what-next { --card-accent: var(--accent); }
+.panel-unsorted { --card-accent: var(--warning); }
+.panel-backlog { --card-accent: var(--warning); }
+.panel-nudge { --card-accent: #8b5cf6; }
+.panel-track { --card-accent: var(--accent); }
+.panel-rescue { --card-accent: var(--danger); }
+
+/* ── Watermark art — faded illustration in bottom-right ── */
+
+.card-watermark {
+  position: absolute;
+  bottom: var(--s-3);
+  right: var(--s-3);
+  opacity: 0.04;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Content sits above the watermark */
+.panel-right-now,
+.panel-today-agenda,
+.panel-unsorted,
+.panel-due-soon,
+.panel-what-next,
+.panel-backlog,
+.panel-nudge,
+.panel-track,
+.panel-rescue {
+  position: relative;
+  z-index: 1;
+}
+
+/* ── Today's Agenda — flex layout for light-day message ── */
+
+.panel-today-agenda {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.panel-today-agenda__light-day {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  font-style: italic;
+  margin-top: auto;
+  padding-top: var(--s-3);
 }
 
 .flip-card:hover .flip-card__front {


### PR DESCRIPTION
## Summary

Makes Focus dashboard cards feel like real physical collectible cards:

- **Fixed card dimensions** — hero cards 340px, competing cards 280px. No more stretching to content. Consistent card-like form factor.
- **Watermark illustrations** — each card's pixel art renders as a large (120px), faded (4% opacity) watermark in the bottom-right corner. Gives each card its own visual identity without competing with content.
- **Geometric inner border frame** — subtle `::before` pseudo-element creates a double-border effect (inner border inset 8px), like a collectible card frame. Hero cards get accent-tinted frames.
- **Hero gradient backgrounds** — Right Now gets a warm danger-tinted wash, Today's Agenda gets a cool accent-tinted wash. Replaced the thin top border.
- **Content overflow** — `::after` fade-out gradient at bottom when content exceeds fixed height. Graceful clip, not harsh cutoff.
- **Grid row alignment** — `align-items: stretch` ensures cards in the same row match height.
- **Light day message** — Today's Agenda shows "Light day — room to get ahead." when only 1-2 tasks, preventing empty card syndrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)