### PR TITLE
[codex] stabilize local db and domain routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,43 @@ Important current limitations:
 - `npm run docker:reset` - Reset Docker volumes (deletes all data)
 - `npm run docker:logs` - View PostgreSQL logs
 
+### Local Domain Routing
+
+To use a stable local host alias on this laptop without touching production or staging:
+
+1. Add an `/etc/hosts` entry:
+
+```bash
+echo '127.0.0.1 dev.todos.karthikg.in' | sudo tee -a /etc/hosts
+```
+
+2. Start the API on port `3000`:
+
+```bash
+npm run dev
+```
+
+3. Start the React dev server on port `5173`:
+
+```bash
+npm run dev:react
+```
+
+4. Open the app at:
+
+```text
+http://dev.todos.karthikg.in:5173/app/
+```
+
+The Vite config explicitly allows `dev.todos.karthikg.in`, and API requests continue to proxy to the backend on `http://localhost:3000`.
+
+If you need the backend to generate links for the local host alias, set:
+
+```bash
+BASE_URL=http://dev.todos.karthikg.in:3000
+GOOGLE_REDIRECT_URI=http://dev.todos.karthikg.in:3000/auth/google/callback
+```
+
 ### Testing
 
 - `npm test` - Run all tests

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const localAllowedHosts = ["dev.todos.karthikg.in"];
+
 export default defineConfig({
   plugins: [react()],
   base: "/app/",
@@ -10,10 +12,12 @@ export default defineConfig({
   },
   preview: {
     host: "127.0.0.1",
+    allowedHosts: localAllowedHosts,
     port: 4173,
     strictPort: true,
   },
   server: {
+    allowedHosts: localAllowedHosts,
     proxy: {
       "/auth": "http://localhost:3000",
       "/todos": "http://localhost:3000",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: todos-api
+
 version: "3.9"
 
 services:


### PR DESCRIPTION
## Summary

Audit and tighten the recently added local PostgreSQL development setup, then add the minimum repo support needed for `dev.todos.karthikg.in` in local development.

This change keeps the local DB on the existing named Docker volume, stabilizes Compose project naming across linked worktrees, and allows the React dev server to answer the requested local host alias. It does not change production or staging behavior.

## Root Cause

The local Postgres setup was close, but it still had a few brittle edges:

- Compose project identity varied by checkout path, which can create extra containers from linked worktrees even while sharing the same explicit volume.
- Vite was not explicitly configured to allow `dev.todos.karthikg.in`, so host-based local routing could fail even with an `/etc/hosts` entry.
- The local domain workflow was not documented alongside the DB scripts and startup path.

## Fix

- Set the Compose project name explicitly to `todos-api` in `docker-compose.yml` so linked worktrees target the same local project consistently.
- Allow `dev.todos.karthikg.in` in both Vite dev and preview config.
- Document the exact `/etc/hosts`, backend, frontend, and optional `BASE_URL` / `GOOGLE_REDIRECT_URI` steps in the README.

## Validation

- `npx tsc --noEmit`
- `npm run format:check`
- `npm --prefix client-react run build`
- `CI=1 npm run test:ui:fast`
- Live Docker persistence check: wrote a probe row to `todos_dev`, ran `docker compose down`, recreated the container, and confirmed the row still existed on the named volume
