### PR TITLE
fix(tests): fix type compatibility for extracted AppShell utilities

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -60,6 +60,13 @@ import {
   getQuickEntryPlaceholder,
   type HorizonSegment,
 } from "./appShellFilters";
+import {
+  buildQueryParams,
+  getViewTitle,
+  shouldShowListViewHeader,
+  isBlockingOverlayOpen,
+  DRAFT_PROJECT_ID,
+} from "./appShellViews";
 
 // Lazy-loaded heavy components (code splitting)
 const BoardView = lazy(() =>
@@ -93,8 +100,6 @@ interface UndoAction {
   message: string;
   onUndo?: () => void;
 }
-
-const DRAFT_PROJECT_ID = "draft-project";
 
 function createDraftProject(): Project {
   const now = new Date().toISOString();
@@ -205,35 +210,16 @@ export function AppShell() {
   const { projects, loadProjects } = useProjectsStore();
 
   // Build query params based on active view + project
-  const queryParams = useMemo(() => {
-    const params: Record<string, string | undefined> = {};
-    if (selectedProjectId && selectedProjectId !== DRAFT_PROJECT_ID) {
-      params.projectId = selectedProjectId;
-    } else {
-      switch (activeView) {
-        case "home":
-          // Focus dashboard fetches all active todos for tiles
-          break;
-        case "today":
-          params.sortBy = "dueDate";
-          params.sortOrder = "asc";
-          break;
-        case "completed":
-          params.completed = "true";
-          break;
-        case "horizon":
-          params.sortBy = "dueDate";
-          params.sortOrder = "asc";
-          break;
-      }
-    }
-    // User sort overrides view defaults
-    if (sortBy !== "order") {
-      params.sortBy = sortBy;
-      params.sortOrder = sortOrder;
-    }
-    return params;
-  }, [activeView, selectedProjectId, sortBy, sortOrder]);
+  const queryParams = useMemo(
+    () =>
+      buildQueryParams({
+        activeView,
+        selectedProjectId,
+        sortBy,
+        sortOrder,
+      }),
+    [activeView, selectedProjectId, sortBy, sortOrder],
+  );
 
   // Load data on mount and when filters change
   useEffect(() => {
@@ -339,51 +325,10 @@ export function AppShell() {
     };
   }, [hasBlockingOverlay]);
 
-  const horizonCounts = useMemo(() => {
-    const active = todos.filter((t) => !t.completed);
-    const today = new Date().toISOString().split("T")[0];
-    const upcomingEnd = new Date();
-    upcomingEnd.setDate(upcomingEnd.getDate() + 14);
-    const upcomingEndIso = upcomingEnd.toISOString().split("T")[0];
-    return {
-      due: active.filter(
-        (t) =>
-          !!t.dueDate &&
-          t.dueDate.split("T")[0] > today &&
-          t.dueDate.split("T")[0] <= upcomingEndIso,
-      ).length,
-      pending: active.filter((t) => t.status === "waiting").length,
-      planned: active.filter((t) => !!t.scheduledDate).length,
-      later: active.filter((t) => t.status === "someday").length,
-    };
-  }, [todos]);
+  const horizonCounts = useMemo(() => computeHorizonCounts(todos), [todos]);
 
   // Count badges for workspace views
-  const viewCounts = useMemo(() => {
-    const active = todos.filter((t) => !t.completed);
-    const horizonIds = new Set<string>();
-    const today = new Date().toISOString().split("T")[0];
-    const upcomingEnd = new Date();
-    upcomingEnd.setDate(upcomingEnd.getDate() + 14);
-    const upcomingEndIso = upcomingEnd.toISOString().split("T")[0];
-    for (const todo of active) {
-      if (
-        (todo.dueDate &&
-          todo.dueDate.split("T")[0] > today &&
-          todo.dueDate.split("T")[0] <= upcomingEndIso) ||
-        todo.status === "waiting" ||
-        !!todo.scheduledDate ||
-        todo.status === "someday"
-      ) {
-        horizonIds.add(todo.id);
-      }
-    }
-    return {
-      today: active.filter((t) => t.dueDate && t.dueDate.split("T")[0] <= today)
-        .length,
-      horizon: horizonIds.size,
-    };
-  }, [todos]);
+  const viewCounts = useMemo(() => computeViewCounts(todos), [todos]);
 
   // Context-aware quick entry placeholder
   const quickEntryPlaceholder = useMemo(() => {

--- a/client-react/src/components/layout/appShellFilters.ts
+++ b/client-react/src/components/layout/appShellFilters.ts
@@ -109,7 +109,7 @@ export function filterVisibleTodos(options: FilterTodosOptions): Todo[] {
   return filtered;
 }
 
-interface HorizonCounts {
+interface HorizonCounts extends Record<string, number> {
   due: number;
   pending: number;
   planned: number;
@@ -136,7 +136,7 @@ export function computeHorizonCounts(todos: Todo[]): HorizonCounts {
   };
 }
 
-interface ViewCounts {
+interface ViewCounts extends Record<string, number> {
   today: number;
   horizon: number;
 }

--- a/client-react/src/components/layout/appShellViews.test.ts
+++ b/client-react/src/components/layout/appShellViews.test.ts
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  buildQueryParams,
+  getViewTitle,
+  shouldShowListViewHeader,
+  isBlockingOverlayOpen,
+  getActiveViewFromHash,
+  DRAFT_PROJECT_ID,
+} from "./appShellViews";
+
+describe("appShellViews", () => {
+  describe("DRAFT_PROJECT_ID", () => {
+    it("is a constant string", () => {
+      expect(DRAFT_PROJECT_ID).toBe("draft-project");
+    });
+  });
+
+  describe("buildQueryParams", () => {
+    it("returns empty params for home view", () => {
+      const params = buildQueryParams({
+        activeView: "home",
+        selectedProjectId: null,
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params).toEqual({});
+    });
+
+    it("sets dueDate sort for today view", () => {
+      const params = buildQueryParams({
+        activeView: "today",
+        selectedProjectId: null,
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params.sortBy).toBe("dueDate");
+      expect(params.sortOrder).toBe("asc");
+    });
+
+    it("sets completed flag for completed view", () => {
+      const params = buildQueryParams({
+        activeView: "completed",
+        selectedProjectId: null,
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params.completed).toBe("true");
+    });
+
+    it("sets dueDate sort for horizon view", () => {
+      const params = buildQueryParams({
+        activeView: "horizon",
+        selectedProjectId: null,
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params.sortBy).toBe("dueDate");
+      expect(params.sortOrder).toBe("asc");
+    });
+
+    it("includes projectId when project selected", () => {
+      const params = buildQueryParams({
+        activeView: "home",
+        selectedProjectId: "p1",
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params.projectId).toBe("p1");
+    });
+
+    it("excludes draft project ID", () => {
+      const params = buildQueryParams({
+        activeView: "home",
+        selectedProjectId: "draft-project",
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params.projectId).toBeUndefined();
+    });
+
+    it("overrides view defaults with user sort", () => {
+      const params = buildQueryParams({
+        activeView: "today",
+        selectedProjectId: null,
+        sortBy: "title",
+        sortOrder: "desc",
+      });
+      expect(params.sortBy).toBe("title");
+      expect(params.sortOrder).toBe("desc");
+    });
+
+    it("keeps view defaults when user sort is default", () => {
+      const params = buildQueryParams({
+        activeView: "today",
+        selectedProjectId: null,
+        sortBy: "order",
+        sortOrder: "asc",
+      });
+      expect(params.sortBy).toBe("dueDate");
+    });
+  });
+
+  describe("getViewTitle", () => {
+    it("returns project name when project selected", () => {
+      const title = getViewTitle("home", "due", "p1", [
+        { id: "p1", name: "My Project" },
+      ]);
+      expect(title).toBe("My Project");
+    });
+
+    it("returns generic Project when project not found", () => {
+      const title = getViewTitle("home", "due", "missing", [
+        { id: "p1", name: "Other" },
+      ]);
+      expect(title).toBe("Project");
+    });
+
+    it("returns Focus for home view", () => {
+      expect(getViewTitle("home", "due", null, [])).toBe("Focus");
+    });
+
+    it("returns Today for today view", () => {
+      expect(getViewTitle("today", "due", null, [])).toBe("Today");
+    });
+
+    it("returns Horizon for horizon/due", () => {
+      expect(getViewTitle("horizon", "due", null, [])).toBe("Horizon");
+    });
+
+    it("returns Waiting for horizon/pending", () => {
+      expect(getViewTitle("horizon", "pending", null, [])).toBe("Waiting");
+    });
+
+    it("returns Planned for horizon/planned", () => {
+      expect(getViewTitle("horizon", "planned", null, [])).toBe("Planned");
+    });
+
+    it("returns Later for horizon/later", () => {
+      expect(getViewTitle("horizon", "later", null, [])).toBe("Later");
+    });
+
+    it("returns Completed for completed view", () => {
+      expect(getViewTitle("completed", "due", null, [])).toBe("Completed");
+    });
+
+    it("returns Everything for all view", () => {
+      expect(getViewTitle("all", "due", null, [])).toBe("Everything");
+    });
+  });
+
+  describe("shouldShowListViewHeader", () => {
+    it("returns true when project selected", () => {
+      expect(shouldShowListViewHeader("home", "p1")).toBe(true);
+    });
+
+    it("returns true for all view", () => {
+      expect(shouldShowListViewHeader("all", null)).toBe(true);
+    });
+
+    it("returns false for today view", () => {
+      expect(shouldShowListViewHeader("today", null)).toBe(false);
+    });
+
+    it("returns false for home view", () => {
+      expect(shouldShowListViewHeader("home", null)).toBe(false);
+    });
+
+    it("returns false for horizon view", () => {
+      expect(shouldShowListViewHeader("horizon", null)).toBe(false);
+    });
+  });
+
+  describe("isBlockingOverlayOpen", () => {
+    it("returns false when nothing is open", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: false,
+          paletteOpen: false,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: null,
+          deleteTarget: null,
+          activeTodo: null,
+          showOnboarding: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns true when mobile nav is open", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: true,
+          paletteOpen: false,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: null,
+          deleteTarget: null,
+          activeTodo: null,
+          showOnboarding: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when palette is open", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: false,
+          paletteOpen: true,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: null,
+          deleteTarget: null,
+          activeTodo: null,
+          showOnboarding: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when project CRUD is active", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: false,
+          paletteOpen: false,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: "create",
+          deleteTarget: null,
+          activeTodo: null,
+          showOnboarding: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when delete target is set", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: false,
+          paletteOpen: false,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: null,
+          deleteTarget: "t1",
+          activeTodo: null,
+          showOnboarding: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when onboarding is shown", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: false,
+          paletteOpen: false,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: null,
+          deleteTarget: null,
+          activeTodo: null,
+          showOnboarding: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when active todo is open", () => {
+      expect(
+        isBlockingOverlayOpen({
+          mobileNavOpen: false,
+          paletteOpen: false,
+          shortcutsOpen: false,
+          composerOpen: false,
+          projectCrudMode: null,
+          deleteTarget: null,
+          activeTodo: { id: "t1" },
+          showOnboarding: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("getActiveViewFromHash", () => {
+    it("returns home for #/home", () => {
+      expect(getActiveViewFromHash("#/home")).toBe("home");
+    });
+
+    it("returns today for #/today", () => {
+      expect(getActiveViewFromHash("#/today")).toBe("today");
+    });
+
+    it("returns horizon for #/horizon", () => {
+      expect(getActiveViewFromHash("#/horizon")).toBe("horizon");
+    });
+
+    it("returns completed for #/completed", () => {
+      expect(getActiveViewFromHash("#/completed")).toBe("completed");
+    });
+
+    it("returns all for #/all", () => {
+      expect(getActiveViewFromHash("#/all")).toBe("all");
+    });
+
+    it("returns undefined for empty hash", () => {
+      expect(getActiveViewFromHash("")).toBeUndefined();
+    });
+
+    it("returns undefined for unknown route", () => {
+      expect(getActiveViewFromHash("#/settings")).toBeUndefined();
+    });
+
+    it("returns undefined for task route", () => {
+      expect(getActiveViewFromHash("#/task/t1")).toBeUndefined();
+    });
+  });
+});

--- a/client-react/src/components/layout/appShellViews.ts
+++ b/client-react/src/components/layout/appShellViews.ts
@@ -1,0 +1,120 @@
+// Pure utility functions for AppShell view title, labels, and query params.
+import type { SortField, SortOrder } from "../../types/viewTypes";
+import type { WorkspaceView, HorizonSegment } from "./appShellFilters";
+
+export const DRAFT_PROJECT_ID = "draft-project";
+
+export interface QueryParams {
+  projectId?: string;
+  sortBy?: string;
+  sortOrder?: SortOrder;
+  completed?: string;
+}
+
+export function buildQueryParams(options: {
+  activeView: WorkspaceView;
+  selectedProjectId: string | null;
+  sortBy: SortField;
+  sortOrder: SortOrder;
+}): QueryParams {
+  const { activeView, selectedProjectId, sortBy, sortOrder } = options;
+  const params: QueryParams = {};
+
+  if (selectedProjectId && selectedProjectId !== DRAFT_PROJECT_ID) {
+    params.projectId = selectedProjectId;
+  } else {
+    switch (activeView) {
+      case "home":
+        break;
+      case "today":
+        params.sortBy = "dueDate";
+        params.sortOrder = "asc";
+        break;
+      case "completed":
+        params.completed = "true";
+        break;
+      case "horizon":
+        params.sortBy = "dueDate";
+        params.sortOrder = "asc";
+        break;
+    }
+  }
+
+  // User sort overrides view defaults
+  if (sortBy !== "order") {
+    params.sortBy = sortBy;
+    params.sortOrder = sortOrder;
+  }
+
+  return params;
+}
+
+export function getViewTitle(
+  activeView: WorkspaceView,
+  horizonSegment: HorizonSegment,
+  selectedProjectId: string | null,
+  projects: Array<{ id: string; name: string }>,
+): string {
+  if (selectedProjectId) {
+    const project = projects.find((p) => p.id === selectedProjectId);
+    return project ? project.name : "Project";
+  }
+  switch (activeView) {
+    case "home":
+      return "Focus";
+    case "today":
+      return "Today";
+    case "horizon":
+      switch (horizonSegment) {
+        case "due":
+          return "Horizon";
+        case "pending":
+          return "Waiting";
+        case "planned":
+          return "Planned";
+        case "later":
+          return "Later";
+      }
+    case "completed":
+      return "Completed";
+    case "all":
+      return "Everything";
+  }
+}
+
+export function shouldShowListViewHeader(
+  activeView: WorkspaceView,
+  selectedProjectId: string | null,
+): boolean {
+  return selectedProjectId !== null || activeView === "all";
+}
+
+export function isBlockingOverlayOpen(options: {
+  mobileNavOpen: boolean;
+  paletteOpen: boolean;
+  shortcutsOpen: boolean;
+  composerOpen: boolean;
+  projectCrudMode: string | null;
+  deleteTarget: string | null;
+  activeTodo: unknown;
+  showOnboarding: boolean;
+}): boolean {
+  return (
+    options.mobileNavOpen ||
+    options.paletteOpen ||
+    options.shortcutsOpen ||
+    options.composerOpen ||
+    !!options.projectCrudMode ||
+    !!options.deleteTarget ||
+    !!options.activeTodo ||
+    options.showOnboarding
+  );
+}
+
+export function getActiveViewFromHash(
+  hash: string,
+): WorkspaceView | undefined {
+  const match = hash.match(/^#\/(home|today|horizon|completed|all)$/);
+  if (!match) return undefined;
+  return match[1] as WorkspaceView;
+}

--- a/client-react/src/components/layout/appShellViews.ts
+++ b/client-react/src/components/layout/appShellViews.ts
@@ -4,7 +4,7 @@ import type { WorkspaceView, HorizonSegment } from "./appShellFilters";
 
 export const DRAFT_PROJECT_ID = "draft-project";
 
-export interface QueryParams {
+export interface QueryParams extends Record<string, string | undefined> {
   projectId?: string;
   sortBy?: string;
   sortOrder?: SortOrder;


### PR DESCRIPTION
Fixes TypeScript errors from Phase 26:\n\n- **TS2345**: `QueryParams` now extends `Record<string, string | undefined>` to match `loadTodos` parameter type\n- **TS2322**: `ViewCounts` and `HorizonCounts` now extend `Record<string, number>` to match `Sidebar` props