### PR TITLE
fix(react): polish sidebar projects — remove dots, indent under areas

### DIFF
--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -65,10 +65,6 @@ function ProjectRailItem({
       data-project-key={p.name}
       onClick={onClick}
     >
-      <span
-        className="projects-rail-item__status-dot"
-        style={{ background: STATUS_COLORS[p.status] || "var(--muted)" }}
-      />
       <span className="nav-label">{p.name}</span>
     </button>
   );

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -379,11 +379,10 @@ body {
 .projects-rail-item {
   display: flex;
   align-items: center;
-  gap: var(--s-2);
-  padding: var(--s-2) var(--s-3);
+  padding: var(--s-1h) var(--s-2);
   border-radius: var(--r-sm);
-  font-size: var(--fs-meta);
-  color: var(--muted);
+  font-size: var(--fs-label);
+  color: var(--text);
   cursor: pointer;
   border: none;
   background: none;
@@ -404,13 +403,7 @@ body {
   color: var(--accent);
 }
 
-/* Status dot */
-.projects-rail-item__status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
+/* Status dot — removed, replaced by area left accent */
 
 /* --- Todo row --- */
 .todo-item {
@@ -1942,7 +1935,7 @@ body {
   flex: 1;
 }
 
-/* Area group headers */
+/* Area group headers — subtle separator, not competing with project names */
 .projects-rail-area-header {
   display: flex;
   align-items: center;
@@ -1950,29 +1943,39 @@ body {
   width: 100%;
   border: none;
   background: none;
-  padding: var(--s-2) var(--s-3);
-  font-size: var(--fs-label);
-  font-weight: var(--fw-semibold);
-  color: var(--muted);
+  padding: var(--s-1) var(--s-3);
+  margin-top: var(--s-2);
+  font-size: 10px;
+  font-weight: 500;
+  color: color-mix(in oklab, var(--muted) 70%, transparent);
   cursor: pointer;
   font-family: inherit;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
+}
+
+.projects-rail-area-header:first-child {
+  margin-top: 0;
 }
 
 .projects-rail-area-header:hover {
-  color: var(--text);
+  color: var(--muted);
 }
 
 .projects-rail-area-header__chevron {
-  font-size: var(--fs-label);
-  width: 12px;
+  font-size: 9px;
+  width: 10px;
   text-align: center;
+  opacity: 0.6;
 }
 
+/* Area group — left accent bar for visual grouping */
 .projects-rail-area-group {
   display: flex;
   flex-direction: column;
+  margin-left: var(--s-3);
+  padding-left: var(--s-2);
+  border-left: 1px solid var(--border-light);
 }
 
 /* Spacer between projects and utilities */


### PR DESCRIPTION
## Summary

The project sidebar had two visual problems: green status dots on every project (always green = zero information), and area headers competing at the same visual weight as project names.

**Changes:**
- **Removed status dots** — they were always green (active). No information conveyed.
- **Indented projects under areas** — projects now have left padding + a subtle left border accent line, creating clear visual hierarchy
- **Lighter area headers** — smaller (10px), more transparent, more letter-spacing. They read as section labels, not content items.
- **Better spacing** — area headers have top margin for separation, project items use tighter padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)