### PR TITLE
fix(auth): add userId and email to OAuth callback redirect URL

### DIFF
--- a/src/routes/authRouter.ts
+++ b/src/routes/authRouter.ts
@@ -1218,6 +1218,8 @@ export function createAuthRouter({
           auth: "success",
           token: result.token,
           refreshToken: result.refreshToken,
+          userId: result.user.id,
+          email: result.user.email ?? "",
         });
         if (next) {
           params.set("next", next);
@@ -1377,6 +1379,8 @@ export function createAuthRouter({
           auth: "success",
           token: result.token,
           refreshToken: result.refreshToken,
+          userId: result.user.id,
+          email: result.user.email ?? "",
         });
         if (next) {
           params.set("next", next);


### PR DESCRIPTION
## Bug

Google (and Apple) OAuth login completes successfully on the provider side, but the user is bounced back to the login page with no error message. The session is never persisted.

## Root Cause

The OAuth callback redirect was only passing `token` and `refreshToken` to the React AuthPage:
\`\`\`
/auth?auth=success&token=...&refreshToken=...
\`\`\`

But the React \`AuthPage\` requires \`userId\` to call \`setTokens()\`:
\`\`\`ts
if (token && refreshToken && userId) {
  setTokens(token, refreshToken, { id: userId, email, name: "" });
  // ...redirect to /app
}
\`\`\`

Without \`userId\`, the condition fails, tokens are never persisted, and the user stays stuck on the auth page.

## Fix

Added \`userId\` and \`email\` to the redirect URL params for both Google and Apple OAuth callbacks.

## Verification
| Check | Result |
|-------|--------|
| \`npx tsc --noEmit\` | ✅ |
| \`npm run test:unit\` (414 tests) | ✅ |

## Cross-client impact
No \`src/types.ts\` changes. No API contract changes.