### PR TITLE
fix(tests): fix TodayScreen test ambiguity — task title collides with group heading

### DIFF
--- a/client-react/src/mobile/screens/TodayScreen.test.tsx
+++ b/client-react/src/mobile/screens/TodayScreen.test.tsx
@@ -107,11 +107,13 @@ describe("TodayScreen", () => {
   it("groups scheduled tasks with future due dates", () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const scheduled = makeTodo({ title: "Scheduled", dueDate: tomorrow.toISOString().split("T")[0] });
+    const scheduled = makeTodo({ title: "Future task", dueDate: tomorrow.toISOString().split("T")[0] });
 
     render(ce(TodayScreen, { ...defaultProps, todos: [scheduled] }));
+    // Group title exists
     expect(screen.getByText("Scheduled")).toBeTruthy();
-    expect(screen.getByText("Scheduled")).toBeTruthy();
+    // Task title exists in the group
+    expect(screen.getByText("Future task")).toBeTruthy();
   });
 
   it("excludes completed tasks", () => {


### PR DESCRIPTION
The task titled `Scheduled` collided with the `<h2>Scheduled</h2>` group heading, causing TestingLibrary to find multiple elements and fail in CI (jsdom is stricter about exact text matching).\n\n**Fix:** renamed the task to `Future task` to eliminate the collision.