### PR TITLE
fix(tests): fix ActiveFilters type in appShellFilters test

### DIFF
--- a/client-react/src/components/layout/appShellFilters.test.ts
+++ b/client-react/src/components/layout/appShellFilters.test.ts
@@ -49,9 +49,8 @@ function makeTodo(overrides: Partial<Todo> = {}): Todo {
 
 const defaultFilters = {
   dateFilter: "all" as const,
-  priority: null as string | null,
-  status: null as string | null,
-  tag: null as string | null,
+  priority: "" as const,
+  status: "" as const,
 };
 
 describe("appShellFilters", () => {


### PR DESCRIPTION
ActiveFilters uses `Priority | ""` and `TodoStatus | ""` (not null). Fixed defaultFilters to match the actual type.