### PR TITLE
test(ui): Phase 35 — add 5 AdminFeedbackWorkflow rendering tests

### DIFF
--- a/client-react/src/components/admin/AdminFeedbackWorkflow.test.tsx
+++ b/client-react/src/components/admin/AdminFeedbackWorkflow.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+// @ts-nocheck — complex component with many dependencies
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import React from "react";
+import { AdminFeedbackWorkflow } from "./AdminFeedbackWorkflow";
+import * as apiClient from "../../api/client";
+
+vi.mock("../../api/client", () => ({
+  apiCall: vi.fn(),
+}));
+
+const mockApiCall = vi.mocked(apiClient.apiCall);
+
+// Mock child components
+vi.mock("./FeedbackTriagePage", () => ({
+  FeedbackTriagePage: ({ feedbackId, onBack }: any) =>
+    React.createElement("div", { "data-testid": "feedback-triage-page", "data-feedback-id": feedbackId },
+      React.createElement("button", { onClick: onBack }, "Back to queue"),
+      React.createElement("span", null, `Triage: ${feedbackId}`),
+    ),
+}));
+
+function setupMocks(overrides: {
+  feedbackList?: any[];
+  config?: any;
+  decisions?: any[];
+} = {}) {
+  const {
+    feedbackList = [
+      { id: "fb-1", title: "Bug report 1", type: "bug", status: "new", createdAt: "2026-04-10T10:00:00Z", userId: "u1" },
+    ],
+    config = {
+      feedbackAutomationEnabled: false,
+      feedbackAutoPromoteEnabled: false,
+      feedbackAutoPromoteMinConfidence: 0.7,
+      allowlistedClassifications: ["bug", "feature"],
+    },
+    decisions = [],
+  } = overrides;
+
+  mockApiCall.mockImplementation(async (url: string) => {
+    if (url.includes("/feedback/automation/config")) {
+      return { ok: true, json: async () => config };
+    }
+    if (url.includes("/feedback/automation/decisions")) {
+      return { ok: true, json: async () => decisions };
+    }
+    if (url.includes("/feedback/automation/run")) {
+      return { ok: true, json: async () => ({}) };
+    }
+    if (url.includes("/admin/feedback") && !url.includes("/automation")) {
+      if (!url.includes("/fb-")) {
+        return { ok: true, json: async () => feedbackList };
+      }
+      const feedbackId = url.split("/feedback/")[1]?.split("/")[0];
+      const item = feedbackList.find((f) => f.id === feedbackId);
+      return { ok: !!item, json: async () => item || {} };
+    }
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+describe("AdminFeedbackWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  describe("initial rendering", () => {
+    it("renders the page title", async () => {
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("Feedback Queue")).toBeTruthy();
+      });
+    });
+
+    it("renders feedback list items", async () => {
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("Bug report 1")).toBeTruthy();
+      });
+    });
+
+    it("shows feedback type pills", async () => {
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("bug")).toBeTruthy();
+      });
+    });
+
+    it("shows feedback status pills", async () => {
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("new")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty message when no feedback items", async () => {
+      setupMocks({ feedbackList: [] });
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText(/No feedback/i)).toBeTruthy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Phase 35 of the React test coverage initiative. Adds 5 rendering tests for AdminFeedbackWorkflow.

## New Tests

| File | Tests | Coverage Target |
|------|-------|----------------|
| `AdminFeedbackWorkflow.test.tsx` | 5 | Basic rendering verification |

### Tests (5)

**Initial rendering** (4 tests):
- Page title rendered
- Feedback list items rendered
- Feedback type pills rendered
- Feedback status pills rendered

**Empty state** (1 test):
- Empty message shown when no feedback items

## Results

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Vitest tests | 1407 | 1412 | +5 tests |
| AdminFeedbackWorkflow coverage | 0% | ~15% | **+~15 pts** |
| Overall coverage | ~62% | ~62.5% | **+~0.5 pts** |

### Cross-client impact
None — test-only changes.