### PR TITLE
ci: add release pipeline with staging/uat/production branch promotion

### DIFF
--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -1,0 +1,24 @@
+name: Promote Master to Staging
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Promote master → staging
+        run: |
+          chmod +x scripts/fast-forward-promote.sh
+          ./scripts/fast-forward-promote.sh master staging

--- a/.github/workflows/promote-to-uat.yml
+++ b/.github/workflows/promote-to-uat.yml
@@ -1,0 +1,24 @@
+name: Promote Staging to UAT
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Promote staging → uat
+        run: |
+          chmod +x scripts/fast-forward-promote.sh
+          ./scripts/fast-forward-promote.sh staging uat

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,33 @@
+name: Production Release Train
+
+on:
+  schedule:
+    - cron: "13 9 * * 1-5" # 09:13 UTC Mon-Fri (off :00 to avoid GitHub queue congestion)
+  workflow_dispatch:
+    inputs:
+      is_hotfix:
+        description: "Bypass daily limit for emergency hotfix"
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Release Train
+        env:
+          IS_HOTFIX: ${{ inputs.is_hotfix }}
+        run: |
+          chmod +x scripts/create-production-release.sh
+          ./scripts/create-production-release.sh

--- a/scripts/create-production-release.sh
+++ b/scripts/create-production-release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UAT_BRANCH="uat"
+PROD_BRANCH="production"
+TODAY=$(date -u +'%Y.%m.%d')
+BASE_TAG="v${TODAY}"
+IS_HOTFIX=${IS_HOTFIX:-false}
+
+echo "Starting Release Train process for $TODAY..."
+
+git fetch origin "$UAT_BRANCH" --tags
+
+# 1. Bootstrap Check — safe on first run (production may not exist yet)
+if ! git ls-remote --exit-code --heads origin "$PROD_BRANCH" > /dev/null 2>&1; then
+  echo "🐣 '$PROD_BRANCH' does not exist yet. Bootstrapping from '$UAT_BRANCH'..."
+  git checkout -B "$PROD_BRANCH" "origin/$UAT_BRANCH"
+  git tag -a "$BASE_TAG" -m "Initial release $BASE_TAG"
+  git push origin "$PROD_BRANCH"
+  git push origin "$BASE_TAG"
+  echo "✅ Initial production bootstrap complete."
+  exit 0
+fi
+
+git fetch origin "$PROD_BRANCH"
+
+# 2. Check for new commits
+COMMITS_BEHIND=$(git rev-list --count "origin/$PROD_BRANCH..origin/$UAT_BRANCH")
+if [ "$COMMITS_BEHIND" -eq 0 ]; then
+  echo "✅ No new commits on $UAT_BRANCH since last release. Skipping."
+  exit 0
+fi
+
+# 3. Rate Limit Enforcement
+EXISTING_TAGS=$(git tag -l "${BASE_TAG}*")
+if [ -n "$EXISTING_TAGS" ] && [ "$IS_HOTFIX" != "true" ]; then
+  echo "🚨 ERROR: A release already exists for today: $EXISTING_TAGS"
+  echo "To release again, you must explicitly trigger a Hotfix."
+  exit 1
+fi
+
+# 4. Determine Tag Name
+if [ "$IS_HOTFIX" == "true" ]; then
+  HOTFIX_COUNT=$(echo "$EXISTING_TAGS" | grep -c "hotfix" || true)
+  NEXT_HOTFIX=$((HOTFIX_COUNT + 1))
+  NEW_TAG="${BASE_TAG}-hotfix.${NEXT_HOTFIX}"
+  echo "🔥 Hotfix mode: Creating $NEW_TAG"
+else
+  NEW_TAG="${BASE_TAG}"
+  echo "🏷️  Daily Release mode: Creating $NEW_TAG"
+fi
+
+# 5. Fast-Forward Production
+if ! git merge-base --is-ancestor "origin/$PROD_BRANCH" "origin/$UAT_BRANCH"; then
+  echo "❌ ERROR: $PROD_BRANCH has diverged from $UAT_BRANCH. Fast-forward failed."
+  exit 1
+fi
+
+git checkout -B "$PROD_BRANCH" "origin/$PROD_BRANCH"
+git merge --ff-only "origin/$UAT_BRANCH"
+git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+
+# 6. Push (no --force)
+git push origin "$PROD_BRANCH"
+git push origin "$NEW_TAG"
+
+echo "✅ Production release $NEW_TAG successful!"

--- a/scripts/fast-forward-promote.sh
+++ b/scripts/fast-forward-promote.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE=$1
+TARGET=$2
+
+echo "🔍 Checking $TARGET status..."
+
+git fetch origin "$SOURCE" --tags
+
+# 1. Bootstrap Check: If target does not exist on remote, create it from source
+if ! git ls-remote --exit-code --heads origin "$TARGET" > /dev/null 2>&1; then
+  echo "🐣 Target branch '$TARGET' does not exist. Bootstrapping from '$SOURCE'..."
+  git checkout -B "$TARGET" "origin/$SOURCE"
+  git push origin "$TARGET"
+  echo "✅ Bootstrap complete."
+  exit 0
+fi
+
+git fetch origin "$TARGET"
+
+# 2. Fast-Forward Check
+SOURCE_SHA=$(git rev-parse "origin/$SOURCE")
+TARGET_SHA=$(git rev-parse "origin/$TARGET")
+
+if [ "$SOURCE_SHA" == "$TARGET_SHA" ]; then
+  echo "✅ Target '$TARGET' is already up to date with '$SOURCE'. No-op."
+  exit 0
+fi
+
+if ! git merge-base --is-ancestor "origin/$TARGET" "origin/$SOURCE"; then
+  echo "❌ ERROR: Target branch '$TARGET' has diverged from '$SOURCE'."
+  echo "A fast-forward is not possible. Please manually merge '$TARGET' into '$SOURCE' and resolve conflicts."
+  exit 1
+fi
+
+echo "🚀 Fast-forwarding '$TARGET' to '$SOURCE'..."
+git checkout -B "$TARGET" "origin/$TARGET"
+git merge --ff-only "origin/$SOURCE"
+git push origin "$TARGET"
+
+echo "✅ Successfully promoted '$SOURCE' to '$TARGET'."


### PR DESCRIPTION
## Summary

Adds the full Railway + GitHub Actions branch-promotion pipeline for persistent test environments and once-daily production releases.

## Changes

- `scripts/fast-forward-promote.sh` — safe FF-only promotion with first-run bootstrap
- `scripts/create-production-release.sh` — daily release train with CalVer tags, once-per-day enforcement, hotfix support, and first-run production bootstrap
- `.github/workflows/promote-to-staging.yml` — manual promote master → staging
- `.github/workflows/promote-to-uat.yml` — manual promote staging → uat
- `.github/workflows/release-train.yml` — daily 09:13 UTC uat → production + hotfix override

## Branch Strategy

`master` → *(manual)* → `staging` → *(manual)* → `uat` → *(daily 09:13 UTC)* → `production`

## Railway Setup Required (manual)
See `~/Documents/todos-api-devops/release-strategy-v4-final.md` for full Railway environment setup, DB provisioning, and GitHub branch protection steps.