### PR TITLE
[codex] refine project page inline editing

### DIFF
--- a/client-react/src/components/projects/ProjectEditorView.test.tsx
+++ b/client-react/src/components/projects/ProjectEditorView.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Heading, Project, Todo } from "../../types";
@@ -94,6 +95,7 @@ function renderEditor(opts: {
   projectTodos?: Todo[];
   headings?: Heading[];
   isDraft?: boolean;
+  hookOverrides?: Partial<ReturnType<typeof useProjectHeadings>>;
 } = {}) {
   const project = opts.project ?? makeProject();
   const projects = opts.projects ?? [project];
@@ -110,6 +112,7 @@ function renderEditor(opts: {
     updateHeading,
     deleteHeading,
     reorderHeadings: vi.fn().mockResolvedValue(headings),
+    ...opts.hookOverrides,
   });
 
   const onSaveProject = vi.fn().mockResolvedValue(undefined);
@@ -257,13 +260,102 @@ describe("ProjectEditorView", () => {
     );
   });
 
-  it("adds tasks from the compact composer", async () => {
+  it("adds tasks from the inline composer", async () => {
     const { onAddTodo } = renderEditor();
 
-    fireEvent.change(screen.getByPlaceholderText("Add a task"), {
+    fireEvent.click(screen.getAllByRole("button", { name: "Add task" })[0]!);
+    const input = screen.getByPlaceholderText("Type a task");
+    fireEvent.change(input, {
       target: { value: "Sweep floor" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    fireEvent.click(
+      within(input.closest(".project-page__task-composer-form") as HTMLElement).getByRole(
+        "button",
+        { name: "Add task" },
+      ),
+    );
+
+    expect(onAddTodo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Sweep floor",
+        projectId: "project-1",
+        headingId: null,
+      }),
+    );
+  });
+
+  it("adds headings from the inline composer", async () => {
+    const addHeading = vi.fn().mockResolvedValue(makeHeading({ id: "heading-2" }));
+    renderEditor({ hookOverrides: { addHeading } });
+
+    fireEvent.click(screen.getByRole("button", { name: "New heading" }));
+    fireEvent.change(screen.getByPlaceholderText("Type a heading and press Enter"), {
+      target: { value: "Second" },
+    });
+    fireEvent.keyDown(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+      { key: "Enter" },
+    );
+
+    expect(addHeading).toHaveBeenCalledWith("Second");
+  });
+
+  it("adds tasks inside a heading from that section composer", async () => {
+    const { onAddTodo } = renderEditor({
+      headings: [makeHeading({ id: "heading-1", name: "Backlog" })],
+      projectTodos: [
+        makeTodo({
+          id: "todo-1",
+          title: "Sort donation pile",
+          headingId: "heading-1",
+        }),
+      ],
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add task" })[1]!);
+    const input = screen.getByPlaceholderText("Type a task");
+    fireEvent.change(input, {
+      target: { value: "Label storage bins" },
+    });
+    fireEvent.click(
+      within(input.closest(".project-page__task-composer-form") as HTMLElement).getByRole(
+        "button",
+        { name: "Add task" },
+      ),
+    );
+
+    expect(onAddTodo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Label storage bins",
+        projectId: "project-1",
+        headingId: "heading-1",
+      }),
+    );
+  });
+
+  it("keeps a project-level task composer before the first heading when backlog is empty", async () => {
+    const { onAddTodo } = renderEditor({
+      headings: [makeHeading({ id: "heading-1", name: "Backlog" })],
+      projectTodos: [
+        makeTodo({
+          id: "todo-1",
+          title: "Sort donation pile",
+          headingId: "heading-1",
+        }),
+      ],
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Add task" })[0]!);
+    const input = screen.getByPlaceholderText("Type a task");
+    fireEvent.change(input, {
+      target: { value: "Sweep floor" },
+    });
+    fireEvent.click(
+      within(input.closest(".project-page__task-composer-form") as HTMLElement).getByRole(
+        "button",
+        { name: "Add task" },
+      ),
+    );
 
     expect(onAddTodo).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -303,7 +395,7 @@ describe("ProjectEditorView", () => {
     expect(screen.getByText(/save the project first/i)).toBeTruthy();
     expect(screen.getByText(/headings and tasks will appear here/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: /show settings/i })).toBeTruthy();
-    expect(screen.queryByPlaceholderText("Add a task")).toBeNull();
+    expect(screen.queryByPlaceholderText(/Type .*press Enter/i)).toBeNull();
   });
 
   it("renders heading inline editing and heading actions", () => {
@@ -325,6 +417,27 @@ describe("ProjectEditorView", () => {
     expect(screen.getByText("Move to project")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Convert to project" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
+  });
+
+  it("collapses and expands tasks under a heading", () => {
+    renderEditor({
+      headings: [makeHeading({ id: "heading-1", name: "Backlog" })],
+      projectTodos: [
+        makeTodo({
+          id: "todo-1",
+          title: "Sort donation pile",
+          headingId: "heading-1",
+        }),
+      ],
+    });
+
+    expect(screen.getByRole("button", { name: "Sort donation pile" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse Backlog" }));
+    expect(screen.queryByRole("button", { name: "Sort donation pile" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Backlog" }));
+    expect(screen.getByRole("button", { name: "Sort donation pile" })).toBeTruthy();
   });
 
   it("moves heading tasks into a new same-named heading in the destination project", async () => {

--- a/client-react/src/components/projects/ProjectEditorView.tsx
+++ b/client-react/src/components/projects/ProjectEditorView.tsx
@@ -1,9 +1,13 @@
 import {
   DndContext,
+  DragOverlay,
+  MeasuringStrategy,
   PointerSensor,
   closestCenter,
   useSensor,
   useSensors,
+  type DragOverEvent,
+  type DragStartEvent,
   type DragEndEvent,
 } from "@dnd-kit/core";
 import {
@@ -37,7 +41,6 @@ import {
   IconGrip,
   IconKebab,
   IconMenu,
-  IconPlus,
 } from "../shared/Icons";
 import { VerificationBanner } from "../shared/VerificationBanner";
 import { BulkToolbar } from "../todos/BulkToolbar";
@@ -213,10 +216,12 @@ function buildFlatItems(headings: Heading[], todos: Todo[]) {
 function SortableRow({
   id,
   className,
+  isDropTarget = false,
   children,
 }: {
   id: string;
   className: string;
+  isDropTarget?: boolean;
   children: ReactNode;
 }) {
   const {
@@ -231,11 +236,14 @@ function SortableRow({
   return (
     <div
       ref={setNodeRef}
-      className={className}
+      className={`${className}${isDragging ? " project-page__sortable-row--dragging" : ""}${
+        isDropTarget ? " project-page__sortable-row--drop-target" : ""
+      }`}
       style={{
         transform: CSS.Transform.toString(transform),
         transition,
         opacity: isDragging ? 0.55 : 1,
+        zIndex: isDragging ? 2 : undefined,
       }}
     >
       <button
@@ -375,8 +383,6 @@ export function ProjectEditorView({
   onReplaceNext: _onReplaceNext,
 }: Props) {
   const titleInputRef = useRef<HTMLInputElement>(null);
-  const quickAddInputRef = useRef<HTMLInputElement>(null);
-  const headingInputRef = useRef<HTMLInputElement>(null);
 
   const [name, setName] = useState(project.name);
   const [description, setDescription] = useState(project.description ?? "");
@@ -392,14 +398,19 @@ export function ProjectEditorView({
     project.status,
   );
   const [savingProject, setSavingProject] = useState(false);
-  const [quickAddTitle, setQuickAddTitle] = useState("");
-  const [quickAddHeadingId, setQuickAddHeadingId] = useState<string | null>(
+  const [activeTaskComposerScope, setActiveTaskComposerScope] = useState<string | null>(
     null,
   );
-  const [headingDraftOpen, setHeadingDraftOpen] = useState(false);
-  const [headingDraft, setHeadingDraft] = useState("");
+  const [taskComposerValue, setTaskComposerValue] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [activeDropTargetId, setActiveDropTargetId] = useState<string | null>(null);
+  const [collapsedHeadingIds, setCollapsedHeadingIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [headingComposerOpen, setHeadingComposerOpen] = useState(false);
+  const [headingComposerValue, setHeadingComposerValue] = useState("");
   const [headingNameDrafts, setHeadingNameDrafts] = useState<Record<string, string>>({});
   const [moveTargetByHeadingId, setMoveTargetByHeadingId] = useState<
     Record<string, string>
@@ -435,8 +446,12 @@ export function ProjectEditorView({
 
   useEffect(() => {
     setOpenMenuId(null);
-    setHeadingDraftOpen(false);
-    setQuickAddHeadingId(null);
+    setActiveTaskComposerScope(null);
+    setTaskComposerValue("");
+    setActiveDropTargetId(null);
+    setCollapsedHeadingIds(new Set());
+    setHeadingComposerOpen(false);
+    setHeadingComposerValue("");
   }, [project.id]);
 
   useEffect(() => {
@@ -444,6 +459,13 @@ export function ProjectEditorView({
       Object.fromEntries(headings.map((heading) => [heading.id, heading.name])),
     );
     setMoveTargetByHeadingId({});
+    setCollapsedHeadingIds((current) => {
+      const next = new Set<string>();
+      for (const heading of headings) {
+        if (current.has(heading.id)) next.add(heading.id);
+      }
+      return next;
+    });
   }, [headings, project.id]);
 
   const projectDirty = useMemo(() => {
@@ -519,6 +541,22 @@ export function ProjectEditorView({
         ),
       ).sort((a, b) => a.localeCompare(b)),
     [projects],
+  );
+  const displayedFlatItems = useMemo(
+    () =>
+      flatItems.filter((item) =>
+        item.kind === "heading"
+          ? true
+          : !item.parentHeadingId || !collapsedHeadingIds.has(item.parentHeadingId),
+      ),
+    [collapsedHeadingIds, flatItems],
+  );
+  const activeDragItem = useMemo(
+    () =>
+      activeDragId
+        ? displayedFlatItems.find((item) => item.sortableId === activeDragId) ?? null
+        : null,
+    [activeDragId, displayedFlatItems],
   );
 
   const buildDerivedProjectName = useCallback(
@@ -648,30 +686,102 @@ export function ProjectEditorView({
     targetDate,
   ]);
 
-  const handleQuickAdd = useCallback(async () => {
-    const title = quickAddTitle.trim();
+  const handleAddTaskInline = useCallback(async () => {
+    const title = taskComposerValue.trim();
+    const headingId =
+      activeTaskComposerScope && activeTaskComposerScope !== "backlog"
+        ? activeTaskComposerScope
+        : null;
     if (!title) return;
 
     await onAddTodo({
       title,
       projectId: project.id,
-      headingId: quickAddHeadingId,
+      headingId,
     });
 
-    setQuickAddTitle("");
-  }, [onAddTodo, project.id, quickAddHeadingId, quickAddTitle]);
+    setTaskComposerValue("");
+  }, [activeTaskComposerScope, onAddTodo, project.id, taskComposerValue]);
 
-  const handleCreateHeading = useCallback(async () => {
-    const nextName = headingDraft.trim();
-    if (!nextName) return;
-
-    const created = await addHeading(nextName);
+  const handleAddHeadingInline = useCallback(async () => {
+    const name = headingComposerValue.trim();
+    if (!name) return;
+    const created = await addHeading(name);
     if (!created) return;
+    setHeadingComposerValue("");
+    setHeadingComposerOpen(false);
+  }, [addHeading, headingComposerValue]);
 
-    setHeadingDraft("");
-    setHeadingDraftOpen(false);
-    setQuickAddHeadingId(created.id);
-  }, [addHeading, headingDraft]);
+  const renderTaskComposer = useCallback(
+    (scope: string) => {
+      const open = activeTaskComposerScope === scope;
+      return (
+        <div
+          className={`project-page__task-composer${
+            open ? " project-page__task-composer--open" : ""
+          }`}
+        >
+          {open ? (
+            <div className="project-page__task-composer-form">
+              <input
+                type="text"
+                className="project-page__task-composer-input"
+                value={taskComposerValue}
+                placeholder="Type a task"
+                onChange={(event) => setTaskComposerValue(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    void handleAddTaskInline();
+                  }
+                  if (event.key === "Escape") {
+                    setTaskComposerValue("");
+                    setActiveTaskComposerScope(null);
+                  }
+                }}
+                autoFocus
+              />
+              <div className="project-page__task-composer-actions">
+                <button
+                  type="button"
+                  className="btn btn--primary"
+                  onClick={() => void handleAddTaskInline()}
+                  disabled={!taskComposerValue.trim()}
+                >
+                  Add task
+                </button>
+                <button
+                  type="button"
+                  className="btn btn--ghost"
+                  onClick={() => {
+                    setTaskComposerValue("");
+                    setActiveTaskComposerScope(null);
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="project-page__task-composer-trigger"
+              onClick={() => {
+                setActiveTaskComposerScope(scope);
+                setTaskComposerValue("");
+              }}
+            >
+              <span className="project-page__task-composer-plus" aria-hidden="true">
+                +
+              </span>
+              <span className="project-page__task-composer-label">Add task</span>
+              <span className="project-page__heading-rule" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      );
+    },
+    [activeTaskComposerScope, handleAddTaskInline, taskComposerValue],
+  );
 
   const handleSaveHeadingName = useCallback(
     async (heading: Heading) => {
@@ -760,10 +870,12 @@ export function ProjectEditorView({
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
       const { active, over } = event;
+      setActiveDragId(null);
+      setActiveDropTargetId(null);
       if (!over || active.id === over.id) return;
 
-      const activeItem = flatItems.find((item) => item.sortableId === active.id);
-      const overItem = flatItems.find((item) => item.sortableId === over.id);
+      const activeItem = displayedFlatItems.find((item) => item.sortableId === active.id);
+      const overItem = displayedFlatItems.find((item) => item.sortableId === over.id);
       if (!activeItem || !overItem) return;
 
       if (activeItem.kind === "heading") {
@@ -787,7 +899,33 @@ export function ProjectEditorView({
         return;
       }
 
-      const flatWithoutActive = flatItems.filter(
+      if (overItem.kind === "heading" && collapsedHeadingIds.has(overItem.heading.id)) {
+        const targetHeadingId = overItem.heading.id;
+        const activeTodoId = activeItem.todo.id;
+        const targetFlatIndex = flatItems.findIndex(
+          (item) => item.kind === "heading" && item.heading.id === targetHeadingId,
+        );
+        const nextTodoAfterSection = flatItems
+          .slice(targetFlatIndex + 1)
+          .find((item): item is Extract<FlatItem, { kind: "todo" }> => {
+            if (item.kind !== "todo") return false;
+            return item.parentHeadingId !== targetHeadingId && item.todo.id !== activeTodoId;
+          });
+
+        if (nextTodoAfterSection) {
+          await onSave(activeTodoId, { headingId: targetHeadingId });
+          onReorder(activeTodoId, nextTodoAfterSection.todo.id);
+          return;
+        }
+
+        await onSave(activeTodoId, {
+          headingId: targetHeadingId,
+          order: sortedTodos.reduce((max, todo) => Math.max(max, todo.order), -1) + 1,
+        });
+        return;
+      }
+
+      const flatWithoutActive = displayedFlatItems.filter(
         (item) => item.sortableId !== activeItem.sortableId,
       );
       const overIndex = flatWithoutActive.findIndex(
@@ -830,8 +968,87 @@ export function ProjectEditorView({
 
       onReorder(activeItem.todo.id, overTodoId);
     },
-    [flatItems, onReorder, onSave, reorderHeadings, sortedHeadings, sortedTodos],
+    [
+      collapsedHeadingIds,
+      displayedFlatItems,
+      flatItems,
+      onReorder,
+      onSave,
+      reorderHeadings,
+      sortedHeadings,
+      sortedTodos,
+    ],
   );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(String(event.active.id));
+    setActiveDropTargetId(String(event.active.id));
+  }, []);
+
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    setActiveDropTargetId(event.over ? String(event.over.id) : null);
+  }, []);
+
+  const handleDragCancel = useCallback(() => {
+    setActiveDragId(null);
+    setActiveDropTargetId(null);
+  }, []);
+
+  const toggleHeadingCollapsed = useCallback((headingId: string) => {
+    setCollapsedHeadingIds((current) => {
+      const next = new Set(current);
+      if (next.has(headingId)) {
+        next.delete(headingId);
+      } else {
+        next.add(headingId);
+      }
+      return next;
+    });
+  }, []);
+
+  const renderDragOverlay = useCallback(() => {
+    if (!activeDragItem) return null;
+
+    if (activeDragItem.kind === "heading") {
+      const headingTodos = todosByHeading.get(activeDragItem.heading.id) ?? [];
+      return (
+        <div className="project-page__drag-overlay project-page__drag-overlay--heading">
+          <div className="project-page__drag-handle project-page__drag-handle--overlay">
+            <IconGrip size={14} />
+          </div>
+          <div className="project-page__heading-copy">
+            <span className="project-page__heading-title">
+              {activeDragItem.heading.name}
+            </span>
+            <span className="project-page__heading-count">{headingTodos.length}</span>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="project-page__drag-overlay project-page__drag-overlay--task">
+        <div className="project-page__drag-handle project-page__drag-handle--overlay">
+          <IconGrip size={14} />
+        </div>
+        <label className="project-page__task-check">
+          <input type="checkbox" checked={activeDragItem.todo.completed} readOnly />
+        </label>
+        <span
+          className={`project-page__task-title${
+            activeDragItem.todo.completed ? " project-page__task-title--done" : ""
+          }`}
+        >
+          {activeDragItem.todo.title}
+        </span>
+        {activeDragItem.todo.dueDate ? (
+          <span className="project-page__task-meta">
+            {formatDueFriendly(activeDragItem.todo.dueDate)}
+          </span>
+        ) : null}
+      </div>
+    );
+  }, [activeDragItem, todosByHeading]);
 
   if (loadState === "loading" && sortedTodos.length === 0) {
     return (
@@ -1051,73 +1268,6 @@ export function ProjectEditorView({
           <section className="project-page__draft-hint">
             Save the project first, then add headings and tasks.
           </section>
-        ) : (
-          <section className="project-page__composer">
-            <input
-              ref={quickAddInputRef}
-              type="text"
-              className="project-page__quick-add"
-              value={quickAddTitle}
-              placeholder={
-                quickAddHeadingId
-                  ? `Add a task to ${
-                      headings.find((heading) => heading.id === quickAddHeadingId)?.name ??
-                      "section"
-                    }`
-                  : "Add a task"
-              }
-              onChange={(event) => setQuickAddTitle(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  void handleQuickAdd();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="project-page__icon-btn"
-              aria-label="Add heading"
-              onClick={() => {
-                setHeadingDraftOpen((open) => !open);
-                setOpenMenuId(null);
-                requestAnimationFrame(() => headingInputRef.current?.focus());
-              }}
-            >
-              <IconPlus size={16} />
-            </button>
-            <button
-              type="button"
-              className="btn btn--primary"
-              onClick={() => void handleQuickAdd()}
-            >
-              Add
-            </button>
-          </section>
-        )}
-
-        {headingDraftOpen && !isDraft ? (
-          <section className="project-page__heading-draft">
-            <input
-              ref={headingInputRef}
-              type="text"
-              className="project-page__input"
-              value={headingDraft}
-              placeholder="New heading"
-              onChange={(event) => setHeadingDraft(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  void handleCreateHeading();
-                }
-              }}
-            />
-            <button
-              type="button"
-              className="btn"
-              onClick={() => void handleCreateHeading()}
-            >
-              Create heading
-            </button>
-          </section>
         ) : null}
 
         <section className="project-page__list-shell">
@@ -1126,21 +1276,23 @@ export function ProjectEditorView({
               Start with the project name and optional settings. Once you create it,
               headings and tasks will appear here.
             </div>
-          ) : sortedTodos.length === 0 && sortedHeadings.length === 0 ? (
-            <div className="project-page__empty">
-              No headings or tasks yet. Start with a task or add a heading.
-            </div>
           ) : (
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
+              measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragCancel={handleDragCancel}
               onDragEnd={(event) => void handleDragEnd(event)}
             >
               <SortableContext
-                items={flatItems.map((item) => item.sortableId)}
+                items={displayedFlatItems.map((item) => item.sortableId)}
                 strategy={verticalListSortingStrategy}
               >
                 <div className="project-page__list">
+                  {backlogTodos.length === 0 ? renderTaskComposer("backlog") : null}
+
                   {showStandaloneTasksLabel ? (
                     <div className="project-page__section-label">Tasks</div>
                   ) : null}
@@ -1158,6 +1310,7 @@ export function ProjectEditorView({
                         key={menuId}
                         id={menuId}
                         className="project-page__task-row"
+                        isDropTarget={activeDropTargetId === menuId}
                       >
                         <label className="project-page__task-check">
                           <input
@@ -1216,17 +1369,44 @@ export function ProjectEditorView({
                     );
                   })}
 
+                  {backlogTodos.length > 0 ? renderTaskComposer("backlog") : null}
+
                   {sortedHeadings.map((heading) => {
                     const headingTodos = todosByHeading.get(heading.id) ?? [];
                     const headingMenuId = `heading:${heading.id}`;
+                    const collapsed = collapsedHeadingIds.has(heading.id);
 
                     return (
-                      <div key={heading.id} className="project-page__section">
+                      <div
+                        key={heading.id}
+                        className={`project-page__section${
+                          activeDropTargetId === headingMenuId
+                            ? " project-page__section--drop-target"
+                            : ""
+                        }`}
+                      >
                         <SortableRow
                           id={headingMenuId}
                           className="project-page__heading-row"
+                          isDropTarget={activeDropTargetId === headingMenuId}
                         >
                           <div className="project-page__heading-copy">
+                            <button
+                              type="button"
+                              className="project-page__collapse-toggle"
+                              aria-label={`${collapsed ? "Expand" : "Collapse"} ${heading.name}`}
+                              aria-expanded={!collapsed}
+                              onClick={() => toggleHeadingCollapsed(heading.id)}
+                            >
+                              <span
+                                className={`project-page__collapse-glyph${
+                                  collapsed ? "" : " project-page__collapse-glyph--open"
+                                }`}
+                                aria-hidden="true"
+                              >
+                                ▾
+                              </span>
+                            </button>
                             <input
                               className="project-page__heading-input"
                               data-heading-input-id={heading.id}
@@ -1255,6 +1435,7 @@ export function ProjectEditorView({
                             <span className="project-page__heading-count">
                               {headingTodos.length}
                             </span>
+                            <span className="project-page__heading-rule" aria-hidden="true" />
                           </div>
                           <RowMenu
                             label="Heading actions"
@@ -1342,14 +1523,19 @@ export function ProjectEditorView({
                           </RowMenu>
                         </SortableRow>
 
-                        <div className="project-page__section-tasks">
-                          {headingTodos.length === 0 ? (
+                        <div
+                          className={`project-page__section-tasks${
+                            collapsed ? " project-page__section-tasks--collapsed" : ""
+                          }`}
+                        >
+                          {!collapsed && headingTodos.length === 0 ? (
                             <div className="project-page__section-empty">
                               Empty heading. Drop a task here or add one from the menu.
                             </div>
                           ) : null}
 
-                          {headingTodos.map((todo) => {
+                          {!collapsed
+                            ? headingTodos.map((todo) => {
                             const menuId = `todo:${todo.id}`;
                             const dueLabel = formatDueFriendly(todo.dueDate);
 
@@ -1358,6 +1544,7 @@ export function ProjectEditorView({
                                 key={menuId}
                                 id={menuId}
                                 className="project-page__task-row project-page__task-row--nested"
+                                isDropTarget={activeDropTargetId === menuId}
                               >
                                 <label className="project-page__task-check">
                                   <input
@@ -1429,13 +1616,61 @@ export function ProjectEditorView({
                                 </RowMenu>
                               </SortableRow>
                             );
-                          })}
+                            })
+                            : null}
+
+                          {!collapsed ? renderTaskComposer(heading.id) : null}
                         </div>
                       </div>
                     );
                   })}
+                  <div
+                    className={`project-page__heading-composer${
+                      headingComposerOpen ? " project-page__heading-composer--open" : ""
+                    }`}
+                  >
+                    {headingComposerOpen ? (
+                      <>
+                        <input
+                          type="text"
+                          className="project-page__heading-composer-input"
+                          value={headingComposerValue}
+                          placeholder="Type a heading and press Enter"
+                          onChange={(event) => setHeadingComposerValue(event.target.value)}
+                          onBlur={() => {
+                            if (!headingComposerValue.trim()) {
+                              setHeadingComposerOpen(false);
+                            }
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              void handleAddHeadingInline();
+                            }
+                            if (event.key === "Escape") {
+                              setHeadingComposerValue("");
+                              setHeadingComposerOpen(false);
+                            }
+                          }}
+                          autoFocus
+                        />
+                        <span className="project-page__heading-rule" aria-hidden="true" />
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        className="project-page__heading-composer-trigger"
+                        onClick={() => setHeadingComposerOpen(true)}
+                      >
+                        <span className="project-page__heading-rule" aria-hidden="true" />
+                        <span className="project-page__heading-composer-label">New heading</span>
+                      </button>
+                    )}
+                  </div>
                 </div>
               </SortableContext>
+              <DragOverlay dropAnimation={null}>
+                {renderDragOverlay()}
+              </DragOverlay>
             </DndContext>
           )}
         </section>

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -4638,7 +4638,7 @@ body {
   align-items: center;
   justify-content: center;
   padding: var(--s-1h);
-  border: none;
+  border: 1px solid transparent;
   border-radius: var(--r-sm);
   background: transparent;
   color: var(--muted);
@@ -4646,10 +4646,19 @@ body {
   opacity: 0;
   transition:
     opacity var(--dur-fast) ease,
-    background var(--dur-fast) ease;
+    background var(--dur-fast) ease,
+    border-color var(--dur-fast) ease,
+    color var(--dur-fast) ease;
+}
+
+.project-page .project-kebab__trigger {
+  opacity: 0.72;
+  border-color: color-mix(in oklab, var(--border-light) 88%, transparent);
+  background: color-mix(in oklab, var(--surface) 78%, transparent);
 }
 
 .project-workspace__title-row:hover .project-kebab__trigger,
+.project-page__topbar-actions:hover .project-kebab__trigger,
 .project-kebab__trigger:focus-visible,
 .project-kebab__trigger[aria-expanded="true"] {
   opacity: 1;
@@ -4658,6 +4667,7 @@ body {
 .project-kebab__trigger:hover {
   background: var(--surface-2);
   color: var(--text);
+  border-color: var(--border);
 }
 
 .project-kebab__menu {

--- a/client-react/src/styles/project-editor.css
+++ b/client-react/src/styles/project-editor.css
@@ -13,7 +13,6 @@
 .project-page__topbar-actions,
 .project-page__header,
 .project-page__header-meta,
-.project-page__composer,
 .project-page__heading-row,
 .project-page__task-row,
 .project-page__settings-actions {
@@ -22,7 +21,6 @@
 }
 
 .project-page__topbar,
-.project-page__composer,
 .project-page__heading-row,
 .project-page__task-row {
   justify-content: space-between;
@@ -60,9 +58,7 @@
 .project-page__topbar,
 .project-page__header,
 .project-page__list-shell,
-.project-page__composer,
 .project-page__draft-hint,
-.project-page__heading-draft,
 .project-page__settings,
 .project-page .bulk-toolbar {
   width: min(100%, 72rem);
@@ -124,9 +120,9 @@
 
 .project-page__settings,
 .project-page__list-shell {
-  border: 1px solid var(--border-light);
-  border-radius: var(--r-lg);
-  background: var(--surface);
+  border: none;
+  border-radius: 0;
+  background: transparent;
   box-shadow: none;
 }
 
@@ -175,33 +171,12 @@
   resize: vertical;
 }
 
-.project-page__composer {
-  gap: var(--s-2);
-  padding: var(--s-2) 0;
-  border-top: 1px solid var(--border-light);
-  border-bottom: 1px solid var(--border-light);
-}
-
 .project-page__quick-add {
   flex: 1;
 }
 
-.project-page__heading-draft {
-  display: flex;
-  gap: var(--s-2);
-  align-items: center;
-  padding: var(--s-2);
-  border: 1px solid var(--border-light);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-}
-
-.project-page__heading-draft .project-page__input {
-  flex: 1;
-}
-
 .project-page__list-shell {
-  padding: var(--s-3) var(--s-3) var(--s-4);
+  padding: 0 0 var(--s-4);
 }
 
 .project-page__list {
@@ -224,57 +199,60 @@
 .project-page__heading-row,
 .project-page__task-row {
   gap: var(--s-2);
-  padding: 0.75rem 0.9rem;
-  border-radius: var(--r-md);
-  background: var(--surface);
+  padding: 0.45rem 0;
+  border-radius: 0;
+  background: transparent;
   transition:
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
     background var(--dur-fast) var(--ease-out),
     border-color var(--dur-fast) var(--ease-out),
     box-shadow var(--dur-fast) var(--ease-out);
 }
 
 .project-page__heading-row {
-  border: 1px solid transparent;
+  border: none;
   background: transparent;
-  padding: 0.3rem 0;
+  padding: 0.3rem 0 0.2rem;
 }
 
 .project-page__task-row {
-  border: 1px solid var(--border-light);
+  border: none;
+  border-bottom: 1px solid color-mix(in oklab, var(--border-light) 92%, transparent);
 }
 
 .project-page__task-row:hover,
 .project-page__heading-row:hover {
-  border-color: var(--border);
   box-shadow: none;
 }
 
 .project-page__task-row:hover {
-  background: var(--surface-2);
+  background: color-mix(in oklab, var(--surface-2) 42%, transparent);
 }
 
 .project-page__heading-row:hover {
-  background: color-mix(in oklab, var(--surface-2) 52%, transparent);
+  background: color-mix(in oklab, var(--surface-2) 38%, transparent);
 }
 
 .project-page__task-row:focus-within,
 .project-page__heading-row:focus-within {
-  border-color: color-mix(in oklab, var(--accent) 30%, transparent);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 12%, transparent);
+  box-shadow: inset 0 -1px 0 color-mix(in oklab, var(--accent) 28%, transparent);
 }
 
 .project-page__section-tasks {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-top: 0.5rem;
-  padding-left: 2.35rem;
-  border-left: 1px solid color-mix(in oklab, var(--border-light) 90%, transparent);
-  margin-left: 0.4rem;
+  margin-top: 0.55rem;
+  padding-left: 1.8rem;
+  margin-left: 0.9rem;
 }
 
 .project-page__task-row--nested {
   margin-left: 0;
+}
+
+.project-page__section-tasks--collapsed {
+  display: none;
 }
 
 .project-page__drag-handle {
@@ -311,21 +289,89 @@
 
 .project-page__heading-copy {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--s-2);
   flex: 1;
   min-width: 0;
+}
+
+.project-page__sortable-row--dragging {
+  z-index: 2;
+}
+
+.project-page__sortable-row--drop-target {
   position: relative;
 }
 
-.project-page__heading-copy::after {
+.project-page__sortable-row--drop-target::after {
   content: "";
+  position: absolute;
+  left: 1.85rem;
+  right: 0;
+  bottom: -0.15rem;
+  height: 2px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 68%, var(--border-light));
+}
+
+.project-page__section--drop-target .project-page__heading-rule {
+  background: color-mix(in oklab, var(--accent) 68%, transparent);
+}
+
+.project-page__drag-overlay {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  min-width: min(100%, 58rem);
+  padding: 0.75rem 0.9rem;
+  border: 1px solid color-mix(in oklab, var(--accent) 12%, var(--border-light));
+  border-radius: var(--r-md);
+  background: color-mix(in oklab, var(--surface) 94%, white);
+  box-shadow: 0 12px 28px color-mix(in oklab, var(--ink) 12%, transparent);
+  transform: rotate(-0.4deg);
+}
+
+.project-page__drag-handle--overlay {
+  opacity: 1;
+  pointer-events: none;
+}
+
+.project-page__heading-rule {
   flex: 1;
   min-width: 2rem;
   height: 1px;
-  margin-left: 0.35rem;
-  transform: translateY(-0.18rem);
+  margin-left: 0.15rem;
   background: color-mix(in oklab, var(--border) 58%, transparent);
+}
+
+.project-page__collapse-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.3rem;
+  height: 1.3rem;
+  padding: 0;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--muted);
+}
+
+.project-page__collapse-toggle:hover {
+  background: color-mix(in oklab, var(--surface-2) 56%, transparent);
+  color: var(--text);
+}
+
+.project-page__collapse-glyph {
+  display: inline-block;
+  font-size: 0.9rem;
+  line-height: 1;
+  transform: rotate(-90deg);
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
+.project-page__collapse-glyph--open {
+  transform: rotate(0deg);
 }
 
 .project-page__heading-title,
@@ -362,12 +408,11 @@
 
 .project-page__section-empty {
   margin-left: 0.1rem;
-  padding: 0.7rem 0.9rem;
-  border-left: 1px solid color-mix(in oklab, var(--border) 40%, transparent);
+  padding: 0.35rem 0;
   color: var(--muted);
   font-size: 0.95rem;
-  background: color-mix(in oklab, var(--surface-2) 68%, var(--surface));
-  border-radius: 0 var(--r-md) var(--r-md) 0;
+  background: transparent;
+  border-radius: 0;
 }
 
 .project-page__task-check {
@@ -396,6 +441,135 @@
   color: var(--muted);
   font-size: var(--fs-meta);
   white-space: nowrap;
+}
+
+.project-page__task-composer {
+  padding-left: 1.8rem;
+  margin-left: 0.9rem;
+}
+
+.project-page__task-composer-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  padding: 0.35rem 0;
+  border: none;
+  background: transparent;
+  color: var(--muted-light);
+  text-align: left;
+}
+
+.project-page__task-composer-plus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 999px;
+  color: var(--muted);
+  background: transparent;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.project-page__task-composer-trigger:hover .project-page__task-composer-plus,
+.project-page__task-composer-trigger:focus-visible .project-page__task-composer-plus {
+  background: color-mix(in oklab, var(--accent) 88%, white);
+  color: white;
+}
+
+.project-page__task-composer-label {
+  font-size: var(--fs-meta);
+  white-space: nowrap;
+}
+
+.project-page__task-composer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.25rem 0 0.35rem;
+}
+
+.project-page__task-composer-input {
+  width: 100%;
+  min-height: 2.5rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 1rem;
+}
+
+.project-page__task-composer-input:focus {
+  outline: none;
+}
+
+.project-page__task-composer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.project-page__heading-composer {
+  margin-top: 0.75rem;
+  padding-left: 1.8rem;
+  margin-left: 0.9rem;
+}
+
+.project-page__heading-composer-trigger,
+.project-page__heading-composer--open {
+  width: 100%;
+}
+
+.project-page__heading-composer-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.25rem 0;
+  border: none;
+  background: transparent;
+  color: var(--muted-light);
+  opacity: 0.28;
+  transition: opacity var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
+}
+
+.project-page__heading-composer:hover .project-page__heading-composer-trigger,
+.project-page__heading-composer-trigger:focus-visible,
+.project-page__heading-composer--open {
+  opacity: 1;
+}
+
+.project-page__heading-composer-trigger:hover {
+  color: var(--muted);
+}
+
+.project-page__heading-composer-label {
+  font-size: var(--fs-meta);
+  white-space: nowrap;
+}
+
+.project-page__heading-composer--open {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.project-page__heading-composer-input {
+  min-width: 14rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-strong);
+  font: inherit;
+  font-size: 1.02rem;
+  font-weight: var(--fw-semibold);
+}
+
+.project-page__heading-composer-input:focus {
+  outline: none;
 }
 
 .project-page__menu {
@@ -513,9 +687,7 @@
   .project-page__title,
   .project-page__header-meta,
   .project-page__list-shell,
-  .project-page__composer,
   .project-page__draft-hint,
-  .project-page__heading-draft,
   .project-page__settings,
   .project-page .bulk-toolbar {
     width: 100%;
@@ -525,14 +697,13 @@
     grid-template-columns: 1fr;
   }
 
-  .project-page__composer,
-  .project-page__heading-draft,
   .project-page__task-row,
   .project-page__heading-row {
     flex-wrap: wrap;
   }
 
-  .project-page__task-row--nested {
+  .project-page__section-tasks {
+    padding-left: 1rem;
     margin-left: 0;
   }
 


### PR DESCRIPTION
## Summary
This PR continues the project page redesign so the editor reads more like authoring a project page than filling out a settings form.

The main user-facing changes are:
- flatten the project editor onto the app canvas instead of a distinct background panel
- replace the global task add row with inline task composers that appear at real insertion points
- add a subtle inline heading composer at the end of the page flow
- make headings collapsible and allow dropping tasks into collapsed sections
- add visible drop targets during drag and drop so the insertion point is obvious
- refine drag behavior to feel less jumpy with a drag overlay and clearer movement feedback
- make the project metadata/actions kebab in the header easier to discover

## Root cause
The previous project editor still behaved like a control surface: a dedicated add row, separate add-heading controls, card-like task boxes, and low-discoverability actions. That created too much visual chrome and made the page feel detached from the rest of the app.

## Fix
The editor now uses inline composition and lighter structure:
- task creation happens inline at the project level and at the end of each heading section
- project-level unsectioned tasks always keep their own composer before the first heading when backlog is empty, and after the last backlog task once backlog exists
- heading creation is moved to a subtle end-of-page affordance instead of a persistent top-level control
- headings render with a clearer rule line and can collapse/expand their task list
- dropping onto a collapsed heading appends the task into that section without forcing it open
- drag targets render visually so the user can see where the drop will land
- the project kebab keeps metadata/settings hidden by default but is more visible on the project page

## Validation
Validated with:
- `npx tsc --noEmit`
- `npm run format:check`
- `npm --prefix client-react test -- ProjectEditorView`
- `npm --prefix client-react test -- ProjectKebabMenu`

I did not run the full UI suite in this final pass; the focused component coverage for the touched surfaces is green.
