### PR TITLE
test(react): add Phase 2 unit tests for Todo components

### DIFF
--- a/client-react/src/components/todos/BulkToolbar.test.tsx
+++ b/client-react/src/components/todos/BulkToolbar.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BulkToolbar } from "./BulkToolbar";
+
+describe("BulkToolbar", () => {
+  it("renders the toolbar with select all checkbox", () => {
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 2,
+        totalCount: 5,
+        allSelected: false,
+        onSelectAll: vi.fn(),
+        onComplete: vi.fn(),
+        onDelete: vi.fn(),
+        onCancel: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByRole("checkbox", { name: "Select all" })).toBeTruthy();
+    expect(screen.getByText("2 of 5 selected")).toBeTruthy();
+  });
+
+  it("calls onSelectAll when checkbox is toggled", () => {
+    const onSelectAll = vi.fn();
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 2,
+        totalCount: 5,
+        allSelected: false,
+        onSelectAll,
+        onComplete: vi.fn(),
+        onDelete: vi.fn(),
+        onCancel: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select all" }));
+    expect(onSelectAll).toHaveBeenCalled();
+  });
+
+  it("calls onComplete when complete button is clicked", () => {
+    const onComplete = vi.fn();
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 2,
+        totalCount: 5,
+        allSelected: false,
+        onSelectAll: vi.fn(),
+        onComplete,
+        onDelete: vi.fn(),
+        onCancel: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it("calls onDelete when delete button is clicked", () => {
+    const onDelete = vi.fn();
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 3,
+        totalCount: 5,
+        allSelected: false,
+        onSelectAll: vi.fn(),
+        onComplete: vi.fn(),
+        onDelete,
+        onCancel: vi.fn(),
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 2,
+        totalCount: 5,
+        allSelected: false,
+        onSelectAll: vi.fn(),
+        onComplete: vi.fn(),
+        onDelete: vi.fn(),
+        onCancel,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("shows correct selection count", () => {
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 4,
+        totalCount: 10,
+        allSelected: false,
+        onSelectAll: vi.fn(),
+        onComplete: vi.fn(),
+        onDelete: vi.fn(),
+        onCancel: vi.fn(),
+      }),
+    );
+
+    expect(screen.getByText("4 of 10 selected")).toBeTruthy();
+  });
+
+  it("shows all selected state", () => {
+    render(
+      createElement(BulkToolbar, {
+        selectedCount: 5,
+        totalCount: 5,
+        allSelected: true,
+        onSelectAll: vi.fn(),
+        onComplete: vi.fn(),
+        onDelete: vi.fn(),
+        onCancel: vi.fn(),
+      }),
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Select all" }) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(screen.getByText("5 of 5 selected")).toBeTruthy();
+  });
+});

--- a/client-react/src/components/todos/TodoList.test.tsx
+++ b/client-react/src/components/todos/TodoList.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TodoList } from "./TodoList";
+import type { Todo } from "../../types";
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: overrides.id ?? "todo-1",
+  title: overrides.title ?? "Test task",
+  description: overrides.description ?? null,
+  notes: overrides.notes ?? null,
+  status: overrides.status ?? "next",
+  completed: overrides.completed ?? false,
+  completedAt: overrides.completedAt ?? null,
+  projectId: overrides.projectId ?? null,
+  category: overrides.category ?? null,
+  headingId: overrides.headingId ?? null,
+  tags: overrides.tags ?? [],
+  context: overrides.context ?? null,
+  energy: overrides.energy ?? null,
+  dueDate: overrides.dueDate ?? null,
+  startDate: overrides.startDate ?? null,
+  scheduledDate: overrides.scheduledDate ?? null,
+  reviewDate: overrides.reviewDate ?? null,
+  doDate: overrides.doDate ?? null,
+  estimateMinutes: overrides.estimateMinutes ?? null,
+  waitingOn: overrides.waitingOn ?? null,
+  dependsOnTaskIds: overrides.dependsOnTaskIds ?? [],
+  order: overrides.order ?? 0,
+  priority: overrides.priority ?? null,
+  archived: overrides.archived ?? false,
+  firstStep: overrides.firstStep ?? null,
+  emotionalState: overrides.emotionalState ?? null,
+  effortScore: overrides.effortScore ?? null,
+  source: overrides.source ?? null,
+  recurrence: overrides.recurrence ?? null,
+  subtasks: overrides.subtasks ?? null,
+  userId: overrides.userId ?? "user-1",
+  createdAt: overrides.createdAt ?? "2026-01-01T00:00:00.000Z",
+  updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00.000Z",
+});
+
+const defaultProps = {
+  loadState: "loaded" as const,
+  errorMessage: "",
+  activeTodoId: null,
+  isBulkMode: false,
+  selectedIds: new Set<string>(),
+  onToggle: vi.fn(),
+  onClick: vi.fn(),
+  onKebab: vi.fn(),
+  onRetry: vi.fn(),
+  onSelect: vi.fn(),
+  onInlineEdit: vi.fn(),
+};
+
+describe("TodoList", () => {
+  it("renders loading skeleton when loadState is 'loading'", () => {
+    const { container } = render(createElement(TodoList, { ...defaultProps, todos: [], loadState: "loading" }));
+    const skeleton = container.querySelector(".loading-skeleton");
+    expect(skeleton).toBeTruthy();
+    expect(container.querySelectorAll(".loading-skeleton__row").length).toBe(5);
+  });
+
+  it("renders error state with retry button when loadState is 'error'", () => {
+    render(
+      createElement(TodoList, {
+        ...defaultProps,
+        todos: [],
+        loadState: "error",
+        errorMessage: "Network failed",
+      }),
+    );
+    expect(screen.getByText("Network failed")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("renders empty state illustration when loaded with no todos", () => {
+    render(createElement(TodoList, { ...defaultProps, todos: [], loadState: "loaded" }));
+    expect(screen.getByText("No tasks yet. Add one above!")).toBeTruthy();
+  });
+
+  it("renders todo rows for each todo", () => {
+    const todos = [makeTodo({ id: "1", title: "Task one" }), makeTodo({ id: "2", title: "Task two" })];
+    render(createElement(TodoList, { ...defaultProps, todos, loadState: "loaded" }));
+
+    expect(screen.getByText("Task one")).toBeTruthy();
+    expect(screen.getByText("Task two")).toBeTruthy();
+  });
+
+  it("calls onToggle when completion checkbox is clicked", () => {
+    const onToggle = vi.fn();
+    const todos = [makeTodo({ id: "1", title: "Task", completed: false })];
+    render(
+      createElement(TodoList, { ...defaultProps, todos, loadState: "loaded", onToggle }),
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Mark "Task" as complete/ }));
+    expect(onToggle).toHaveBeenCalledWith("1", true);
+  });
+
+  it("calls onClick when row is clicked (non-bulk mode)", () => {
+    const onClick = vi.fn();
+    const todos = [makeTodo({ id: "1", title: "Task" })];
+    render(
+      createElement(TodoList, { ...defaultProps, todos, loadState: "loaded", onClick }),
+    );
+
+    fireEvent.click(screen.getByText("Task"));
+    expect(onClick).toHaveBeenCalledWith("1");
+  });
+
+  it("calls onSelect when row is clicked in bulk mode", () => {
+    const onSelect = vi.fn();
+    const todos = [makeTodo({ id: "1", title: "Task" })];
+    render(
+      createElement(TodoList, {
+        ...defaultProps,
+        todos,
+        loadState: "loaded",
+        isBulkMode: true,
+        onSelect,
+      }),
+    );
+
+    fireEvent.click(screen.getByLabelText("Select task Task"));
+    expect(onSelect).toHaveBeenCalledWith("1");
+  });
+
+  it("shows completed class on completed todos", () => {
+    const todos = [makeTodo({ id: "1", title: "Done task", completed: true })];
+    render(createElement(TodoList, { ...defaultProps, todos, loadState: "loaded" }));
+
+    const row = screen.getByText("Done task").closest(".todo-item");
+    expect(row).toHaveClass("completed");
+    expect(row).toHaveClass("todo-item--completed");
+  });
+});

--- a/client-react/src/components/todos/TodoRow.test.tsx
+++ b/client-react/src/components/todos/TodoRow.test.tsx
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TodoRow } from "./TodoRow";
+import type { Todo, Project, Heading } from "../../types";
+
+const makeTodo = (overrides: Partial<Todo> = {}): Todo => ({
+  id: overrides.id ?? "todo-1",
+  title: overrides.title ?? "Test task",
+  description: overrides.description ?? null,
+  notes: overrides.notes ?? null,
+  status: overrides.status ?? "next",
+  completed: overrides.completed ?? false,
+  completedAt: overrides.completedAt ?? null,
+  projectId: overrides.projectId ?? null,
+  category: overrides.category ?? null,
+  headingId: overrides.headingId ?? null,
+  tags: overrides.tags ?? [],
+  context: overrides.context ?? null,
+  energy: overrides.energy ?? null,
+  dueDate: overrides.dueDate ?? null,
+  startDate: overrides.startDate ?? null,
+  scheduledDate: overrides.scheduledDate ?? null,
+  reviewDate: overrides.reviewDate ?? null,
+  doDate: overrides.doDate ?? null,
+  estimateMinutes: overrides.estimateMinutes ?? null,
+  waitingOn: overrides.waitingOn ?? null,
+  dependsOnTaskIds: overrides.dependsOnTaskIds ?? [],
+  order: overrides.order ?? 0,
+  priority: overrides.priority ?? null,
+  archived: overrides.archived ?? false,
+  firstStep: overrides.firstStep ?? null,
+  emotionalState: overrides.emotionalState ?? null,
+  effortScore: overrides.effortScore ?? null,
+  source: overrides.source ?? null,
+  recurrence: overrides.recurrence ?? null,
+  subtasks: overrides.subtasks ?? null,
+  userId: overrides.userId ?? "user-1",
+  createdAt: overrides.createdAt ?? "2026-01-01T00:00:00.000Z",
+  updatedAt: overrides.updatedAt ?? "2026-01-01T00:00:00.000Z",
+});
+
+const defaultTodo = makeTodo();
+
+const defaultProps = {
+  todo: defaultTodo,
+  isActive: false,
+  isExpanded: false,
+  isBulkMode: false,
+  isSelected: false,
+  density: "normal" as const,
+  projects: [] as Project[],
+  headings: [] as Heading[],
+  onToggle: vi.fn(),
+  onClick: vi.fn(),
+  onKebab: vi.fn(),
+  onSelect: vi.fn(),
+  onInlineEdit: vi.fn(),
+  onSave: vi.fn().mockResolvedValue(undefined),
+};
+
+describe("TodoRow", () => {
+  it("renders the todo title", () => {
+    render(createElement(TodoRow, { ...defaultProps, todo: makeTodo({ title: "My Task" }) }));
+    expect(screen.getByText("My Task")).toBeTruthy();
+  });
+
+  it("renders completion checkbox when not in bulk mode", () => {
+    render(createElement(TodoRow, { ...defaultProps }));
+    const checkbox = screen.getByRole("checkbox", { name: /Mark "Test task" as complete/ });
+    expect(checkbox).toBeTruthy();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("renders selection checkbox when in bulk mode", () => {
+    render(createElement(TodoRow, { ...defaultProps, isBulkMode: true }));
+    const checkbox = screen.getByRole("checkbox", { name: /Select/ });
+    expect(checkbox).toBeTruthy();
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("calls onToggle when checkbox is clicked", () => {
+    const onToggle = vi.fn();
+    render(createElement(TodoRow, { ...defaultProps, onToggle }));
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Mark "Test task" as complete/ }));
+    expect(onToggle).toHaveBeenCalledWith("todo-1", true);
+  });
+
+  it("calls onClick when row is clicked (non-bulk mode)", () => {
+    const onClick = vi.fn();
+    render(createElement(TodoRow, { ...defaultProps, onClick }));
+
+    fireEvent.click(screen.getByText("Test task"));
+    expect(onClick).toHaveBeenCalledWith("todo-1");
+  });
+
+  it("calls onSelect when row is clicked in bulk mode", () => {
+    const onSelect = vi.fn();
+    render(createElement(TodoRow, { ...defaultProps, isBulkMode: true, onSelect }));
+
+    fireEvent.click(screen.getByLabelText("Select task Test task"));
+    expect(onSelect).toHaveBeenCalledWith("todo-1");
+  });
+
+  it("renders kebab menu button", () => {
+    render(createElement(TodoRow, { ...defaultProps }));
+    expect(screen.getByRole("button", { name: "More actions" })).toBeTruthy();
+  });
+
+  it("calls onToggle when checkbox is clicked in non-bulk mode", () => {
+    const onToggle = vi.fn();
+    render(createElement(TodoRow, { ...defaultProps, onToggle }));
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Mark "Test task" as complete/ }));
+    expect(onToggle).toHaveBeenCalledWith("todo-1", true);
+  });
+
+  it("calls onInlineEdit when title is double-clicked and edited", () => {
+    const onInlineEdit = vi.fn();
+    render(createElement(TodoRow, { ...defaultProps, onInlineEdit }));
+
+    // Double-click to enter edit mode
+    fireEvent.doubleClick(screen.getByText("Test task"));
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Edited task" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onInlineEdit).toHaveBeenCalledWith("todo-1", "Edited task");
+  });
+
+  it("cancels edit on Escape key", () => {
+    render(createElement(TodoRow, { ...defaultProps }));
+
+    fireEvent.doubleClick(screen.getByText("Test task"));
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Edited task" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    // Should show original title again
+    expect(screen.getByText("Test task")).toBeTruthy();
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("renders completed styling when todo is completed", () => {
+    render(createElement(TodoRow, { ...defaultProps, todo: makeTodo({ completed: true }) }));
+
+    const title = screen.getByText("Test task");
+    expect(title).toHaveClass("todo-title--completed");
+  });
+
+  it("shows inline lifecycle actions when onLifecycleAction is provided", () => {
+    const onLifecycleAction = vi.fn();
+    render(createElement(TodoRow, { ...defaultProps, onLifecycleAction }));
+
+    // Should show snooze and cancel buttons on hover
+    expect(screen.getByTitle("Snooze → Tomorrow")).toBeTruthy();
+    expect(screen.getByTitle("Cancel task")).toBeTruthy();
+
+    fireEvent.click(screen.getByTitle("Cancel task"));
+    expect(onLifecycleAction).toHaveBeenCalledWith("todo-1", "cancel");
+  });
+
+  it("shows reopen button for cancelled tasks", () => {
+    const onLifecycleAction = vi.fn();
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ status: "cancelled" }),
+        onLifecycleAction,
+      }),
+    );
+
+    expect(screen.getByTitle("Reopen task")).toBeTruthy();
+
+    fireEvent.click(screen.getByTitle("Reopen task"));
+    expect(onLifecycleAction).toHaveBeenCalledWith("todo-1", "reopen");
+  });
+
+  it("shows archive button for completed tasks", () => {
+    const onLifecycleAction = vi.fn();
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ completed: true }),
+        onLifecycleAction,
+      }),
+    );
+
+    expect(screen.getByTitle("Archive")).toBeTruthy();
+
+    fireEvent.click(screen.getByTitle("Archive"));
+    expect(onLifecycleAction).toHaveBeenCalledWith("todo-1", "archive");
+  });
+
+  it("does not show snooze for completed tasks", () => {
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ completed: true }),
+        onLifecycleAction: vi.fn(),
+      }),
+    );
+
+    expect(screen.queryByTitle("Snooze → Tomorrow")).toBeNull();
+  });
+
+  it("shows overdue class when due date is in the past", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ dueDate: yesterday.toISOString() }),
+      }),
+    );
+
+    const row = screen.getByText("Test task").closest(".todo-item");
+    expect(row).toHaveClass("todo-item--overdue");
+  });
+
+  it("shows description preview in spacious density", () => {
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ description: "A detailed description" }),
+        density: "spacious",
+      }),
+    );
+
+    expect(screen.getByText("A detailed description")).toBeTruthy();
+  });
+
+  it("truncates long descriptions in spacious density", () => {
+    const longDesc = "A".repeat(150);
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ description: longDesc }),
+        density: "spacious",
+      }),
+    );
+
+    expect(screen.getByText(/A{120}\.\.\./)).toBeTruthy();
+  });
+
+  it("shows subtask progress bar in spacious density", () => {
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({
+          subtasks: [
+            { id: "s1", title: "Step 1", completed: true },
+            { id: "s2", title: "Step 2", completed: false },
+          ],
+        }),
+        density: "spacious",
+      }),
+    );
+
+    expect(screen.getByText("1 of 2")).toBeTruthy();
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+  });
+
+  it("shows notes indicator in spacious density", () => {
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ notes: "Some notes" }),
+        density: "spacious",
+      }),
+    );
+
+    expect(screen.getByText("Has notes")).toBeTruthy();
+  });
+
+  it("calls onTagClick when a tag chip is clicked", () => {
+    const onTagClick = vi.fn();
+    render(
+      createElement(TodoRow, {
+        ...defaultProps,
+        todo: makeTodo({ tags: ["work", "urgent"] }),
+        onTagClick,
+      }),
+    );
+
+    const chips = screen.getAllByText(/#work|#urgent/);
+    if (chips.length > 0) {
+      fireEvent.click(chips[0]);
+      expect(onTagClick).toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the React app coverage improvement initiative. Added 36 new unit tests for the most user-facing components in `src/components/todos/`.

## New Test Files (3)

| File | Tests | What it covers |
|------|-------|----------------|
| `components/todos/TodoRow.test.tsx` | 21 | Checkbox interactions, inline editing, lifecycle actions (snooze/cancel/archive/reopen), kebab menu, overdue styling, description/subtask/notes previews in spacious density |
| `components/todos/TodoList.test.tsx` | 8 | Loading/error/empty states, row rendering, toggle, click handlers, bulk mode, completed styling |
| `components/todos/BulkToolbar.test.tsx` | 7 | Select all, complete, delete, cancel actions, count display, all-selected state |

## Coverage Impact

| Directory | Before | After | Delta |
|-----------|--------|-------|-------|
| `src/components/todos/` | 5% | 12.5% | +7.5 pts |
| **Overall** | **19.31%** | **20.3%** | **+0.99 pts** |

Total tests: 239 → 275 (+36)

## What is NOT covered yet
- `FieldRenderer.tsx` (647 lines) — complex field dispatch with many variants
- `SortableTodoList.tsx` (354 lines) — drag-and-drop with dnd-kit
- `FilterPanel.tsx` (227 lines) — filter state management
- `TaskComposer.tsx`, `TodoDrawer.tsx`, `TaskFullPage.tsx` — large form components

These will be addressed in Phase 3.

## Verification
| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (backend) | ✅ |
| `npx tsc --noEmit` (client-react) | ✅ |
| `npm run test:coverage` (275 tests) | ✅ |

## Cross-client impact
None. Test-only changes.