### PR TITLE
fix(ci): add debug logging to ui-e2e test detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,14 @@ jobs:
       - name: Verify tests/ui exists — must fail on release/manual
         id: check-ui-tests
         run: |
+          echo "=== Debug: working directory ==="
+          pwd
+          echo "=== Debug: ls -la ==="
+          ls -la
+          echo "=== Debug: tests/ui contents ==="
+          ls -la tests/ui/ 2>&1 || echo "tests/ui/ NOT FOUND"
+          echo "=== Debug: find spec files ==="
+          find tests/ui -type f \( -name '*.spec.ts' -o -name '*.test.ts' \) 2>&1 || echo "find returned error"
           if [ -d "tests/ui" ] && [ "$(find tests/ui -type f \( -name '*.spec.ts' -o -name '*.test.ts' \) | head -1)" ]; then
             echo "ui_tests_present=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Adds debug output (pwd, ls, find) to the ui-e2e test detection step to diagnose why `tests/ui/` appears to be missing on master push despite the files existing in the commit.