### PR TITLE
feat(react): port feedback forms to React SPA

### DIFF
--- a/client-react/src/App.tsx
+++ b/client-react/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { AuthProvider, useAuth } from "./auth/AuthProvider";
 import { AuthPage } from "./auth/AuthPage";
+import { FeedbackView } from "./views/FeedbackView";
 import { AppShell } from "./components/layout/AppShell";
 import { MobileShell } from "./mobile/MobileShell";
 import { useIsMobile } from "./hooks/useIsMobile";
@@ -51,8 +52,10 @@ function AuthGate() {
 }
 
 function AppContent() {
-  // If we're at /auth, render the auth page directly (no auth gate needed)
-  if (window.location.pathname === "/auth") {
+  const path = window.location.pathname;
+
+  // /auth — standalone auth page (no auth gate needed)
+  if (path === "/auth") {
     return (
       <AuthProvider>
         <AuthPage />
@@ -60,6 +63,16 @@ function AppContent() {
     );
   }
 
+  // /feedback or /feedback/new — feedback pages (auth-gated internally)
+  if (path === "/feedback" || path === "/feedback/new") {
+    return (
+      <AuthProvider>
+        <FeedbackView />
+      </AuthProvider>
+    );
+  }
+
+  // Everything else — main app with auth gate
   return (
     <AuthProvider>
       <AuthGate />

--- a/client-react/src/api/feedbackApi.ts
+++ b/client-react/src/api/feedbackApi.ts
@@ -1,0 +1,67 @@
+import { apiCall } from "./client";
+
+export type FeedbackType = "bug" | "feature" | "general";
+export type FeedbackStatus = "new" | "triaged" | "promoted" | "rejected" | "resolved";
+
+export interface CreateFeedbackPayload {
+  type: FeedbackType;
+  title: string;
+  body: string;
+  screenshotUrl?: string | null;
+  attachmentMetadata?: {
+    name: string | null;
+    type: string | null;
+    size: number | null;
+    lastModified: number | null;
+  } | null;
+  pageUrl?: string | null;
+  userAgent?: string | null;
+  appVersion?: string | null;
+}
+
+export interface FeedbackItem {
+  id: string;
+  userId: string;
+  type: FeedbackType;
+  title: string;
+  body: string;
+  screenshotUrl: string | null;
+  pageUrl: string | null;
+  userAgent: string | null;
+  appVersion: string | null;
+  status: FeedbackStatus;
+  githubIssueUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UserFeedbackListItem {
+  id: string;
+  type: FeedbackType;
+  title: string;
+  status: FeedbackStatus;
+  githubIssueUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function submitFeedback(
+  payload: CreateFeedbackPayload,
+): Promise<FeedbackItem> {
+  const res = await apiCall("/api/feedback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: "Submission failed" }));
+    throw new Error(err.error ?? "Submission failed");
+  }
+  return res.json();
+}
+
+export async function fetchUserFeedback(): Promise<UserFeedbackListItem[]> {
+  const res = await apiCall("/api/feedback");
+  if (!res.ok) throw new Error("Failed to fetch feedback");
+  return res.json();
+}

--- a/client-react/src/components/FeedbackForm.tsx
+++ b/client-react/src/components/FeedbackForm.tsx
@@ -1,0 +1,251 @@
+import { useState, useCallback, useMemo } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { submitFeedback, type FeedbackType, type FeedbackItem } from "../api/feedbackApi";
+import { navigateWithFade } from "../utils/pageTransitions";
+
+interface Props {
+  onSuccess: (item: FeedbackItem) => void;
+}
+
+const QUESTIONS: Record<FeedbackType, { q1: string; q2: string; q3: string }> = {
+  bug: {
+    q1: "What happened?",
+    q2: "What did you expect?",
+    q3: "What were you doing right before it happened?",
+  },
+  feature: {
+    q1: "What are you trying to do?",
+    q2: "What is hard today?",
+    q3: "What would make this better?",
+  },
+  general: {
+    q1: "What's on your mind?",
+    q2: "Any suggestions?",
+    q3: "Anything else?",
+  },
+};
+
+function buildBody(
+  type: FeedbackType,
+  a1: string,
+  a2: string,
+  a3: string,
+): string {
+  const q = QUESTIONS[type];
+  const parts: string[] = [];
+  if (a1.trim()) {
+    parts.push(`${q.q1}\n${a1.trim()}`);
+  }
+  if (a2.trim()) {
+    parts.push(`${q.q2}\n${a2.trim()}`);
+  }
+  if (a3.trim()) {
+    parts.push(`${q.q3}\n${a3.trim()}`);
+  }
+  return parts.join("\n\n");
+}
+
+const APP_VERSION =
+  (document.querySelector('meta[name="app-version"]') as HTMLMetaElement | null)?.content ?? "unknown";
+
+export function FeedbackForm({ onSuccess }: Props) {
+  const { user } = useAuth();
+  const [type, setType] = useState<FeedbackType>("bug");
+  const [title, setTitle] = useState("");
+  const [a1, setA1] = useState("");
+  const [a2, setA2] = useState("");
+  const [a3, setA3] = useState("");
+  const [screenshotUrl, setScreenshotUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const q = useMemo(() => QUESTIONS[type], [type]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+
+      const trimmedTitle = title.trim();
+      if (!trimmedTitle) {
+        setError("Please add a short title.");
+        return;
+      }
+      if (!a1.trim()) {
+        setError("Please answer the first question before sending.");
+        return;
+      }
+
+      setSubmitting(true);
+      try {
+        const item = await submitFeedback({
+          type,
+          title: trimmedTitle,
+          body: buildBody(type, a1, a2, a3),
+          screenshotUrl: screenshotUrl.trim() || null,
+          attachmentMetadata: null,
+          pageUrl: window.location.href,
+          userAgent: navigator.userAgent,
+          appVersion: APP_VERSION,
+        });
+        onSuccess(item);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Submission failed");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [type, title, a1, a2, a3, screenshotUrl, onSuccess],
+  );
+
+  const reset = useCallback(() => {
+    setType("bug");
+    setTitle("");
+    setA1("");
+    setA2("");
+    setA3("");
+    setScreenshotUrl("");
+    setError(null);
+  }, []);
+
+  return (
+    <form className="feedback-form" onSubmit={handleSubmit}>
+      {/* Type selector */}
+      <div className="feedback-form__field">
+        <label htmlFor="feedback-type" className="feedback-form__label">
+          Submission type
+        </label>
+        <select
+          id="feedback-type"
+          className="feedback-form__select"
+          value={type}
+          onChange={(e) => setType(e.target.value as FeedbackType)}
+        >
+          <option value="bug">Bug report</option>
+          <option value="feature">Feature request</option>
+          <option value="general">General feedback</option>
+        </select>
+      </div>
+
+      {/* Title */}
+      <div className="feedback-form__field">
+        <label htmlFor="feedback-title" className="feedback-form__label">
+          Title
+        </label>
+        <input
+          id="feedback-title"
+          type="text"
+          className="feedback-form__input"
+          maxLength={200}
+          required
+          placeholder="Short summary"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </div>
+
+      {/* Question 1 */}
+      <div className="feedback-form__field">
+        <label htmlFor="feedback-q1" className="feedback-form__label">
+          {q.q1}
+        </label>
+        <textarea
+          id="feedback-q1"
+          className="feedback-form__textarea"
+          rows={4}
+          required
+          placeholder="Describe in your own words…"
+          value={a1}
+          onChange={(e) => setA1(e.target.value)}
+        />
+      </div>
+
+      {/* Question 2 */}
+      <div className="feedback-form__field">
+        <label htmlFor="feedback-q2" className="feedback-form__label">
+          {q.q2}
+        </label>
+        <textarea
+          id="feedback-q2"
+          className="feedback-form__textarea"
+          rows={4}
+          placeholder="Optional"
+          value={a2}
+          onChange={(e) => setA2(e.target.value)}
+        />
+      </div>
+
+      {/* Question 3 */}
+      <div className="feedback-form__field">
+        <label htmlFor="feedback-q3" className="feedback-form__label">
+          {q.q3}
+        </label>
+        <textarea
+          id="feedback-q3"
+          className="feedback-form__textarea"
+          rows={4}
+          placeholder="Optional"
+          value={a3}
+          onChange={(e) => setA3(e.target.value)}
+        />
+      </div>
+
+      {/* Screenshot URL */}
+      <div className="feedback-form__field">
+        <label htmlFor="feedback-screenshot" className="feedback-form__label">
+          Screenshot URL (optional)
+        </label>
+        <input
+          id="feedback-screenshot"
+          type="url"
+          inputMode="url"
+          className="feedback-form__input"
+          placeholder="https://…"
+          value={screenshotUrl}
+          onChange={(e) => setScreenshotUrl(e.target.value)}
+        />
+      </div>
+
+      {/* Error message */}
+      {error && (
+        <div className="feedback-form__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {/* Context info */}
+      <div className="feedback-form__context">
+        <dl className="feedback-form__context-list">
+          <div className="feedback-form__context-row">
+            <dt>Page</dt>
+            <dd>{window.location.pathname}</dd>
+          </div>
+          <div className="feedback-form__context-row">
+            <dt>Version</dt>
+            <dd>{APP_VERSION}</dd>
+          </div>
+          {user && (
+            <div className="feedback-form__context-row">
+              <dt>User</dt>
+              <dd>{user.email}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {/* Submit */}
+      <button
+        type="submit"
+        className="feedback-form__submit"
+        disabled={submitting}
+      >
+        {submitting ? "Sending…" : "Send feedback"}
+      </button>
+
+      {/* Reset link (shown after success via parent) */}
+      <button type="button" className="feedback-form__reset" onClick={reset}>
+        Send another
+      </button>
+    </form>
+  );
+}

--- a/client-react/src/styles/feedback.css
+++ b/client-react/src/styles/feedback.css
@@ -1,0 +1,410 @@
+/* Feedback Page Styles — composed from tokens.css */
+@import "../styles/tokens.css";
+
+/* ── Page wrapper ────────────────────────────────────────────────────── */
+
+.feedback-page {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: var(--s-6) var(--s-4);
+}
+
+/* ── Card ───────────────────────────────────────────────────────────── */
+
+.feedback-standalone {
+  width: 100%;
+  max-width: 640px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--s-7) var(--s-6);
+  box-shadow: var(--shadow-md);
+}
+
+/* ── Header ────────────────────────────────────────────────────────── */
+
+.feedback-standalone__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--s-5);
+  padding-bottom: var(--s-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.feedback-standalone__back {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: var(--fs-sm);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  transition: color var(--dur-base);
+}
+
+.feedback-standalone__back:hover {
+  color: var(--text);
+}
+
+.feedback-standalone__logo {
+  font-weight: var(--fw-bold);
+  font-size: var(--fs-lg);
+  color: var(--text-strong);
+}
+
+.feedback-standalone h2 {
+  margin: 0 0 var(--s-2);
+  font-size: var(--fs-xl);
+  color: var(--text-strong);
+}
+
+.feedback-standalone__lede {
+  color: var(--muted);
+  font-size: var(--fs-sm);
+  margin: 0 0 var(--s-5);
+  line-height: var(--lh-relaxed);
+}
+
+/* ── Buttons ────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s-2) var(--s-4);
+  border-radius: var(--r-sm);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  text-decoration: none;
+  transition: background var(--dur-base), transform var(--dur-base) var(--ease-spring);
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn--primary:hover {
+  background: var(--accent-3);
+  transform: translateY(-1px);
+}
+
+.btn--secondary {
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.btn--secondary:hover {
+  background: var(--surface-3);
+}
+
+.feedback-standalone__actions {
+  display: flex;
+  gap: var(--s-3);
+  margin-top: var(--s-5);
+}
+
+/* ── Feedback List ─────────────────────────────────────────────────── */
+
+.feedback-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.feedback-list__empty {
+  text-align: center;
+  color: var(--muted);
+  padding: var(--s-8) 0;
+  font-size: var(--fs-sm);
+}
+
+.feedback-list__item {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.feedback-list__item:last-child {
+  border-bottom: none;
+}
+
+.feedback-list__type {
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: var(--r-sm);
+  flex-shrink: 0;
+}
+
+.feedback-list__type--bug {
+  background: color-mix(in oklab, var(--danger) 10%, transparent);
+  color: var(--danger);
+}
+
+.feedback-list__type--feature {
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.feedback-list__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-sm);
+  color: var(--text);
+}
+
+.feedback-list__status {
+  font-size: var(--fs-xs);
+  padding: 2px 8px;
+  border-radius: var(--r-full);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.feedback-list__status--new {
+  background: var(--surface-2);
+  color: var(--muted);
+}
+
+.feedback-list__status--triaged {
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.feedback-list__status--promoted {
+  background: color-mix(in oklab, var(--success) 10%, transparent);
+  color: var(--success);
+}
+
+.feedback-list__status--rejected {
+  background: var(--surface-2);
+  color: var(--muted-light);
+}
+
+.feedback-list__date {
+  font-size: var(--fs-xs);
+  color: var(--muted-light);
+  flex-shrink: 0;
+}
+
+.feedback-list__link {
+  font-size: var(--fs-xs);
+  flex-shrink: 0;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.feedback-list__link:hover {
+  text-decoration: underline;
+}
+
+/* ── Feedback Form ─────────────────────────────────────────────────── */
+
+.feedback-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+}
+
+.feedback-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+.feedback-form__label {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--text);
+}
+
+.feedback-form__input,
+.feedback-form__select,
+.feedback-form__textarea {
+  width: 100%;
+  padding: var(--s-2) var(--s-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  color: var(--text);
+  font-size: var(--fs-body);
+  font-family: inherit;
+  transition: border-color var(--dur-base), box-shadow var(--dur-base);
+}
+
+.feedback-form__input:focus,
+.feedback-form__select:focus,
+.feedback-form__textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--shadow-focus);
+}
+
+.feedback-form__input::placeholder,
+.feedback-form__textarea::placeholder {
+  color: var(--muted-light);
+}
+
+.feedback-form__textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.feedback-form__select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--s-3) center;
+  padding-right: var(--s-7);
+}
+
+.feedback-form__error {
+  padding: var(--s-2) var(--s-3);
+  border-radius: var(--r-sm);
+  background: color-mix(in oklab, var(--danger) 10%, transparent);
+  color: var(--danger);
+  border: 1px solid color-mix(in oklab, var(--danger) 20%, transparent);
+  font-size: var(--fs-sm);
+}
+
+.feedback-form__context {
+  padding: var(--s-3);
+  background: var(--surface-2);
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+}
+
+.feedback-form__context-list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+.feedback-form__context-row {
+  display: flex;
+  gap: var(--s-2);
+  font-size: var(--fs-xs);
+}
+
+.feedback-form__context-row dt {
+  color: var(--muted);
+  min-width: 48px;
+  font-weight: var(--fw-medium);
+}
+
+.feedback-form__context-row dd {
+  color: var(--text);
+  margin: 0;
+  word-break: break-all;
+}
+
+.feedback-form__submit {
+  width: 100%;
+  padding: var(--s-3) var(--s-4);
+  border: none;
+  border-radius: var(--r-sm);
+  background: var(--accent);
+  color: #fff;
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--dur-base), transform var(--dur-base) var(--ease-spring);
+}
+
+.feedback-form__submit:hover {
+  background: var(--accent-3);
+  transform: translateY(-1px);
+}
+
+.feedback-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.feedback-form__reset {
+  display: block;
+  text-align: center;
+  margin-top: var(--s-2);
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+}
+
+.feedback-form__reset:hover {
+  text-decoration: underline;
+}
+
+/* ── Confirmation ───────────────────────────────────────────────────── */
+
+.feedback-confirmation h3 {
+  margin: 0 0 var(--s-2);
+  font-size: var(--fs-lg);
+  color: var(--text-strong);
+}
+
+.feedback-confirmation p {
+  margin: 0 0 var(--s-3);
+  color: var(--muted);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-relaxed);
+}
+
+.feedback-confirmation__meta {
+  font-size: var(--fs-xs) !important;
+  color: var(--muted-light) !important;
+  font-family: "SF Mono", SFMono-Regular, monospace;
+}
+
+.feedback-confirmation__actions {
+  display: flex;
+  gap: var(--s-3);
+  margin-top: var(--s-4);
+}
+
+/* ── Responsive ──────────────────────────────────────────────────────── */
+
+@media (max-width: 640px) {
+  .feedback-page {
+    padding: 0;
+  }
+
+  .feedback-standalone {
+    max-width: 100%;
+    min-height: 100vh;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: var(--s-5) var(--s-4);
+  }
+
+  .feedback-confirmation__actions {
+    flex-direction: column;
+  }
+}

--- a/client-react/src/views/FeedbackView.tsx
+++ b/client-react/src/views/FeedbackView.tsx
@@ -1,0 +1,262 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { FeedbackForm } from "../components/FeedbackForm";
+import { fetchUserFeedback, type FeedbackItem, type UserFeedbackListItem } from "../api/feedbackApi";
+import { navigateWithFade } from "../utils/pageTransitions";
+import "../styles/feedback.css";
+
+type FeedbackViewMode = "list" | "form" | "confirmation";
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "new": return "Submitted";
+    case "triaged": return "Under review";
+    case "promoted": return "Tracked";
+    case "rejected": return "Closed";
+    case "resolved": return "Resolved";
+    default: return status;
+  }
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case "new": return "feedback-list__status--new";
+    case "triaged": return "feedback-list__status--triaged";
+    case "promoted": return "feedback-list__status--promoted";
+    case "rejected": return "feedback-list__status--rejected";
+    default: return "feedback-list__status--new";
+  }
+}
+
+function typeLabel(type: string): string {
+  switch (type) {
+    case "bug": return "Bug";
+    case "feature": return "Feature";
+    case "general": return "Feedback";
+    default: return type;
+  }
+}
+
+function typeClass(type: string): string {
+  switch (type) {
+    case "bug": return "feedback-list__type--bug";
+    case "feature": return "feedback-list__type--feature";
+    default: return "feedback-list__type--bug";
+  }
+}
+
+function ConfirmationView({
+  item,
+  onSendAnother,
+}: {
+  item: FeedbackItem;
+  onSendAnother: () => void;
+}) {
+  const isBug = item.type === "bug";
+  return (
+    <div className="feedback-confirmation">
+      <h3>{isBug ? "Bug report sent" : "Feature request sent"}</h3>
+      <p>
+        {isBug
+          ? "Thanks for the report. We'll review it and get back to you."
+          : "Thanks for the idea. We'll review it and consider it for the roadmap."}
+      </p>
+      <p className="feedback-confirmation__meta">
+        Reference ID: {item.id}
+      </p>
+      <div className="feedback-confirmation__actions">
+        <button
+          type="button"
+          className="btn btn--secondary"
+          onClick={() => navigateWithFade("/feedback")}
+        >
+          View your submissions
+        </button>
+        <button type="button" className="btn btn--secondary" onClick={onSendAnother}>
+          Send another
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FeedbackListView({
+  items,
+  loading,
+  onNew,
+}: {
+  items: UserFeedbackListItem[];
+  loading: boolean;
+  onNew: () => void;
+}) {
+  return (
+    <div>
+      <div className="feedback-standalone__actions">
+        <button type="button" className="btn btn--primary" onClick={onNew}>
+          Submit feedback
+        </button>
+      </div>
+      {loading ? (
+        <div className="feedback-list__empty">Loading your submissions…</div>
+      ) : items.length === 0 ? (
+        <div className="feedback-list__empty">
+          You haven't submitted any feedback yet.
+        </div>
+      ) : (
+        <ul className="feedback-list" role="list">
+          {items.map((item) => (
+            <li key={item.id} className="feedback-list__item">
+              <span className={`feedback-list__type ${typeClass(item.type)}`}>
+                {typeLabel(item.type)}
+              </span>
+              <span className="feedback-list__title" title={item.title}>
+                {item.title}
+              </span>
+              <span className={`feedback-list__status ${statusClass(item.status)}`}>
+                {statusLabel(item.status)}
+              </span>
+              <span className="feedback-list__date">{formatDate(item.createdAt)}</span>
+              {item.githubIssueUrl && (
+                <a
+                  href={item.githubIssueUrl}
+                  className="feedback-list__link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View issue →
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function FeedbackView() {
+  const { user, loading: authLoading } = useAuth();
+  const [mode, setMode] = useState<FeedbackViewMode>("list");
+  const [items, setItems] = useState<UserFeedbackListItem[]>([]);
+  const [listLoading, setListLoading] = useState(true);
+  const [lastSubmitted, setLastSubmitted] = useState<FeedbackItem | null>(null);
+
+  // Auth gate — redirect to /auth if not logged in
+  useEffect(() => {
+    if (!authLoading && !user) {
+      navigateWithFade("/auth?next=/feedback", { replace: true });
+    }
+  }, [authLoading, user]);
+
+  // Load feedback list when in list mode
+  useEffect(() => {
+    if (mode !== "list" || authLoading || !user) return;
+    setListLoading(true);
+    fetchUserFeedback()
+      .then(setItems)
+      .catch(() => setItems([]))
+      .finally(() => setListLoading(false));
+  }, [mode, authLoading, user]);
+
+  // Check URL for /feedback/new
+  useEffect(() => {
+    if (window.location.pathname === "/feedback/new") {
+      setMode("form");
+    }
+  }, []);
+
+  if (authLoading || !user) {
+    return (
+      <div className="feedback-page">
+        <div className="feedback-standalone">
+          <div className="loading">Loading…</div>
+        </div>
+      </div>
+    );
+  }
+
+  const goHome = () => navigateWithFade("/app", { replace: true });
+  const goList = () => {
+    window.history.pushState({}, "", "/feedback");
+    setMode("list");
+  };
+  const goForm = () => {
+    window.history.pushState({}, "", "/feedback/new");
+    setMode("form");
+  };
+
+  return (
+    <div className="feedback-page">
+      <div className="feedback-standalone">
+        {/* Header */}
+        <div className="feedback-standalone__header">
+          <button className="feedback-standalone__back" onClick={goHome}>
+            ← Workspace
+          </button>
+          <span className="feedback-standalone__logo">Todos</span>
+        </div>
+
+        {/* Content */}
+        {mode === "list" && (
+          <>
+            <h2>Your submissions</h2>
+            <p className="feedback-standalone__lede">
+              Track the status of your bug reports and feature requests.
+            </p>
+            <FeedbackListView items={items} loading={listLoading} onNew={goForm} />
+          </>
+        )}
+
+        {mode === "form" && (
+          <>
+            <h2>Submit feedback</h2>
+            <p className="feedback-standalone__lede">
+              Tell us what's broken, what's missing, or what could be better.
+              Your feedback helps shape the product.
+            </p>
+            {lastSubmitted ? (
+              <ConfirmationView
+                item={lastSubmitted}
+                onSendAnother={() => {
+                  setLastSubmitted(null);
+                  setMode("form");
+                }}
+              />
+            ) : (
+              <FeedbackForm
+                onSuccess={(item: FeedbackItem) => {
+                  setLastSubmitted(item);
+                  setMode("confirmation");
+                }}
+              />
+            )}
+          </>
+        )}
+
+        {mode === "confirmation" && lastSubmitted && (
+          <>
+            <ConfirmationView
+              item={lastSubmitted}
+              onSendAnother={() => {
+                setLastSubmitted(null);
+                setMode("form");
+              }}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -257,6 +257,20 @@ export function createApp(deps: AppDependencies = {}) {
   // React app (primary) at /app
   app.use("/app", express.static(path.join(__dirname, "../client-react/dist")));
 
+  // React SPA fallbacks — serve dist/index.html for app routes
+  const reactIndex = path.join(__dirname, "../client-react/dist/index.html");
+  app.get("/app/{*path}", (_req: Request, res: Response) =>
+    res.sendFile(reactIndex),
+  );
+
+  // React feedback page at /feedback and /feedback/new
+  app.get("/feedback", (_req: Request, res: Response) =>
+    res.sendFile(reactIndex),
+  );
+  app.get("/feedback/{*path}", (_req: Request, res: Response) =>
+    res.sendFile(reactIndex),
+  );
+
   // React landing page at / (serves dist-landing/)
   const landingIndex = path.join(__dirname, "../client-react/dist-landing/landing.html");
   app.get("/", (_req: Request, res: Response) => {

--- a/src/routes/staticPagesRouter.ts
+++ b/src/routes/staticPagesRouter.ts
@@ -2,6 +2,9 @@
  * Static page routes — serves standalone HTML pages at product URLs.
  *
  * Extracted from app.ts to keep the factory focused on service wiring.
+ *
+ * NOTE: /auth, /feedback, /app are now served by React builds in app.ts.
+ * Only legacy fallbacks remain here until the client/ folder is fully retired.
  */
 
 import { Router, Request, Response } from "express";
@@ -9,32 +12,10 @@ import path from "path";
 
 const CLIENT_PUBLIC = path.join(__dirname, "../../client/public");
 
-const PAGE_ROUTES: Array<{ path: string; file: string }> = [
-  { path: "/auth", file: "auth.html" },
-  { path: "/feedback", file: "feedback.html" },
-  { path: "/feedback/new", file: "feedback-new.html" },
-];
-
 export function createStaticPagesRouter(): Router {
   const router = Router();
 
-  for (const route of PAGE_ROUTES) {
-    const filePath = path.join(CLIENT_PUBLIC, route.file);
-    router.get(route.path, (_req: Request, res: Response) =>
-      res.sendFile(filePath),
-    );
-  }
-
-  // React SPA — primary app at /app and /app/*
-  const reactIndex = path.join(__dirname, "../../client-react/dist/index.html");
-  router.get("/app", (_req: Request, res: Response) =>
-    res.sendFile(reactIndex),
-  );
-  router.get("/app/{*path}", (_req: Request, res: Response) =>
-    res.sendFile(reactIndex),
-  );
-
-  // Vanilla SPA — classic fallback at /app-classic and /app-classic/*
+  // Vanilla classic — SPA fallback at /app-classic and /app-classic/*
   const classicPage = path.join(CLIENT_PUBLIC, "app.html");
   router.get("/app-classic", (_req: Request, res: Response) =>
     res.sendFile(classicPage),


### PR DESCRIPTION
## Summary

Port the `/feedback` and `/feedback/new` pages from vanilla HTML to React, removing the last dependency on `client/public/` for product-facing pages.

## What This Covers

The feedback system has two views, both now in React:

| View | Route | API | Purpose |
|------|-------|-----|---------|
| List | `/feedback` | `GET /api/feedback` | View your past submissions |
| Form | `/feedback/new` | `POST /api/feedback` | Submit new feedback |

## Features Preserved (from legacy)
- **Dynamic question labels** — 3 questions change based on type (bug/feature/general)
- **Body composition** — Q&A pairs concatenated with labels into single `body` string
- **Context capture** — page URL, app version, user agent auto-populated
- **Screenshot URL** — optional field for image link
- **Confirmation panel** — shows reference ID, "View submissions" + "Send another"
- **Submission list** — type pills (bug/feature), status pills (submitted/under review/tracked/closed), date, GitHub link
- **Auth gate** — redirects to `/auth` if not logged in

## New Files (4)
- `src/api/feedbackApi.ts` — Typed API functions
- `src/components/FeedbackForm.tsx` — Submission form with validation
- `src/views/FeedbackView.tsx` — List + form views with URL routing
- `src/styles/feedback.css` — All styles from `tokens.css`, zero new hex

## Modified (3)
- `client-react/src/App.tsx` — Added `/feedback` and `/feedback/new` route detection
- `src/app.ts` — SPA fallbacks for `/feedback/*` serving `dist/index.html`
- `src/routes/staticPagesRouter.ts` — Removed legacy `/auth`, `/feedback`, `/feedback/new` HTML routes

## Verification
| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (backend) | ✅ |
| `npx tsc --noEmit` (client-react) | ✅ |
| `npm run build:all` (3 targets) | ✅ |
| `vitest run` (172 tests) | ✅ |

## Cross-client impact
No `src/types.ts` changes. API contract unchanged — same POST body shape, same GET response shape.

## Next Step
After this lands, `client/public/feedback.html`, `feedback-new.html`, `feedback-page.css`, `feedback-list-page.js`, and `feedback-new-page.js` can be deleted as part of the final `client/` folder cleanup.