### PR TITLE
[codex] fix project editor todo order type

### DIFF
--- a/client-react/src/types/index.ts
+++ b/client-react/src/types/index.ts
@@ -179,6 +179,7 @@ export interface UpdateTodoDto {
   projectId?: string | null;
   category?: string | null;
   dueDate?: string | null;
+  order?: number;
   priority?: Priority | null;
   tags?: string[];
   notes?: string | null;


### PR DESCRIPTION
## Summary
This fixes the follow-up TypeScript regression from the project page inline editing work.

## Root cause
The server-side canonical `UpdateTodoDto` already included `order`, but the React client copy in `client-react/src/types/index.ts` did not. The new project editor code uses `order` when dropping a task into a collapsed heading section, so TypeScript rejected the client build even though the API contract already supported that field.

## Fix
Add `order?: number` to the client-side `UpdateTodoDto` so the React type matches the canonical server contract.

## Validation
- `npx tsc --noEmit`
- `npm run format:check`
