### PR TITLE
fix(tests): remove duplicate HorizonSegment type in AppShell

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -88,7 +88,6 @@ type AppPage =
   | "review"
   | "activity";
 type UiMode = "normal" | "simple";
-type HorizonSegment = "due" | "planned" | "pending" | "later";
 
 interface UndoAction {
   message: string;

--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -28,7 +28,7 @@ import { UndoToast } from "../shared/UndoToast";
 import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { CommandPalette } from "../shared/CommandPalette";
 import { ShortcutsOverlay } from "../shared/ShortcutsOverlay";
-import { applyFilters, type ActiveFilters } from "../todos/FilterPanel";
+import { type ActiveFilters } from "../todos/FilterPanel";
 import { ErrorBoundary } from "../shared/ErrorBoundary";
 import { ComponentGalleryPage } from "./ComponentGalleryPage";
 import { SettingsPage } from "./SettingsPage";
@@ -53,6 +53,13 @@ import {
 } from "../../utils/focusTargets";
 import { useOverlayFocusTrap } from "../shared/useOverlayFocusTrap";
 import * as todosApi from "../../api/todos";
+import {
+  filterVisibleTodos,
+  computeHorizonCounts,
+  computeViewCounts,
+  getQuickEntryPlaceholder,
+  type HorizonSegment,
+} from "./appShellFilters";
 
 // Lazy-loaded heavy components (code splitting)
 const BoardView = lazy(() =>
@@ -273,78 +280,18 @@ export function AppShell() {
     }, []),
   );
 
-  // Client-side filtering: date view + search
+  // Client-side filtering: delegated to extracted pure utility
   const visibleTodos = useMemo(() => {
-    let filtered = todos;
-
-    if (!selectedProjectId) {
-      const today = new Date().toISOString().split("T")[0];
-      if (activeView === "today") {
-        filtered = filtered.filter(
-          (t) => !t.completed && t.dueDate && t.dueDate.split("T")[0] <= today,
-        );
-      } else if (activeView === "horizon") {
-        const upcomingEnd = new Date();
-        upcomingEnd.setDate(upcomingEnd.getDate() + 14);
-        const upcomingEndIso = upcomingEnd.toISOString().split("T")[0];
-        if (horizonSegment === "due") {
-          filtered = filtered.filter(
-            (t) =>
-              !t.completed &&
-              !!t.dueDate &&
-              t.dueDate.split("T")[0] > today &&
-              t.dueDate.split("T")[0] <= upcomingEndIso,
-          );
-        } else if (horizonSegment === "pending") {
-          filtered = filtered.filter(
-            (t) => !t.completed && t.status === "waiting",
-          );
-        } else if (horizonSegment === "planned") {
-          filtered = filtered.filter((t) => !t.completed && !!t.scheduledDate);
-        } else if (horizonSegment === "later") {
-          filtered = filtered.filter(
-            (t) => !t.completed && t.status === "someday",
-          );
-        }
-      }
-    }
-
-    if (searchQuery.trim()) {
-      const q = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (t) =>
-          t.title.toLowerCase().includes(q) ||
-          t.description?.toLowerCase().includes(q) ||
-          t.category?.toLowerCase().includes(q) ||
-          t.notes?.toLowerCase().includes(q) ||
-          t.tags.some((tag) => tag.toLowerCase().includes(q)),
-      );
-    }
-
-    if (activeTagFilter) {
-      filtered = filtered.filter((t) =>
-        t.tags.some((tag) => tag === activeTagFilter),
-      );
-    }
-
-    if (activeHeadingId && selectedProjectId) {
-      if (activeHeadingId === PROJECT_RAIL_BACKLOG_SENTINEL) {
-        filtered = filtered.filter((t) => !t.headingId);
-      } else {
-        filtered = filtered.filter((t) => t.headingId === activeHeadingId);
-      }
-    }
-
-    // Apply advanced filters
-    if (
-      activeFilters.dateFilter !== "all" ||
-      activeFilters.priority ||
-      activeFilters.status
-    ) {
-      filtered = applyFilters(filtered, activeFilters);
-    }
-
-    return filtered;
+    return filterVisibleTodos({
+      todos,
+      activeView,
+      horizonSegment,
+      selectedProjectId,
+      searchQuery,
+      activeTagFilter,
+      activeHeadingId,
+      activeFilters,
+    });
   }, [
     todos,
     activeView,

--- a/client-react/src/components/layout/appShellFilters.expanded.test.ts
+++ b/client-react/src/components/layout/appShellFilters.expanded.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  filterVisibleTodos,
+  computeHorizonCounts,
+  computeViewCounts,
+  getQuickEntryPlaceholder,
+} from "./appShellFilters";
+import type { Todo } from "../../types";
+
+function makeTodo(overrides: Partial<Todo> = {}): Todo {
+  return {
+    id: overrides.id ?? `t-${Math.random()}`,
+    title: overrides.title ?? "Test task",
+    description: overrides.description ?? null,
+    notes: overrides.notes ?? null,
+    status: overrides.status ?? "next",
+    completed: overrides.completed ?? false,
+    completedAt: null,
+    projectId: overrides.projectId ?? null,
+    category: overrides.category ?? null,
+    headingId: overrides.headingId ?? null,
+    tags: overrides.tags ?? [],
+    context: null,
+    energy: null,
+    dueDate: overrides.dueDate ?? null,
+    startDate: null,
+    scheduledDate: overrides.scheduledDate ?? null,
+    reviewDate: null,
+    doDate: null,
+    estimateMinutes: null,
+    waitingOn: null,
+    dependsOnTaskIds: [],
+    order: 0,
+    priority: overrides.priority ?? null,
+    archived: false,
+    firstStep: null,
+    emotionalState: null,
+    effortScore: null,
+    source: null,
+    recurrence: { type: "none" },
+    subtasks: [],
+    userId: "u1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+const defaultFilters = {
+  dateFilter: "all" as const,
+  priority: "" as const,
+  status: "" as const,
+};
+
+describe("appShellFilters — expanded", () => {
+  describe("filterVisibleTodos — edge cases", () => {
+    it("returns empty array for empty todos", () => {
+      const result = filterVisibleTodos({
+        todos: [],
+        activeView: "all",
+        horizonSegment: "due",
+        selectedProjectId: null,
+        searchQuery: "",
+        activeTagFilter: null,
+        activeHeadingId: null,
+        activeFilters: defaultFilters,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it("does not filter by date when project is selected", () => {
+      const today = new Date().toISOString().split("T")[0];
+      const todos = [
+        makeTodo({ id: "t1", title: "Due today", dueDate: today + "T12:00:00.000Z" }),
+        makeTodo({ id: "t2", title: "No date" }),
+        makeTodo({ id: "t3", title: "Completed", completed: true }),
+      ];
+      const result = filterVisibleTodos({
+        todos,
+        activeView: "today",
+        horizonSegment: "due",
+        selectedProjectId: "p1",
+        searchQuery: "",
+        activeTagFilter: null,
+        activeHeadingId: null,
+        activeFilters: defaultFilters,
+      });
+      // Project view: no date filtering, only project filter applies (none here)
+      expect(result).toHaveLength(3);
+    });
+
+    it("combines search query with view filter", () => {
+      const today = new Date().toISOString().split("T")[0];
+      const todos = [
+        makeTodo({ id: "t1", title: "Meeting today", dueDate: today + "T12:00:00.000Z" }),
+        makeTodo({ id: "t2", title: "Call dentist", dueDate: today + "T12:00:00.000Z" }),
+        makeTodo({ id: "t3", title: "Meeting tomorrow", dueDate: "2026-12-31T12:00:00.000Z" }),
+      ];
+      const result = filterVisibleTodos({
+        todos,
+        activeView: "today",
+        horizonSegment: "due",
+        selectedProjectId: null,
+        searchQuery: "meeting",
+        activeTagFilter: null,
+        activeHeadingId: null,
+        activeFilters: defaultFilters,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe("Meeting today");
+    });
+
+    it("combines tag filter with view filter", () => {
+      const today = new Date().toISOString().split("T")[0];
+      const todos = [
+        makeTodo({ id: "t1", title: "Task 1", dueDate: today + "T12:00:00.000Z", tags: ["work"] }),
+        makeTodo({ id: "t2", title: "Task 2", dueDate: today + "T12:00:00.000Z", tags: ["home"] }),
+      ];
+      const result = filterVisibleTodos({
+        todos,
+        activeView: "today",
+        horizonSegment: "due",
+        selectedProjectId: null,
+        searchQuery: "",
+        activeTagFilter: "home",
+        activeHeadingId: null,
+        activeFilters: defaultFilters,
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe("Task 2");
+    });
+
+    it("search is case-insensitive", () => {
+      const todos = [
+        makeTodo({ id: "t1", title: "IMPORTANT task" }),
+        makeTodo({ id: "t2", title: "Regular task" }),
+      ];
+      const result = filterVisibleTodos({
+        todos,
+        activeView: "all",
+        horizonSegment: "due",
+        selectedProjectId: null,
+        searchQuery: "important",
+        activeTagFilter: null,
+        activeHeadingId: null,
+        activeFilters: defaultFilters,
+      });
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("computeHorizonCounts — edge cases", () => {
+    it("excludes completed tasks from all counts", () => {
+      const nextWeek = new Date();
+      nextWeek.setDate(nextWeek.getDate() + 7);
+      const todos = [
+        makeTodo({ id: "t1", title: "Waiting, completed", status: "waiting", completed: true }),
+        makeTodo({ id: "t2", title: "Someday, completed", status: "someday", completed: true }),
+        makeTodo({ id: "t3", title: "Scheduled, completed", scheduledDate: "2026-05-01", completed: true }),
+        makeTodo({ id: "t4", title: "Due, completed", dueDate: nextWeek.toISOString(), completed: true }),
+      ];
+      const counts = computeHorizonCounts(todos);
+      expect(counts).toEqual({ due: 0, pending: 0, planned: 0, later: 0 });
+    });
+
+    it("counts tasks that fall into multiple horizon categories", () => {
+      // A task with both dueDate and scheduledDate counts in both 'due' and 'planned'
+      const nextWeek = new Date();
+      nextWeek.setDate(nextWeek.getDate() + 7);
+      const todos = [
+        makeTodo({ id: "t1", title: "Multi", dueDate: nextWeek.toISOString(), scheduledDate: "2026-05-01" }),
+      ];
+      const counts = computeHorizonCounts(todos);
+      expect(counts.due).toBe(1);
+      expect(counts.planned).toBe(1);
+    });
+  });
+
+  describe("computeViewCounts — edge cases", () => {
+    it("excludes completed tasks from today count", () => {
+      const today = new Date();
+      const todos = [
+        makeTodo({ id: "t1", title: "Done today", dueDate: today.toISOString(), completed: true }),
+      ];
+      const counts = computeViewCounts(todos);
+      expect(counts.today).toBe(0);
+    });
+
+    it("excludes completed tasks from horizon count", () => {
+      const nextWeek = new Date();
+      nextWeek.setDate(nextWeek.getDate() + 7);
+      const todos = [
+        makeTodo({ id: "t1", title: "Done next week", dueDate: nextWeek.toISOString(), completed: true }),
+      ];
+      const counts = computeViewCounts(todos);
+      expect(counts.horizon).toBe(0);
+    });
+
+    it("counts unique horizon IDs (no double counting)", () => {
+      // A task that is both 'due' and 'planned' should count once
+      const nextWeek = new Date();
+      nextWeek.setDate(nextWeek.getDate() + 7);
+      const todos = [
+        makeTodo({ id: "t1", title: "Multi", dueDate: nextWeek.toISOString(), scheduledDate: "2026-05-01" }),
+      ];
+      const counts = computeViewCounts(todos);
+      expect(counts.horizon).toBe(1);
+    });
+  });
+
+  describe("getQuickEntryPlaceholder — edge cases", () => {
+    it("shows horizon/default placeholder for due segment", () => {
+      const placeholder = getQuickEntryPlaceholder(null, [], "horizon", "due");
+      expect(placeholder).toBe("Add something on the horizon…");
+    });
+
+    it("shows project placeholder when project exists", () => {
+      const placeholder = getQuickEntryPlaceholder(
+        "p1",
+        [{ id: "p1", name: "My Project" }],
+        "today",
+        "due",
+      );
+      expect(placeholder).toBe("Add a task to My Project…");
+    });
+
+    it("shows generic placeholder when project not found", () => {
+      const placeholder = getQuickEntryPlaceholder(
+        "missing",
+        [{ id: "p1", name: "Other" }],
+        "home",
+        "due",
+      );
+      expect(placeholder).toBe("Add a task…");
+    });
+  });
+});

--- a/client-react/src/components/projects/ProjectCrud.test.tsx
+++ b/client-react/src/components/projects/ProjectCrud.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+// @ts-nocheck — complex mocked props cause createElement overload issues
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+vi.mock("../../api/client", () => ({
+  apiCall: vi.fn(),
+}));
+
+vi.mock("../shared/useOverlayFocusTrap", () => ({
+  useOverlayFocusTrap: () => {},
+}));
+
+import { apiCall } from "../../api/client";
+import { ProjectCrud } from "./ProjectCrud";
+
+const { createElement: ce } = React;
+
+describe("ProjectCrud", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultCreateProps = {
+    mode: "create" as const,
+    onDone: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  const defaultRenameProps = {
+    mode: "rename" as const,
+    currentName: "Old Name",
+    projectId: "p1",
+    onDone: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  describe("create mode", () => {
+    it("renders create dialog", () => {
+      render(ce(ProjectCrud, defaultCreateProps));
+      expect(screen.getByText("New Project")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Project name")).toBeTruthy();
+    });
+
+    it("disables submit when name is empty", () => {
+      render(ce(ProjectCrud, defaultCreateProps));
+      expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+    });
+
+    it("enables submit when name is entered", () => {
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "New Project" } });
+      expect(screen.getByRole("button", { name: "Create" })).not.toBeDisabled();
+    });
+
+    it("creates project on submit", async () => {
+      vi.mocked(apiCall).mockResolvedValue({ ok: true });
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "New Project" } });
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+      await vi.waitFor(() => {
+        expect(apiCall).toHaveBeenCalledWith(
+          "/projects",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ name: "New Project" }),
+          }),
+        );
+      });
+    });
+
+    it("calls onDone after successful creation", async () => {
+      vi.mocked(apiCall).mockResolvedValue({ ok: true });
+      const onDone = vi.fn();
+      render(ce(ProjectCrud, { ...defaultCreateProps, onDone }));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "New Project" } });
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+      await vi.waitFor(() => {
+        expect(onDone).toHaveBeenCalled();
+      });
+    });
+
+    it("shows error on creation failure", async () => {
+      vi.mocked(apiCall).mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: "Name taken" }),
+      });
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Existing" } });
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("Name taken")).toBeTruthy();
+      });
+    });
+
+    it("shows generic error on network failure", async () => {
+      vi.mocked(apiCall).mockRejectedValue(new Error("Network"));
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "Test" } });
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("Network error")).toBeTruthy();
+      });
+    });
+
+    it("calls onCancel when Cancel button is clicked", () => {
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(defaultCreateProps.onCancel).toHaveBeenCalled();
+    });
+
+    it("calls onCancel when overlay is clicked", () => {
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.click(screen.getByRole("dialog").parentElement!);
+      expect(defaultCreateProps.onCancel).toHaveBeenCalled();
+    });
+
+    it("creates on Enter key", async () => {
+      vi.mocked(apiCall).mockResolvedValue({ ok: true });
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "New Project" } });
+      fireEvent.keyDown(screen.getByPlaceholderText("Project name"), { key: "Enter" });
+
+      await vi.waitFor(() => {
+        expect(apiCall).toHaveBeenCalledWith("/projects", expect.any(Object));
+      });
+    });
+
+    it("cancels on Escape key", () => {
+      render(ce(ProjectCrud, defaultCreateProps));
+      fireEvent.keyDown(screen.getByPlaceholderText("Project name"), { key: "Escape" });
+      expect(defaultCreateProps.onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe("rename mode", () => {
+    it("renders rename dialog with current name", () => {
+      render(ce(ProjectCrud, defaultRenameProps));
+      expect(screen.getByText("Rename Project")).toBeTruthy();
+      expect(screen.getByDisplayValue("Old Name")).toBeTruthy();
+    });
+
+    it("renames project on submit", async () => {
+      vi.mocked(apiCall).mockResolvedValue({ ok: true });
+      render(ce(ProjectCrud, defaultRenameProps));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "New Name" } });
+      fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+      await vi.waitFor(() => {
+        expect(apiCall).toHaveBeenCalledWith(
+          "/projects/p1",
+          expect.objectContaining({
+            method: "PUT",
+            body: JSON.stringify({ name: "New Name" }),
+          }),
+        );
+      });
+    });
+
+    it("calls onDone after successful rename", async () => {
+      vi.mocked(apiCall).mockResolvedValue({ ok: true });
+      const onDone = vi.fn();
+      render(ce(ProjectCrud, { ...defaultRenameProps, onDone }));
+      fireEvent.change(screen.getByPlaceholderText("Project name"), { target: { value: "New Name" } });
+      fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+
+      await vi.waitFor(() => {
+        expect(onDone).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/client-react/src/components/projects/ProjectInlineTaskRow.test.tsx
+++ b/client-react/src/components/projects/ProjectInlineTaskRow.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+// @ts-nocheck — complex mocked props cause createElement overload issues
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import type { Todo, Heading } from "../../types";
+
+import { ProjectInlineTaskRow } from "./ProjectInlineTaskRow";
+
+const { createElement: ce } = React;
+
+function makeTodo(overrides: Partial<Todo> = {}): Todo {
+  return {
+    id: overrides.id ?? "t1",
+    title: overrides.title ?? "Test task",
+    description: null,
+    notes: overrides.notes ?? null,
+    status: overrides.status ?? "next",
+    completed: overrides.completed ?? false,
+    completedAt: null,
+    projectId: overrides.projectId ?? "p1",
+    category: null,
+    headingId: overrides.headingId ?? null,
+    tags: [],
+    context: null,
+    energy: null,
+    dueDate: null,
+    startDate: null,
+    scheduledDate: null,
+    reviewDate: null,
+    doDate: null,
+    estimateMinutes: null,
+    waitingOn: null,
+    dependsOnTaskIds: [],
+    order: 0,
+    priority: null,
+    archived: false,
+    firstStep: null,
+    emotionalState: null,
+    effortScore: null,
+    source: null,
+    recurrence: { type: "none" },
+    subtasks: [],
+    userId: "u1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+const defaultHeadings: Heading[] = [
+  { id: "h1", name: "Phase 1", projectId: "p1", sortOrder: 0 },
+  { id: "h2", name: "Phase 2", projectId: "p1", sortOrder: 1 },
+];
+
+const defaultProps = {
+  index: 0,
+  todo: makeTodo(),
+  projectId: "p1",
+  headings: defaultHeadings,
+  isBulkMode: false,
+  selected: false,
+  onSelect: vi.fn(),
+  onSave: vi.fn().mockResolvedValue(undefined),
+  onAddTodo: vi.fn().mockResolvedValue(undefined),
+  onRequestDeleteTodo: vi.fn(),
+};
+
+describe("ProjectInlineTaskRow", () => {
+  it("renders task title input", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByLabelText("Task title")).toBeTruthy();
+    expect(screen.getByDisplayValue("Test task")).toBeTruthy();
+  });
+
+  it("renders task index", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("renders status select with options", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByLabelText("Status")).toBeTruthy();
+    expect(screen.getByText("Next up")).toBeTruthy();
+  });
+
+  it("renders effort display", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByText("Quick win")).toBeTruthy();
+  });
+
+  it("renders due date display", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByText("No date")).toBeTruthy();
+  });
+
+  it("renders notes textarea", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByPlaceholderText("Notes…")).toBeTruthy();
+  });
+
+  it("renders section select with Backlog and headings", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByText("Backlog")).toBeTruthy();
+    expect(screen.getByText("Phase 1")).toBeTruthy();
+    expect(screen.getByText("Phase 2")).toBeTruthy();
+  });
+
+  it("renders Duplicate and Delete buttons", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    expect(screen.getByText("Duplicate")).toBeTruthy();
+    expect(screen.getByText("Delete")).toBeTruthy();
+  });
+
+  it("calls onSave with new title on blur", async () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    const input = screen.getByLabelText("Task title");
+    fireEvent.change(input, { target: { value: "Updated title" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith("t1", { title: "Updated title" });
+    });
+  });
+
+  it("calls onSave with new status on select change", async () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    fireEvent.change(screen.getByLabelText("Status"), { target: { value: "waiting" } });
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith("t1", { status: "waiting" });
+    });
+  });
+
+  it("calls onSave with new heading on section change", async () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    const sectionSelect = screen.getByLabelText("Section");
+    fireEvent.change(sectionSelect, { target: { value: "h1" } });
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith("t1", { headingId: "h1" });
+    });
+  });
+
+  it("calls onAddTodo with copied task on Duplicate click", async () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    fireEvent.click(screen.getByText("Duplicate"));
+
+    await waitFor(() => {
+      expect(defaultProps.onAddTodo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Test task (copy)",
+          projectId: "p1",
+          headingId: null,
+        }),
+      );
+    });
+  });
+
+  it("calls onRequestDeleteTodo on Delete click", () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(defaultProps.onRequestDeleteTodo).toHaveBeenCalledWith("t1");
+  });
+
+  it("shows checkbox in bulk mode", () => {
+    render(ce(ProjectInlineTaskRow, { ...defaultProps, isBulkMode: true }));
+    expect(screen.getByRole("checkbox")).toBeTruthy();
+  });
+
+  it("calls onSelect when checkbox is clicked in bulk mode", () => {
+    render(ce(ProjectInlineTaskRow, { ...defaultProps, isBulkMode: true }));
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(defaultProps.onSelect).toHaveBeenCalledWith("t1");
+  });
+
+  it("does not show checkbox outside bulk mode", () => {
+    render(ce(ProjectInlineTaskRow, { ...defaultProps, isBulkMode: false }));
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("updates title draft when todo changes", () => {
+    const { rerender } = render(ce(ProjectInlineTaskRow, defaultProps));
+    fireEvent.change(screen.getByLabelText("Task title"), { target: { value: "Changed" } });
+
+    // Re-render with different todo
+    rerender(ce(ProjectInlineTaskRow, { ...defaultProps, todo: makeTodo({ id: "t2", title: "New task" }) }));
+    expect(screen.getByDisplayValue("New task")).toBeTruthy();
+  });
+
+  it("saves notes on blur when changed", async () => {
+    render(ce(ProjectInlineTaskRow, defaultProps));
+    const textarea = screen.getByPlaceholderText("Notes…");
+    fireEvent.change(textarea, { target: { value: "Some notes" } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith("t1", { notes: "Some notes" });
+    });
+  });
+
+  it("saves null notes when textarea is cleared", async () => {
+    // Start with existing notes so clearing triggers a save
+    render(ce(ProjectInlineTaskRow, { ...defaultProps, todo: makeTodo({ notes: "Existing" }) }));
+    const textarea = screen.getByPlaceholderText("Notes…");
+    fireEvent.change(textarea, { target: { value: "" } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith("t1", { notes: null });
+    });
+  });
+});


### PR DESCRIPTION
Fixes TS2440 — `HorizonSegment` is now imported from `appShellFilters` instead of declared locally.