### PR TITLE
feat(react): add Agent Activity sidebar view

### DIFF
--- a/client-react/src/components/activity/AgentActivityView.tsx
+++ b/client-react/src/components/activity/AgentActivityView.tsx
@@ -1,0 +1,21 @@
+import { AgentActivityFeed } from "../home/AgentActivityFeed";
+
+interface Props {
+  onBack: () => void;
+}
+
+export function AgentActivityView({ onBack }: Props) {
+  return (
+    <>
+      <header className="app-header">
+        <button className="btn" onClick={onBack}>
+          ← Back
+        </button>
+        <span className="app-header__title">Agent Activity</span>
+      </header>
+      <div className="app-content">
+        <AgentActivityFeed standalone />
+      </div>
+    </>
+  );
+}

--- a/client-react/src/components/home/AgentActivityFeed.tsx
+++ b/client-react/src/components/home/AgentActivityFeed.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from "react";
 import { apiCall } from "../../api/client";
-import { useAgentProfiles, getAgentProfile } from "../../agents/useAgentProfiles";
+import {
+  useAgentProfiles,
+  getAgentProfile,
+} from "../../agents/useAgentProfiles";
 import { AgentSigil } from "./AgentSigil";
 
 interface ActivityEntry {
   agentId: string;
-  agentName: string;
   jobName: string;
   periodKey: string;
   narration: string;
@@ -13,7 +15,49 @@ interface ActivityEntry {
   createdAt: string;
 }
 
-export function AgentActivityFeed() {
+interface Props {
+  standalone?: boolean;
+}
+
+function dayLabel(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const entryDay = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  );
+  const diffMs = today.getTime() - entryDay.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays <= 5)
+    return date.toLocaleDateString("en-US", { weekday: "long" });
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function groupByDay(
+  entries: ActivityEntry[],
+): Array<{ label: string; entries: ActivityEntry[] }> {
+  const groups: Array<{ label: string; entries: ActivityEntry[] }> = [];
+  let currentLabel = "";
+
+  for (const entry of entries) {
+    const label = dayLabel(entry.createdAt);
+    if (label !== currentLabel) {
+      groups.push({ label, entries: [entry] });
+      currentLabel = label;
+    } else {
+      groups[groups.length - 1].entries.push(entry);
+    }
+  }
+
+  return groups;
+}
+
+export function AgentActivityFeed({ standalone = false }: Props) {
   const profiles = useAgentProfiles();
   const [entries, setEntries] = useState<ActivityEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -26,42 +70,84 @@ export function AgentActivityFeed() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading || entries.length === 0) return null;
-
-  return (
-    <div className="activity-feed">
-      {entries.map((entry, i) => {
-        const agent = getAgentProfile(profiles, entry.agentId);
-        return (
-          <div key={`${entry.agentId}-${entry.periodKey}-${i}`} className="activity-entry">
-            {agent && (
-              <AgentSigil
-                agentId={agent.id}
-                color={agent.colors.stroke}
-                bg={agent.colors.bg}
-                size={32}
-              />
-            )}
-            <div className="activity-entry__body">
-              <div className="activity-entry__header">
-                <span
-                  className="activity-entry__name"
-                  style={{ color: agent?.colors.textDark }}
-                >
-                  {entry.agentName}
-                </span>
-                <span className="activity-entry__meta">
-                  {entry.jobName} &middot; {new Date(entry.createdAt).toLocaleString([], {
-                    hour: "numeric",
-                    minute: "2-digit",
-                  })}
-                </span>
-              </div>
-              <p className="activity-entry__narration">{entry.narration}</p>
-            </div>
+  if (loading) {
+    if (standalone) {
+      return (
+        <div className="activity-feed activity-feed--loading">
+          <div className="loading-skeleton">
+            <div className="loading-skeleton__row" />
+            <div className="loading-skeleton__row" />
+            <div className="loading-skeleton__row" />
           </div>
-        );
-      })}
-    </div>
-  );
+        </div>
+      );
+    }
+    return null;
+  }
+
+  if (entries.length === 0) {
+    if (standalone) {
+      return (
+        <div className="activity-feed activity-feed--empty">
+          <p className="activity-feed__empty-text">
+            No agent activity in the last 7 days.
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const renderEntry = (entry: ActivityEntry, i: number) => {
+    const agent = getAgentProfile(profiles, entry.agentId);
+    return (
+      <div
+        key={`${entry.agentId}-${entry.periodKey}-${i}`}
+        className="activity-entry"
+      >
+        {agent && (
+          <AgentSigil
+            agentId={agent.id}
+            color={agent.colors.stroke}
+            bg={agent.colors.bg}
+            size={32}
+          />
+        )}
+        <div className="activity-entry__body">
+          <div className="activity-entry__header">
+            <span
+              className="activity-entry__name"
+              style={{ color: agent?.colors.textDark }}
+            >
+              {agent?.name ?? entry.agentId}
+            </span>
+            <span className="activity-entry__meta">
+              {entry.jobName} &middot;{" "}
+              {new Date(entry.createdAt).toLocaleString([], {
+                hour: "numeric",
+                minute: "2-digit",
+              })}
+            </span>
+          </div>
+          <p className="activity-entry__narration">{entry.narration}</p>
+        </div>
+      </div>
+    );
+  };
+
+  if (standalone) {
+    const groups = groupByDay(entries);
+    return (
+      <div className="activity-feed">
+        {groups.map((group) => (
+          <div key={group.label} className="activity-feed__day">
+            <h3 className="activity-feed__date-header">{group.label}</h3>
+            {group.entries.map(renderEntry)}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return <div className="activity-feed">{entries.map(renderEntry)}</div>;
 }

--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -66,6 +66,7 @@ const FeedbackForm = lazy(() =>
 const WeeklyReview = lazy(() =>
   import("./WeeklyReview").then((m) => ({ default: m.WeeklyReview })),
 );
+import { AgentActivityView } from "../activity/AgentActivityView";
 
 type AppPage =
   | "todos"
@@ -73,7 +74,8 @@ type AppPage =
   | "components"
   | "admin"
   | "feedback"
-  | "review";
+  | "review"
+  | "activity";
 type UiMode = "normal" | "simple";
 type HorizonSegment = "due" | "planned" | "pending" | "later";
 
@@ -853,7 +855,9 @@ export function AppShell() {
             ? "Admin"
             : page === "feedback"
               ? "Feedback"
-              : headerTitle;
+              : page === "activity"
+                ? "Agent Activity"
+                : headerTitle;
     document.title = `${pageLabel} — Todos`;
   }, [page, headerTitle]);
 
@@ -899,6 +903,11 @@ export function AppShell() {
         startTransition(() => setPage("admin"));
         setMobileNavOpen(false);
       }}
+      onOpenActivity={() => {
+        startTransition(() => setPage("activity"));
+        setMobileNavOpen(false);
+      }}
+      activePage={page}
       onToggleTheme={toggleDarkMode}
       onOpenShortcuts={() => setShortcutsOpen(true)}
       onOpenProfile={() => {
@@ -1034,6 +1043,10 @@ export function AppShell() {
                 }}
               />
             </Suspense>
+          ) : page === "activity" ? (
+            <AgentActivityView
+              onBack={() => startTransition(() => setPage("todos"))}
+            />
           ) : (
             <ViewRouter activeViewKey={activeViewKey} capacity={3}>
               <ViewRoute viewKey="home">
@@ -1308,9 +1321,12 @@ export function AppShell() {
                       loadProjects();
                     }}
                     onDeleteProject={async (id) => {
-                      await apiCall(`/projects/${id}?taskDisposition=unsorted`, {
-                        method: "DELETE",
-                      });
+                      await apiCall(
+                        `/projects/${id}?taskDisposition=unsorted`,
+                        {
+                          method: "DELETE",
+                        },
+                      );
                       handleSelectProject(null);
                       loadProjects();
                     }}

--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   IconToday,
   IconUpcoming,
   IconCompleted,
+  IconActivity,
   IconPlus,
   IconSidebar,
   IconSearch,
@@ -82,6 +83,8 @@ interface Props {
   onOpenComponents: () => void;
   onOpenFeedback: () => void;
   onOpenAdmin: () => void;
+  onOpenActivity: () => void;
+  activePage: string;
   onToggleTheme: () => void;
   onOpenShortcuts: () => void;
   onOpenProfile: () => void;
@@ -109,6 +112,8 @@ export function Sidebar({
   onOpenComponents,
   onOpenFeedback,
   onOpenAdmin,
+  onOpenActivity,
+  activePage,
   onToggleTheme,
   onOpenShortcuts,
   onOpenProfile,
@@ -284,6 +289,16 @@ export function Sidebar({
               )}
             </button>
           ))}
+        </nav>
+
+        <nav className="projects-rail__primary" style={{ marginTop: 4 }}>
+          <button
+            className={`workspace-view-item${activePage === "activity" ? " projects-rail-item--active" : ""}`}
+            onClick={onOpenActivity}
+          >
+            <IconActivity />
+            <span className="nav-label">Activity</span>
+          </button>
         </nav>
 
         {/* Section 2: Projects grouped by area */}

--- a/client-react/src/components/shared/Icons.tsx
+++ b/client-react/src/components/shared/Icons.tsx
@@ -445,3 +445,11 @@ export function IconRefresh({ size = 14, className = "app-icon" }: IconProps) {
     </Icon>
   );
 }
+
+export function IconActivity(p: IconProps) {
+  return (
+    <Icon {...p}>
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </Icon>
+  );
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -11615,3 +11615,26 @@ body.dark-mode {
 .activity-entry__name { font-weight: 600; font-size: 13px; }
 .activity-entry__meta { font-size: 11px; color: var(--text-muted, #999); }
 .activity-entry__narration { margin: 4px 0 0; font-size: 13px; line-height: 1.5; }
+.activity-feed__date-header {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted, #999);
+  margin: var(--s-4, 16px) 0 var(--s-2, 8px);
+  padding-bottom: var(--s-1, 4px);
+  border-bottom: 1px solid var(--border, #eee);
+}
+.activity-feed__day:first-child .activity-feed__date-header {
+  margin-top: 0;
+}
+.activity-feed--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+.activity-feed__empty-text {
+  color: var(--text-muted, #999);
+  font-size: 14px;
+}

--- a/docs/superpowers/plans/2026-04-06-agent-activity-view.md
+++ b/docs/superpowers/plans/2026-04-06-agent-activity-view.md
@@ -1,0 +1,590 @@
+# Agent Activity View — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated "Activity" sidebar view showing narrated agent actions from the last 7 days.
+
+**Architecture:** New backend endpoint queries audit table for narrated entries, grouped by agent/job/period. Frontend adds "Activity" as an `AppPage` (like Settings/Review), renders the existing `AgentActivityFeed` component with date headers and standalone mode.
+
+**Tech Stack:** Express/Prisma (backend endpoint), React/TypeScript (frontend view)
+
+**Spec:** `docs/superpowers/specs/2026-04-06-agent-activity-view-design.md`
+
+---
+
+## File Map
+
+### New files
+- `src/routes/agentActivityRouter.ts` — `GET /agent-activity` endpoint
+- `client-react/src/components/activity/AgentActivityView.tsx` — page wrapper with header + back button
+
+### Modified files
+- `src/app.ts:347-362,461+` — mount router, add to `protectedRoutes`
+- `client-react/src/components/shared/Icons.tsx` — add `IconActivity`
+- `client-react/src/components/projects/Sidebar.tsx:73-98,267-287` — add `onOpenActivity` + `activePage` props, add nav entry
+- `client-react/src/components/layout/AppShell.tsx:70-76,847-856,1021-1037` — add `"activity"` to `AppPage`, wire sidebar, add page branch
+- `client-react/src/components/home/AgentActivityFeed.tsx:1-67` — remove `agentName`, add `standalone` prop, date headers, empty/loading states
+
+---
+
+## Task 1: Backend endpoint — GET /agent-activity
+
+**Files:**
+- Create: `src/routes/agentActivityRouter.ts`
+- Modify: `src/app.ts`
+
+- [ ] **Step 1: Create `src/routes/agentActivityRouter.ts`**
+
+```typescript
+import { Router, Request, Response } from "express";
+import { PrismaClient, Prisma } from "@prisma/client";
+
+interface ActivityRow {
+  agent_id: string;
+  job_name: string;
+  job_period_key: string;
+  narration: string;
+  metadata: Prisma.JsonValue;
+  created_at: Date;
+}
+
+export function createAgentActivityRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  router.get("/agent-activity", async (req: Request, res: Response) => {
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    try {
+      const rows = await prisma.$queryRaw<ActivityRow[]>`
+        SELECT DISTINCT ON (agent_id, job_name, job_period_key)
+          agent_id, job_name, job_period_key, narration, metadata, created_at
+        FROM agent_action_audits
+        WHERE user_id = ${userId}
+          AND narration IS NOT NULL
+          AND created_at >= ${sevenDaysAgo}
+        ORDER BY agent_id, job_name, job_period_key, created_at DESC
+      `;
+
+      const entries = rows
+        .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+        .map((row) => ({
+          agentId: row.agent_id,
+          jobName: row.job_name,
+          periodKey: row.job_period_key,
+          narration: row.narration,
+          metadata: row.metadata ?? {},
+          createdAt: row.created_at.toISOString(),
+        }));
+
+      res.json({ entries });
+    } catch (err) {
+      console.error("Failed to fetch agent activity:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  return router;
+}
+```
+
+- [ ] **Step 2: Mount in `src/app.ts`**
+
+Add import at the top with other router imports (around line 19-65):
+
+```typescript
+import { createAgentActivityRouter } from "./routes/agentActivityRouter";
+```
+
+Add `"/agent-activity"` to the `protectedRoutes` array (line 347-362), after `"/adaptation"`:
+
+```typescript
+      "/adaptation",
+      "/agent-activity",
+```
+
+Mount the router inside the `if (persistencePrisma)` block (around line 461). Add after an existing `app.use(...)` call:
+
+```typescript
+    app.use(createAgentActivityRouter(persistencePrisma));
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx tsc --noEmit'`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/agentActivityRouter.ts src/app.ts
+git commit -m "feat(api): add GET /agent-activity endpoint for narrated agent actions"
+```
+
+---
+
+## Task 2: IconActivity icon
+
+**Files:**
+- Modify: `client-react/src/components/shared/Icons.tsx`
+
+- [ ] **Step 1: Add IconActivity**
+
+In `client-react/src/components/shared/Icons.tsx`, add after the last icon export:
+
+```typescript
+export function IconActivity(p: IconProps) {
+  return (
+    <Icon {...p}>
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </Icon>
+  );
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx tsc --noEmit'`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client-react/src/components/shared/Icons.tsx
+git commit -m "feat(react): add IconActivity pulse icon"
+```
+
+---
+
+## Task 3: Sidebar — add Activity nav entry
+
+**Files:**
+- Modify: `client-react/src/components/projects/Sidebar.tsx:73-98,267-287`
+
+- [ ] **Step 1: Add props to Sidebar interface**
+
+In `client-react/src/components/projects/Sidebar.tsx`, add to the `Props` interface (after `onOpenAdmin` on line 84):
+
+```typescript
+  onOpenActivity: () => void;
+  activePage: string;
+```
+
+Add to the destructured params in the function signature (after `onOpenAdmin` on line 111):
+
+```typescript
+  onOpenActivity,
+  activePage,
+```
+
+- [ ] **Step 2: Import IconActivity**
+
+Add to the icon imports at the top of the file:
+
+```typescript
+import { IconActivity } from "../shared/Icons";
+```
+
+(Check the existing import line for Icons — it may be a combined import. Add `IconActivity` to it.)
+
+- [ ] **Step 3: Add nav entry after workspace views**
+
+After the `</nav>` that closes the workspace views loop (line 287), add a new nav entry before the projects section (before line 289 `{/* Section 2: Projects grouped by area */}`):
+
+```tsx
+        <nav className="projects-rail__primary" style={{ marginTop: 4 }}>
+          <button
+            className={`workspace-view-item${activePage === "activity" ? " projects-rail-item--active" : ""}`}
+            onClick={onOpenActivity}
+          >
+            <IconActivity />
+            <span className="nav-label">Activity</span>
+          </button>
+        </nav>
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx tsc --noEmit'`
+Expected: FAIL — AppShell doesn't pass the new props yet. That's fine, we'll fix in the next task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client-react/src/components/projects/Sidebar.tsx
+git commit -m "feat(react): add Activity nav entry to sidebar"
+```
+
+---
+
+## Task 4: AppShell — wire Activity page
+
+**Files:**
+- Modify: `client-react/src/components/layout/AppShell.tsx:70-76,847-856,1021-1037`
+- Create: `client-react/src/components/activity/AgentActivityView.tsx`
+
+- [ ] **Step 1: Create `AgentActivityView` wrapper**
+
+Create `client-react/src/components/activity/AgentActivityView.tsx`:
+
+```typescript
+import { AgentActivityFeed } from "../home/AgentActivityFeed";
+
+interface Props {
+  onBack: () => void;
+}
+
+export function AgentActivityView({ onBack }: Props) {
+  return (
+    <>
+      <header className="app-header">
+        <button className="btn" onClick={onBack}>
+          ← Back
+        </button>
+        <span className="app-header__title">Agent Activity</span>
+      </header>
+      <div className="app-content">
+        <AgentActivityFeed standalone />
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Add `"activity"` to `AppPage` type**
+
+In `client-react/src/components/layout/AppShell.tsx`, line 70-76, add `"activity"`:
+
+```typescript
+type AppPage =
+  | "todos"
+  | "settings"
+  | "components"
+  | "admin"
+  | "feedback"
+  | "review"
+  | "activity";
+```
+
+- [ ] **Step 3: Add page label to document title**
+
+In the `useEffect` that sets `document.title` (around line 847-858), add `"activity"` case. Find:
+
+```typescript
+            : page === "feedback"
+              ? "Feedback"
+              : headerTitle;
+```
+
+Replace with:
+
+```typescript
+            : page === "feedback"
+              ? "Feedback"
+              : page === "activity"
+                ? "Agent Activity"
+                : headerTitle;
+```
+
+- [ ] **Step 4: Add rendering branch**
+
+Import `AgentActivityView` at the top:
+
+```typescript
+import { AgentActivityView } from "../activity/AgentActivityView";
+```
+
+In the page rendering chain, after the `page === "review"` branch (line 1021-1036) and before the `ViewRouter` fallback (line 1037), add:
+
+Find:
+```typescript
+            </Suspense>
+          ) : (
+            <ViewRouter activeViewKey={activeViewKey} capacity={3}>
+```
+
+Replace with:
+```typescript
+            </Suspense>
+          ) : page === "activity" ? (
+            <AgentActivityView
+              onBack={() => startTransition(() => setPage("todos"))}
+            />
+          ) : (
+            <ViewRouter activeViewKey={activeViewKey} capacity={3}>
+```
+
+- [ ] **Step 5: Pass new props to Sidebar**
+
+Find where `<Sidebar` is rendered in AppShell and add the new props:
+
+```typescript
+onOpenActivity={() => {
+  startTransition(() => setPage("activity"));
+  setMobileNavOpen(false);
+}}
+activePage={page}
+```
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx tsc --noEmit'`
+Expected: FAIL — `AgentActivityFeed` doesn't accept `standalone` prop yet. That's expected.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client-react/src/components/activity/AgentActivityView.tsx client-react/src/components/layout/AppShell.tsx
+git commit -m "feat(react): wire Activity page into AppShell with sidebar navigation"
+```
+
+---
+
+## Task 5: AgentActivityFeed — standalone mode with date headers
+
+**Files:**
+- Modify: `client-react/src/components/home/AgentActivityFeed.tsx`
+
+- [ ] **Step 1: Remove `agentName` from interface, add `standalone` prop**
+
+Replace the entire file content:
+
+```typescript
+import { useState, useEffect } from "react";
+import { apiCall } from "../../api/client";
+import {
+  useAgentProfiles,
+  getAgentProfile,
+} from "../../agents/useAgentProfiles";
+import { AgentSigil } from "./AgentSigil";
+
+interface ActivityEntry {
+  agentId: string;
+  jobName: string;
+  periodKey: string;
+  narration: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+interface Props {
+  standalone?: boolean;
+}
+
+function dayLabel(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const entryDay = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  );
+  const diffMs = today.getTime() - entryDay.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays <= 5)
+    return date.toLocaleDateString("en-US", { weekday: "long" });
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function groupByDay(
+  entries: ActivityEntry[],
+): Array<{ label: string; entries: ActivityEntry[] }> {
+  const groups: Array<{ label: string; entries: ActivityEntry[] }> = [];
+  let currentLabel = "";
+
+  for (const entry of entries) {
+    const label = dayLabel(entry.createdAt);
+    if (label !== currentLabel) {
+      groups.push({ label, entries: [entry] });
+      currentLabel = label;
+    } else {
+      groups[groups.length - 1].entries.push(entry);
+    }
+  }
+
+  return groups;
+}
+
+export function AgentActivityFeed({ standalone = false }: Props) {
+  const profiles = useAgentProfiles();
+  const [entries, setEntries] = useState<ActivityEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    apiCall("/agent-activity")
+      .then((res) => res.json())
+      .then((data: { entries: ActivityEntry[] }) => setEntries(data.entries))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    if (standalone) {
+      return (
+        <div className="activity-feed activity-feed--loading">
+          <div className="loading-skeleton">
+            <div className="loading-skeleton__row" />
+            <div className="loading-skeleton__row" />
+            <div className="loading-skeleton__row" />
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  if (entries.length === 0) {
+    if (standalone) {
+      return (
+        <div className="activity-feed activity-feed--empty">
+          <p className="activity-feed__empty-text">
+            No agent activity in the last 7 days.
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const renderEntry = (entry: ActivityEntry, i: number) => {
+    const agent = getAgentProfile(profiles, entry.agentId);
+    return (
+      <div
+        key={`${entry.agentId}-${entry.periodKey}-${i}`}
+        className="activity-entry"
+      >
+        {agent && (
+          <AgentSigil
+            agentId={agent.id}
+            color={agent.colors.stroke}
+            bg={agent.colors.bg}
+            size={32}
+          />
+        )}
+        <div className="activity-entry__body">
+          <div className="activity-entry__header">
+            <span
+              className="activity-entry__name"
+              style={{ color: agent?.colors.textDark }}
+            >
+              {agent?.name ?? entry.agentId}
+            </span>
+            <span className="activity-entry__meta">
+              {entry.jobName} &middot;{" "}
+              {new Date(entry.createdAt).toLocaleString([], {
+                hour: "numeric",
+                minute: "2-digit",
+              })}
+            </span>
+          </div>
+          <p className="activity-entry__narration">{entry.narration}</p>
+        </div>
+      </div>
+    );
+  };
+
+  if (standalone) {
+    const groups = groupByDay(entries);
+    return (
+      <div className="activity-feed">
+        {groups.map((group) => (
+          <div key={group.label} className="activity-feed__day">
+            <h3 className="activity-feed__date-header">{group.label}</h3>
+            {group.entries.map(renderEntry)}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="activity-feed">
+      {entries.map(renderEntry)}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add CSS for date headers and standalone states**
+
+In `client-react/src/styles/app.css`, find the existing `.activity-feed` styles and add:
+
+```css
+.activity-feed__date-header {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted, #999);
+  margin: var(--s-4, 16px) 0 var(--s-2, 8px);
+  padding-bottom: var(--s-1, 4px);
+  border-bottom: 1px solid var(--border, #eee);
+}
+.activity-feed__day:first-child .activity-feed__date-header {
+  margin-top: 0;
+}
+.activity-feed--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+.activity-feed__empty-text {
+  color: var(--text-muted, #999);
+  font-size: 14px;
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx tsc --noEmit'`
+Expected: PASS — all pieces connected now.
+
+- [ ] **Step 4: Run format check**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npm run format:check 2>&1 | grep -v eval-lab'`
+If formatting issues, run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx prettier --write src/routes/agentActivityRouter.ts client-react/src/components/home/AgentActivityFeed.tsx client-react/src/components/activity/AgentActivityView.tsx client-react/src/components/projects/Sidebar.tsx client-react/src/components/layout/AppShell.tsx'`
+
+- [ ] **Step 5: Run unit tests**
+
+Run: `/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npm run test:unit'`
+Expected: PASS (no test regressions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client-react/src/components/home/AgentActivityFeed.tsx client-react/src/styles/app.css
+git commit -m "feat(react): add standalone mode with date headers to AgentActivityFeed"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run all checks**
+
+```bash
+/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npx tsc --noEmit'
+/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npm run check:architecture'
+/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npm run format:check'
+/bin/bash -c 'source "$HOME/.nvm/nvm.sh" && nvm use 22 && npm run test:unit'
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 2: Fix any failures and commit**
+
+```bash
+git add -A
+git commit -m "fix: address verification failures"
+```

--- a/docs/superpowers/specs/2026-04-06-agent-activity-view-design.md
+++ b/docs/superpowers/specs/2026-04-06-agent-activity-view-design.md
@@ -1,0 +1,256 @@
+# Agent Activity View — Design Spec v2
+
+## Overview
+
+Add a dedicated "Activity" view accessible from the sidebar that shows narrated
+agent actions from the last 7 days. This is a standalone page (like Settings or
+Weekly Review), not a todo workspace view.
+
+---
+
+## Backend: `GET /agent-activity`
+
+New authenticated endpoint. The existing `AgentActivityFeed` component already
+calls `apiCall("/agent-activity")` (currently fails silently), so the route path
+is pre-determined.
+
+### Router
+
+Create `src/routes/agentActivityRouter.ts` — a small dedicated router. Do NOT
+add to `agentProfileRouter.ts` (that router is public, takes no deps, and has
+no Prisma access).
+
+```ts
+// src/routes/agentActivityRouter.ts
+import { Router, Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
+
+export function createAgentActivityRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  router.get("/agent-activity", async (req: Request, res: Response) => {
+    // ... implementation
+  });
+
+  return router;
+}
+```
+
+### Mount & auth (app.ts)
+
+1. Mount at root: `app.use(createAgentActivityRouter(persistencePrisma));`
+2. Add `"/agent-activity"` to the `protectedRoutes` array (line ~347) so user
+   auth middleware is applied automatically.
+
+### Query
+
+```sql
+SELECT DISTINCT ON (agent_id, job_name, job_period_key)
+  agent_id, job_name, job_period_key, narration, metadata, created_at
+FROM agent_action_audits
+WHERE user_id = $userId
+  AND narration IS NOT NULL
+  AND created_at >= NOW() - INTERVAL '7 days'
+ORDER BY agent_id, job_name, job_period_key, created_at DESC
+```
+
+This gives the **latest** narration per (agent, job, period) group. Then sort
+the final result set by `created_at DESC` in application code.
+
+In Prisma, use `$queryRaw` or a grouped findMany with ordering. The key
+requirement: one entry per agent per job run, latest narration wins.
+
+### Response shape
+
+```json
+{
+  "entries": [
+    {
+      "agentId": "echo",
+      "jobName": "inbox",
+      "periodKey": "2026-04-06",
+      "narration": "Sorted. 6 items — 3 to projects, 2 flagged urgent, 1 archived.",
+      "metadata": {},
+      "createdAt": "2026-04-06T08:02:00Z"
+    }
+  ]
+}
+```
+
+`agentName` is NOT in the response — the client derives it from cached agent
+profiles via `useAgentProfiles()`. The existing component already does this
+(line 34 of `AgentActivityFeed.tsx`). However, the `ActivityEntry` interface
+currently has an `agentName` field (line 8) — **remove it** from the interface
+since the backend won't provide it and the component already resolves the name
+from profiles.
+
+---
+
+## Frontend: Navigation Model
+
+### What changes: `AppPage`, not `WorkspaceView`
+
+Agent activity is a standalone content page with no todo plumbing. It follows
+the same pattern as Settings, Admin, Feedback, and Weekly Review:
+
+- **`AppPage` type** — add `"activity"` to the union (line ~70 of `AppShell.tsx`)
+- **Rendering** — add a branch in the `page ===` chain (after `"review"`, before
+  the `ViewRouter` fallback)
+- **No changes** to `WorkspaceView`, `queryParams`, `visibleTodos`, `viewCounts`,
+  or `quickEntryPlaceholder`
+
+### Sidebar entry (`Sidebar.tsx`)
+
+Add a new prop `onOpenActivity: () => void` to the `Sidebar` `Props` interface.
+Add a nav entry in the `projects-rail__primary` nav, after the workspace views
+and before the projects section:
+
+```tsx
+<button
+  className={`workspace-view-item${page === "activity" ? " projects-rail-item--active" : ""}`}
+  onClick={onOpenActivity}
+>
+  <IconActivity />
+  <span className="nav-label">Activity</span>
+</button>
+```
+
+This requires a way for the sidebar to know when the activity page is active.
+Options (pick simplest):
+- Pass `page` (or a boolean `isActivityActive`) as a prop
+- Or: use the existing `activeView` with a sentinel — but this pollutes
+  `WorkspaceView`, so prefer a prop
+
+Recommended: add `activePage: AppPage` prop to Sidebar so it can highlight
+correctly. When any workspace view is selected, `activePage` will be `"todos"`.
+
+### Wiring in `AppShell.tsx`
+
+```tsx
+// In sidebarContent:
+onOpenActivity={() => {
+  startTransition(() => setPage("activity"));
+  setMobileNavOpen(false);
+}}
+
+// In the page === chain:
+) : page === "activity" ? (
+  <AgentActivityView
+    onBack={() => startTransition(() => setPage("todos"))}
+  />
+) : (
+  <ViewRouter ...>
+```
+
+---
+
+## Component: `AgentActivityView`
+
+New wrapper component at `client-react/src/components/activity/AgentActivityView.tsx`.
+
+This is thin — it provides the page chrome (header with back button + title)
+and renders `AgentActivityFeed` in standalone mode.
+
+```tsx
+interface Props {
+  onBack: () => void;
+}
+
+export function AgentActivityView({ onBack }: Props) {
+  return (
+    <>
+      <header className="app-header">
+        <button className="btn" onClick={onBack}>← Back</button>
+        <span className="app-header__title">Agent Activity</span>
+      </header>
+      <div className="app-content">
+        <AgentActivityFeed standalone />
+      </div>
+    </>
+  );
+}
+```
+
+---
+
+## Component: `AgentActivityFeed` enhancements
+
+File: `client-react/src/components/home/AgentActivityFeed.tsx`
+
+### Interface cleanup
+
+Remove `agentName` from `ActivityEntry` — the backend doesn't provide it, and
+the component resolves it from `useAgentProfiles()`.
+
+### `standalone` prop
+
+Add an optional `standalone?: boolean` prop that controls two behaviors:
+
+1. **Empty state** — when `standalone` is true and `entries.length === 0`,
+   render a message: "No agent activity in the last 7 days." When `standalone`
+   is false (default, embedded in HomeDashboard), keep the current behavior
+   of returning `null`.
+
+2. **Date headers** — when `standalone` is true, group entries under day
+   labels before rendering. Labels:
+   - Same calendar day as now → **"Today"**
+   - Previous calendar day → **"Yesterday"**
+   - 2–5 days ago → **day name** ("Saturday", "Thursday", etc.)
+   - 6–7 days ago → **formatted date** ("Mar 31", "Mar 30")
+
+   Use a simple grouping pass over the sorted entries array. Render each
+   group as a `<div>` with a `<h3 className="activity-feed__date-header">`
+   followed by the entries for that day.
+
+### Loading state for standalone
+
+When `standalone` is true, show a skeleton/spinner during load instead of
+returning `null`.
+
+---
+
+## Icon: `IconActivity`
+
+Add to `client-react/src/components/shared/Icons.tsx`. Feather "activity" icon
+(pulse/heartbeat line):
+
+```tsx
+export function IconActivity(p: IconProps) {
+  return (
+    <Icon {...p}>
+      <path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36-3.18-19.64A2 2 0 0 0 10.12 1h-.24a2 2 0 0 0-1.94 1.52L5.21 13H2" />
+    </Icon>
+  );
+}
+```
+
+Verify this renders correctly at 15×15 — if the path is too complex for the
+viewBox, simplify to:
+
+```tsx
+<polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/routes/agentActivityRouter.ts` | **New.** `GET /agent-activity` endpoint |
+| `src/app.ts` | Import + mount router; add to `protectedRoutes` |
+| `client-react/src/components/shared/Icons.tsx` | Add `IconActivity` |
+| `client-react/src/components/projects/Sidebar.tsx` | Add `onOpenActivity` prop + nav entry; add `activePage` prop for highlight |
+| `client-react/src/components/layout/AppShell.tsx` | Add `"activity"` to `AppPage`; wire sidebar prop; add rendering branch |
+| `client-react/src/components/activity/AgentActivityView.tsx` | **New.** Wrapper with header + back button |
+| `client-react/src/components/home/AgentActivityFeed.tsx` | Remove `agentName` from interface; add `standalone` prop with date headers, empty state, loading state |
+
+## What Doesn't Change
+
+- No new DB columns or migrations
+- No agent-runner changes
+- No changes to `WorkspaceView` type or any todo-related memos
+- No changes to agent profile endpoint or registry
+- `AgentActivityFeed`'s core rendering (sigil + narration layout) stays the same
+- Existing embedded usage on HomeDashboard (if any) is unaffected (`standalone`
+  defaults to `false`)

--- a/src/app.ts
+++ b/src/app.ts
@@ -68,6 +68,7 @@ import { createGoalsRouter } from "./routes/goalsRouter";
 import { createDayPlanRouter } from "./routes/dayPlanRouter";
 import { createStaticPagesRouter } from "./routes/staticPagesRouter";
 import { createAdaptationRouter } from "./routes/adaptationRouter";
+import { createAgentActivityRouter } from "./routes/agentActivityRouter";
 import { DayPlanService } from "./services/dayPlanService";
 import { UserAdaptationService } from "./services/userAdaptationService";
 import { AdaptationLlmInferenceService } from "./services/adaptationLlmInference";
@@ -359,6 +360,7 @@ export function createApp(deps: AppDependencies = {}) {
       "/goals",
       "/plans",
       "/adaptation",
+      "/agent-activity",
     ];
     for (const route of protectedRoutes) {
       app.use(route, auth);
@@ -531,6 +533,8 @@ export function createApp(deps: AppDependencies = {}) {
         resolveUserId,
       }),
     );
+
+    app.use(createAgentActivityRouter(persistencePrisma));
   }
 
   app.use(errorHandler);

--- a/src/routes/agentActivityRouter.ts
+++ b/src/routes/agentActivityRouter.ts
@@ -1,0 +1,56 @@
+import { Router, Request, Response } from "express";
+import { PrismaClient, Prisma } from "@prisma/client";
+
+interface ActivityRow {
+  agent_id: string;
+  job_name: string;
+  job_period_key: string;
+  narration: string;
+  metadata: Prisma.JsonValue;
+  created_at: Date;
+}
+
+export function createAgentActivityRouter(prisma: PrismaClient): Router {
+  const router = Router();
+
+  router.get("/agent-activity", async (req: Request, res: Response) => {
+    const userId = req.user?.userId;
+    if (!userId) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    try {
+      const rows = await prisma.$queryRaw<ActivityRow[]>`
+        SELECT DISTINCT ON (agent_id, job_name, job_period_key)
+          agent_id, job_name, job_period_key, narration, metadata, created_at
+        FROM agent_action_audits
+        WHERE user_id = ${userId}
+          AND narration IS NOT NULL
+          AND created_at >= ${sevenDaysAgo}
+        ORDER BY agent_id, job_name, job_period_key, created_at DESC
+      `;
+
+      const entries = rows
+        .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+        .map((row) => ({
+          agentId: row.agent_id,
+          jobName: row.job_name,
+          periodKey: row.job_period_key,
+          narration: row.narration,
+          metadata: row.metadata ?? {},
+          createdAt: row.created_at.toISOString(),
+        }));
+
+      res.json({ entries });
+    } catch (err) {
+      console.error("Failed to fetch agent activity:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- **Backend:** `GET /agent-activity` endpoint — queries narrated audit entries from last 7 days, grouped by (agent, job, period), latest narration wins
- **Sidebar:** New "Activity" nav entry using `AppPage` pattern (like Settings/Review), not `WorkspaceView`
- **AgentActivityView:** Page wrapper with back button + header
- **AgentActivityFeed:** `standalone` mode with date headers (Today/Yesterday/day name), empty state, loading skeleton. Removed unused `agentName` from interface

## Test plan
- [x] TypeScript typecheck passes (zero errors)
- [x] Architecture invariant check passes
- [x] Prettier format check passes
- [x] Unit tests: 412/413 pass (1 pre-existing failure)
- [ ] Manual: click Activity in sidebar, verify page renders
- [ ] Manual: verify back button returns to Focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)