### PR TITLE
fix(ui): use string literals for Todo createdAt/updatedAt dates

### DIFF
--- a/client-react/src/components/shared/TaskPicker.test.tsx
+++ b/client-react/src/components/shared/TaskPicker.test.tsx
@@ -39,8 +39,8 @@ function makeTodo(overrides: Partial<Todo> = {}): Todo {
     effortScore: null,
     frustrationScore: null,
     userId: "u1",
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: "2026-01-01T00:00:00.000Z" as unknown as Date,
+    updatedAt: "2026-01-01T00:00:00.000Z" as unknown as Date,
     deletedAt: null,
     ...overrides,
   };

--- a/client-react/src/mobile/screens/TodayScreen.test.tsx
+++ b/client-react/src/mobile/screens/TodayScreen.test.tsx
@@ -51,8 +51,8 @@ function makeTodo(overrides: Partial<Todo> = {}): Todo {
     effortScore: null,
     frustrationScore: null,
     userId: "u1",
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: "2026-01-01T00:00:00.000Z" as unknown as Date,
+    updatedAt: "2026-01-01T00:00:00.000Z" as unknown as Date,
     deletedAt: null,
     ...overrides,
   };


### PR DESCRIPTION
Fixes remaining `Date is not assignable to string` CI errors.\n\nUses string date literals (as used by existing passing tests) instead of `new Date()` for `createdAt`/`updatedAt` fields.