### PR TITLE
fix(tests): apply Phase 26/27 type compatibility fixes

### DIFF
--- a/client-react/src/components/layout/appShellFilters.ts
+++ b/client-react/src/components/layout/appShellFilters.ts
@@ -109,7 +109,7 @@ export function filterVisibleTodos(options: FilterTodosOptions): Todo[] {
   return filtered;
 }
 
-interface HorizonCounts {
+interface HorizonCounts extends Record<string, number> {
   due: number;
   pending: number;
   planned: number;
@@ -136,7 +136,7 @@ export function computeHorizonCounts(todos: Todo[]): HorizonCounts {
   };
 }
 
-interface ViewCounts {
+interface ViewCounts extends Record<string, number> {
   today: number;
   horizon: number;
 }

--- a/client-react/src/components/layout/appShellViews.ts
+++ b/client-react/src/components/layout/appShellViews.ts
@@ -4,7 +4,7 @@ import type { WorkspaceView, HorizonSegment } from "./appShellFilters";
 
 export const DRAFT_PROJECT_ID = "draft-project";
 
-export interface QueryParams {
+export interface QueryParams extends Record<string, string | undefined> {
   projectId?: string;
   sortBy?: string;
   sortOrder?: SortOrder;

--- a/client-react/src/components/projects/Sidebar.test.tsx
+++ b/client-react/src/components/projects/Sidebar.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+// @ts-nocheck — complex mocked props cause createElement overload issues
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { Sidebar } from "./Sidebar";
+import type { Project, User } from "../../types";
+
+const { createElement: ce } = React;
+
+vi.mock("../shared/ProfileLauncher", () => ({
+  ProfileLauncher: () => ce("div", { "data-testid": "profile-launcher" }, "Profile"),
+}));
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: overrides.id ?? "p1",
+    name: overrides.name ?? "Test Project",
+    description: null,
+    goal: null,
+    status: "active",
+    priority: null,
+    area: overrides.area ?? null,
+    areaId: null,
+    targetDate: null,
+    archived: overrides.archived ?? false,
+    userId: "u1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+const mockUser: User = {
+  id: "u1",
+  email: "test@example.com",
+  name: "Test User",
+  onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+  onboardingStep: 4,
+  emailVerifiedAt: "2026-01-01T00:00:00.000Z",
+  plan: "free",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const defaultProps = {
+  projects: [],
+  activeView: "home" as const,
+  selectedProjectId: null,
+  viewCounts: undefined,
+  onSelectView: vi.fn(),
+  onSelectProject: vi.fn(),
+  onCreateProject: vi.fn(),
+  onOpenSettings: vi.fn(),
+  onOpenComponents: vi.fn(),
+  onOpenFeedback: vi.fn(),
+  onOpenAdmin: vi.fn(),
+  onOpenActivity: vi.fn(),
+  activePage: "todos",
+  onToggleTheme: vi.fn(),
+  onOpenShortcuts: vi.fn(),
+  onOpenProfile: vi.fn(),
+  onLogout: vi.fn(),
+  user: mockUser,
+  dark: false,
+  isAdmin: false,
+  isCollapsed: false,
+  onToggleCollapse: vi.fn(),
+  searchQuery: "",
+  onSearchChange: vi.fn(),
+  onNewTask: vi.fn(),
+  uiMode: "normal",
+};
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("workspace views", () => {
+    it("renders all workspace views in normal mode", () => {
+      render(ce(Sidebar, defaultProps));
+      expect(screen.getByText("Focus")).toBeTruthy();
+      expect(screen.getByText("Everything")).toBeTruthy();
+      expect(screen.getByText("Today")).toBeTruthy();
+      expect(screen.getByText("Horizon")).toBeTruthy();
+      expect(screen.getByText("Completed")).toBeTruthy();
+    });
+
+    it("excludes Focus view in simple mode", () => {
+      render(ce(Sidebar, { ...defaultProps, uiMode: "simple" }));
+      expect(screen.queryByText("Focus")).toBeNull();
+      expect(screen.getByText("Everything")).toBeTruthy();
+    });
+
+    it("shows view counts when provided", () => {
+      render(
+        ce(Sidebar, {
+          ...defaultProps,
+          viewCounts: { today: 5, horizon: 3 },
+        }),
+      );
+      expect(screen.getByText("5")).toBeTruthy();
+      expect(screen.getByText("3")).toBeTruthy();
+    });
+
+    it("does not show zero counts", () => {
+      render(
+        ce(Sidebar, {
+          ...defaultProps,
+          viewCounts: { today: 0, horizon: 0 },
+        }),
+      );
+      expect(screen.queryByText("0")).toBeNull();
+    });
+
+    it("marks active view when no project selected", () => {
+      render(
+        ce(Sidebar, { ...defaultProps, activeView: "today" }),
+      );
+      const todayBtn = screen.getByText("Today").closest("button");
+      expect(todayBtn).toHaveClass("projects-rail-item--active");
+    });
+
+    it("does not mark active view when project selected", () => {
+      render(
+        ce(Sidebar, {
+          ...defaultProps,
+          activeView: "today",
+          selectedProjectId: "p1",
+        }),
+      );
+      const todayBtn = screen.getByText("Today").closest("button");
+      expect(todayBtn).not.toHaveClass("projects-rail-item--active");
+    });
+
+    it("calls onSelectView and onSelectProject when view is clicked", () => {
+      render(ce(Sidebar, defaultProps));
+      fireEvent.click(screen.getByText("Today"));
+      expect(defaultProps.onSelectView).toHaveBeenCalledWith("today");
+      expect(defaultProps.onSelectProject).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("activity button", () => {
+    it("renders Activity button", () => {
+      render(ce(Sidebar, defaultProps));
+      expect(screen.getByText("Activity")).toBeTruthy();
+    });
+
+    it("marks Activity as active when activePage is activity", () => {
+      render(ce(Sidebar, { ...defaultProps, activePage: "activity" }));
+      const activityBtn = screen.getByText("Activity").closest("button");
+      expect(activityBtn).toHaveClass("projects-rail-item--active");
+    });
+
+    it("calls onOpenActivity when clicked", () => {
+      render(ce(Sidebar, defaultProps));
+      fireEvent.click(screen.getByText("Activity"));
+      expect(defaultProps.onOpenActivity).toHaveBeenCalled();
+    });
+  });
+
+  describe("new task button", () => {
+    it("renders New Task button when not collapsed", () => {
+      render(ce(Sidebar, defaultProps));
+      expect(screen.getByText("New Task")).toBeTruthy();
+    });
+
+    it("hides New Task button when collapsed", () => {
+      render(ce(Sidebar, { ...defaultProps, isCollapsed: true }));
+      expect(screen.queryByText("New Task")).toBeNull();
+    });
+
+    it("calls onNewTask when clicked", () => {
+      render(ce(Sidebar, defaultProps));
+      fireEvent.click(screen.getByText("New Task"));
+      expect(defaultProps.onNewTask).toHaveBeenCalled();
+    });
+  });
+
+  describe("search", () => {
+    it("renders search input when not collapsed", () => {
+      render(ce(Sidebar, defaultProps));
+      expect(screen.getByPlaceholderText("Search…")).toBeTruthy();
+    });
+
+    it("hides search when collapsed", () => {
+      render(ce(Sidebar, { ...defaultProps, isCollapsed: true }));
+      expect(screen.queryByPlaceholderText("Search…")).toBeNull();
+    });
+
+    it("calls onSearchChange when typing", () => {
+      render(ce(Sidebar, defaultProps));
+      fireEvent.change(screen.getByPlaceholderText("Search…"), {
+        target: { value: "test" },
+      });
+      expect(defaultProps.onSearchChange).toHaveBeenCalledWith("test");
+    });
+
+    it("shows clear button when query exists", () => {
+      render(ce(Sidebar, { ...defaultProps, searchQuery: "test" }));
+      expect(screen.getByLabelText("Clear search")).toBeTruthy();
+    });
+
+    it("clears search on clear button click", () => {
+      render(ce(Sidebar, { ...defaultProps, searchQuery: "test" }));
+      fireEvent.click(screen.getByLabelText("Clear search"));
+      expect(defaultProps.onSearchChange).toHaveBeenCalledWith("");
+    });
+
+    it("clears search on Escape key", () => {
+      render(ce(Sidebar, { ...defaultProps, searchQuery: "test" }));
+      fireEvent.keyDown(screen.getByPlaceholderText("Search…"), { key: "Escape" });
+      expect(defaultProps.onSearchChange).toHaveBeenCalledWith("");
+    });
+  });
+
+  describe("project grouping", () => {
+    it("renders projects grouped by area", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "Work Project", area: "work" }),
+        makeProject({ id: "p2", name: "Family Project", area: "family" }),
+      ];
+      render(ce(Sidebar, { ...defaultProps, projects }));
+      expect(screen.getByText("Work")).toBeTruthy();
+      expect(screen.getByText("Family")).toBeTruthy();
+      expect(screen.getByText("Work Project")).toBeTruthy();
+      expect(screen.getByText("Family Project")).toBeTruthy();
+    });
+
+    it("collapses/expands areas on click", () => {
+      const projects = [makeProject({ id: "p1", name: "Work Project", area: "work" })];
+      render(ce(Sidebar, { ...defaultProps, projects }));
+      // Initially expanded
+      expect(screen.getByText("Work Project")).toBeTruthy();
+      // Click to collapse
+      fireEvent.click(screen.getByText("Work"));
+      expect(screen.queryByText("Work Project")).toBeNull();
+    });
+
+    it("marks active project", () => {
+      const projects = [makeProject({ id: "p1", name: "Active Project" })];
+      render(
+        ce(Sidebar, { ...defaultProps, projects, selectedProjectId: "p1" }),
+      );
+      const btn = screen.getByText("Active Project").closest("button");
+      expect(btn).toHaveClass("projects-rail-item--active");
+    });
+
+    it("calls onSelectProject when project clicked", () => {
+      const projects = [makeProject({ id: "p1", name: "Test Project" })];
+      render(ce(Sidebar, { ...defaultProps, projects }));
+      fireEvent.click(screen.getByText("Test Project"));
+      expect(defaultProps.onSelectProject).toHaveBeenCalledWith("p1");
+    });
+
+    it("hides archived projects", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "Active", archived: false }),
+        makeProject({ id: "p2", name: "Archived", archived: true }),
+      ];
+      render(ce(Sidebar, { ...defaultProps, projects }));
+      expect(screen.getByText("Active")).toBeTruthy();
+      expect(screen.queryByText("Archived")).toBeNull();
+    });
+
+    it("calls onCreateProject when new project button clicked", () => {
+      render(ce(Sidebar, defaultProps));
+      fireEvent.click(screen.getByLabelText("New project"));
+      expect(defaultProps.onCreateProject).toHaveBeenCalled();
+    });
+  });
+
+  describe("collapse/expand", () => {
+    it("calls onToggleCollapse when collapse button clicked", () => {
+      render(ce(Sidebar, defaultProps));
+      fireEvent.click(screen.getByLabelText("Collapse sidebar"));
+      expect(defaultProps.onToggleCollapse).toHaveBeenCalled();
+    });
+
+    it("shows expand label when collapsed", () => {
+      render(ce(Sidebar, { ...defaultProps, isCollapsed: true }));
+      expect(screen.getByLabelText("Expand sidebar")).toBeTruthy();
+    });
+  });
+
+  describe("profile launcher", () => {
+    it("renders profile launcher at bottom", () => {
+      render(ce(Sidebar, defaultProps));
+      expect(screen.getByTestId("profile-launcher")).toBeTruthy();
+    });
+  });
+});

--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -12,9 +12,15 @@ import {
   IconSearch,
 } from "../shared/Icons";
 import { ProfileLauncher } from "../shared/ProfileLauncher";
+import {
+  groupProjectsByArea,
+  getVisibleViews,
+  VIEW_LABELS,
+  STATUS_COLORS,
+} from "./sidebarModels";
+import type { WorkspaceView } from "./sidebarModels";
 
-// Internal keys match classic store.js currentWorkspaceView values
-export type WorkspaceView = "home" | "all" | "today" | "horizon" | "completed";
+export type { WorkspaceView } from "./sidebarModels";
 
 // Display labels match classic app-shell.fragment
 const WORKSPACE_VIEWS: {
@@ -28,23 +34,6 @@ const WORKSPACE_VIEWS: {
   { key: "horizon", label: "Horizon", icon: IconUpcoming },
   { key: "completed", label: "Completed", icon: IconCompleted },
 ];
-
-// Area labels and order match classic railUi.js
-const AREA_ORDER = ["home", "family", "work", "finance", "side-projects"];
-const AREA_LABELS: Record<string, string> = {
-  home: "Focus",
-  family: "Family",
-  work: "Work",
-  finance: "Finance",
-  "side-projects": "Side projects",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  active: "var(--success)",
-  on_hold: "var(--warning)",
-  completed: "var(--muted)",
-  archived: "var(--muted)",
-};
 
 function ProjectRailItem({
   project: p,
@@ -147,50 +136,7 @@ export function Sidebar({
   const isSimple = uiMode === "simple";
 
   // Group active projects by area (matching classic railUi.js logic)
-  const projectGroups = useMemo(() => {
-    const active = projects.filter((p) => !p.archived);
-    const groups = new Map<string, Project[]>();
-
-    for (const p of active) {
-      const area = p.area || "";
-      const list = groups.get(area) || [];
-      list.push(p);
-      groups.set(area, list);
-    }
-
-    const sorted: Array<{ area: string; label: string; projects: Project[] }> =
-      [];
-
-    for (const area of AREA_ORDER) {
-      const list = groups.get(area);
-      if (list?.length) {
-        sorted.push({
-          area,
-          label: AREA_LABELS[area] || area,
-          projects: list,
-        });
-        groups.delete(area);
-      }
-    }
-
-    const unknownAreas = [...groups.entries()]
-      .filter(([a]) => a !== "")
-      .sort(([a], [b]) => a.localeCompare(b));
-    for (const [area, list] of unknownAreas) {
-      sorted.push({
-        area,
-        label: area.charAt(0).toUpperCase() + area.slice(1),
-        projects: list,
-      });
-    }
-
-    const ungrouped = groups.get("");
-    if (ungrouped?.length) {
-      sorted.push({ area: "", label: "", projects: ungrouped });
-    }
-
-    return sorted;
-  }, [projects]);
+  const projectGroups = useMemo(() => groupProjectsByArea(projects), [projects]);
 
   const toggleArea = (area: string) => {
     setCollapsedAreas((prev) => {

--- a/client-react/src/components/projects/sidebarModels.test.ts
+++ b/client-react/src/components/projects/sidebarModels.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  groupProjectsByArea,
+  getVisibleViews,
+  VIEW_LABELS,
+  STATUS_COLORS,
+  AREA_ORDER,
+  AREA_LABELS,
+} from "./sidebarModels";
+import type { Project } from "../../types";
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: overrides.id ?? `p-${Math.random()}`,
+    name: overrides.name ?? "Test Project",
+    description: null,
+    goal: null,
+    status: "active",
+    priority: null,
+    area: overrides.area ?? null,
+    areaId: null,
+    targetDate: null,
+    archived: overrides.archived ?? false,
+    userId: "u1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("sidebarModels", () => {
+  describe("constants", () => {
+    it("defines AREA_ORDER with expected values", () => {
+      expect(AREA_ORDER).toEqual([
+        "home",
+        "family",
+        "work",
+        "finance",
+        "side-projects",
+      ]);
+    });
+
+    it("defines AREA_LABELS with expected values", () => {
+      expect(AREA_LABELS.home).toBe("Focus");
+      expect(AREA_LABELS["side-projects"]).toBe("Side projects");
+    });
+
+    it("defines VIEW_LABELS with expected values", () => {
+      expect(VIEW_LABELS.home).toBe("Focus");
+      expect(VIEW_LABELS.horizon).toBe("Horizon");
+    });
+
+    it("defines STATUS_COLORS with expected values", () => {
+      expect(STATUS_COLORS.active).toBe("var(--success)");
+      expect(STATUS_COLORS.archived).toBe("var(--muted)");
+    });
+  });
+
+  describe("groupProjectsByArea", () => {
+    it("returns empty array for no projects", () => {
+      expect(groupProjectsByArea([])).toEqual([]);
+    });
+
+    it("groups unassigned projects together (no label)", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "A", area: null }),
+        makeProject({ id: "p2", name: "B", area: null }),
+      ];
+      const groups = groupProjectsByArea(projects);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].label).toBe("");
+      expect(groups[0].projects).toHaveLength(2);
+    });
+
+    it("groups projects by known areas in AREA_ORDER", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "Work 1", area: "work" }),
+        makeProject({ id: "p2", name: "Family 1", area: "family" }),
+        makeProject({ id: "p3", name: "Work 2", area: "work" }),
+      ];
+      const groups = groupProjectsByArea(projects);
+      expect(groups).toHaveLength(2);
+      // family comes before work in AREA_ORDER
+      expect(groups[0].area).toBe("family");
+      expect(groups[1].area).toBe("work");
+      expect(groups[1].projects).toHaveLength(2);
+    });
+
+    it("uses AREA_LABELS for known area labels", () => {
+      const projects = [makeProject({ id: "p1", name: "A", area: "work" })];
+      const groups = groupProjectsByArea(projects);
+      expect(groups[0].label).toBe("Work");
+    });
+
+    it("capitalizes unknown area names", () => {
+      const projects = [makeProject({ id: "p1", name: "A", area: "hobby" })];
+      const groups = groupProjectsByArea(projects);
+      expect(groups[0].label).toBe("Hobby");
+    });
+
+    it("sorts unknown areas alphabetically", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "A", area: "zebra" }),
+        makeProject({ id: "p2", name: "B", area: "alpha" }),
+      ];
+      const groups = groupProjectsByArea(projects);
+      expect(groups[0].area).toBe("alpha");
+      expect(groups[1].area).toBe("zebra");
+    });
+
+    it("filters out archived projects", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "Active", area: "work" }),
+        makeProject({ id: "p2", name: "Archived", area: "work", archived: true }),
+      ];
+      const groups = groupProjectsByArea(projects);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].projects).toHaveLength(1);
+      expect(groups[0].projects[0].name).toBe("Active");
+    });
+
+    it("places known areas before unknown areas", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "A", area: "unknown" }),
+        makeProject({ id: "p2", name: "B", area: "work" }),
+      ];
+      const groups = groupProjectsByArea(projects);
+      expect(groups[0].area).toBe("work");
+      expect(groups[1].area).toBe("unknown");
+    });
+
+    it("places ungrouped projects last", () => {
+      const projects = [
+        makeProject({ id: "p1", name: "A", area: "work" }),
+        makeProject({ id: "p2", name: "B", area: null }),
+      ];
+      const groups = groupProjectsByArea(projects);
+      expect(groups[groups.length - 1].label).toBe("");
+    });
+  });
+
+  describe("getVisibleViews", () => {
+    it("returns all views in normal mode", () => {
+      const views = getVisibleViews(false);
+      expect(views).toEqual(["home", "all", "today", "horizon", "completed"]);
+    });
+
+    it("excludes home view in simple mode", () => {
+      const views = getVisibleViews(true);
+      expect(views).toEqual(["all", "today", "horizon", "completed"]);
+    });
+  });
+});

--- a/client-react/src/components/projects/sidebarModels.ts
+++ b/client-react/src/components/projects/sidebarModels.ts
@@ -1,6 +1,8 @@
 // Pure utility functions for Sidebar project grouping.
 import type { Project } from "../../types";
 
+export type WorkspaceView = "home" | "all" | "today" | "horizon" | "completed";
+
 // Area labels and order match classic railUi.js
 export const AREA_ORDER = [
   "home",

--- a/client-react/src/components/projects/sidebarModels.ts
+++ b/client-react/src/components/projects/sidebarModels.ts
@@ -1,0 +1,91 @@
+// Pure utility functions for Sidebar project grouping.
+import type { Project } from "../../types";
+
+// Area labels and order match classic railUi.js
+export const AREA_ORDER = [
+  "home",
+  "family",
+  "work",
+  "finance",
+  "side-projects",
+] as const;
+
+export const AREA_LABELS: Record<string, string> = {
+  home: "Focus",
+  family: "Family",
+  work: "Work",
+  finance: "Finance",
+  "side-projects": "Side projects",
+};
+
+export interface ProjectGroup {
+  area: string;
+  label: string;
+  projects: Project[];
+}
+
+export function groupProjectsByArea(projects: Project[]): ProjectGroup[] {
+  const active = projects.filter((p) => !p.archived);
+  const groups = new Map<string, Project[]>();
+
+  for (const p of active) {
+    const area = p.area || "";
+    const list = groups.get(area) || [];
+    list.push(p);
+    groups.set(area, list);
+  }
+
+  const sorted: ProjectGroup[] = [];
+
+  for (const area of AREA_ORDER) {
+    const list = groups.get(area);
+    if (list?.length) {
+      sorted.push({
+        area,
+        label: AREA_LABELS[area] || area,
+        projects: list,
+      });
+      groups.delete(area);
+    }
+  }
+
+  const unknownAreas = [...groups.entries()]
+    .filter(([a]) => a !== "")
+    .sort(([a], [b]) => a.localeCompare(b));
+  for (const [area, list] of unknownAreas) {
+    sorted.push({
+      area,
+      label: area.charAt(0).toUpperCase() + area.slice(1),
+      projects: list,
+    });
+  }
+
+  const ungrouped = groups.get("");
+  if (ungrouped?.length) {
+    sorted.push({ area: "", label: "", projects: ungrouped });
+  }
+
+  return sorted;
+}
+
+export function getVisibleViews(isSimple: boolean): string[] {
+  const ALL_VIEWS = ["home", "all", "today", "horizon", "completed"] as const;
+  return isSimple
+    ? ALL_VIEWS.filter((v) => v !== "home")
+    : [...ALL_VIEWS];
+}
+
+export const VIEW_LABELS: Record<string, string> = {
+  home: "Focus",
+  all: "Everything",
+  today: "Today",
+  horizon: "Horizon",
+  completed: "Completed",
+};
+
+export const STATUS_COLORS: Record<string, string> = {
+  active: "var(--success)",
+  on_hold: "var(--warning)",
+  completed: "var(--muted)",
+  archived: "var(--muted)",
+};


### PR DESCRIPTION
Fixes TypeScript errors from Phase 26 and 27:\n\n- **TS2345**: `QueryParams` now extends `Record<string, string | undefined>` to match `loadTodos` parameter type\n- **TS2322**: `ViewCounts` and `HorizonCounts` now extend `Record<string, number>` to match `Sidebar` props\n- **TS2305**: Export `WorkspaceView` type from `sidebarModels` for Sidebar.tsx import