### PR TITLE
fix(ui): fix remaining TypeScript errors in Phase 13 test files

### DIFF
--- a/client-react/src/components/shared/ProfileLauncher.test.tsx
+++ b/client-react/src/components/shared/ProfileLauncher.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, createElement } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { ProfileLauncher } from "./ProfileLauncher";
 

--- a/client-react/src/components/shared/TaskPicker.test.tsx
+++ b/client-react/src/components/shared/TaskPicker.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, createElement } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { TaskPicker } from "./TaskPicker";
 import type { Todo } from "../../types";

--- a/client-react/src/mobile/components/QuickCapture.test.tsx
+++ b/client-react/src/mobile/components/QuickCapture.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, createElement } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { QuickCapture } from "./QuickCapture";
 

--- a/client-react/src/mobile/screens/TodayScreen.test.tsx
+++ b/client-react/src/mobile/screens/TodayScreen.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, createElement } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import { TodayScreen } from "./TodayScreen";
 import type { Todo, Project, User } from "../../types";


### PR DESCRIPTION
Fixes remaining CI failures from PR #911:\n\n- Fix `createElement` import: `@testing-library/react` → `React` (4 files)\n\nNo functional changes — test-only fix.