### PR TITLE
feat(react): tarot card design system for Focus dashboard

### DIFF
--- a/client-react/src/components/home/CardBack.test.tsx
+++ b/client-react/src/components/home/CardBack.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import { CardBack } from "./CardBack";
+import { CardBackContent } from "./CardBack";
 import type { PanelProvenance } from "../../types/focusBrief";
 
-describe("CardBack", () => {
+describe("CardBackContent", () => {
   it("renders AI provenance with model info", () => {
     const provenance: PanelProvenance = {
       source: "ai",
@@ -16,11 +16,15 @@ describe("CardBack", () => {
       inputSummary: "40 open tasks, 8 projects",
       promptIntent: "Identify urgent items and pick one impactful task.",
     };
-    render(<CardBack provenance={provenance} reason="Pinned — always visible" />);
-    expect(screen.getByText("AI-generated")).toBeInTheDocument();
+    render(<CardBackContent provenance={provenance} reason="Pinned — always visible" />);
+    expect(screen.getByText("Divined by")).toBeInTheDocument();
     expect(screen.getByText("claude-sonnet-4-6")).toBeInTheDocument();
-    expect(screen.getByText("0.3")).toBeInTheDocument();
-    expect(screen.getByText("40 open tasks, 8 projects")).toBeInTheDocument();
+    expect(
+      screen.getByText(/temp 0\.3.*1500 tokens.*40 open tasks/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/"Identify urgent items and pick one impactful task\."/),
+    ).toBeInTheDocument();
   });
 
   it("renders deterministic provenance with filter info", () => {
@@ -33,23 +37,21 @@ describe("CardBack", () => {
       itemsShown: "3 of 3",
       logic: "Tasks grouped by days until due.",
     };
-    render(<CardBack provenance={provenance} reason="5 tasks due soon" />);
-    expect(screen.getByText("Deterministic")).toBeInTheDocument();
+    render(<CardBackContent provenance={provenance} reason="5 tasks due soon" />);
+    expect(screen.getByText("Computed by")).toBeInTheDocument();
     expect(screen.getByText("Database query + date math")).toBeInTheDocument();
     expect(screen.getByText("dueDate within 3 days")).toBeInTheDocument();
   });
 
-  it("renders ranking reason", () => {
+  it("renders surfaced-because reason for deterministic", () => {
     const provenance: PanelProvenance = { source: "deterministic" };
-    render(<CardBack provenance={provenance} reason="3 items need triaging" />);
-    expect(screen.getByText("3 items need triaging")).toBeInTheDocument();
+    render(<CardBackContent provenance={provenance} reason="3 items need triaging" />);
+    expect(screen.getByText(/"3 items need triaging"/)).toBeInTheDocument();
   });
 
-  it("renders pixel art when provided", () => {
-    const provenance: PanelProvenance = { source: "ai" };
-    render(
-      <CardBack provenance={provenance} reason="test" pixelArt={<svg data-testid="art" />} />,
-    );
-    expect(screen.getByTestId("art")).toBeInTheDocument();
+  it("renders source unknown when no provenance", () => {
+    render(<CardBackContent reason="test reason" />);
+    expect(screen.getByText("Source unknown")).toBeInTheDocument();
+    expect(screen.getByText("test reason")).toBeInTheDocument();
   });
 });

--- a/client-react/src/components/home/CardBack.tsx
+++ b/client-react/src/components/home/CardBack.tsx
@@ -4,144 +4,102 @@ import type { PanelProvenance } from "../../types/focusBrief";
 interface Props {
   provenance?: PanelProvenance;
   reason: string;
+  /** @deprecated Use TarotCardBack illustration prop instead */
   pixelArt?: ReactNode;
 }
 
-export function CardBack({ provenance, reason, pixelArt }: Props) {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function CardBackContent({ provenance, reason, pixelArt: _pixelArt }: Props) {
   if (!provenance) {
     return (
-      <div className="card-back">
-        <div className="card-back__header">How this was generated</div>
-        {pixelArt && <div className="card-back__art">{pixelArt}</div>}
-        <p className="card-back__section-text">Provenance data not available. Try refreshing.</p>
-        <div className="card-back__section">
-          <div className="card-back__section-label">Why this panel is showing</div>
-          <p className="card-back__section-text">{reason}</p>
-        </div>
-      </div>
+      <>
+        <div className="tarot-inscription__label tarot-inscription__label--sys">Source unknown</div>
+        <div className="tarot-inscription__rule" />
+        <div className="tarot-inscription__label tarot-inscription__label--sys">Surfaced because</div>
+        <div className="tarot-inscription__text">{reason}</div>
+      </>
     );
   }
 
   const isAi = provenance.source === "ai";
 
-  return (
-    <div className="card-back">
-      <div className="card-back__header">How this was generated</div>
+  if (isAi) {
+    return (
+      <>
+        <div className="tarot-inscription__label tarot-inscription__label--ai">Divined by</div>
+        {provenance.model && (
+          <div className="tarot-inscription__source">{provenance.model}</div>
+        )}
+        <div className="tarot-inscription__detail">
+          {[
+            provenance.temperature != null && `temp ${provenance.temperature}`,
+            provenance.maxTokens != null && `${provenance.maxTokens} tokens`,
+            provenance.inputSummary,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </div>
 
-      <div className={`card-back__badge card-back__badge--${isAi ? "ai" : "deterministic"}`}>
-        <span className="card-back__badge-dot" />
-        {isAi ? "AI-generated" : "Deterministic"}
-      </div>
-
-      {pixelArt && <div className="card-back__art">{pixelArt}</div>}
-
-      <div className="card-back__grid">
-        {isAi ? (
+        {provenance.promptIntent && (
           <>
-            {provenance.model && (
-              <>
-                <span className="card-back__label">Model</span>
-                <span className="card-back__value card-back__value--mono">{provenance.model}</span>
-              </>
-            )}
-            {provenance.temperature != null && (
-              <>
-                <span className="card-back__label">Temperature</span>
-                <span className="card-back__value card-back__value--mono">
-                  {provenance.temperature}
-                </span>
-              </>
-            )}
-            {provenance.maxTokens != null && (
-              <>
-                <span className="card-back__label">Max tokens</span>
-                <span className="card-back__value card-back__value--mono">
-                  {provenance.maxTokens}
-                </span>
-              </>
-            )}
-            {provenance.generatedAt && (
-              <>
-                <span className="card-back__label">Generated</span>
-                <span className="card-back__value">
-                  {new Date(provenance.generatedAt).toLocaleTimeString([], {
-                    hour: "numeric",
-                    minute: "2-digit",
-                  })}
-                </span>
-              </>
-            )}
-            {provenance.cacheStatus && (
-              <>
-                <span className="card-back__label">Cache</span>
-                <span className="card-back__value">
-                  {provenance.cacheStatus === "fresh" ? "Fresh" : "Stale"}
-                  {provenance.cacheExpiresAt &&
-                    ` (expires ${new Date(provenance.cacheExpiresAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })})`}
-                </span>
-              </>
-            )}
-            {provenance.inputSummary && (
-              <>
-                <span className="card-back__label">Input</span>
-                <span className="card-back__value">{provenance.inputSummary}</span>
-              </>
-            )}
-          </>
-        ) : (
-          <>
-            {provenance.method && (
-              <>
-                <span className="card-back__label">Method</span>
-                <span className="card-back__value">{provenance.method}</span>
-              </>
-            )}
-            {provenance.freshness && (
-              <>
-                <span className="card-back__label">Freshness</span>
-                <span className="card-back__value">{provenance.freshness}</span>
-              </>
-            )}
-            {provenance.filter && (
-              <>
-                <span className="card-back__label">Filter</span>
-                <span className="card-back__value card-back__value--mono">{provenance.filter}</span>
-              </>
-            )}
-            {provenance.dataBreakdown && (
-              <>
-                <span className="card-back__label">Data</span>
-                <span className="card-back__value">{provenance.dataBreakdown}</span>
-              </>
-            )}
-            {provenance.itemsShown && (
-              <>
-                <span className="card-back__label">Shown</span>
-                <span className="card-back__value">{provenance.itemsShown}</span>
-              </>
-            )}
+            <div className="tarot-inscription__rule" />
+            <div className="tarot-inscription__label tarot-inscription__label--ai">Intent</div>
+            <p className="tarot-inscription__intent">"{provenance.promptIntent}"</p>
           </>
         )}
-      </div>
 
-      {isAi && provenance.promptIntent && (
-        <div className="card-back__section">
-          <div className="card-back__section-label">Prompt Intent</div>
-          <p className="card-back__section-text">{provenance.promptIntent}</p>
-        </div>
+        {provenance.generatedAt && (
+          <>
+            <div className="tarot-inscription__rule" />
+            <div className="tarot-inscription__label tarot-inscription__label--ai">Cast at</div>
+            <div className="tarot-inscription__text">
+              {new Date(provenance.generatedAt).toLocaleTimeString([], {
+                hour: "numeric",
+                minute: "2-digit",
+              })}
+              {provenance.cacheExpiresAt &&
+                ` · Fresh until ${new Date(provenance.cacheExpiresAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`}
+            </div>
+          </>
+        )}
+      </>
+    );
+  }
+
+  // Deterministic
+  return (
+    <>
+      <div className="tarot-inscription__label tarot-inscription__label--sys">Computed by</div>
+      <div className="tarot-inscription__source">{provenance.method || "System Query"}</div>
+      <div className="tarot-inscription__detail">{provenance.freshness || "real-time"}</div>
+
+      {provenance.filter && (
+        <>
+          <div className="tarot-inscription__rule" />
+          <div className="tarot-inscription__label tarot-inscription__label--sys">Rule</div>
+          <p className="tarot-inscription__mono">{provenance.filter}</p>
+        </>
       )}
 
-      {!isAi && provenance.logic && (
-        <div className="card-back__section">
-          <div className="card-back__section-label">Logic</div>
-          <p className="card-back__section-text">{provenance.logic}</p>
-        </div>
+      {provenance.dataBreakdown && (
+        <>
+          <div className="tarot-inscription__rule" />
+          <div className="tarot-inscription__label tarot-inscription__label--sys">Reading</div>
+          <div className="tarot-inscription__text">{provenance.dataBreakdown}</div>
+        </>
       )}
 
-      <div className="card-back__section">
-        <div className="card-back__section-label">Why this panel is showing</div>
-        <p className="card-back__section-text">{reason}</p>
-      </div>
-    </div>
+      {reason && (
+        <>
+          <div className="tarot-inscription__rule" />
+          <div className="tarot-inscription__label tarot-inscription__label--sys">
+            Surfaced because
+          </div>
+          <div className="tarot-inscription__text" style={{ fontStyle: "italic" }}>
+            "{reason}"
+          </div>
+        </>
+      )}
+    </>
   );
 }

--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -1,6 +1,7 @@
 // client-react/src/components/home/PanelRenderer.tsx
 import { FlipCard } from "./FlipCard";
-import { CardBackContent as CardBack } from "./CardBack";
+import { TarotCardFront, TarotCardBack } from "./TarotCard";
+import { CardBackContent } from "./CardBack";
 import { PANEL_ART } from "./pixel-art";
 import type { RankedPanel, PanelProvenance } from "../../types/focusBrief";
 
@@ -11,7 +12,7 @@ interface Props {
   onEditTodo?: (id: string, updates: Record<string, unknown>) => void;
 }
 
-// ─── Unsorted Panel ────────────────────────────────────────────────────────
+// ─── Unsorted Panel (The Inbox, V, SYS) ──────────────────────────────────
 
 function UnsortedPanel({
   data,
@@ -30,15 +31,13 @@ function UnsortedPanel({
   const topItem = data.items[0];
 
   const front = (
-    <div className="panel-unsorted" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-unsorted__header">
-        <Art size={18} />
-        <span className="panel-unsorted__title">Unsorted Items</span>
-        <span className="focus-panel__subtitle">{data.items.length} items</span>
-      </div>
+    <TarotCardFront
+      name="The Inbox"
+      numeral="V"
+      source="sys"
+      illustration={<Art size={48} />}
+      illustrationCaption={data.items.length + " unsorted"}
+    >
       <div className="inbox-stack">
         <div className="inbox-stack__shadow inbox-stack__shadow--far" />
         <div className="inbox-stack__shadow inbox-stack__shadow--near" />
@@ -112,21 +111,24 @@ function UnsortedPanel({
           ))}
         </div>
       )}
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="The Inbox"
+      numeral="V"
+      source="sys"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;
 }
 
-// ─── Due Soon Panel ────────────────────────────────────────────────────────
+// ─── Due Soon Panel (The Hourglass, III, SYS) ────────────────────────────
 
 function DueSoonPanel({
   data,
@@ -147,15 +149,13 @@ function DueSoonPanel({
   const maxCount = Math.max(...data.groups.map((g: any) => g.items.length), 1);
 
   const front = (
-    <div className="panel-due-soon" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-due-soon__header">
-        <Art size={18} />
-        <span className="panel-due-soon__title">Due Soon</span>
-        <span className="focus-panel__subtitle">{totalItems} tasks</span>
-      </div>
+    <TarotCardFront
+      name="The Hourglass"
+      numeral="III"
+      source="sys"
+      illustration={<Art size={48} />}
+      illustrationCaption={totalItems + " tasks due"}
+    >
       <div className="urgency-bars">
         {data.groups.map((group: any) => (
           <div key={group.label} className="urgency-bar">
@@ -163,14 +163,22 @@ function DueSoonPanel({
               <span>{group.label}</span>
               <span>{group.items.length}</span>
             </div>
-            <div className="urgency-bar__track">
+            <div
+              style={{
+                height: 4,
+                background: "var(--tarot-frame)",
+                borderRadius: 2,
+                overflow: "hidden",
+              }}
+            >
               <div
-                className="urgency-bar__fill"
                 style={{
                   width: `${Math.round((group.items.length / maxCount) * 100)}%`,
+                  height: "100%",
                   background: group.items.some((i: any) => i.overdue)
-                    ? "var(--danger)"
-                    : "var(--warning)",
+                    ? "var(--tarot-red)"
+                    : "var(--tarot-amber)",
+                  borderRadius: 2,
                 }}
               />
             </div>
@@ -198,21 +206,24 @@ function DueSoonPanel({
             </button>
           ))}
       </div>
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="The Hourglass"
+      numeral="III"
+      source="sys"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;
 }
 
-// ─── What Next Panel ───────────────────────────────────────────────────────
+// ─── What Next Panel (The Compass, IV, AI) ───────────────────────────────
 
 function WhatNextPanel({
   data,
@@ -228,55 +239,78 @@ function WhatNextPanel({
   const Art = PANEL_ART["whatNext"];
 
   const front = (
-    <div className="panel-what-next" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-what-next__header">
-        <Art size={18} />
-        <span className="panel-what-next__title">What Next</span>
-        <span className="focus-panel__subtitle">
-          {data.items.length} recommendations
-        </span>
-      </div>
-      <div className="focus-list">
-        {data.items.map((item: any) => (
-          <div
-            key={item.id}
-            className="impact-card"
-            onClick={() => onTaskClick(item.id)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => e.key === "Enter" && onTaskClick(item.id)}
-          >
-            <div className="impact-card__top">
-              <span className="focus-list__item-title">{item.title}</span>
-              <div style={{ display: "flex", gap: "var(--s-1)" }}>
-                <span className={`focus-badge focus-badge--${item.impact}`}>
-                  {item.impact}
-                </span>
-                <span className="focus-badge">{item.effort}</span>
-              </div>
-            </div>
-            <div className="impact-card__reason">{item.reason}</div>
+    <TarotCardFront
+      name="The Compass"
+      numeral="IV"
+      source="ai"
+      illustration={<Art size={48} />}
+      illustrationCaption={data.items.length + " paths forward"}
+    >
+      {data.items.map((item: any, i: number) => (
+        <div
+          key={item.id}
+          className="tarot-ranked-entry"
+          style={{
+            opacity: i === 0 ? 1 : i === 1 ? 0.85 : 0.65,
+            cursor: "pointer",
+          }}
+          onClick={() => onTaskClick(item.id)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => e.key === "Enter" && onTaskClick(item.id)}
+        >
+          <div className="tarot-ranked-entry__header">
+            <span
+              className="tarot-ranked-numeral"
+              style={{ fontSize: `${18 - i * 2}px` }}
+            >
+              {i + 1}
+            </span>
+            <span
+              style={{
+                fontSize: `${14 - i}px`,
+                fontWeight: 500,
+                color: "var(--tarot-text)",
+              }}
+            >
+              {item.title}
+            </span>
           </div>
-        ))}
-      </div>
-    </div>
+          <div className="tarot-ranked-entry__reason">{item.reason}</div>
+          <div className="tarot-ranked-entry__meta">
+            <span
+              className={`tarot-micro-label tarot-micro-label--${item.impact}`}
+            >
+              {item.impact}
+            </span>
+            <span className="tarot-micro-sep">{"\u00b7"}</span>
+            <span
+              className="tarot-micro-label"
+              style={{ color: "var(--tarot-muted)" }}
+            >
+              {item.effort}
+            </span>
+          </div>
+        </div>
+      ))}
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="The Compass"
+      numeral="IV"
+      source="ai"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;
 }
 
-// ─── Backlog Hygiene Panel ─────────────────────────────────────────────────
+// ─── Backlog Hygiene Panel (The Web, VI, SYS) ────────────────────────────
 
 function BacklogHygienePanel({
   data,
@@ -292,54 +326,74 @@ function BacklogHygienePanel({
   const Art = PANEL_ART["backlogHygiene"];
 
   const front = (
-    <div className="panel-backlog" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-backlog__header">
-        <Art size={18} />
-        <span className="panel-backlog__title">Backlog Hygiene</span>
-        <span className="focus-panel__subtitle">{data.items.length} stale</span>
-      </div>
+    <TarotCardFront
+      name="The Web"
+      numeral="VI"
+      source="sys"
+      illustration={<Art size={48} />}
+      illustrationCaption={data.items.length + " stale"}
+    >
       <div className="focus-list">
-        {data.items.map((item: any) => (
+        {data.items.map((item: any, i: number) => (
           <button
             key={item.id}
             className="focus-list__item decay-item"
             onClick={() => onTaskClick(item.id)}
           >
             <div className="decay-item__row">
+              <span
+                style={{
+                  fontFamily: "var(--tarot-serif, Georgia, serif)",
+                  marginRight: "var(--s-2)",
+                  color: "var(--tarot-muted)",
+                }}
+              >
+                {i + 1}.
+              </span>
               <span>{item.title}</span>
               <span className="focus-list__meta">
                 {item.staleDays}d untouched
               </span>
             </div>
-            <div className="decay-item__bar">
+            <div
+              style={{
+                height: 3,
+                background: "var(--tarot-frame)",
+                borderRadius: 2,
+                overflow: "hidden",
+                marginTop: 4,
+              }}
+            >
               <div
-                className="decay-item__fill"
                 style={{
                   width: `${Math.min(Math.round((item.staleDays / 30) * 100), 100)}%`,
+                  height: "100%",
+                  background: `linear-gradient(90deg, var(--tarot-amber), var(--tarot-red))`,
+                  borderRadius: 2,
                 }}
               />
             </div>
           </button>
         ))}
       </div>
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="The Web"
+      numeral="VI"
+      source="sys"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;
 }
 
-// ─── Projects To Nudge Panel ───────────────────────────────────────────────
+// ─── Projects To Nudge Panel (The Guardian, VII, SYS) ────────────────────
 
 function ProjectsToNudgePanel({
   data,
@@ -355,14 +409,12 @@ function ProjectsToNudgePanel({
   const Art = PANEL_ART["projectsToNudge"];
 
   const front = (
-    <div className="panel-nudge" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-nudge__header">
-        <Art size={18} />
-        <span className="panel-nudge__title">Projects to Nudge</span>
-      </div>
+    <TarotCardFront
+      name="The Guardian"
+      numeral="VII"
+      source="sys"
+      illustration={<Art size={48} />}
+    >
       <div className="focus-list">
         {data.items.map((item: any) => {
           const isCritical = item.overdueCount > 0;
@@ -386,28 +438,31 @@ function ProjectsToNudgePanel({
                     item.dueSoonCount > 0 && `${item.dueSoonCount} due soon`,
                   ]
                     .filter(Boolean)
-                    .join(" · ")}
+                    .join(" \u00b7 ")}
                 </div>
               </div>
             </button>
           );
         })}
       </div>
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="The Guardian"
+      numeral="VII"
+      source="sys"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;
 }
 
-// ─── Track Overview Panel ──────────────────────────────────────────────────
+// ─── Track Overview Panel (The Road, VIII, SYS) ──────────────────────────
 
 function TrackOverviewPanel({
   data,
@@ -420,19 +475,26 @@ function TrackOverviewPanel({
 }) {
   const Art = PANEL_ART["trackOverview"];
 
+  const columnColors: Record<string, string> = {
+    thisWeek: "var(--tarot-warm, var(--tarot-amber))",
+    next14Days: "var(--tarot-sage, var(--tarot-text))",
+    later: "var(--tarot-muted)",
+  };
+
   const front = (
-    <div className="panel-track" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-track__header">
-        <Art size={18} />
-        <span className="panel-track__title">Task Timeline</span>
-      </div>
+    <TarotCardFront
+      name="The Road"
+      numeral="VIII"
+      source="sys"
+      illustration={<Art size={48} />}
+    >
       <div className="focus-track">
         {(["thisWeek", "next14Days", "later"] as const).map((col) => (
           <div key={col} className="focus-track__column">
-            <div className={`focus-track__header focus-track__header--${col}`}>
+            <div
+              className="focus-track__header"
+              style={{ color: columnColors[col] }}
+            >
               {col === "thisWeek"
                 ? "This week"
                 : col === "next14Days"
@@ -447,21 +509,24 @@ function TrackOverviewPanel({
           </div>
         ))}
       </div>
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="The Road"
+      numeral="VIII"
+      source="sys"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;
 }
 
-// ─── Rescue Mode Panel ─────────────────────────────────────────────────────
+// ─── Rescue Mode Panel (Rescue, SYS) ─────────────────────────────────────
 
 function RescueModePanel({
   data,
@@ -477,28 +542,29 @@ function RescueModePanel({
   const Art = PANEL_ART["rescueMode"];
 
   const front = (
-    <div className="panel-rescue" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <Art size={120} />
-      </div>
-      <div className="panel-rescue__header">
-        <Art size={18} />
-        <span className="panel-rescue__title">Rescue Mode</span>
-      </div>
+    <TarotCardFront
+      name="Rescue"
+      numeral=""
+      source="sys"
+      illustration={<Art size={48} />}
+    >
       <p className="focus-rescue__text">
         You have <strong>{data.openCount}</strong> open tasks and{" "}
         <strong>{data.overdueCount}</strong> are overdue. Consider triaging or
         deferring some tasks.
       </p>
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason={reason}
-      pixelArt={<Art size={64} />}
-    />
+    <TarotCardBack
+      name="Rescue"
+      numeral=""
+      source="sys"
+      illustration={<Art size={80} />}
+    >
+      <CardBackContent provenance={provenance} reason={reason} />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;

--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -1,6 +1,6 @@
 // client-react/src/components/home/PanelRenderer.tsx
 import { FlipCard } from "./FlipCard";
-import { CardBack } from "./CardBack";
+import { CardBackContent as CardBack } from "./CardBack";
 import { PANEL_ART } from "./pixel-art";
 import type { RankedPanel, PanelProvenance } from "../../types/focusBrief";
 

--- a/client-react/src/components/home/RightNowPanel.tsx
+++ b/client-react/src/components/home/RightNowPanel.tsx
@@ -1,6 +1,7 @@
 // client-react/src/components/home/RightNowPanel.tsx
 import { FlipCard } from "./FlipCard";
-import { CardBack } from "./CardBack";
+import { TarotCardFront, TarotCardBack } from "./TarotCard";
+import { CardBackContent } from "./CardBack";
 import { FlameArt } from "./pixel-art";
 import type { RightNow, PanelProvenance } from "../../types/focusBrief";
 
@@ -16,40 +17,46 @@ export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
   }
 
   const front = (
-    <div className="panel-right-now" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <FlameArt size={120} />
-      </div>
-      <div className="panel-right-now__header">
-        <FlameArt size={18} />
-        <span className="panel-right-now__title">Right Now</span>
-      </div>
-
-      {data.narrative && (
-        <p className="panel-right-now__narrative">{data.narrative}</p>
-      )}
-
+    <TarotCardFront
+      name="The Flame"
+      numeral="I"
+      source="ai"
+      illustration={<FlameArt size={64} />}
+      hero
+    >
+      {data.narrative && <p className="tarot-narrative">{data.narrative}</p>}
       {data.topRecommendation && (
         <button
-          className="focus-recommendation"
+          className="tarot-action-band"
           onClick={() => onTaskClick(data.topRecommendation!.taskId)}
+          style={{
+            border: "none",
+            cursor: "pointer",
+            textAlign: "left",
+            width: "100%",
+            fontFamily: "inherit",
+          }}
         >
-          <div className="focus-recommendation__label">→ Strongest next action</div>
-          <div className="focus-recommendation__title">{data.topRecommendation.title}</div>
-          <div className="focus-recommendation__reasoning">
-            {data.topRecommendation.reasoning}
-          </div>
+          <div className="tarot-action-band__label">Strongest action</div>
+          <div className="tarot-action-band__title">{data.topRecommendation.title}</div>
+          <div className="tarot-action-band__reason">{data.topRecommendation.reasoning}</div>
         </button>
       )}
-    </div>
+    </TarotCardFront>
   );
 
   const back = (
-    <CardBack
-      provenance={provenance}
-      reason="Pinned — always visible. Urgent items and your strongest next action."
-      pixelArt={<FlameArt size={64} />}
-    />
+    <TarotCardBack
+      name="The Flame"
+      numeral="I"
+      source="ai"
+      illustration={<FlameArt size={80} />}
+    >
+      <CardBackContent
+        provenance={provenance}
+        reason="Pinned — always visible. Urgent items and your strongest next action."
+      />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;

--- a/client-react/src/components/home/TarotCard.tsx
+++ b/client-react/src/components/home/TarotCard.tsx
@@ -1,0 +1,84 @@
+// client-react/src/components/home/TarotCard.tsx
+import type { ReactNode } from "react";
+
+export interface TarotCardProps {
+  name: string;
+  numeral: string;
+  source: "ai" | "sys";
+  illustration: ReactNode;
+  illustrationCaption?: string;
+  children: ReactNode;
+  hero?: boolean;
+}
+
+export function TarotCardFront({
+  name,
+  numeral,
+  source,
+  illustration,
+  illustrationCaption,
+  children,
+  hero,
+}: TarotCardProps) {
+  const cornerClass = source === "ai" ? "tarot-corner--ai" : "tarot-corner--sys";
+  const sourceLabel = source === "ai" ? "◇ AI" : "▪ SYS";
+
+  return (
+    <div className="tarot-frame">
+      <div className="tarot-corners">
+        <span className={`tarot-corner ${cornerClass}`}>{sourceLabel}</span>
+        <span className={`tarot-corner ${cornerClass}`}>{numeral}</span>
+      </div>
+      <div className="tarot-name">{name}</div>
+      <div className={`tarot-illustration${hero ? " tarot-illustration--hero" : ""}`}>
+        {illustration}
+      </div>
+      {illustrationCaption && (
+        <div className="tarot-illustration__caption">{illustrationCaption}</div>
+      )}
+      <div className="tarot-divider" />
+      <div className="tarot-content">
+        {children}
+      </div>
+      <div className="tarot-corners tarot-corners--bottom">
+        <span className={`tarot-corner ${cornerClass}`}>{numeral}</span>
+        <span className={`tarot-corner ${cornerClass}`}>{sourceLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+export function TarotCardBack({
+  name,
+  numeral,
+  source,
+  illustration,
+  children,
+}: Omit<TarotCardProps, "illustrationCaption" | "hero">) {
+  const cornerClass = source === "ai" ? "tarot-corner--ai" : "tarot-corner--sys";
+  const sourceLabel = source === "ai" ? "◇ AI" : "▪ SYS";
+  const suitSymbol = source === "ai" ? "◇" : "▪";
+
+  return (
+    <div className="tarot-frame">
+      <div className="tarot-corners">
+        <span className={`tarot-corner ${cornerClass}`}>{sourceLabel}</span>
+        <span className={`tarot-corner ${cornerClass}`}>{numeral}</span>
+      </div>
+      <div className="tarot-name">{name} — Reversed</div>
+      <div className="tarot-illustration">
+        {illustration}
+      </div>
+      <div className="tarot-divider--ornament">
+        <span>{suitSymbol}</span>
+      </div>
+      <div className="tarot-inscription">
+        {children}
+      </div>
+      <div className="tarot-corners tarot-corners--bottom">
+        <span className={`tarot-corner ${cornerClass}`}>{numeral}</span>
+        <span className={`tarot-corner ${cornerClass}`}>{sourceLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/client-react/src/components/home/TodayAgendaPanel.tsx
+++ b/client-react/src/components/home/TodayAgendaPanel.tsx
@@ -1,6 +1,7 @@
 // client-react/src/components/home/TodayAgendaPanel.tsx
 import { FlipCard } from "./FlipCard";
-import { CardBack } from "./CardBack";
+import { TarotCardFront, TarotCardBack } from "./TarotCard";
+import { CardBackContent } from "./CardBack";
 import { SunriseArt } from "./pixel-art";
 import type { AgendaItem, PanelProvenance } from "../../types/focusBrief";
 
@@ -12,78 +13,65 @@ interface Props {
 }
 
 function dotColor(item: AgendaItem): string {
-  if (item.overdue) return "var(--danger)";
-  if (item.estimateMinutes != null && item.estimateMinutes <= 15) return "var(--success, #4ade80)";
-  return "var(--accent)";
+  if (item.overdue) return "var(--tarot-red)";
+  if (item.estimateMinutes != null && item.estimateMinutes <= 15) return "var(--tarot-sage)";
+  return "var(--tarot-gold)";
 }
 
-export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle }: Props) {
-  const back = (
-    <CardBack
-      provenance={provenance}
-      reason="Pinned — your day at a glance."
-      pixelArt={<SunriseArt size={64} />}
-    />
+export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle: _onToggle }: Props) {
+  const front = (
+    <TarotCardFront
+      name="The Dawn"
+      numeral="II"
+      source="sys"
+      illustration={<SunriseArt size={64} />}
+      illustrationCaption={`${items.length} task${items.length !== 1 ? "s" : ""}`}
+      hero
+    >
+      {items.length === 0 ? (
+        <p className="tarot-light-day">All clear. Enjoy your day.</p>
+      ) : (
+        <>
+          <div className="timeline">
+            <div className="timeline__line" />
+            {items.map((item) => (
+              <div key={item.id} className="timeline__item">
+                <div className="timeline__dot" style={{ background: dotColor(item) }} />
+                <div className="timeline__content">
+                  <button className="timeline__title" onClick={() => onTaskClick(item.id)}>
+                    {item.title}
+                  </button>
+                  <span className="timeline__meta">
+                    {item.overdue ? (
+                      <span className="timeline__overdue">overdue</span>
+                    ) : item.estimateMinutes ? (
+                      `${item.estimateMinutes}m`
+                    ) : null}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+          {items.length <= 2 && (
+            <p className="tarot-light-day">Light day — room to get ahead.</p>
+          )}
+        </>
+      )}
+    </TarotCardFront>
   );
 
-  if (items.length === 0) {
-    const front = (
-      <div className="panel-today-agenda" style={{ position: "relative" }}>
-        <div className="card-watermark">
-          <SunriseArt size={120} />
-        </div>
-        <div className="panel-today-agenda__header">
-          <SunriseArt size={18} />
-          <span className="panel-today-agenda__title">Today's Agenda</span>
-        </div>
-        <p className="focus-panel__empty">Nothing scheduled for today.</p>
-      </div>
-    );
-    return <FlipCard front={front} back={back} />;
-  }
-
-  const front = (
-    <div className="panel-today-agenda" style={{ position: "relative" }}>
-      <div className="card-watermark">
-        <SunriseArt size={120} />
-      </div>
-      <div className="panel-today-agenda__header">
-        <SunriseArt size={18} />
-        <span className="panel-today-agenda__title">Today's Agenda</span>
-        <span className="panel-today-agenda__subtitle">{items.length} tasks</span>
-      </div>
-
-      <div className="timeline">
-        <div className="timeline__line" />
-        {items.map((item) => (
-          <div key={item.id} className="timeline__item">
-            <div
-              className="timeline__dot"
-              style={{ background: dotColor(item) }}
-            />
-            <div className="timeline__content">
-              <button
-                className={`timeline__title${item.completed ? " timeline__title--done" : ""}`}
-                onClick={() => onTaskClick(item.id)}
-              >
-                {item.title}
-              </button>
-              <span className="timeline__meta">
-                {item.overdue ? (
-                  <span className="timeline__overdue">overdue</span>
-                ) : item.estimateMinutes ? (
-                  `${item.estimateMinutes}m`
-                ) : null}
-              </span>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {items.length <= 2 && items.length > 0 && (
-        <p className="panel-today-agenda__light-day">Light day — room to get ahead.</p>
-      )}
-    </div>
+  const back = (
+    <TarotCardBack
+      name="The Dawn"
+      numeral="II"
+      source="sys"
+      illustration={<SunriseArt size={80} />}
+    >
+      <CardBackContent
+        provenance={provenance}
+        reason="Pinned — your day at a glance."
+      />
+    </TarotCardBack>
   );
 
   return <FlipCard front={front} back={back} />;

--- a/client-react/src/components/home/pixel-art/index.tsx
+++ b/client-react/src/components/home/pixel-art/index.tsx
@@ -14,12 +14,12 @@ export function FlameArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="7" y="1" width="2" height="2" fill="#ef4444" />
-      <rect x="6" y="3" width="4" height="2" fill="#ef4444" />
-      <rect x="5" y="5" width="6" height="2" fill="#f59e0b" />
-      <rect x="5" y="7" width="6" height="2" fill="#f59e0b" />
-      <rect x="6" y="9" width="4" height="2" fill="#fbbf24" />
-      <rect x="7" y="11" width="2" height="2" fill="#fbbf24" />
+      <rect x="7" y="1" width="2" height="2" fill="#c45a3c" />
+      <rect x="6" y="3" width="4" height="2" fill="#c45a3c" />
+      <rect x="5" y="5" width="6" height="2" fill="#d4864a" />
+      <rect x="5" y="7" width="6" height="2" fill="#d4864a" />
+      <rect x="6" y="9" width="4" height="2" fill="#daa85c" />
+      <rect x="7" y="11" width="2" height="2" fill="#daa85c" />
     </svg>
   );
 }
@@ -34,12 +34,12 @@ export function SunriseArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="6" y="2" width="4" height="2" fill="#fbbf24" />
-      <rect x="4" y="4" width="8" height="2" fill="#f59e0b" />
-      <rect x="3" y="6" width="10" height="2" fill="#f59e0b" />
-      <rect x="2" y="8" width="12" height="1" fill="#e5e7eb" />
-      <rect x="0" y="9" width="16" height="1" fill="#d1d5db" />
-      <rect x="0" y="10" width="16" height="6" fill="#e5e7eb" />
+      <rect x="6" y="2" width="4" height="2" fill="#daa85c" />
+      <rect x="4" y="4" width="8" height="2" fill="#d4864a" />
+      <rect x="3" y="6" width="10" height="2" fill="#d4864a" />
+      <rect x="2" y="8" width="12" height="1" fill="#e0dbd3" />
+      <rect x="0" y="9" width="16" height="1" fill="#d0c8b8" />
+      <rect x="0" y="10" width="16" height="6" fill="#e0dbd3" />
     </svg>
   );
 }
@@ -54,14 +54,14 @@ export function HourglassArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="4" y="1" width="8" height="2" fill="#6b7280" />
-      <rect x="5" y="3" width="6" height="1" fill="#ef4444" />
-      <rect x="6" y="4" width="4" height="1" fill="#ef4444" />
-      <rect x="7" y="5" width="2" height="2" fill="#f59e0b" />
-      <rect x="6" y="7" width="4" height="1" fill="#fbbf24" />
-      <rect x="5" y="8" width="6" height="1" fill="#fbbf24" />
-      <rect x="5" y="9" width="6" height="2" fill="#e5e7eb" />
-      <rect x="4" y="11" width="8" height="2" fill="#6b7280" />
+      <rect x="4" y="1" width="8" height="2" fill="#8a8a7e" />
+      <rect x="5" y="3" width="6" height="1" fill="#c45a3c" />
+      <rect x="6" y="4" width="4" height="1" fill="#c45a3c" />
+      <rect x="7" y="5" width="2" height="2" fill="#d4864a" />
+      <rect x="6" y="7" width="4" height="1" fill="#daa85c" />
+      <rect x="5" y="8" width="6" height="1" fill="#daa85c" />
+      <rect x="5" y="9" width="6" height="2" fill="#e0dbd3" />
+      <rect x="4" y="11" width="8" height="2" fill="#8a8a7e" />
     </svg>
   );
 }
@@ -76,13 +76,13 @@ export function CompassArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="5" y="1" width="6" height="1" fill="#4a7dff" />
-      <rect x="3" y="2" width="10" height="1" fill="#4a7dff" />
-      <rect x="2" y="3" width="12" height="10" fill="#e0e7ff" />
-      <rect x="7" y="4" width="2" height="3" fill="#ef4444" />
-      <rect x="7" y="8" width="2" height="3" fill="#d1d5db" />
-      <rect x="3" y="13" width="10" height="1" fill="#4a7dff" />
-      <rect x="5" y="14" width="6" height="1" fill="#4a7dff" />
+      <rect x="5" y="1" width="6" height="1" fill="#6a7a9a" />
+      <rect x="3" y="2" width="10" height="1" fill="#6a7a9a" />
+      <rect x="2" y="3" width="12" height="10" fill="#d8dce8" />
+      <rect x="7" y="4" width="2" height="3" fill="#c45a3c" />
+      <rect x="7" y="8" width="2" height="3" fill="#d0c8b8" />
+      <rect x="3" y="13" width="10" height="1" fill="#6a7a9a" />
+      <rect x="5" y="14" width="6" height="1" fill="#6a7a9a" />
     </svg>
   );
 }
@@ -102,8 +102,8 @@ export function PapersArt({ size = 64 }: ArtProps) {
         y="2"
         width="8"
         height="10"
-        fill="#fef3c7"
-        stroke="#f59e0b"
+        fill="#f0e8d8"
+        stroke="#d4864a"
         strokeWidth="1"
       />
       <rect
@@ -111,13 +111,13 @@ export function PapersArt({ size = 64 }: ArtProps) {
         y="4"
         width="8"
         height="10"
-        fill="#fefce8"
-        stroke="#f59e0b"
+        fill="#f5efe5"
+        stroke="#d4864a"
         strokeWidth="1"
       />
-      <rect x="6" y="6" width="4" height="1" fill="#d1d5db" />
-      <rect x="6" y="8" width="3" height="1" fill="#d1d5db" />
-      <rect x="6" y="10" width="5" height="1" fill="#d1d5db" />
+      <rect x="6" y="6" width="4" height="1" fill="#d0c8b8" />
+      <rect x="6" y="8" width="3" height="1" fill="#d0c8b8" />
+      <rect x="6" y="10" width="5" height="1" fill="#d0c8b8" />
     </svg>
   );
 }
@@ -132,14 +132,14 @@ export function CobwebArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="0" y="0" width="1" height="16" fill="#d1d5db" opacity="0.5" />
-      <rect x="0" y="0" width="16" height="1" fill="#d1d5db" opacity="0.5" />
-      <rect x="1" y="1" width="1" height="1" fill="#9ca3af" />
-      <rect x="3" y="3" width="1" height="1" fill="#9ca3af" />
-      <rect x="5" y="5" width="1" height="1" fill="#9ca3af" />
-      <rect x="7" y="7" width="2" height="2" fill="#6b7280" />
-      <rect x="2" y="4" width="3" height="1" fill="#d1d5db" opacity="0.3" />
-      <rect x="4" y="2" width="1" height="3" fill="#d1d5db" opacity="0.3" />
+      <rect x="0" y="0" width="1" height="16" fill="#d0c8b8" opacity="0.5" />
+      <rect x="0" y="0" width="16" height="1" fill="#d0c8b8" opacity="0.5" />
+      <rect x="1" y="1" width="1" height="1" fill="#9a968e" />
+      <rect x="3" y="3" width="1" height="1" fill="#9a968e" />
+      <rect x="5" y="5" width="1" height="1" fill="#9a968e" />
+      <rect x="7" y="7" width="2" height="2" fill="#8a8a7e" />
+      <rect x="2" y="4" width="3" height="1" fill="#d0c8b8" opacity="0.3" />
+      <rect x="4" y="2" width="1" height="3" fill="#d0c8b8" opacity="0.3" />
     </svg>
   );
 }
@@ -154,15 +154,15 @@ export function SleepyCatArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="3" y="5" width="2" height="2" fill="#8b5cf6" />
-      <rect x="11" y="5" width="2" height="2" fill="#8b5cf6" />
-      <rect x="4" y="7" width="8" height="4" fill="#a78bfa" />
-      <rect x="3" y="8" width="10" height="3" fill="#a78bfa" />
-      <rect x="6" y="8" width="1" height="1" fill="#1f2937" />
-      <rect x="9" y="8" width="1" height="1" fill="#1f2937" />
-      <rect x="7" y="9" width="2" height="1" fill="#ec4899" />
-      <rect x="2" y="11" width="12" height="2" fill="#a78bfa" />
-      <rect x="13" y="10" width="2" height="1" fill="#a78bfa" />
+      <rect x="3" y="5" width="2" height="2" fill="#7a6a9a" />
+      <rect x="11" y="5" width="2" height="2" fill="#7a6a9a" />
+      <rect x="4" y="7" width="8" height="4" fill="#9a8ab8" />
+      <rect x="3" y="8" width="10" height="3" fill="#9a8ab8" />
+      <rect x="6" y="8" width="1" height="1" fill="#3d3730" />
+      <rect x="9" y="8" width="1" height="1" fill="#3d3730" />
+      <rect x="7" y="9" width="2" height="1" fill="#c45a7a" />
+      <rect x="2" y="11" width="12" height="2" fill="#9a8ab8" />
+      <rect x="13" y="10" width="2" height="1" fill="#9a8ab8" />
     </svg>
   );
 }
@@ -177,14 +177,14 @@ export function RoadArt({ size = 64 }: ArtProps) {
       xmlns="http://www.w3.org/2000/svg"
       style={{ imageRendering: "pixelated" }}
     >
-      <rect x="0" y="12" width="16" height="4" fill="#4ade80" />
-      <rect x="3" y="10" width="10" height="2" fill="#9ca3af" />
-      <rect x="5" y="8" width="6" height="2" fill="#9ca3af" />
-      <rect x="6" y="6" width="4" height="2" fill="#9ca3af" />
-      <rect x="7" y="4" width="2" height="2" fill="#9ca3af" />
-      <rect x="7" y="11" width="2" height="1" fill="#fbbf24" />
-      <rect x="7" y="9" width="2" height="1" fill="#fbbf24" />
-      <rect x="7" y="7" width="2" height="1" fill="#fbbf24" />
+      <rect x="0" y="12" width="16" height="4" fill="#8a9a8e" />
+      <rect x="3" y="10" width="10" height="2" fill="#9a968e" />
+      <rect x="5" y="8" width="6" height="2" fill="#9a968e" />
+      <rect x="6" y="6" width="4" height="2" fill="#9a968e" />
+      <rect x="7" y="4" width="2" height="2" fill="#9a968e" />
+      <rect x="7" y="11" width="2" height="1" fill="#daa85c" />
+      <rect x="7" y="9" width="2" height="1" fill="#daa85c" />
+      <rect x="7" y="7" width="2" height="1" fill="#daa85c" />
     </svg>
   );
 }

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2760,27 +2760,79 @@ body {
   }
 }
 
-/* --- Home dashboard (classic Focus — pixel-matched) --- */
+/* ── Dashboard Tabletop ────────────────────── */
+
 .home-dashboard {
   display: grid;
   gap: var(--s-4);
-  max-width: 960px;
+  max-width: 720px;
   margin: 0 auto;
-  padding: var(--s-4);
+  padding: var(--s-5);
+  background: var(--tarot-tabletop);
+  min-height: 100%;
 }
 
 .home-dashboard__pinned {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--s-4);
+  gap: 20px;
   align-items: stretch;
+}
+
+.home-dashboard__pinned .flip-card__inner {
+  height: 360px;
+}
+
+.home-dashboard__pinned .flip-card__front,
+.home-dashboard__pinned .flip-card__back {
+  height: 360px;
+}
+
+/* Hero gradient washes */
+.home-dashboard__pinned .flip-card:first-child .flip-card__front {
+  background: linear-gradient(
+    135deg,
+    var(--tarot-parchment),
+    color-mix(in oklab, var(--tarot-red) 2%, var(--tarot-parchment))
+  );
+}
+
+.home-dashboard__pinned .flip-card:nth-child(2) .flip-card__front {
+  background: linear-gradient(
+    135deg,
+    var(--tarot-parchment),
+    color-mix(in oklab, var(--tarot-sage) 3%, var(--tarot-parchment))
+  );
 }
 
 .home-dashboard__ranked {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--s-4);
+  gap: 20px;
   align-items: stretch;
+}
+
+.home-dashboard__ranked .flip-card__inner {
+  height: 300px;
+}
+
+.home-dashboard__ranked .flip-card__front,
+.home-dashboard__ranked .flip-card__back {
+  height: 300px;
+}
+
+/* Content overflow fade */
+.home-dashboard__ranked .flip-card__front::after,
+.home-dashboard__pinned .flip-card__front::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  background: linear-gradient(transparent, var(--tarot-parchment));
+  pointer-events: none;
+  border-radius: 0 0 4px 4px;
 }
 
 @media (max-width: 768px) {
@@ -3026,11 +3078,21 @@ body {
   font-weight: 600;
 }
 
-.focus-panel__title--danger { color: var(--danger); }
-.focus-panel__title--accent { color: var(--accent); }
-.focus-panel__title--warning { color: var(--warning); }
-.focus-panel__title--purple { color: #8b5cf6; }
-.focus-panel__title--success { color: var(--success); }
+.focus-panel__title--danger {
+  color: var(--danger);
+}
+.focus-panel__title--accent {
+  color: var(--accent);
+}
+.focus-panel__title--warning {
+  color: var(--warning);
+}
+.focus-panel__title--purple {
+  color: #8b5cf6;
+}
+.focus-panel__title--success {
+  color: var(--success);
+}
 
 .focus-panel__subtitle {
   font-size: var(--fs-xs);
@@ -3050,7 +3112,7 @@ body {
   padding: var(--s-4) 0;
 }
 
-/* ── Flip Card System ──────────────────────── */
+/* ── Tarot Card Shell ──────────────────────── */
 
 .flip-card {
   perspective: 1000px;
@@ -3069,11 +3131,14 @@ body {
 .flip-card__front,
 .flip-card__back {
   backface-visibility: hidden;
-  border-radius: var(--r-lg);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 4px 16px rgba(0, 0, 0, 0.06);
-  border: 1px solid var(--border-light);
-  background: var(--surface);
-  padding: var(--s-4);
+  background: var(--tarot-parchment);
+  border: 1px solid var(--tarot-border);
+  border-radius: 6px;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 12px rgba(0, 0, 0, 0.06),
+    0 8px 24px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
 }
 
 .flip-card__front {
@@ -3082,102 +3147,188 @@ body {
   position: relative;
 }
 
-/* Geometric inner border frame — collectible card feel */
-.flip-card__front::before {
-  content: "";
+.flip-card__back {
+  transform: rotateY(180deg);
   position: absolute;
-  inset: 8px;
-  border: 1px solid color-mix(in oklab, var(--muted) 10%, transparent);
-  border-radius: calc(var(--r-lg) - 6px);
-  pointer-events: none;
-}
-
-/* ── Competing (ranked) cards — fixed 280px ── */
-
-.home-dashboard__ranked .flip-card__inner {
-  height: 280px;
-}
-
-.home-dashboard__ranked .flip-card__front {
-  height: 280px;
-  overflow: hidden;
-}
-
-/* Fade-out gradient at bottom if content overflows */
-.home-dashboard__ranked .flip-card__front::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 40px;
-  background: linear-gradient(transparent, var(--surface));
-  pointer-events: none;
-}
-
-.home-dashboard__ranked .flip-card__back {
-  height: 280px;
+  inset: 0;
+  background: var(--tarot-parchment-dark);
   overflow-y: auto;
 }
 
-/* ── Hero pinned cards — fixed 340px ── */
-
-.home-dashboard__pinned .flip-card__inner {
-  height: 340px;
-}
-
-.home-dashboard__pinned .flip-card__front,
-.home-dashboard__pinned .flip-card__back {
-  padding: var(--s-5);
-}
-
-.home-dashboard__pinned .flip-card__front {
-  height: 340px;
+/* Inner frame — printed margin effect */
+.tarot-frame {
+  margin: 8px;
+  border: 1px solid var(--tarot-frame);
+  border-radius: 4px;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: calc(100% - 16px);
 }
 
-.home-dashboard__pinned .flip-card__front::after {
+/* Corner markers */
+.tarot-corners {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px 0;
+}
+
+.tarot-corner {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.tarot-corner--ai {
+  color: var(--tarot-gold);
+}
+.tarot-corner--sys {
+  color: var(--tarot-sage);
+}
+
+/* Card name plate */
+.tarot-name {
+  text-align: center;
+  padding: 4px 16px 8px;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--tarot-muted);
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+/* Central illustration */
+.tarot-illustration {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 24px 12px;
+}
+
+.tarot-illustration svg {
+  opacity: 0.5;
+}
+
+.tarot-illustration--hero svg {
+  opacity: 0.7;
+}
+
+/* Content divider */
+.tarot-divider {
+  margin: 0 16px;
+  border-top: 1px solid var(--tarot-frame);
+}
+
+/* Ornamental divider (for card back) */
+.tarot-divider--ornament {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 24px;
+}
+
+.tarot-divider--ornament::before,
+.tarot-divider--ornament::after {
   content: "";
+  flex: 1;
+  border-top: 1px solid var(--tarot-frame);
+}
+
+.tarot-divider--ornament span {
+  font-size: 8px;
+  color: var(--tarot-faint);
+}
+
+/* Content area */
+.tarot-content {
+  padding: 12px 16px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Bottom corners (mirrored) */
+.tarot-corners--bottom {
+  padding: 0 12px 8px;
+}
+
+.tarot-corners--bottom .tarot-corner:last-child {
+  transform: rotate(180deg);
+}
+
+/* Dog ear fold */
+.dog-ear {
   position: absolute;
-  bottom: 0;
-  left: 0;
+  top: 0;
   right: 0;
-  height: 40px;
-  background: linear-gradient(transparent, var(--surface));
-  pointer-events: none;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  z-index: 5;
 }
 
-.home-dashboard__pinned .flip-card__back {
-  height: 340px;
-  overflow-y: auto;
+.dog-ear__fold {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 28px 28px 0;
+  border-color: transparent
+    color-mix(in oklab, var(--tarot-muted) 15%, transparent) transparent
+    transparent;
+  transition: border-color 0.2s ease;
 }
 
-/* Hero inner border frame — accent tinted */
-.home-dashboard__pinned .flip-card__front::before {
-  border-color: color-mix(in oklab, var(--accent) 15%, transparent);
-  inset: 10px;
+.dog-ear__under {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 26px 26px 0;
+  border-color: transparent var(--tarot-parchment) transparent transparent;
 }
 
-/* Hero gradient backgrounds instead of thin top border */
-.home-dashboard__pinned .flip-card:first-child .flip-card__front {
-  background: linear-gradient(135deg, var(--surface), color-mix(in oklab, var(--danger) 3%, var(--surface)));
-}
-
-.home-dashboard__pinned .flip-card:nth-child(2) .flip-card__front {
-  background: linear-gradient(135deg, var(--surface), color-mix(in oklab, var(--accent) 3%, var(--surface)));
+.dog-ear:hover .dog-ear__fold {
+  border-color: transparent
+    color-mix(in oklab, var(--tarot-muted) 30%, transparent) transparent
+    transparent;
 }
 
 /* ── Card accent colors per panel type ── */
 
-.panel-right-now { --card-accent: var(--danger); }
-.panel-today-agenda { --card-accent: var(--accent); }
-.panel-due-soon { --card-accent: var(--danger); }
-.panel-what-next { --card-accent: var(--accent); }
-.panel-unsorted { --card-accent: var(--warning); }
-.panel-backlog { --card-accent: var(--warning); }
-.panel-nudge { --card-accent: #8b5cf6; }
-.panel-track { --card-accent: var(--accent); }
-.panel-rescue { --card-accent: var(--danger); }
+.panel-right-now {
+  --card-accent: var(--danger);
+}
+.panel-today-agenda {
+  --card-accent: var(--accent);
+}
+.panel-due-soon {
+  --card-accent: var(--danger);
+}
+.panel-what-next {
+  --card-accent: var(--accent);
+}
+.panel-unsorted {
+  --card-accent: var(--warning);
+}
+.panel-backlog {
+  --card-accent: var(--warning);
+}
+.panel-nudge {
+  --card-accent: #8b5cf6;
+}
+.panel-track {
+  --card-accent: var(--accent);
+}
+.panel-rescue {
+  --card-accent: var(--danger);
+}
 
 /* ── Watermark art — faded illustration in bottom-right ── */
 
@@ -3218,59 +3369,6 @@ body {
   font-style: italic;
   margin-top: auto;
   padding-top: var(--s-3);
-}
-
-.flip-card:hover .flip-card__front {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1), 0 8px 24px rgba(0, 0, 0, 0.08);
-  transform: translateY(-1px);
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.flip-card__back {
-  transform: rotateY(180deg);
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, var(--surface), color-mix(in oklab, var(--surface) 95%, var(--muted)));
-  overflow-y: auto;
-}
-
-/* ── Dog Ear Fold ──────────────────────────── */
-
-.dog-ear {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 28px;
-  height: 28px;
-  cursor: pointer;
-  z-index: 5;
-}
-
-.dog-ear__fold {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 0 28px 28px 0;
-  border-color: transparent color-mix(in oklab, var(--muted) 15%, transparent) transparent transparent;
-  transition: border-color var(--dur-fast) ease;
-}
-
-.dog-ear__under {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 0 26px 26px 0;
-  border-color: transparent var(--surface) transparent transparent;
-}
-
-.dog-ear:hover .dog-ear__fold {
-  border-color: transparent color-mix(in oklab, var(--muted) 30%, transparent) transparent transparent;
 }
 
 /* ── Card Back ─────────────────────────────── */
@@ -3584,9 +3682,18 @@ body {
   color: var(--muted);
 }
 
-.focus-badge--high { background: color-mix(in oklab, var(--danger) 10%, transparent); color: var(--danger); }
-.focus-badge--medium { background: color-mix(in oklab, var(--warning) 10%, transparent); color: var(--warning); }
-.focus-badge--low { background: var(--surface-2); color: var(--muted); }
+.focus-badge--high {
+  background: color-mix(in oklab, var(--danger) 10%, transparent);
+  color: var(--danger);
+}
+.focus-badge--medium {
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
+  color: var(--warning);
+}
+.focus-badge--low {
+  background: var(--surface-2);
+  color: var(--muted);
+}
 
 /* ── Focus Group (for due soon bands) ──────── */
 
@@ -3623,9 +3730,17 @@ body {
   margin-bottom: var(--s-2);
 }
 
-.focus-track__header--thisWeek { color: var(--warning); border-color: var(--warning); }
-.focus-track__header--next14Days { color: var(--accent); border-color: var(--accent); }
-.focus-track__header--later { color: var(--muted); }
+.focus-track__header--thisWeek {
+  color: var(--warning);
+  border-color: var(--warning);
+}
+.focus-track__header--next14Days {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.focus-track__header--later {
+  color: var(--muted);
+}
 
 .focus-track__item {
   font-size: var(--fs-label);
@@ -3633,32 +3748,210 @@ body {
   color: var(--text);
 }
 
-/* ── Surfaced divider ──────────────────────── */
+/* ── Tarot Data Composition ────────────────── */
 
-.focus-divider {
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
+/* Ranked entries (The Compass) */
+.tarot-ranked-entry {
+  margin-bottom: 12px;
+}
+
+.tarot-ranked-entry__header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+
+.tarot-ranked-numeral {
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 300;
+  color: var(--tarot-gold);
+  line-height: 1;
+}
+
+.tarot-ranked-entry__reason {
+  padding-left: 26px;
+  font-size: 11px;
+  color: var(--tarot-muted);
+  line-height: 1.4;
+}
+
+.tarot-ranked-entry__meta {
+  padding-left: 26px;
+  margin-top: 4px;
+}
+
+.tarot-micro-label {
+  font-size: 9px;
   letter-spacing: 0.06em;
-  color: var(--muted);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.tarot-micro-label--high {
+  color: var(--tarot-red);
+}
+.tarot-micro-label--medium {
+  color: var(--tarot-amber);
+}
+.tarot-micro-label--low {
+  color: var(--tarot-muted);
+}
+
+.tarot-micro-sep {
+  font-size: 9px;
+  color: var(--tarot-faint);
+  margin: 0 4px;
+}
+
+/* Narrative (The Flame) */
+.tarot-narrative {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--tarot-text);
+  margin: 0 0 12px;
+}
+
+/* Action band (The Flame) */
+.tarot-action-band {
+  padding: 10px 12px;
+  background: color-mix(in oklab, var(--tarot-gold) 4%, transparent);
+  border-radius: 4px;
+  border-left: 2px solid var(--tarot-gold);
+}
+
+.tarot-action-band__label {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--tarot-muted);
+  margin-bottom: 4px;
+}
+
+.tarot-action-band__title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--tarot-text);
+}
+
+.tarot-action-band__reason {
+  font-size: 11px;
+  color: var(--tarot-muted);
+  margin-top: 3px;
+}
+
+/* Illustration caption */
+.tarot-illustration__caption {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--tarot-muted);
+  text-align: center;
+  margin-top: 4px;
+}
+
+/* Card back inscription */
+.tarot-inscription {
+  padding: 12px 24px;
+  text-align: center;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  font-family: -apple-system, sans-serif;
+}
+
+.tarot-inscription__label {
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.tarot-inscription__label--ai {
+  color: var(--tarot-gold);
+}
+.tarot-inscription__label--sys {
+  color: var(--tarot-sage);
+}
+
+.tarot-inscription__source {
+  font-size: 13px;
+  color: var(--tarot-text);
+  font-weight: 500;
+  font-family: Georgia, "Times New Roman", serif;
+  margin-bottom: 2px;
+}
+
+.tarot-inscription__detail {
+  font-size: 10px;
+  color: var(--tarot-muted);
+  letter-spacing: 0.04em;
+}
+
+.tarot-inscription__rule {
+  margin: 12px auto;
+  width: 40px;
+  border-top: 1px solid var(--tarot-frame);
+}
+
+.tarot-inscription__intent {
+  font-size: 11px;
+  color: var(--tarot-muted);
+  line-height: 1.5;
+  margin: 0;
+  font-style: italic;
+}
+
+.tarot-inscription__mono {
+  font-size: 11px;
+  color: var(--tarot-muted);
+  line-height: 1.5;
+  margin: 0;
+  font-family: "SF Mono", SFMono-Regular, monospace;
+  letter-spacing: -0.02em;
+}
+
+.tarot-inscription__text {
+  font-size: 11px;
+  color: var(--tarot-muted);
+}
+
+/* Light day message */
+.tarot-light-day {
+  font-size: 11px;
+  color: var(--tarot-muted);
+  font-style: italic;
+  margin-top: auto;
+  padding-top: 12px;
+  text-align: center;
+}
+
+/* Surfaced divider */
+.focus-divider {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--tarot-muted);
   padding: var(--s-2) 0;
 }
 
-/* ── Disclosure toggle ─────────────────────── */
-
+/* Disclosure */
 .focus-disclosure {
   background: none;
   border: none;
   font-family: inherit;
-  font-size: var(--fs-label);
-  color: var(--muted);
+  font-size: 11px;
+  color: var(--tarot-muted);
   cursor: pointer;
   padding: var(--s-2) 0;
   text-align: center;
   width: 100%;
+  letter-spacing: 0.04em;
 }
 
 .focus-disclosure:hover {
-  color: var(--text);
+  color: var(--tarot-text);
 }
 
 /* --- Task composer modal --- */
@@ -4122,9 +4415,21 @@ body {
   flex-direction: column;
   gap: var(--s-4);
   background:
-    radial-gradient(circle at top right, color-mix(in oklab, var(--accent) 8%, transparent), transparent 34%),
-    radial-gradient(circle at 14% 12%, color-mix(in oklab, #c4d4ff 20%, transparent), transparent 26%),
-    linear-gradient(180deg, color-mix(in oklab, var(--surface) 98%, var(--bg)) 0%, var(--bg) 100%);
+    radial-gradient(
+      circle at top right,
+      color-mix(in oklab, var(--accent) 8%, transparent),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 14% 12%,
+      color-mix(in oklab, #c4d4ff 20%, transparent),
+      transparent 26%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--surface) 98%, var(--bg)) 0%,
+      var(--bg) 100%
+    );
 }
 
 .project-workspace__hero {
@@ -4135,12 +4440,11 @@ body {
   padding: var(--s-4) var(--s-5);
   border: 1px solid var(--border-light);
   border-radius: calc(var(--r-lg) + 4px);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--surface) 98%, #f7f4ee) 0%,
-      color-mix(in oklab, var(--surface) 95%, #efe7db) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--surface) 98%, #f7f4ee) 0%,
+    color-mix(in oklab, var(--surface) 95%, #efe7db) 100%
+  );
   box-shadow: 0 14px 36px rgba(15, 23, 42, 0.06);
   overflow: hidden;
 }
@@ -4152,7 +4456,11 @@ body {
   width: 36%;
   height: 100%;
   background:
-    radial-gradient(circle at top left, rgb(255 255 255 / 0.6), transparent 58%),
+    radial-gradient(
+      circle at top left,
+      rgb(255 255 255 / 0.6),
+      transparent 58%
+    ),
     linear-gradient(135deg, rgb(255 255 255 / 0.14), transparent 72%);
   pointer-events: none;
 }
@@ -4220,12 +4528,11 @@ body {
   padding: var(--s-4);
   border-radius: calc(var(--r-lg) + 2px);
   border: 1px solid color-mix(in oklab, var(--border-light) 72%, white);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, white 70%, var(--surface)) 0%,
-      color-mix(in oklab, var(--surface) 92%, #f6eadc) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, white 70%, var(--surface)) 0%,
+    color-mix(in oklab, var(--surface) 92%, #f6eadc) 100%
+  );
   box-shadow:
     0 12px 24px rgba(15, 23, 42, 0.06),
     inset 0 1px 0 rgb(255 255 255 / 0.45);
@@ -4289,7 +4596,9 @@ body {
   color: var(--muted);
   cursor: pointer;
   opacity: 0;
-  transition: opacity var(--dur-fast) ease, background var(--dur-fast) ease;
+  transition:
+    opacity var(--dur-fast) ease,
+    background var(--dur-fast) ease;
 }
 
 .project-workspace__title-row:hover .project-kebab__trigger,
@@ -4562,7 +4871,11 @@ body {
 .project-workspace__progress-fill {
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--accent), color-mix(in oklab, var(--accent) 76%, white));
+  background: linear-gradient(
+    90deg,
+    var(--accent),
+    color-mix(in oklab, var(--accent) 76%, white)
+  );
 }
 
 .project-workspace__hero-note {
@@ -4644,39 +4957,53 @@ body {
 
 .project-workspace-card--focus::before,
 .project-workspace-card--chapters::before {
-  background: linear-gradient(90deg, color-mix(in oklab, var(--accent) 72%, white), transparent 78%);
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--accent) 72%, white),
+    transparent 78%
+  );
 }
 
 .project-workspace-card--risk::before {
-  background: linear-gradient(90deg, color-mix(in oklab, var(--danger) 76%, white), transparent 78%);
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--danger) 76%, white),
+    transparent 78%
+  );
 }
 
 .project-workspace-card--cleanup::before {
-  background: linear-gradient(90deg, color-mix(in oklab, var(--warning) 76%, white), transparent 78%);
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--warning) 76%, white),
+    transparent 78%
+  );
 }
 
 .project-workspace-card--recent::before,
 .project-workspace-card--section-detail::before,
 .project-workspace-card--insights::before {
-  background: linear-gradient(90deg, color-mix(in oklab, var(--success) 66%, white), transparent 78%);
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--success) 66%, white),
+    transparent 78%
+  );
 }
 
 .project-workspace-card--next {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--surface) 99%, #faf6f0) 0%,
-      color-mix(in oklab, var(--surface) 96%, #f6eee3) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--surface) 99%, #faf6f0) 0%,
+    color-mix(in oklab, var(--surface) 96%, #f6eee3) 100%
+  );
 }
 
 .project-workspace-card--primary {
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--surface) 98%, var(--surface-2)) 0%,
-      color-mix(in oklab, var(--surface) 95%, #f7f8fb) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--surface) 98%, var(--surface-2)) 0%,
+    color-mix(in oklab, var(--surface) 95%, #f7f8fb) 100%
+  );
 }
 
 .project-workspace-card--insights {
@@ -4748,7 +5075,10 @@ body {
   gap: var(--s-1);
   width: 100%;
   text-align: left;
-  transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+  transition:
+    transform 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
 }
 
 .project-workspace-task-preview {
@@ -4815,12 +5145,11 @@ body {
   padding: var(--s-4);
   border-radius: var(--r-lg);
   border: 1px solid var(--border-light);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--surface) 98%, var(--surface-2)) 0%,
-      color-mix(in oklab, var(--surface) 92%, var(--surface-2)) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--surface) 98%, var(--surface-2)) 0%,
+    color-mix(in oklab, var(--surface) 92%, var(--surface-2)) 100%
+  );
   overflow: hidden;
 }
 
@@ -4830,7 +5159,11 @@ body {
   inset: 0;
   background:
     linear-gradient(180deg, rgb(255 255 255 / 0.3), transparent 32%),
-    radial-gradient(circle at top right, color-mix(in oklab, var(--accent) 12%, transparent), transparent 36%);
+    radial-gradient(
+      circle at top right,
+      color-mix(in oklab, var(--accent) 12%, transparent),
+      transparent 36%
+    );
   pointer-events: none;
 }
 
@@ -4846,7 +5179,11 @@ body {
   display: block;
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(90deg, var(--accent), color-mix(in oklab, var(--accent) 72%, white));
+  background: linear-gradient(
+    90deg,
+    var(--accent),
+    color-mix(in oklab, var(--accent) 72%, white)
+  );
 }
 
 .project-workspace-insights-grid {
@@ -6349,7 +6686,6 @@ body {
   color: var(--success);
 }
 
-
 /* --- Projects to nudge --- */
 .home-project-row {
   display: flex;
@@ -6430,7 +6766,6 @@ body {
   color: var(--success);
   font-weight: var(--fw-medium);
 }
-
 
 .plan-slot {
   display: flex;
@@ -6707,7 +7042,6 @@ body {
   padding: var(--s-1) var(--s-3);
 }
 
-
 /* --- Drag handle --- */
 .sortable-row {
   display: flex;
@@ -6897,7 +7231,7 @@ body {
   }
 
   .home-dashboard {
-    max-width: 960px;
+    max-width: 720px;
   }
 }
 
@@ -7347,7 +7681,6 @@ body {
 [data-density="spacious"] .workspace-view-item {
   padding: var(--s-3) var(--s-4);
 }
-
 
 /* --- Today coaching banner --- */
 .today-coaching-banner {
@@ -9652,17 +9985,19 @@ body {
   --ds-toggle-pill-hover: color-mix(in oklab, var(--surface) 52%, transparent);
   --ds-toggle-meta: color-mix(in oklab, var(--surface) 40%, var(--surface-3));
   --ds-toggle-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.82),
-    inset 0 -1px 0 rgb(23 23 23 / 0.02);
+    inset 0 1px 0 rgb(255 255 255 / 0.82), inset 0 -1px 0 rgb(23 23 23 / 0.02);
   --ds-toggle-pill-shadow:
-    0 1px 2px rgb(15 23 42 / 0.08),
-    0 10px 18px rgb(15 23 42 / 0.04),
+    0 1px 2px rgb(15 23 42 / 0.08), 0 10px 18px rgb(15 23 42 / 0.04),
     inset 0 1px 0 rgb(255 255 255 / 0.9);
 }
 
 body.dark-mode {
   --ds-warm-surface: color-mix(in oklab, var(--surface) 92%, var(--surface-2));
-  --ds-warm-surface-strong: color-mix(in oklab, var(--surface-2) 88%, var(--surface-3));
+  --ds-warm-surface-strong: color-mix(
+    in oklab,
+    var(--surface-2) 88%,
+    var(--surface-3)
+  );
   --ds-soft-border: color-mix(in oklab, var(--border) 76%, var(--surface-3));
   --ds-quiet-text: color-mix(in oklab, var(--muted) 78%, var(--text));
   --ds-toggle-rail: color-mix(in oklab, var(--surface-2) 88%, var(--surface-3));
@@ -9670,11 +10005,9 @@ body.dark-mode {
   --ds-toggle-pill-hover: color-mix(in oklab, var(--surface) 32%, transparent);
   --ds-toggle-meta: color-mix(in oklab, var(--surface-2) 32%, var(--surface-3));
   --ds-toggle-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.04),
-    inset 0 -1px 0 rgb(0 0 0 / 0.2);
+    inset 0 1px 0 rgb(255 255 255 / 0.04), inset 0 -1px 0 rgb(0 0 0 / 0.2);
   --ds-toggle-pill-shadow:
-    0 1px 2px rgb(0 0 0 / 0.35),
-    0 10px 18px rgb(0 0 0 / 0.14),
+    0 1px 2px rgb(0 0 0 / 0.35), 0 10px 18px rgb(0 0 0 / 0.14),
     inset 0 1px 0 rgb(255 255 255 / 0.05);
 }
 
@@ -10917,7 +11250,8 @@ body.dark-mode {
    Project View Enhancements
    ========================================================================== */
 
-.project-workspace__snapshot-item--actionable .project-workspace__snapshot-value {
+.project-workspace__snapshot-item--actionable
+  .project-workspace__snapshot-value {
   color: var(--warning);
 }
 
@@ -11027,61 +11361,204 @@ body.dark-mode {
    Urgency Bars (Due Soon)
    ========================================================================== */
 
-.urgency-bars { display: flex; flex-direction: column; gap: var(--s-2); }
-.urgency-bar__label { display: flex; justify-content: space-between; font-size: var(--fs-xs); }
-.urgency-bar__track { height: 6px; background: color-mix(in oklab, var(--muted) 8%, transparent); border-radius: 3px; overflow: hidden; }
-.urgency-bar__fill { height: 100%; border-radius: 3px; }
+.urgency-bars {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+}
+.urgency-bar__label {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--fs-xs);
+}
+.urgency-bar__track {
+  height: 6px;
+  background: color-mix(in oklab, var(--muted) 8%, transparent);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.urgency-bar__fill {
+  height: 100%;
+  border-radius: 3px;
+}
 
 /* ==========================================================================
    Stacked Inbox (Unsorted)
    ========================================================================== */
 
-.inbox-stack { position: relative; margin-bottom: var(--s-2); }
-.inbox-stack__shadow { position: absolute; left: 4px; right: 4px; height: 40px; border-radius: var(--r-sm); }
-.inbox-stack__shadow--far { top: 6px; background: color-mix(in oklab, var(--warning) 4%, transparent); border: 1px solid color-mix(in oklab, var(--warning) 8%, transparent); }
-.inbox-stack__shadow--near { top: 3px; left: 2px; right: 2px; background: color-mix(in oklab, var(--warning) 6%, transparent); border: 1px solid color-mix(in oklab, var(--warning) 10%, transparent); }
-.inbox-stack__front { position: relative; padding: var(--s-3); background: var(--surface); border: 1px solid color-mix(in oklab, var(--warning) 15%, transparent); border-radius: var(--r-sm); box-shadow: var(--shadow-0); }
+.inbox-stack {
+  position: relative;
+  margin-bottom: var(--s-2);
+}
+.inbox-stack__shadow {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  height: 40px;
+  border-radius: var(--r-sm);
+}
+.inbox-stack__shadow--far {
+  top: 6px;
+  background: color-mix(in oklab, var(--warning) 4%, transparent);
+  border: 1px solid color-mix(in oklab, var(--warning) 8%, transparent);
+}
+.inbox-stack__shadow--near {
+  top: 3px;
+  left: 2px;
+  right: 2px;
+  background: color-mix(in oklab, var(--warning) 6%, transparent);
+  border: 1px solid color-mix(in oklab, var(--warning) 10%, transparent);
+}
+.inbox-stack__front {
+  position: relative;
+  padding: var(--s-3);
+  background: var(--surface);
+  border: 1px solid color-mix(in oklab, var(--warning) 15%, transparent);
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-0);
+}
 
 /* ==========================================================================
    Decay Bars (Backlog Hygiene)
    ========================================================================== */
 
-.decay-item { display: flex; flex-direction: column; gap: 4px; }
-.decay-item__row { display: flex; justify-content: space-between; font-size: var(--fs-xs); }
-.decay-item__bar { height: 3px; background: color-mix(in oklab, var(--muted) 6%, transparent); border-radius: 2px; overflow: hidden; }
-.decay-item__fill { height: 100%; border-radius: 2px; background: linear-gradient(90deg, var(--warning), var(--danger)); }
+.decay-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.decay-item__row {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--fs-xs);
+}
+.decay-item__bar {
+  height: 3px;
+  background: color-mix(in oklab, var(--muted) 6%, transparent);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.decay-item__fill {
+  height: 100%;
+  border-radius: 2px;
+  background: linear-gradient(90deg, var(--warning), var(--danger));
+}
 
 /* ==========================================================================
    Health Dots (Projects to Nudge)
    ========================================================================== */
 
-.health-item { display: flex; align-items: center; gap: var(--s-3); }
-.health-dot { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 600; flex-shrink: 0; }
-.health-dot--critical { background: color-mix(in oklab, var(--danger) 10%, transparent); color: var(--danger); }
-.health-dot--warning { background: color-mix(in oklab, var(--warning) 10%, transparent); color: var(--warning); }
+.health-item {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+}
+.health-dot {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.health-dot--critical {
+  background: color-mix(in oklab, var(--danger) 10%, transparent);
+  color: var(--danger);
+}
+.health-dot--warning {
+  background: color-mix(in oklab, var(--warning) 10%, transparent);
+  color: var(--warning);
+}
 
 /* ==========================================================================
    Impact Cards (What Next)
    ========================================================================== */
 
-.impact-card { padding: var(--s-2h) var(--s-3); border-radius: var(--r-sm); border: 1px solid var(--border-light); cursor: pointer; transition: background var(--dur-fast) ease; }
-.impact-card:first-child { border-color: color-mix(in oklab, var(--accent) 15%, transparent); background: color-mix(in oklab, var(--accent) 3%, transparent); }
-.impact-card:hover { background: var(--surface-2); }
-.impact-card__top { display: flex; justify-content: space-between; align-items: center; }
-.impact-card__reason { font-size: var(--fs-xs); color: var(--muted); margin-top: var(--s-1); }
+.impact-card {
+  padding: var(--s-2h) var(--s-3);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border-light);
+  cursor: pointer;
+  transition: background var(--dur-fast) ease;
+}
+.impact-card:first-child {
+  border-color: color-mix(in oklab, var(--accent) 15%, transparent);
+  background: color-mix(in oklab, var(--accent) 3%, transparent);
+}
+.impact-card:hover {
+  background: var(--surface-2);
+}
+.impact-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.impact-card__reason {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  margin-top: var(--s-1);
+}
 
 /* ==========================================================================
    Timeline
    ========================================================================== */
 
-.timeline { position: relative; padding-left: 20px; }
-.timeline__line { position: absolute; left: 6px; top: 0; bottom: 0; width: 2px; background: color-mix(in oklab, var(--accent) 15%, transparent); }
-.timeline__item { position: relative; margin-bottom: 14px; }
-.timeline__item:last-child { margin-bottom: 0; }
-.timeline__dot { position: absolute; left: -17px; top: 4px; width: 10px; height: 10px; border-radius: 50%; border: 2px solid var(--surface); }
-.timeline__content { display: flex; justify-content: space-between; align-items: baseline; }
-.timeline__title { background: none; border: none; font-family: inherit; font-size: var(--fs-body); font-weight: 500; color: var(--text); cursor: pointer; padding: 0; text-align: left; }
-.timeline__title:hover { color: var(--accent); }
-.timeline__meta { font-size: var(--fs-xs); color: var(--muted); flex-shrink: 0; }
-.timeline__overdue { color: var(--danger); font-weight: 500; }
-
+.timeline {
+  position: relative;
+  padding-left: 20px;
+}
+.timeline__line {
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: color-mix(in oklab, var(--tarot-gold) 15%, transparent);
+}
+.timeline__item {
+  position: relative;
+  margin-bottom: 14px;
+}
+.timeline__item:last-child {
+  margin-bottom: 0;
+}
+.timeline__dot {
+  position: absolute;
+  left: -17px;
+  top: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--surface);
+}
+.timeline__content {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.timeline__title {
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: var(--fs-body);
+  font-weight: 500;
+  color: var(--text);
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+.timeline__title:hover {
+  color: var(--tarot-gold);
+}
+.timeline__meta {
+  font-size: var(--fs-xs);
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.timeline__overdue {
+  color: var(--tarot-red);
+  font-weight: 500;
+}

--- a/client-react/src/styles/tokens.css
+++ b/client-react/src/styles/tokens.css
@@ -45,8 +45,9 @@
   --s-8: 48px;
 
   /* --- Typography --- */
-  --font-sans: "Inter", "Avenir Next", "Segoe UI", -apple-system,
-    BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  --font-sans:
+    "Inter", "Avenir Next", "Segoe UI", -apple-system, BlinkMacSystemFont,
+    "Helvetica Neue", Arial, sans-serif;
   --fs-xs: 0.688rem;
   --fs-label: 0.75rem;
   --fs-meta: 0.8125rem;
@@ -83,14 +84,16 @@
   --shadow-sm: 0 1px 3px rgb(15 23 42 / 0.08), 0 1px 2px rgb(15 23 42 / 0.04);
   --shadow-md: 0 4px 12px rgb(15 23 42 / 0.08), 0 2px 4px rgb(15 23 42 / 0.04);
   --shadow-lg: 0 12px 24px rgb(15 23 42 / 0.1), 0 4px 8px rgb(15 23 42 / 0.06);
-  --shadow-xl: 0 20px 40px rgb(15 23 42 / 0.14), 0 8px 16px rgb(15 23 42 / 0.08);
+  --shadow-xl:
+    0 20px 40px rgb(15 23 42 / 0.14), 0 8px 16px rgb(15 23 42 / 0.08);
   /* Backward compat aliases */
   --shadow-hover: var(--shadow-sm);
   --shadow-card: var(--shadow-md);
   --shadow-elevated: var(--shadow-lg);
   /* Focus ring */
   --shadow-focus: 0 0 0 3px color-mix(in oklab, var(--accent) 20%, transparent);
-  --shadow-focus-danger: 0 0 0 3px color-mix(in oklab, var(--danger) 20%, transparent);
+  --shadow-focus-danger: 0 0 0 3px
+    color-mix(in oklab, var(--danger) 20%, transparent);
 
   /* --- Motion --- */
   --ease-spring: cubic-bezier(0.22, 1, 0.36, 1);
@@ -100,6 +103,21 @@
   --dur-base: 180ms;
   --dur-slow: 280ms;
   --dur-view: var(--dur-slow);
+
+  /* ── Tarot Card Design System ──────────────── */
+  --tarot-parchment: #faf8f5;
+  --tarot-parchment-dark: #f7f4ee;
+  --tarot-frame: #e0dbd3;
+  --tarot-border: #e8e4de;
+  --tarot-text: #3d3730;
+  --tarot-muted: #8a7e6e;
+  --tarot-gold: #b8a080;
+  --tarot-sage: #8a9a8e;
+  --tarot-red: #c45a3c;
+  --tarot-amber: #d4864a;
+  --tarot-warm: #daa85c;
+  --tarot-faint: #d0c8b8;
+  --tarot-tabletop: #f0ece4;
 }
 
 /* --- Dark mode (warmer, more vibrant) --- */
@@ -134,7 +152,8 @@ body.dark-mode {
   --shadow-card: var(--shadow-md);
   --shadow-elevated: var(--shadow-lg);
   --shadow-focus: 0 0 0 3px color-mix(in oklab, var(--accent) 30%, transparent);
-  --shadow-focus-danger: 0 0 0 3px color-mix(in oklab, var(--danger) 30%, transparent);
+  --shadow-focus-danger: 0 0 0 3px
+    color-mix(in oklab, var(--danger) 30%, transparent);
   --text-2: var(--muted);
   --border-strong: color-mix(in oklab, var(--border) 70%, var(--text));
 }


### PR DESCRIPTION
## Summary

Complete visual overhaul of Focus dashboard cards — from styled containers to tarot-inspired cards with distinct identity, composed data layouts, and thematic provenance.

**Design direction:** "Tarot-inspired productivity cards" — warm, editorial, quietly ceremonial. Each card is a named entity with corner markers, central pixel art, and composed data that's part of the card's visual scene.

## The Deck

| # | Name | Source | Panel |
|---|------|--------|-------|
| I | The Flame | ◇ AI | Right Now |
| II | The Dawn | ▪ SYS | Today's Agenda |
| III | The Hourglass | ▪ SYS | Due Soon |
| IV | The Compass | ◇ AI | What Next |
| V | The Inbox | ▪ SYS | Unsorted Items |
| VI | The Web | ▪ SYS | Backlog Hygiene |
| VII | The Guardian | ▪ SYS | Projects to Nudge |
| VIII | The Road | ▪ SYS | Track Overview |

## Card anatomy

- **Parchment surface** (#faf8f5) with inner frame border
- **Corner markers** — ◇ AI (gold) or ▪ SYS (sage) + Roman numeral rank
- **Card name plate** — centered, spaced uppercase serif
- **Central pixel art** — muted earthy tones, 48-64px
- **Composed data** — not lists. Ranked entries with progressive fade (The Compass), narrative prose (The Flame), vertical timeline (The Dawn), urgency bars (The Hourglass)
- **Card back** — "— Reversed" suffix, centered inscription. AI: "Divined by" / "Intent" / "Cast at". Deterministic: "Computed by" / "Rule" / "Reading"
- **Dashboard tabletop** — warm darker surface (#f0ece4)

## What changed

**New:** `TarotCard.tsx` (shared layout: TarotCardFront + TarotCardBack)

**Rewritten:** `CardBack.tsx` (inscription layout), `RightNowPanel.tsx`, `TodayAgendaPanel.tsx`, `PanelRenderer.tsx` (all 7 panels)

**Updated:** `pixel-art/index.tsx` (muted earthy palette), `app.css` (complete tarot CSS system replacing old focus-panel styles), `tokens.css` (tarot color variables)

## Test plan

- [x] 121 UI tests pass
- [x] Typecheck, format, architecture, CSS lint pass
- [ ] Manual: verify parchment surface and inner frame on all cards
- [ ] Manual: verify corner markers (◇ AI gold / ▪ SYS sage) and Roman numerals
- [ ] Manual: verify card names ("The Flame", "The Dawn", etc.)
- [ ] Manual: flip cards — back shows "— Reversed" with thematic provenance
- [ ] Manual: The Compass shows ranked entries 1/2/3 with progressive fade

🤖 Generated with [Claude Code](https://claude.com/claude-code)