### PR TITLE
ci: add React Vitest unit tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,36 @@ jobs:
         run: npm run test:mcp
 
   # ─────────────────────────────────────────────────────────────
+  # 2h. React Vitest tests (PRs: frontend/workflow changes; master: always)
+  # ─────────────────────────────────────────────────────────────
+  react-tests:
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.workflow == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: client-react/package-lock.json
+
+      - name: Install dependencies
+        working-directory: client-react
+        run: npm ci
+
+      - name: Run Vitest
+        working-directory: client-react
+        run: npm test
+
+  # ─────────────────────────────────────────────────────────────
   # 3. Cross-client sync (only when shared contracts change or on master)
   # ─────────────────────────────────────────────────────────────
   cross-client-sync:


### PR DESCRIPTION
## Summary

Adds a new `react-tests` job to the CI workflow so the 743 Vitest tests in `client-react/` run on every relevant PR and on master pushes.

### What changed

**Job:** `react-tests` (added to `.github/workflows/ci.yml`)

**Triggers:**
- **Pull requests** — when `frontend` paths (`client-react/**`, `playwright.config.ts`, `package.json`, `package-lock.json`) or `workflow` paths (`.github/workflows/**`) change
- **Push to master** — always runs (the `github.event_name != 'pull_request'` clause)

**Commands:**
1. `npm --prefix client-react ci` — installs React client dependencies
2. `npm --prefix client-react test` — runs `vitest run`

**Cache:**
- Uses `actions/setup-node@v4` built-in npm cache
- `cache-dependency-path: client-react/package-lock.json` — scopes the cache to the React client lockfile specifically, avoiding stale root-level cache hits

### Why no coverage threshold

Coverage gating is **intentionally left out** of this change:
1. We first need Vitest green in CI to build trust in the signal
2. Coverage threshold calibration (baseline %, which directories to include/exclude) is a separate policy decision
3. Adding a threshold now would risk flaky PRs while the test suite is still actively growing

Coverage thresholds will be added in a follow-up once the suite is stable and the team agrees on a target.

### CI job placement

Inserted as **2h** between `mcp` (2g) and `cross-client-sync` (3), matching the existing numbering convention and placement style of the workflow.