### PR TITLE
test(agents): add unit tests for getAgentProfile

### DIFF
--- a/client-react/src/agents/useAgentProfiles.test.ts
+++ b/client-react/src/agents/useAgentProfiles.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getAgentProfile } from "./useAgentProfiles";
+import { AGENTS } from "./registry";
+
+// Reset module-level cache between tests
+vi.mock("./useAgentProfiles", async () => {
+  const actual = await vi.importActual("./useAgentProfiles");
+  return { ...actual, cachedProfiles: null };
+});
+
+describe("getAgentProfile", () => {
+  it("returns undefined for undefined agentId", () => {
+    expect(getAgentProfile({}, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for unknown agentId", () => {
+    expect(getAgentProfile({}, "ghost")).toBeUndefined();
+  });
+
+  it("returns the profile for a known agentId", () => {
+    expect(getAgentProfile(AGENTS, "finn")).toBe(AGENTS.finn);
+    expect(getAgentProfile(AGENTS, "orla")).toBe(AGENTS.orla);
+  });
+
+  it("all registry agents are resolvable", () => {
+    const ids = Object.keys(AGENTS);
+    expect(ids.length).toBeGreaterThan(0);
+    ids.forEach((id) => {
+      expect(getAgentProfile(AGENTS, id)).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #860. There were zero tests for the agent profile resolution logic.

## What this tests

`getAgentProfile()` — the pure function that maps agent IDs to profile objects.

- Returns `undefined` for undefined/unknown agentId
- Returns correct profile for known agentId
- Verifies all 6 registry agents are resolvable

## What this doesn't catch

The actual bug in #860 was a wrong API path (`/agent-profiles` vs `/api/agent-profiles`). A unit test mocking the fetch wouldn't validate the URL. The real protection for that is integration/E2E testing.

But having *any* test here is better than zero coverage on a critical data path.