### PR TITLE
fix(agents): correct API path for agent profiles fetch

### DIFF
--- a/client-react/src/agents/useAgentProfiles.ts
+++ b/client-react/src/agents/useAgentProfiles.ts
@@ -12,7 +12,7 @@ export function useAgentProfiles(): Record<string, AgentProfile> {
   useEffect(() => {
     if (cachedProfiles) return;
 
-    apiCall("/agent-profiles")
+    apiCall("/api/agent-profiles")
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();


### PR DESCRIPTION
## Bug

Agent identities (FINN, ORLA) never appear in tarot cards. Cards always show generic **AI** / **SYS** labels instead of agent sigils, names, and colored borders.

## Root Cause

`useAgentProfiles()` fetches `/agent-profiles` which returns **404**. The backend serves profiles at `/api/agent-profiles`.

Because the request fails, `profiles` stays `{}`, `getAgentProfile()` returns `undefined` for every agentId, and `TarotCardFront` falls through to the fallback label.

## Fix

```diff
- apiCall("/agent-profiles")
+ apiCall("/api/agent-profiles")
```

## Verification
- `npx tsc --noEmit` clean
- No `src/types.ts` changes