### PR TITLE
fix(ci): install client-react dependencies and build before UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install client-react dependencies
+        run: npm ci --prefix client-react
+
+      - name: Build React app
+        run: npm run build:react
+
       - name: Get Playwright version
         id: pw-version
         run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ui-visual.yml
+++ b/.github/workflows/ui-visual.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install client-react dependencies
+        run: npm ci --prefix client-react
+
+      - name: Build React app
+        run: npm run build:react
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 


### PR DESCRIPTION
## Bug

The **UI Tests** and **UI Visual** CI workflows have been failing across all recent PRs with:
```
sh: 1: vite: not found
Error: server closed unexpectedly
```

## Root Cause

The `test:ui:fast` script uses `start-server-and-test preview:react`, which runs:
1. `npm --prefix client-react run preview` → `vite preview`
2. But `vite` was not found because `client-react/` dependencies were never installed in CI
3. Additionally, the React app build output (`client-react/dist/`) did not exist

## Fix

Added two steps to both UI test workflows (`ui-tests.yml` and `ui-visual.yml`):

1. **Install client-react dependencies** — `npm ci --prefix client-react`
2. **Build React app** — `npm run build:react`

This ensures the React app is fully built and ready to serve before Playwright tests run.

## Verification

The fix will be verified when CI runs on this PR. The changes:
- ✅ Do not modify any source code
- ✅ Only affect CI workflow configuration
- ✅ Match the same steps that `build:react` runs locally