### PR TITLE
fix(react): restore generative pattern features — AvatarMode, avatarSeed, startAnimation

### DIFF
--- a/client-react/src/agents/avatarEngine.test.ts
+++ b/client-react/src/agents/avatarEngine.test.ts
@@ -1,19 +1,36 @@
 import { describe, it, expect } from "vitest";
-import { drawAgentAvatar, AVATAR_AGENTS } from "./avatarEngine";
+import { drawAgentAvatar, startAnimation } from "./avatarEngine";
+import type { AgentProfile } from "./types";
+
+const mockAgent: AgentProfile = {
+  id: "kodo",
+  name: "KŌDO",
+  role: "focus guardian",
+  traits: ["disciplined", "quiet", "fierce"],
+  quote: "Not now.",
+  superpower: "Shields deep work",
+  quirk: "Sometimes blocks needed things",
+  bestCalledWhen: "You need 2 unbroken hours",
+  colors: {
+    stroke: "#3A3A38",
+    bg: "#F4F3F0",
+    textDark: "#2C2C2A",
+    traitBg: "#E8E7E3",
+  },
+  voice: {
+    tone: "terse",
+    avgWordsPerSentence: 5,
+    openers: ["Focus."],
+    closers: ["."],
+    thinkingLines: ["..."],
+    emptyStateLines: ["Ready."],
+    errorLines: ["Error."],
+  },
+  avatarSeed: 111,
+};
 
 describe("avatarEngine", () => {
-  it("exports draw functions for all 6 agents", () => {
-    expect(AVATAR_AGENTS).toEqual([
-      "orla",
-      "finn",
-      "mira",
-      "echo",
-      "sol",
-      "kodo",
-    ]);
-  });
-
-  it("drawAgentAvatar does not throw for any agent", () => {
+  it("drawAgentAvatar does not throw", () => {
     const ops: string[] = [];
     const ctx = {
       beginPath: () => ops.push("beginPath"),
@@ -21,8 +38,13 @@ describe("avatarEngine", () => {
       lineTo: () => ops.push("lineTo"),
       arc: () => ops.push("arc"),
       stroke: () => ops.push("stroke"),
+      fill: () => ops.push("fill"),
+      clearRect: () => ops.push("clearRect"),
       set strokeStyle(_: string) {
         ops.push("strokeStyle");
+      },
+      set fillStyle(_: string) {
+        ops.push("fillStyle");
       },
       set lineWidth(_: number) {
         ops.push("lineWidth");
@@ -38,14 +60,11 @@ describe("avatarEngine", () => {
       },
     } as unknown as CanvasRenderingContext2D;
 
-    for (const id of AVATAR_AGENTS) {
-      ops.length = 0;
-      expect(() => drawAgentAvatar(ctx, id, 40, 40, "#000")).not.toThrow();
-      expect(ops.length).toBeGreaterThan(0);
-    }
+    expect(() => drawAgentAvatar(ctx, 80, mockAgent, "idle")).not.toThrow();
+    expect(ops.length).toBeGreaterThan(0);
   });
 
-  it("kodo draws exactly 2 arcs", () => {
+  it("kodo draws exactly 2 arcs (plus background circle)", () => {
     const arcCalls: number[] = [];
     const ctx = {
       beginPath: () => {},
@@ -53,14 +72,30 @@ describe("avatarEngine", () => {
       lineTo: () => {},
       arc: () => arcCalls.push(1),
       stroke: () => {},
+      fill: () => {},
+      clearRect: () => {},
       set strokeStyle(_: string) {},
+      set fillStyle(_: string) {},
       set lineWidth(_: number) {},
       set globalAlpha(_: number) {},
       set lineCap(_: string) {},
       set lineJoin(_: string) {},
     } as unknown as CanvasRenderingContext2D;
 
-    drawAgentAvatar(ctx, "kodo", 40, 40, "#000");
-    expect(arcCalls).toHaveLength(2);
+    drawAgentAvatar(ctx, 80, mockAgent, "idle");
+    // 1 for background circle + 2 for kodo's strokes = 3
+    expect(arcCalls).toHaveLength(3);
+  });
+
+  it("startAnimation returns a cleanup function", () => {
+    const canvas = {
+      getContext: () => null,
+      width: 80,
+      height: 80,
+    } as unknown as HTMLCanvasElement;
+
+    const cleanup = startAnimation(canvas, mockAgent);
+    expect(typeof cleanup).toBe("function");
+    cleanup();
   });
 });

--- a/client-react/src/agents/avatarEngine.ts
+++ b/client-react/src/agents/avatarEngine.ts
@@ -1,4 +1,4 @@
-type AgentAvatarId = "orla" | "finn" | "mira" | "echo" | "sol" | "kodo";
+import type { AgentProfile, AgentId, AvatarMode } from "./types";
 
 function mkRng(seed: number) {
   let s = seed;
@@ -10,153 +10,124 @@ function mkRng(seed: number) {
   };
 }
 
-function drawOrla(
+type DrawerFn = (
   ctx: CanvasRenderingContext2D,
   cx: number,
   cy: number,
-  color: string,
-): void {
-  const radii = [36, 27, 19, 11];
-  const offsets = [0.3, 1.0, 1.8, 2.7];
-  const lws = [1.55, 1.6, 1.5, 1.4];
-  const alphas = [0.75, 0.65, 0.55, 0.45];
-  ctx.strokeStyle = color;
-  ctx.lineCap = "round";
-  for (let i = 0; i < 4; i++) {
-    ctx.beginPath();
-    ctx.lineWidth = lws[i];
-    ctx.globalAlpha = alphas[i];
-    ctx.arc(cx, cy, radii[i], offsets[i], offsets[i] + Math.PI * 1.65);
-    ctx.stroke();
-  }
-  ctx.globalAlpha = 1;
-}
+  size: number,
+  agent: AgentProfile,
+  mode: AvatarMode,
+  frame: number,
+) => void;
 
-function drawFinn(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  cy: number,
-  color: string,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineCap = "round";
-  ctx.lineWidth = 2;
-  ctx.globalAlpha = 0.7;
+const drawOrla: DrawerFn = (ctx, cx, cy) => {
+  (
+    [
+      [36, 0.3, 1.55],
+      [27, 1.0, 1.6],
+      [19, 1.8, 1.5],
+      [11, 2.7, 1.4],
+    ] as [number, number, number][]
+  ).forEach(([r, off, sw], i) => {
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, off, off + Math.PI * 1.65);
+    ctx.lineWidth = sw;
+    ctx.globalAlpha = 0.75 - i * 0.1;
+    ctx.stroke();
+  });
+};
+
+const drawFinn: DrawerFn = (ctx, cx, cy, _size, _agent, mode, frame) => {
+  const animOffset = mode === "thinking" ? frame * 0.04 : 0;
   ctx.beginPath();
-  for (let i = 0; i <= 280; i++) {
+  for (let i = 0; i < 280; i++) {
     const t = i / 280;
     const r = t * 36;
-    const a = t * Math.PI * 7 + 0.4;
-    const x = cx + Math.cos(a) * r;
-    const y = cy + Math.sin(a) * r;
+    const a = t * Math.PI * 7 + 0.4 + animOffset;
+    const x = cx + r * Math.cos(a);
+    const y = cy + r * Math.sin(a);
     if (i === 0) ctx.moveTo(x, y);
     else ctx.lineTo(x, y);
   }
-  ctx.stroke();
-  ctx.globalAlpha = 1;
-}
-
-function drawMira(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  cy: number,
-  color: string,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineCap = "round";
-  ctx.lineWidth = 1.5;
+  ctx.lineWidth = 2;
   ctx.globalAlpha = 0.7;
+  ctx.stroke();
+};
+
+const drawMira: DrawerFn = (ctx, cx, cy) => {
   for (let i = 0; i < 6; i++) {
-    const angle = i * (Math.PI / 3) - Math.PI / 2;
+    const a = i * (Math.PI / 3) - Math.PI / 2;
     ctx.beginPath();
     ctx.moveTo(cx, cy);
-    ctx.arc(cx, cy, 28, angle, angle + Math.PI * 0.52);
+    ctx.arc(cx, cy, 28, a, a + Math.PI * 0.52);
+    ctx.lineWidth = 2.8 - i * 0.1;
+    ctx.globalAlpha = 0.6 + i * 0.04;
     ctx.stroke();
   }
   ctx.beginPath();
-  ctx.globalAlpha = 0.5;
   ctx.arc(cx, cy, 8, 0, Math.PI * 2);
+  ctx.lineWidth = 2;
+  ctx.globalAlpha = 0.35;
   ctx.stroke();
-  ctx.globalAlpha = 1;
-}
+};
 
-function drawEcho(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  cy: number,
-  color: string,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineCap = "round";
-  ctx.lineWidth = 1.5;
-  const rng = mkRng(77);
+const drawEcho: DrawerFn = (ctx, _cx, _cy, size, agent, mode, frame) => {
+  const rng = mkRng(agent.avatarSeed);
   const freq = 0.055;
-  for (let p = 0; p < 9; p++) {
-    let x = cx + (rng() - 0.5) * 60;
-    let y = cy + (rng() - 0.5) * 60;
+  const stepOffset = mode === "thinking" ? frame * 0.5 : 0;
+  for (let i = 0; i < 9; i++) {
+    let x = rng() * size;
+    let y = rng() * size;
     ctx.beginPath();
-    ctx.globalAlpha = 0.4 + rng() * 0.35;
     ctx.moveTo(x, y);
     for (let s = 0; s < 28; s++) {
-      const a = Math.sin(x * freq) * Math.PI * 2 + Math.cos(y * freq) * Math.PI;
+      const a =
+        Math.sin((x + stepOffset) * freq) * Math.PI * 2 +
+        Math.cos((y + stepOffset) * freq * 0.8) * Math.PI;
       x += Math.cos(a) * 3.2;
       y += Math.sin(a) * 3.2;
+      if (x < -5 || x > size + 5 || y < -5 || y > size + 5) break;
       ctx.lineTo(x, y);
     }
+    ctx.lineWidth = 1.5 + rng();
+    ctx.globalAlpha = 0.35 + rng() * 0.4;
     ctx.stroke();
   }
-  ctx.globalAlpha = 1;
-}
+};
 
-function drawSol(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  cy: number,
-  color: string,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineCap = "round";
-  const rng = mkRng(99);
-  const radii = [38, 28, 20, 34];
-  const offsets = [0.2, 1.1, 2.3, 3.0];
-  for (let i = 0; i < 4; i++) {
-    const ocx = cx + rng() * 6 - 3;
-    const ocy = cy + rng() * 6 - 3;
+const drawSol: DrawerFn = (ctx, cx, cy, _size, agent) => {
+  const rng = mkRng(agent.avatarSeed);
+  (
+    [
+      [38, 0.2, 1.3],
+      [28, 1.1, 1.5],
+      [20, 2.3, 1.4],
+      [34, 3.0, 1.2],
+    ] as [number, number, number][]
+  ).forEach(([r, off, sw]) => {
     const sweep = (0.8 + rng() * 0.9) * Math.PI;
     ctx.beginPath();
-    ctx.lineWidth = 1.4 + rng() * 1.2;
-    ctx.globalAlpha = 0.35 + rng() * 0.35;
-    ctx.arc(ocx, ocy, radii[i], offsets[i], offsets[i] + sweep);
+    ctx.arc(cx + rng() * 6 - 3, cy + rng() * 6 - 3, r, off, off + sweep);
+    ctx.lineWidth = sw;
+    ctx.globalAlpha = 0.4 + rng() * 0.35;
     ctx.stroke();
-  }
-  ctx.globalAlpha = 1;
-}
+  });
+};
 
-function drawKodo(
-  ctx: CanvasRenderingContext2D,
-  cx: number,
-  cy: number,
-  color: string,
-): void {
-  ctx.strokeStyle = color;
-  ctx.lineCap = "round";
+const drawKodo: DrawerFn = (ctx, cx, cy) => {
   ctx.beginPath();
+  ctx.arc(cx, cy, 33, 0.18, 0.18 + Math.PI * 1.85);
   ctx.lineWidth = 4.5;
   ctx.globalAlpha = 0.75;
-  ctx.arc(cx, cy, 33, 0.18, 0.18 + Math.PI * 1.85);
   ctx.stroke();
   ctx.beginPath();
+  ctx.arc(cx, cy, 22, 0.5, 0.5 + Math.PI * 1.7);
   ctx.lineWidth = 2;
   ctx.globalAlpha = 0.28;
-  ctx.arc(cx, cy, 22, 0.5, 0.5 + Math.PI * 1.7);
   ctx.stroke();
-  ctx.globalAlpha = 1;
-}
+};
 
-const DRAW_MAP: Record<
-  AgentAvatarId,
-  (ctx: CanvasRenderingContext2D, cx: number, cy: number, color: string) => void
-> = {
+const DRAWERS: Record<AgentId, DrawerFn> = {
   orla: drawOrla,
   finn: drawFinn,
   mira: drawMira,
@@ -165,22 +136,54 @@ const DRAW_MAP: Record<
   kodo: drawKodo,
 };
 
-export const AVATAR_AGENTS: AgentAvatarId[] = [
-  "orla",
-  "finn",
-  "mira",
-  "echo",
-  "sol",
-  "kodo",
-];
-
 export function drawAgentAvatar(
   ctx: CanvasRenderingContext2D,
-  agentId: string,
-  cx: number,
-  cy: number,
-  color: string,
+  size: number,
+  agent: AgentProfile,
+  mode: AvatarMode,
+  frame: number = 0,
 ): void {
-  const draw = DRAW_MAP[agentId as AgentAvatarId];
-  if (draw) draw(ctx, cx, cy, color);
+  const cx = size / 2;
+  const cy = size / 2;
+
+  ctx.clearRect(0, 0, size, size);
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, size / 2, 0, Math.PI * 2);
+  ctx.fillStyle = agent.colors.bg;
+  ctx.fill();
+
+  ctx.strokeStyle = agent.colors.stroke;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  const drawer = DRAWERS[agent.id];
+  drawer(ctx, cx, cy, size, agent, mode, frame);
+
+  ctx.globalAlpha = 1;
+}
+
+export function startAnimation(
+  canvas: HTMLCanvasElement,
+  agent: AgentProfile,
+): () => void {
+  let frame = 0;
+  let rafId = 0;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+
+  const dpr = window.devicePixelRatio || 1;
+  const size = canvas.width / dpr;
+
+  const loop = () => {
+    frame++;
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    drawAgentAvatar(ctx, size, agent, "thinking", frame);
+    ctx.restore();
+    rafId = requestAnimationFrame(loop);
+  };
+
+  rafId = requestAnimationFrame(loop);
+  return () => cancelAnimationFrame(rafId);
 }

--- a/client-react/src/agents/components/AgentAvatar.tsx
+++ b/client-react/src/agents/components/AgentAvatar.tsx
@@ -1,14 +1,20 @@
 import { useRef, useEffect } from "react";
-import type { AgentProfile } from "../types";
-import { drawAgentAvatar } from "../avatarEngine";
+import type { AgentProfile, AvatarMode } from "../types";
+import { drawAgentAvatar, startAnimation } from "../avatarEngine";
 
 interface Props {
   agent: AgentProfile;
   size?: number;
+  mode?: AvatarMode;
   className?: string;
 }
 
-export function AgentAvatar({ agent, size = 48, className }: Props) {
+export function AgentAvatar({
+  agent,
+  size = 48,
+  mode = "idle",
+  className,
+}: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -22,11 +28,13 @@ export function AgentAvatar({ agent, size = 48, className }: Props) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
+    if (mode === "thinking") {
+      return startAnimation(canvas, agent);
+    }
+
     ctx.scale(dpr, dpr);
-    const cx = size / 2;
-    const cy = size / 2;
-    drawAgentAvatar(ctx, agent.id, cx, cy, agent.colors.stroke);
-  }, [agent, size]);
+    drawAgentAvatar(ctx, size, agent, mode);
+  }, [agent, size, mode]);
 
   return (
     <canvas

--- a/client-react/src/agents/components/AgentBadge.tsx
+++ b/client-react/src/agents/components/AgentBadge.tsx
@@ -1,4 +1,4 @@
-import type { AgentProfile } from "../types";
+import type { AgentProfile, AvatarMode } from "../types";
 import { AgentAvatar } from "./AgentAvatar";
 
 const SIZES = { sm: 32, md: 48, lg: 72 } as const;
@@ -6,6 +6,7 @@ const SIZES = { sm: 32, md: 48, lg: 72 } as const;
 interface Props {
   agent: AgentProfile;
   size?: "sm" | "md" | "lg";
+  mode?: AvatarMode;
   showRole?: boolean;
   showName?: boolean;
   onClick?: () => void;
@@ -14,6 +15,7 @@ interface Props {
 export function AgentBadge({
   agent,
   size = "md",
+  mode = "idle",
   showRole = true,
   showName = true,
   onClick,
@@ -34,7 +36,7 @@ export function AgentBadge({
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={onClick ? (e) => e.key === "Enter" && onClick() : undefined}
     >
-      <AgentAvatar agent={agent} size={px} />
+      <AgentAvatar agent={agent} size={px} mode={mode} />
       {showText && (
         <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
           {showName && (

--- a/client-react/src/agents/components/AgentMessage.tsx
+++ b/client-react/src/agents/components/AgentMessage.tsx
@@ -52,7 +52,11 @@ export function AgentMessage({
           marginBottom: 8,
         }}
       >
-        <AgentBadge agent={agent} size="sm" />
+        <AgentBadge
+          agent={agent}
+          size="sm"
+          mode={isStreaming ? "thinking" : "idle"}
+        />
         {timeStr && (
           <span style={{ fontSize: 11, color: "#999" }}>{timeStr}</span>
         )}

--- a/client-react/src/agents/components/useAgent.ts
+++ b/client-react/src/agents/components/useAgent.ts
@@ -1,13 +1,16 @@
-import { useCallback } from "react";
-import type { AgentId } from "../types";
+import { useState, useCallback } from "react";
+import type { AgentId, AvatarMode } from "../types";
 import { AGENTS } from "../registry";
 import { getOpener, getThinkingLine, getEmptyState } from "../voiceEngine";
 
 export function useAgent(id: AgentId) {
   const agent = AGENTS[id];
+  const [avatarMode, setAvatarMode] = useState<AvatarMode>("idle");
 
   return {
     agent,
+    avatarMode,
+    setAvatarMode,
     getOpener: useCallback(() => getOpener(agent), [agent]),
     getThinkingLine: useCallback(() => getThinkingLine(agent), [agent]),
     getEmptyState: useCallback(() => getEmptyState(agent), [agent]),

--- a/client-react/src/agents/index.ts
+++ b/client-react/src/agents/index.ts
@@ -10,4 +10,10 @@ export {
   getEmptyState,
   formatWithVoice,
 } from "./voiceEngine";
-export type { AgentId, AgentProfile, AgentVoice, AgentColors } from "./types";
+export type {
+  AgentId,
+  AgentProfile,
+  AgentVoice,
+  AgentColors,
+  AvatarMode,
+} from "./types";

--- a/client-react/src/agents/registry.ts
+++ b/client-react/src/agents/registry.ts
@@ -37,6 +37,7 @@ const orla: AgentProfile = {
       "Something went wrong mid-analysis. Retrying.",
     ],
   },
+  avatarSeed: 42,
 };
 
 const finn: AgentProfile = {
@@ -66,6 +67,7 @@ const finn: AgentProfile = {
     ],
     errorLines: ["Failed. Retrying.", "Broke. Fixing."],
   },
+  avatarSeed: 55,
 };
 
 const mira: AgentProfile = {
@@ -102,6 +104,7 @@ const mira: AgentProfile = {
       "Something tripped up. Adjusting…",
     ],
   },
+  avatarSeed: 63,
 };
 
 const echo: AgentProfile = {
@@ -131,6 +134,7 @@ const echo: AgentProfile = {
     ],
     errorLines: ["Scan failed. Re-running.", "Missed something. Again."],
   },
+  avatarSeed: 77,
 };
 
 const sol: AgentProfile = {
@@ -167,6 +171,7 @@ const sol: AgentProfile = {
       "The reflection hit a wall. Trying once more.",
     ],
   },
+  avatarSeed: 99,
 };
 
 const kodo: AgentProfile = {
@@ -196,6 +201,7 @@ const kodo: AgentProfile = {
       "Failed. Doesn't matter right now.",
     ],
   },
+  avatarSeed: 111,
 };
 
 export const AGENTS: Record<AgentId, AgentProfile> = {

--- a/client-react/src/agents/types.ts
+++ b/client-react/src/agents/types.ts
@@ -1,5 +1,7 @@
 export type AgentId = "orla" | "finn" | "mira" | "echo" | "sol" | "kodo";
 
+export type AvatarMode = "idle" | "thinking" | "speaking";
+
 export interface AgentColors {
   stroke: string;
   bg: string;
@@ -8,7 +10,7 @@ export interface AgentColors {
 }
 
 export interface AgentVoice {
-  tone: string;
+  tone: "measured" | "blunt" | "warm" | "rapid" | "reflective" | "terse";
   avgWordsPerSentence: number;
   openers: string[];
   closers: string[];
@@ -28,4 +30,5 @@ export interface AgentProfile {
   bestCalledWhen: string;
   colors: AgentColors;
   voice: AgentVoice;
+  avatarSeed: number;
 }

--- a/client-react/src/components/home/AgentSigil.tsx
+++ b/client-react/src/components/home/AgentSigil.tsx
@@ -1,4 +1,6 @@
 import { useRef, useEffect } from "react";
+import type { AgentId } from "../../agents/types";
+import { AGENTS } from "../../agents/registry";
 import { drawAgentAvatar } from "../../agents/avatarEngine";
 
 interface Props {
@@ -20,9 +22,20 @@ export function AgentSigil({ agentId, color, bg, size }: Props) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
     ctx.scale(dpr, dpr);
-    ctx.fillStyle = bg;
-    ctx.fillRect(0, 0, size, size);
-    drawAgentAvatar(ctx, agentId, size / 2, size / 2, color);
+
+    const agent = AGENTS[agentId as AgentId];
+    if (agent) {
+      drawAgentAvatar(ctx, size, agent, "idle");
+    } else {
+      // Fallback for unknown agent IDs: draw a simple circle
+      ctx.fillStyle = bg;
+      ctx.beginPath();
+      ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
   }, [agentId, color, bg, size]);
 
   return (

--- a/client-react/src/components/home/CardBack.tsx
+++ b/client-react/src/components/home/CardBack.tsx
@@ -18,13 +18,22 @@ interface Props {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function CardBackContent({ provenance, reason, pixelArt: _pixelArt, agent }: Props) {
+export function CardBackContent({
+  provenance,
+  reason,
+  pixelArt: _pixelArt,
+  agent,
+}: Props) {
   if (!provenance) {
     return (
       <>
-        <div className="tarot-inscription__label tarot-inscription__label--sys">Source unknown</div>
+        <div className="tarot-inscription__label tarot-inscription__label--sys">
+          Source unknown
+        </div>
         <div className="tarot-inscription__rule" />
-        <div className="tarot-inscription__label tarot-inscription__label--sys">Surfaced because</div>
+        <div className="tarot-inscription__label tarot-inscription__label--sys">
+          Surfaced because
+        </div>
         <div className="tarot-inscription__text">{reason}</div>
       </>
     );
@@ -38,23 +47,65 @@ export function CardBackContent({ provenance, reason, pixelArt: _pixelArt, agent
         {agent && (
           <div style={{ marginBottom: 12 }}>
             <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-              <AgentSigil agentId={agent.id} color={agent.colors.stroke} bg={agent.colors.bg} size={48} />
+              <AgentSigil
+                agentId={agent.id}
+                color={agent.colors.stroke}
+                bg={agent.colors.bg}
+                size={48}
+              />
               <div>
-                <div style={{ fontWeight: 700, color: agent.colors.textDark, fontSize: 15 }}>{agent.name}</div>
-                <div style={{ fontSize: 11, color: agent.colors.textDark, opacity: 0.7 }}>{agent.role}</div>
+                <div
+                  style={{
+                    fontWeight: 700,
+                    color: agent.colors.textDark,
+                    fontSize: 15,
+                  }}
+                >
+                  {agent.name}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: agent.colors.textDark,
+                    opacity: 0.7,
+                  }}
+                >
+                  {agent.role}
+                </div>
                 <div style={{ display: "flex", gap: 4, marginTop: 4 }}>
                   {agent.traits.map((t) => (
-                    <span key={t} style={{ fontSize: 9, background: agent.colors.traitBg, color: agent.colors.textDark, padding: "1px 5px", borderRadius: 6 }}>{t}</span>
+                    <span
+                      key={t}
+                      style={{
+                        fontSize: 9,
+                        background: agent.colors.traitBg,
+                        color: agent.colors.textDark,
+                        padding: "1px 5px",
+                        borderRadius: 6,
+                      }}
+                    >
+                      {t}
+                    </span>
                   ))}
                 </div>
               </div>
             </div>
-            <p style={{ fontSize: 11, color: agent.colors.textDark, fontStyle: "italic", margin: "8px 0 0", opacity: 0.8 }}>
+            <p
+              style={{
+                fontSize: 11,
+                color: agent.colors.textDark,
+                fontStyle: "italic",
+                margin: "8px 0 0",
+                opacity: 0.8,
+              }}
+            >
               "{agent.quote}"
             </p>
           </div>
         )}
-        <div className="tarot-inscription__label tarot-inscription__label--ai">{agent ? "Powered by" : "Divined by"}</div>
+        <div className="tarot-inscription__label tarot-inscription__label--ai">
+          {agent ? "Powered by" : "Divined by"}
+        </div>
         {provenance.model && (
           <div className="tarot-inscription__source">{provenance.model}</div>
         )}
@@ -71,15 +122,21 @@ export function CardBackContent({ provenance, reason, pixelArt: _pixelArt, agent
         {provenance.promptIntent && (
           <>
             <div className="tarot-inscription__rule" />
-            <div className="tarot-inscription__label tarot-inscription__label--ai">Intent</div>
-            <p className="tarot-inscription__intent">"{provenance.promptIntent}"</p>
+            <div className="tarot-inscription__label tarot-inscription__label--ai">
+              Intent
+            </div>
+            <p className="tarot-inscription__intent">
+              "{provenance.promptIntent}"
+            </p>
           </>
         )}
 
         {provenance.generatedAt && (
           <>
             <div className="tarot-inscription__rule" />
-            <div className="tarot-inscription__label tarot-inscription__label--ai">Cast at</div>
+            <div className="tarot-inscription__label tarot-inscription__label--ai">
+              Cast at
+            </div>
             <div className="tarot-inscription__text">
               {new Date(provenance.generatedAt).toLocaleTimeString([], {
                 hour: "numeric",
@@ -97,14 +154,22 @@ export function CardBackContent({ provenance, reason, pixelArt: _pixelArt, agent
   // Deterministic
   return (
     <>
-      <div className="tarot-inscription__label tarot-inscription__label--sys">Computed by</div>
-      <div className="tarot-inscription__source">{provenance.method || "System Query"}</div>
-      <div className="tarot-inscription__detail">{provenance.freshness || "real-time"}</div>
+      <div className="tarot-inscription__label tarot-inscription__label--sys">
+        Computed by
+      </div>
+      <div className="tarot-inscription__source">
+        {provenance.method || "System Query"}
+      </div>
+      <div className="tarot-inscription__detail">
+        {provenance.freshness || "real-time"}
+      </div>
 
       {provenance.filter && (
         <>
           <div className="tarot-inscription__rule" />
-          <div className="tarot-inscription__label tarot-inscription__label--sys">Rule</div>
+          <div className="tarot-inscription__label tarot-inscription__label--sys">
+            Rule
+          </div>
           <p className="tarot-inscription__mono">{provenance.filter}</p>
         </>
       )}
@@ -112,8 +177,12 @@ export function CardBackContent({ provenance, reason, pixelArt: _pixelArt, agent
       {provenance.dataBreakdown && (
         <>
           <div className="tarot-inscription__rule" />
-          <div className="tarot-inscription__label tarot-inscription__label--sys">Reading</div>
-          <div className="tarot-inscription__text">{provenance.dataBreakdown}</div>
+          <div className="tarot-inscription__label tarot-inscription__label--sys">
+            Reading
+          </div>
+          <div className="tarot-inscription__text">
+            {provenance.dataBreakdown}
+          </div>
         </>
       )}
 
@@ -123,7 +192,10 @@ export function CardBackContent({ provenance, reason, pixelArt: _pixelArt, agent
           <div className="tarot-inscription__label tarot-inscription__label--sys">
             Surfaced because
           </div>
-          <div className="tarot-inscription__text" style={{ fontStyle: "italic" }}>
+          <div
+            className="tarot-inscription__text"
+            style={{ fontStyle: "italic" }}
+          >
             "{reason}"
           </div>
         </>

--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -4,7 +4,10 @@ import { TarotCardFront, TarotCardBack } from "./TarotCard";
 import { CardBackContent } from "./CardBack";
 import { PANEL_ART } from "./pixel-art";
 import type { RankedPanel, PanelProvenance } from "../../types/focusBrief";
-import { useAgentProfiles, getAgentProfile } from "../../agents/useAgentProfiles";
+import {
+  useAgentProfiles,
+  getAgentProfile,
+} from "../../agents/useAgentProfiles";
 import type { AgentProfile } from "../../agents/types";
 
 interface Props {

--- a/client-react/src/components/home/RightNowPanel.tsx
+++ b/client-react/src/components/home/RightNowPanel.tsx
@@ -4,7 +4,10 @@ import { TarotCardFront, TarotCardBack } from "./TarotCard";
 import { CardBackContent } from "./CardBack";
 import { FlameArt } from "./pixel-art";
 import type { RightNow, PanelProvenance } from "../../types/focusBrief";
-import { useAgentProfiles, getAgentProfile } from "../../agents/useAgentProfiles";
+import {
+  useAgentProfiles,
+  getAgentProfile,
+} from "../../agents/useAgentProfiles";
 
 interface Props {
   data: RightNow;
@@ -25,7 +28,11 @@ export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
         quote: agentProfile.quote,
       }
     : undefined;
-  if (!data.narrative && data.urgentItems.length === 0 && !data.topRecommendation) {
+  if (
+    !data.narrative &&
+    data.urgentItems.length === 0 &&
+    !data.topRecommendation
+  ) {
     return null;
   }
 
@@ -54,8 +61,12 @@ export function RightNowPanel({ data, provenance, onTaskClick }: Props) {
           }}
         >
           <div className="tarot-action-band__label">Strongest action</div>
-          <div className="tarot-action-band__title">{data.topRecommendation.title}</div>
-          <div className="tarot-action-band__reason">{data.topRecommendation.reasoning}</div>
+          <div className="tarot-action-band__title">
+            {data.topRecommendation.title}
+          </div>
+          <div className="tarot-action-band__reason">
+            {data.topRecommendation.reasoning}
+          </div>
         </button>
       )}
     </TarotCardFront>

--- a/client-react/src/features/settings/AgentsPanel.tsx
+++ b/client-react/src/features/settings/AgentsPanel.tsx
@@ -10,13 +10,18 @@ export function AgentsPanel() {
   return (
     <section className="settings-section">
       <h2 className="settings-section__title">Your Agents</h2>
-      <p className="settings-section__subtitle">Six specialists working behind the scenes</p>
+      <p className="settings-section__subtitle">
+        Six specialists working behind the scenes
+      </p>
       <div className="agents-grid">
         {agents.map((agent) => (
           <div
             key={agent.id}
             className="agent-card"
-            style={{ background: agent.colors.bg, borderColor: agent.colors.stroke }}
+            style={{
+              background: agent.colors.bg,
+              borderColor: agent.colors.stroke,
+            }}
           >
             <div className="agent-card__header">
               <AgentSigil
@@ -26,15 +31,24 @@ export function AgentsPanel() {
                 size={64}
               />
               <div>
-                <div className="agent-card__name" style={{ color: agent.colors.textDark }}>
+                <div
+                  className="agent-card__name"
+                  style={{ color: agent.colors.textDark }}
+                >
                   {agent.name}
                 </div>
-                <div className="agent-card__role" style={{ color: agent.colors.textDark, opacity: 0.7 }}>
+                <div
+                  className="agent-card__role"
+                  style={{ color: agent.colors.textDark, opacity: 0.7 }}
+                >
                   {agent.role}
                 </div>
               </div>
             </div>
-            <p className="agent-card__quote" style={{ color: agent.colors.textDark }}>
+            <p
+              className="agent-card__quote"
+              style={{ color: agent.colors.textDark }}
+            >
               &ldquo;{agent.quote}&rdquo;
             </p>
             <div className="agent-card__traits">
@@ -42,15 +56,25 @@ export function AgentsPanel() {
                 <span
                   key={trait}
                   className="agent-card__trait"
-                  style={{ background: agent.colors.traitBg, color: agent.colors.textDark }}
+                  style={{
+                    background: agent.colors.traitBg,
+                    color: agent.colors.textDark,
+                  }}
                 >
                   {trait}
                 </span>
               ))}
             </div>
-            <div className="agent-card__details" style={{ color: agent.colors.textDark }}>
-              <div><strong>Superpower:</strong> {agent.superpower}</div>
-              <div><strong>Quirk:</strong> {agent.quirk}</div>
+            <div
+              className="agent-card__details"
+              style={{ color: agent.colors.textDark }}
+            >
+              <div>
+                <strong>Superpower:</strong> {agent.superpower}
+              </div>
+              <div>
+                <strong>Quirk:</strong> {agent.quirk}
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
Restores generative pattern features that were accidentally removed during the agent identity merge (#852):

- **`AvatarMode`** type restored to agents/types.ts + all consumers
- **`avatarSeed`** restored to AgentProfile + all 6 profiles in registry
- **`startAnimation`** restored to avatarEngine.ts with animation loop
- **`drawAgentAvatar`** signature restored to `(ctx, size, agent, mode, frame)` — supports thinking animations
- **`AgentAvatar`** component restored with `mode` prop and thinking animation
- **`AgentBadge`** / `AgentMessage`** / `useAgent`** — mode prop chain restored
- **`AgentSigil`** updated to use restored API via AGENTS registry lookup

Note: `accentPattern` on TarotCard accepts the prop but GenerativePattern component was never committed to master — canvas rendering is a follow-up.

## Test plan
- [x] TypeScript typecheck passes
- [x] Avatar engine tests: 3/3 pass
- [x] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)