### PR TITLE
fix(ci): fix ui-e2e test detection and download-artifact path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,19 +466,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ui-build
+          path: .
 
       - name: Verify tests/ui exists — must fail on release/manual
         id: check-ui-tests
         run: |
           echo "=== Debug: working directory ==="
           pwd
-          echo "=== Debug: ls -la ==="
-          ls -la
-          echo "=== Debug: tests/ui contents ==="
+          echo "=== Debug: ls tests/ui ==="
           ls -la tests/ui/ 2>&1 || echo "tests/ui/ NOT FOUND"
-          echo "=== Debug: find spec files ==="
-          find tests/ui -type f \( -name '*.spec.ts' -o -name '*.test.ts' \) 2>&1 || echo "find returned error"
-          if [ -d "tests/ui" ] && [ "$(find tests/ui -type f \( -name '*.spec.ts' -o -name '*.test.ts' \) | head -1)" ]; then
+          TEST_FILES=$(find tests/ui -type f \( -name '*.spec.ts' -o -name '*.test.ts' \) 2>/dev/null)
+          echo "=== Debug: test files found ==="
+          echo "$TEST_FILES"
+          if [ -d "tests/ui" ] && [ -n "$TEST_FILES" ]; then
             echo "ui_tests_present=true" >> "$GITHUB_OUTPUT"
           else
             echo "::error::tests/ui/ is missing or has no spec/test files — E2E cannot run on release/manual trigger"


### PR DESCRIPTION
- Add explicit `path: .` to `download-artifact@v4` to ensure UI build lands in repo root\n- Simplify test detection: store `find` output in variable, use `-n` test instead of pipeline through `head -1`\n- Cleaner debug output