### PR TITLE
fix(react-mobile): full-height cards, responsive swipe, peek hint, subtitles

### DIFF
--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -33,6 +33,7 @@ function UnsortedPanel({
   const front = (
     <TarotCardFront
       name="The Inbox"
+      subtitle="Unsorted items"
       numeral="V"
       source="sys"
       illustration={<Art size={48} />}
@@ -151,6 +152,7 @@ function DueSoonPanel({
   const front = (
     <TarotCardFront
       name="The Hourglass"
+      subtitle="Due soon"
       numeral="III"
       source="sys"
       illustration={<Art size={48} />}
@@ -241,6 +243,7 @@ function WhatNextPanel({
   const front = (
     <TarotCardFront
       name="The Compass"
+      subtitle="What to do next"
       numeral="IV"
       source="ai"
       illustration={<Art size={48} />}
@@ -328,6 +331,7 @@ function BacklogHygienePanel({
   const front = (
     <TarotCardFront
       name="The Web"
+      subtitle="Stale tasks"
       numeral="VI"
       source="sys"
       illustration={<Art size={48} />}
@@ -411,6 +415,7 @@ function ProjectsToNudgePanel({
   const front = (
     <TarotCardFront
       name="The Guardian"
+      subtitle="Projects needing attention"
       numeral="VII"
       source="sys"
       illustration={<Art size={48} />}
@@ -484,6 +489,7 @@ function TrackOverviewPanel({
   const front = (
     <TarotCardFront
       name="The Road"
+      subtitle="Task timeline"
       numeral="VIII"
       source="sys"
       illustration={<Art size={48} />}
@@ -544,6 +550,7 @@ function RescueModePanel({
   const front = (
     <TarotCardFront
       name="Rescue"
+      subtitle="System overloaded"
       numeral=""
       source="sys"
       illustration={<Art size={48} />}

--- a/client-react/src/components/home/RightNowPanel.tsx
+++ b/client-react/src/components/home/RightNowPanel.tsx
@@ -19,6 +19,7 @@ export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
   const front = (
     <TarotCardFront
       name="The Flame"
+      subtitle="Your priorities right now"
       numeral="I"
       source="ai"
       illustration={<FlameArt size={64} />}

--- a/client-react/src/components/home/TarotCard.tsx
+++ b/client-react/src/components/home/TarotCard.tsx
@@ -7,6 +7,7 @@ export interface TarotCardProps {
   source: "ai" | "sys";
   illustration: ReactNode;
   illustrationCaption?: string;
+  subtitle?: string;
   children: ReactNode;
   hero?: boolean;
 }
@@ -17,6 +18,7 @@ export function TarotCardFront({
   source,
   illustration,
   illustrationCaption,
+  subtitle,
   children,
   hero,
 }: TarotCardProps) {
@@ -30,6 +32,7 @@ export function TarotCardFront({
         <span className={`tarot-corner ${cornerClass}`}>{numeral}</span>
       </div>
       <div className="tarot-name">{name}</div>
+      {subtitle && <div className="tarot-subtitle">{subtitle}</div>}
       <div className={`tarot-illustration${hero ? " tarot-illustration--hero" : ""}`}>
         {illustration}
       </div>

--- a/client-react/src/components/home/TodayAgendaPanel.tsx
+++ b/client-react/src/components/home/TodayAgendaPanel.tsx
@@ -22,6 +22,7 @@ export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle: _on
   const front = (
     <TarotCardFront
       name="The Dawn"
+      subtitle="Today's agenda"
       numeral="II"
       source="sys"
       illustration={<SunriseArt size={64} />}

--- a/client-react/src/mobile/components/CardCarousel.tsx
+++ b/client-react/src/mobile/components/CardCarousel.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode, Children } from "react";
+import { useState, useEffect, useRef, type ReactNode, Children } from "react";
 import { useSwipeNavigation } from "../hooks/useSwipeNavigation";
 import { DotIndicator } from "./DotIndicator";
 
@@ -9,24 +9,27 @@ interface Props {
 export function CardCarousel({ children }: Props) {
   const cards = Children.toArray(children);
   const [flippedIndex, setFlippedIndex] = useState<number | null>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
 
-  const { activeIndex, dragOffset, isDragging, handlers } = useSwipeNavigation({
+  const { activeIndex, isDragging, handlers } = useSwipeNavigation({
     count: cards.length,
     locked: flippedIndex !== null,
     onIndexChange: () => setFlippedIndex(null),
   });
 
-  const translateX =
-    -(activeIndex * 100) +
-    (dragOffset /
-      (typeof window !== "undefined" ? window.innerWidth : 375)) *
-      100;
+  // Apply committed index position via DOM (CSS transition handles animation)
+  useEffect(() => {
+    if (trackRef.current && !isDragging) {
+      trackRef.current.style.transform = `translateX(${-(activeIndex * 100)}%)`;
+    }
+  }, [activeIndex, isDragging]);
 
   return (
     <div className="m-carousel">
       <div
-        className={`m-carousel__track${isDragging ? " m-carousel__track--dragging" : ""}`}
-        style={{ transform: `translateX(${translateX}%)` }}
+        ref={trackRef}
+        className="m-carousel__track"
+        style={{ transform: `translateX(${-(activeIndex * 100)}%)` }}
         {...handlers}
       >
         {cards.map((card, i) => (

--- a/client-react/src/mobile/hooks/useSwipeNavigation.ts
+++ b/client-react/src/mobile/hooks/useSwipeNavigation.ts
@@ -12,17 +12,30 @@ interface Options {
 
 export function useSwipeNavigation({ count, locked, onIndexChange }: Options) {
   const [activeIndex, setActiveIndex] = useState(0);
-  const [dragOffset, setDragOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
 
+  // Refs for drag state — mutated directly to avoid React re-renders during drag
   const startX = useRef(0);
   const startTime = useRef(0);
+  const dragOffsetRef = useRef(0);
+  const trackRef = useRef<HTMLElement | null>(null);
+  const indexRef = useRef(0); // mirrors activeIndex without stale closure issues
+
+  const applyTransform = useCallback((index: number, dx: number) => {
+    if (!trackRef.current) return;
+    const width = trackRef.current.parentElement?.clientWidth ?? window.innerWidth;
+    const pct = -(index * 100) + (dx / width) * 100;
+    trackRef.current.style.transform = `translateX(${pct}%)`;
+  }, []);
 
   const goNext = useCallback(() => {
     if (locked) return;
     setActiveIndex((i) => {
       const next = Math.min(i + 1, count - 1);
-      if (next !== i) onIndexChange?.(next);
+      if (next !== i) {
+        indexRef.current = next;
+        onIndexChange?.(next);
+      }
       return next;
     });
   }, [count, locked, onIndexChange]);
@@ -31,7 +44,10 @@ export function useSwipeNavigation({ count, locked, onIndexChange }: Options) {
     if (locked) return;
     setActiveIndex((i) => {
       const next = Math.max(i - 1, 0);
-      if (next !== i) onIndexChange?.(next);
+      if (next !== i) {
+        indexRef.current = next;
+        onIndexChange?.(next);
+      }
       return next;
     });
   }, [locked, onIndexChange]);
@@ -39,47 +55,65 @@ export function useSwipeNavigation({ count, locked, onIndexChange }: Options) {
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
       if (locked) return;
+      const el = e.currentTarget as HTMLElement;
+      trackRef.current = el;
+      // Disable CSS transition during drag
+      el.classList.add("m-carousel__track--dragging");
+
       startX.current = e.clientX;
       startTime.current = Date.now();
+      dragOffsetRef.current = 0;
       setIsDragging(true);
-      setDragOffset(0);
     },
     [locked],
   );
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent) => {
-      if (!isDragging || locked) return;
+      if (!trackRef.current || locked) return;
       let dx = e.clientX - startX.current;
 
-      const atStart = activeIndex === 0 && dx > 0;
-      const atEnd = activeIndex === count - 1 && dx < 0;
+      // Rubber-band at edges
+      const idx = indexRef.current;
+      const atStart = idx === 0 && dx > 0;
+      const atEnd = idx === count - 1 && dx < 0;
       if (atStart || atEnd) {
         dx = dx * RUBBER_DAMPING;
       }
 
-      setDragOffset(dx);
+      dragOffsetRef.current = dx;
+      // Direct DOM mutation — no React state update, no re-render
+      applyTransform(idx, dx);
     },
-    [isDragging, locked, activeIndex, count],
+    [locked, count, applyTransform],
   );
 
   const onPointerUp = useCallback(() => {
-    if (!isDragging) return;
+    const el = trackRef.current;
+    if (!el) return;
+
+    // Re-enable CSS transition for snap animation
+    el.classList.remove("m-carousel__track--dragging");
     setIsDragging(false);
 
+    const dx = dragOffsetRef.current;
     const elapsed = Date.now() - startTime.current;
-    const velocity = Math.abs(dragOffset) / Math.max(elapsed, 1);
+    const velocity = Math.abs(dx) / Math.max(elapsed, 1);
     const committed =
-      Math.abs(dragOffset) > COMMIT_THRESHOLD || velocity > VELOCITY_THRESHOLD;
+      Math.abs(dx) > COMMIT_THRESHOLD || velocity > VELOCITY_THRESHOLD;
 
-    if (committed && dragOffset < 0) {
+    if (committed && dx < 0) {
       goNext();
-    } else if (committed && dragOffset > 0) {
+    } else if (committed && dx > 0) {
       goPrev();
+    } else {
+      // Snap back — apply transform at current index with 0 offset
+      applyTransform(indexRef.current, 0);
     }
 
-    setDragOffset(0);
-  }, [isDragging, dragOffset, goNext, goPrev]);
+    dragOffsetRef.current = 0;
+    trackRef.current = null;
+  }, [goNext, goPrev, applyTransform]);
 
   const handlers = useMemo(
     () => ({
@@ -91,5 +125,5 @@ export function useSwipeNavigation({ count, locked, onIndexChange }: Options) {
     [onPointerDown, onPointerMove, onPointerUp],
   );
 
-  return { activeIndex, dragOffset, isDragging, handlers, goNext, goPrev };
+  return { activeIndex, isDragging, handlers, goNext, goPrev };
 }

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -2009,6 +2009,20 @@
   height: 100%;
 }
 
+.m-screen--focus .flip-card__inner {
+  height: 100%;
+}
+
+.m-screen--focus .flip-card__front,
+.m-screen--focus .flip-card__back {
+  height: 100%;
+}
+
+/* Tarot frame fills the card face */
+.m-screen--focus .tarot-frame {
+  height: calc(100% - 16px);
+}
+
 /* ── Dot Indicator ────────────────────────────── */
 
 .m-dot-indicator {

--- a/client-react/src/mobile/mobile.css
+++ b/client-react/src/mobile/mobile.css
@@ -1976,11 +1976,22 @@
   transition: none;
 }
 
+/*
+ * Slide width is slightly less than 100% so the next card peeks
+ * from the right edge (~20px visible). This is the primary
+ * affordance signaling "swipe for more cards."
+ */
 .m-carousel__slide {
-  flex: 0 0 100%;
+  flex: 0 0 calc(100% - 20px);
   min-width: 0;
-  padding: 0 var(--m-gutter, 16px);
+  padding: 0 0 0 var(--m-gutter, 16px);
   box-sizing: border-box;
+}
+
+/* Last slide gets full width — no peek needed */
+.m-carousel__slide:last-child {
+  flex: 0 0 100%;
+  padding-right: var(--m-gutter, 16px);
 }
 
 /* ── Card height tokens ───────────────────────── */

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -3192,11 +3192,21 @@ body {
 /* Card name plate */
 .tarot-name {
   text-align: center;
-  padding: 4px 16px 8px;
+  padding: 4px 16px 2px;
   font-size: 11px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--tarot-muted);
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.tarot-subtitle {
+  text-align: center;
+  padding: 0 16px 6px;
+  font-size: 11px;
+  color: var(--tarot-muted);
+  opacity: 0.7;
+  font-style: italic;
   font-family: Georgia, "Times New Roman", serif;
 }
 


### PR DESCRIPTION
## Summary

Follow-up polish to #848 (mobile focus tarot carousel):

- **Full-height cards** — explicit `height: 100%` cascade through `flip-card__inner`, `__front`, `__back`, and `tarot-frame` so all cards fill the screen uniformly
- **Ref-based swipe** — rewrote `useSwipeNavigation` to use refs + direct DOM mutation during drag instead of `setState` per pointermove, eliminating React re-renders during active dragging
- **Peek hint** — carousel slides are `calc(100% - 20px)` wide so ~20px of the next card is always visible, signaling "swipe for more"
- **Descriptive subtitles** — each card shows an italic subtitle below the tarot name (e.g., "The Flame" / "Your priorities right now")

## Test plan

- [ ] Typecheck passes
- [ ] 49 tests pass across changed files
- [ ] Visual: all cards fill screen height uniformly
- [ ] Visual: next card peeks from right edge
- [ ] Visual: subtitles visible below card names on all panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)