### PR TITLE
fix(activity): handle undefined entries in AgentActivityFeed

### DIFF
--- a/client-react/src/components/home/AgentActivityFeed.tsx
+++ b/client-react/src/components/home/AgentActivityFeed.tsx
@@ -65,7 +65,7 @@ export function AgentActivityFeed({ standalone = false }: Props) {
   useEffect(() => {
     apiCall("/agent-activity")
       .then((res) => res.json())
-      .then((data: { entries: ActivityEntry[] }) => setEntries(data.entries))
+      .then((data: { entries?: ActivityEntry[] }) => setEntries(data.entries ?? []))
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);


### PR DESCRIPTION
## Bug

Clicking **Activity Feed** in the sidebar throws:
> Cannot read properties of undefined (reading 'length')

After this error, the entire app becomes unresponsive (React error boundary catches it).

## Root Cause

When the API returns  (e.g. 500), `data.entries` is `undefined`. The frontend does `setEntries(data.entries)`, making `entries` undefined, then `entries.length` crashes.

## Fix

Default to empty array via nullish coalescing:
```diff
- setEntries(data.entries)
+ setEntries(data.entries ?? [])
```

## Verification
- `npx tsc --noEmit` clean
- No `src/types.ts` changes