### PR TITLE
test(react): add Phase 9 unit tests for AuthPage, LandingPage, and OnboardingFlow

### DIFF
--- a/client-react/src/auth/AuthPage.test.tsx
+++ b/client-react/src/auth/AuthPage.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { AuthPage } from "./AuthPage";
+import * as pageTransitions from "../utils/pageTransitions";
+
+// Mock useAuth
+vi.mock("./AuthProvider", () => ({
+  useAuth: () => ({
+    setTokens: vi.fn(),
+    user: null,
+    loading: false,
+  }),
+}));
+
+// Mock sub-forms to focus on AuthPage routing logic
+vi.mock("./LoginForm", () => ({
+  LoginForm: () => createElement("div", { "data-testid": "login-form" }),
+}));
+
+vi.mock("./RegisterForm", () => ({
+  RegisterForm: () => createElement("div", { "data-testid": "register-form" }),
+}));
+
+vi.mock("./ForgotPasswordForm", () => ({
+  ForgotPasswordForm: () => createElement("div", { "data-testid": "forgot-form" }),
+}));
+
+vi.mock("./ResetPasswordForm", () => ({
+  ResetPasswordForm: () => createElement("div", { "data-testid": "reset-form" }),
+}));
+
+vi.mock("./PhoneLoginForm", () => ({
+  PhoneLoginForm: () => createElement("div", { "data-testid": "phone-form" }),
+}));
+
+// Mock page transitions
+vi.mock("../utils/pageTransitions", () => ({
+  navigateWithFade: vi.fn(),
+}));
+
+describe("AuthPage", () => {
+  beforeEach(() => {
+    // Clear URL search params
+    window.history.pushState({}, "", "/auth");
+    vi.clearAllMocks();
+  });
+
+  it("renders the auth page container with logo", () => {
+    const { container } = render(createElement(AuthPage));
+    expect(screen.getByText("Todos")).toBeTruthy();
+    expect(container.querySelector(".auth-card")).toBeTruthy();
+  });
+
+  it("shows back to home button", () => {
+    render(createElement(AuthPage));
+    expect(screen.getByRole("button", { name: "←" })).toBeTruthy();
+  });
+
+  it("calls navigateWithFade when back button is clicked", () => {
+    render(createElement(AuthPage));
+    fireEvent.click(screen.getByRole("button", { name: "←" }));
+    expect(pageTransitions.navigateWithFade).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  it("shows login form by default", () => {
+    render(createElement(AuthPage));
+    expect(screen.getByTestId("login-form")).toBeTruthy();
+    expect(screen.queryByTestId("register-form")).toBeNull();
+  });
+
+  it("renders login and register tabs", () => {
+    render(createElement(AuthPage));
+    expect(screen.getByRole("tab", { name: "Login" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Register" })).toBeTruthy();
+  });
+
+  it("has login tab active by default", () => {
+    render(createElement(AuthPage));
+    expect(screen.getByRole("tab", { name: "Login" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Register" })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("switches to register form when Register tab is clicked", () => {
+    render(createElement(AuthPage));
+    fireEvent.click(screen.getByRole("tab", { name: "Register" }));
+    expect(screen.getByTestId("register-form")).toBeTruthy();
+    expect(screen.queryByTestId("login-form")).toBeNull();
+  });
+
+  it("switches back to login form when Login tab is clicked", () => {
+    render(createElement(AuthPage));
+    fireEvent.click(screen.getByRole("tab", { name: "Register" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Login" }));
+    expect(screen.getByTestId("login-form")).toBeTruthy();
+    expect(screen.queryByTestId("register-form")).toBeNull();
+  });
+
+  it("shows success message when verified=1 in URL", () => {
+    window.history.pushState({}, "", "/auth?verified=1");
+    render(createElement(AuthPage));
+    expect(screen.getByText("Email verified. You can now log in.")).toBeTruthy();
+  });
+
+  it("shows error message when verified=0 in URL", () => {
+    window.history.pushState({}, "", "/auth?verified=0");
+    render(createElement(AuthPage));
+    expect(screen.getByText("Verification link expired or invalid.")).toBeTruthy();
+  });
+
+  it("dismisses message when dismiss button is clicked", () => {
+    window.history.pushState({}, "", "/auth?verified=1");
+    render(createElement(AuthPage));
+    expect(screen.getByText("Email verified. You can now log in.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "✕" }));
+    expect(screen.queryByText("Email verified. You can now log in.")).toBeNull();
+  });
+
+  it("switches to reset form when token is in URL", () => {
+    window.history.pushState({}, "", "/auth?token=RESET123");
+    render(createElement(AuthPage));
+    expect(screen.getByTestId("reset-form")).toBeTruthy();
+    expect(screen.queryByTestId("login-form")).toBeNull();
+  });
+
+  it("shows register tab active when ?tab=register in URL", () => {
+    window.history.pushState({}, "", "/auth?tab=register");
+    render(createElement(AuthPage));
+    expect(screen.getByRole("tab", { name: "Register" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("register-form")).toBeTruthy();
+  });
+});

--- a/client-react/src/components/shared/OnboardingFlow.test.tsx
+++ b/client-react/src/components/shared/OnboardingFlow.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { OnboardingFlow } from "./OnboardingFlow";
+
+// Mock API calls
+vi.mock("../../api/client", () => ({
+  apiCall: vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+}));
+
+// Mock AuthProvider
+vi.mock("../../auth/AuthProvider", () => ({
+  useAuth: () => ({
+    user: { id: "1", email: "test@example.com", name: "Test", onboardingStep: 1, onboardingCompletedAt: null },
+    setUser: vi.fn(),
+  }),
+}));
+
+describe("OnboardingFlow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the onboarding component", () => {
+    const { container } = render(
+      createElement(OnboardingFlow, {
+        onComplete: vi.fn(),
+        onAddTodo: vi.fn().mockResolvedValue(undefined),
+      }),
+    );
+    // Should render something (even if just loading state)
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/client-react/src/landing/LandingPage.test.tsx
+++ b/client-react/src/landing/LandingPage.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { LandingPage } from "./LandingPage";
+
+describe("LandingPage", () => {
+  beforeEach(() => {
+    window.history.pushState({}, "", "/");
+  });
+
+  it("renders the navigation bar with logo", () => {
+    const { container } = render(createElement(LandingPage));
+    expect(screen.getByText("Todos")).toBeTruthy();
+    expect(container.querySelector(".landing-nav")).toBeTruthy();
+  });
+
+  it("renders navigation links", () => {
+    render(createElement(LandingPage));
+    const links = screen.getAllByRole("link");
+    expect(links.some(l => l.textContent === "Features")).toBeTruthy();
+    expect(links.some(l => l.textContent === "Log in")).toBeTruthy();
+    expect(links.some(l => l.textContent === "Start for free")).toBeTruthy();
+  });
+
+  it("renders the hero section with heading", () => {
+    render(createElement(LandingPage));
+    expect(
+      screen.getByText(/Plan your days\. Review your weeks/),
+    ).toBeTruthy();
+  });
+
+  it("renders hero CTA buttons", () => {
+    render(createElement(LandingPage));
+    const links = screen.getAllByRole("link");
+    expect(links.some(l => l.textContent === "Start for free")).toBeTruthy();
+    expect(links.some(l => l.textContent === "See features")).toBeTruthy();
+  });
+
+  it("renders hero screenshot", () => {
+    render(createElement(LandingPage));
+    const img = screen.getByAltText(
+      /Planning workspace with home dashboard/,
+    );
+    expect(img).toBeTruthy();
+    expect(img).toHaveAttribute("src", "/images/landing/hero-desktop.png");
+  });
+
+  it("renders the features section with heading", () => {
+    render(createElement(LandingPage));
+    expect(
+      screen.getByText(/A planning workspace that works the way you think/),
+    ).toBeTruthy();
+  });
+
+  it("renders all four feature cards", () => {
+    render(createElement(LandingPage));
+    expect(
+      screen.getByText(/A daily plan that balances priorities and deadlines/),
+    ).toBeTruthy();
+    expect(screen.getByText(/Capture anything, organize later/)).toBeTruthy();
+    expect(screen.getByText(/Review your week, stay honest/)).toBeTruthy();
+    expect(
+      screen.getByText(/Your AI assistant already knows your tasks/),
+    ).toBeTruthy();
+  });
+
+  it("renders the capabilities section with heading", () => {
+    render(createElement(LandingPage));
+    expect(screen.getByText("Built for real workflows")).toBeTruthy();
+  });
+
+  it("renders all six capability cards", () => {
+    render(createElement(LandingPage));
+    expect(screen.getByText("Projects & Areas")).toBeTruthy();
+    expect(screen.getByText("Filters & Views")).toBeTruthy();
+    expect(screen.getByText("Focus Dashboard")).toBeTruthy();
+    expect(screen.getByText("Desk")).toBeTruthy();
+    expect(screen.getByText("Keyboard First")).toBeTruthy();
+    expect(screen.getByText("Dark Mode")).toBeTruthy();
+  });
+
+  it("renders the dark mode card with wide class and image", () => {
+    render(createElement(LandingPage));
+    const darkModeCard = screen.getByText("Dark Mode").closest(
+      ".landing-card",
+    );
+    expect(darkModeCard).toHaveClass("landing-card--wide");
+    const img = screen.getByAltText("Planning workspace in dark mode");
+    expect(img).toHaveAttribute("src", "/images/landing/dark-mode.png");
+  });
+
+  it("renders the final CTA section", () => {
+    render(createElement(LandingPage));
+    expect(screen.getByText(/Get started/i)).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Create free account" }),
+    ).toBeTruthy();
+  });
+
+  it("renders the footer with copyright", () => {
+    render(createElement(LandingPage));
+    const year = new Date().getFullYear();
+    expect(screen.getByText(new RegExp(`© ${year} Todos`))).toBeTruthy();
+  });
+
+  it("has correct anchor links in navigation", () => {
+    render(createElement(LandingPage));
+    const featuresLink = screen.getByRole("link", { name: "Features" });
+    expect(featuresLink).toHaveAttribute("href", "#landing-features");
+  });
+
+  it("has correct auth links with next parameter", () => {
+    render(createElement(LandingPage));
+    const links = screen.getAllByRole("link");
+    const loginLink = links.find(l => l.textContent === "Log in");
+    const registerLink = links.find(l => l.textContent === "Start for free");
+    expect(loginLink).toHaveAttribute("href", "/auth?next=%2Fapp&tab=login");
+    expect(registerLink).toHaveAttribute(
+      "href",
+      "/auth?next=%2Fapp&tab=register",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 9 of the React app coverage improvement initiative. Added 28 new unit tests for AuthPage, LandingPage, and OnboardingFlow.

## New Test Files (3)

| File | Tests | What it covers |
|------|-------|----------------|
| `auth/AuthPage.test.tsx` | 13 | Container rendering, back button navigation, login/register tab switching, URL query parameter handling (verified=1/0, token, tab), message dismissal, form routing |
| `landing/LandingPage.test.tsx` | 14 | Navigation bar, hero section with screenshot, feature cards, capability cards, dark mode wide card, final CTA, footer with copyright, auth link verification |
| `components/shared/OnboardingFlow.test.tsx` | 1 | Component export and basic rendering |

## Coverage Impact

| Directory | Before | After | Delta |
|-----------|--------|-------|-------|
| `src/auth/AuthPage.tsx` | 0% | 71% | +71 pts |
| `src/landing/LandingPage.tsx` | 0% | 68% | +68 pts |
| `src/components/shared/OnboardingFlow.tsx` | 0% | 8% | +8 pts |
| **Overall** | **38.2%** | **42.8%** | **+4.6 pts** |

Total tests: 503 → 531 (+28)

## Verification
| Check | Result |
|-------|--------|
| `npx tsc --noEmit` (backend) | ✅ |
| `npx tsc --noEmit` (client-react) | ✅ |
| `npm run test:coverage` (531 tests) | ✅ |

## Cross-client impact
None. Test-only changes.