### PR TITLE
test(ui): expand Vitest coverage for home, tuneup, and AgentMessage

### DIFF
--- a/client-react/src/agents/components/AgentMessage.test.tsx
+++ b/client-react/src/agents/components/AgentMessage.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import type { AgentProfile } from "../types";
+import { AgentMessage } from "./AgentMessage";
+import { getThinkingLine } from "../voiceEngine";
+
+vi.mock("./AgentBadge", () => ({
+  AgentBadge: ({ mode }: { mode: string }) => (
+    <span data-testid="agent-badge" data-mode={mode} />
+  ),
+}));
+
+vi.mock("../voiceEngine", () => ({
+  getThinkingLine: vi.fn(),
+}));
+
+const agent: AgentProfile = {
+  id: "orla",
+  name: "Orla",
+  role: "Guide",
+  traits: ["a", "b", "c"],
+  quote: "q",
+  superpower: "s",
+  quirk: "k",
+  bestCalledWhen: "now",
+  colors: {
+    stroke: "#112233",
+    bg: "#aabbcc",
+    textDark: "#010101",
+    traitBg: "#eeeeee",
+  },
+  voice: {
+    tone: "warm",
+    avgWordsPerSentence: 8,
+    openers: ["hi"],
+    closers: ["bye"],
+    thinkingLines: ["t1", "t2"],
+    emptyStateLines: ["e"],
+    errorLines: ["err"],
+  },
+  avatarSeed: 1,
+};
+
+describe("AgentMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getThinkingLine).mockReturnValue("thinking-mock");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders idle content and badge mode idle", () => {
+    render(
+      ce(AgentMessage, {
+        agent,
+        content: "Hello from agent",
+        isStreaming: false,
+      }),
+    );
+    expect(screen.getByText("Hello from agent")).toBeTruthy();
+    expect(screen.getByTestId("agent-badge").getAttribute("data-mode")).toBe(
+      "idle",
+    );
+  });
+
+  it("renders streaming thinking text and badge mode thinking", () => {
+    render(
+      ce(AgentMessage, {
+        agent,
+        content: "ignored while streaming",
+        isStreaming: true,
+      }),
+    );
+    expect(screen.getByText("thinking-mock")).toBeTruthy();
+    expect(screen.getByTestId("agent-badge").getAttribute("data-mode")).toBe(
+      "thinking",
+    );
+  });
+
+  it("shows formatted timestamp when provided", () => {
+    const spy = vi
+      .spyOn(Date.prototype, "toLocaleTimeString")
+      .mockReturnValue("9:30 AM");
+    render(
+      ce(AgentMessage, {
+        agent,
+        content: "x",
+        timestamp: new Date("2020-01-01T00:00:00.000Z"),
+      }),
+    );
+    expect(screen.getByText("9:30 AM")).toBeTruthy();
+    spy.mockRestore();
+  });
+
+  it("refreshes thinking line on interval while streaming", () => {
+    const mockFn = vi.mocked(getThinkingLine);
+    let tick = 0;
+    mockFn.mockImplementation(() => `thinking-${tick++}`);
+
+    vi.useFakeTimers();
+    render(
+      ce(AgentMessage, {
+        agent,
+        content: "body",
+        isStreaming: true,
+      }),
+    );
+
+    expect(screen.getByText("thinking-0")).toBeTruthy();
+    const callsAfterMount = mockFn.mock.calls.length;
+    act(() => {
+      vi.advanceTimersByTime(1800);
+    });
+    expect(mockFn.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    expect(screen.getByText("thinking-1")).toBeTruthy();
+  });
+});

--- a/client-react/src/components/activity/AgentActivityView.test.tsx
+++ b/client-react/src/components/activity/AgentActivityView.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { AgentActivityView } from "./AgentActivityView";
+
+vi.mock("../home/AgentActivityFeed", () => ({
+  AgentActivityFeed: ({ standalone }: { standalone?: boolean }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "agent-activity-feed", "data-standalone": String(!!standalone) },
+      "feed",
+    ),
+}));
+
+describe("AgentActivityView", () => {
+  it("renders title and passes standalone to feed", () => {
+    const onBack = vi.fn();
+    render(ce(AgentActivityView, { onBack }));
+    expect(screen.getByText("Agent Activity")).toBeTruthy();
+    const feed = screen.getByTestId("agent-activity-feed");
+    expect(feed.getAttribute("data-standalone")).toBe("true");
+  });
+
+  it("invokes onBack when back button clicked", () => {
+    const onBack = vi.fn();
+    render(ce(AgentActivityView, { onBack }));
+    fireEvent.click(screen.getByRole("button", { name: /Back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/client-react/src/components/admin/AdminFeedbackWorkflow.test.tsx
+++ b/client-react/src/components/admin/AdminFeedbackWorkflow.test.tsx
@@ -30,6 +30,8 @@ function setupMocks(overrides: {
   feedbackList?: any[];
   config?: any;
   decisions?: any[];
+  /** When true, `/admin/feedback?status=promoted` returns []. */
+  emptyPromotedFilter?: boolean;
 } = {}) {
   const {
     feedbackList = mockFeedbackList,
@@ -40,10 +42,14 @@ function setupMocks(overrides: {
       allowlistedClassifications: ["bug", "feature"],
     },
     decisions = [],
+    emptyPromotedFilter = false,
   } = overrides;
 
-  mockApiCall.mockImplementation(async (url: string) => {
+  mockApiCall.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url.includes("/feedback/automation/config")) {
+      if (init?.method === "PATCH") {
+        return { ok: true, json: async () => ({}) };
+      }
       return { ok: true, json: async () => config };
     }
     if (url.includes("/feedback/automation/decisions")) {
@@ -52,8 +58,21 @@ function setupMocks(overrides: {
     if (url.includes("/feedback/automation/run")) {
       return { ok: true, json: async () => ({}) };
     }
+    if (url.includes("/admin/feedback/") && url.includes("/triage")) {
+      return { ok: true, json: async () => ({}) };
+    }
+    if (
+      url.includes("/admin/feedback/") &&
+      init?.method === "PATCH" &&
+      !url.includes("/automation")
+    ) {
+      return { ok: true, json: async () => ({}) };
+    }
     if (url.includes("/admin/feedback") && !url.includes("/automation")) {
       if (!url.includes("/fb-")) {
+        if (emptyPromotedFilter && url.includes("status=promoted")) {
+          return { ok: true, json: async () => [] };
+        }
         return { ok: true, json: async () => feedbackList };
       }
       const feedbackId = url.split("/feedback/")[1]?.split("/")[0];
@@ -192,6 +211,82 @@ describe("AdminFeedbackWorkflow", () => {
       await waitFor(() => {
         expect(screen.getByText("Feedback Queue")).toBeTruthy();
       });
+    });
+  });
+
+  describe("queue filters and empty filtered state", () => {
+    it("shows empty filter message when API returns no rows for a filter", async () => {
+      setupMocks({ emptyPromotedFilter: true });
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("Bug report 1")).toBeTruthy();
+      });
+      const promotedChip = screen.getAllByRole("button", { name: "promoted" })[0]!;
+      fireEvent.click(promotedChip);
+      await waitFor(() => {
+        expect(
+          screen.getByText("No feedback matches the current filters."),
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("quick reject", () => {
+    it("removes an item after quick reject succeeds", async () => {
+      setupMocks();
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("Bug report 1")).toBeTruthy();
+      });
+      const rejectBtn = screen.getAllByLabelText("Quick reject")[0]!;
+      fireEvent.click(rejectBtn);
+      await waitFor(() => {
+        expect(screen.queryByText("Bug report 1")).toBeNull();
+      });
+    });
+  });
+
+  describe("batch triage", () => {
+    it("triages selected items and shows a success toast", async () => {
+      setupMocks();
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("Bug report 1")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByLabelText("Select Bug report 1"));
+      fireEvent.click(screen.getByLabelText("Select Feature request"));
+      fireEvent.click(screen.getByRole("button", { name: "Triage all" }));
+      await waitFor(() => {
+        expect(screen.getByText(/Triaged 2 of 2 items/)).toBeTruthy();
+      });
+    });
+  });
+
+  describe("automation panel", () => {
+    it("loads controls after expanding automation settings", async () => {
+      setupMocks({
+        decisions: [
+          {
+            id: "d1",
+            type: "bug",
+            promotionDecision: "approved",
+            title: "Auto item",
+            promotionReason: "tests",
+            promotionDecidedAt: "2026-04-10T12:00:00Z",
+            githubIssueNumber: null,
+            triageConfidence: 0.9,
+          },
+        ],
+      });
+      render(React.createElement(AdminFeedbackWorkflow));
+      await waitFor(() => {
+        expect(screen.getByText("Feedback Queue")).toBeTruthy();
+      });
+      fireEvent.click(screen.getByRole("button", { name: /Automation settings/i }));
+      await waitFor(() => {
+        expect(screen.getByText("Enable feedback automation")).toBeTruthy();
+      });
+      expect(screen.getByText("Auto item")).toBeTruthy();
     });
   });
 });

--- a/client-react/src/components/home/AgentSigil.test.tsx
+++ b/client-react/src/components/home/AgentSigil.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { AgentSigil } from "./AgentSigil";
+
+const drawAgentAvatar = vi.fn();
+
+vi.mock("../../agents/avatarEngine", () => ({
+  drawAgentAvatar: (...args: unknown[]) => drawAgentAvatar(...args),
+}));
+
+describe("AgentSigil", () => {
+  let origGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+  beforeEach(() => {
+    drawAgentAvatar.mockClear();
+    origGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      scale: vi.fn(),
+      fillStyle: "",
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      strokeStyle: "",
+      lineWidth: 0,
+      stroke: vi.fn(),
+    })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  });
+
+  afterEach(() => {
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+  });
+
+  it("draws registered agent via avatar engine", async () => {
+    render(
+      ce(AgentSigil, { agentId: "orla", color: "#111", bg: "#eee", size: 32 }),
+    );
+    await waitFor(() => {
+      expect(drawAgentAvatar).toHaveBeenCalled();
+    });
+  });
+
+  it("falls back to circle for unknown agent id", async () => {
+    const ctx = {
+      scale: vi.fn(),
+      fillStyle: "",
+      beginPath: vi.fn(),
+      arc: vi.fn(),
+      fill: vi.fn(),
+      strokeStyle: "",
+      lineWidth: 0,
+      stroke: vi.fn(),
+    };
+    HTMLCanvasElement.prototype.getContext = vi.fn(
+      () => ctx,
+    ) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+    render(
+      ce(AgentSigil, {
+        agentId: "no-such-agent",
+        color: "#00f",
+        bg: "#ddd",
+        size: 24,
+      }),
+    );
+    await waitFor(() => {
+      expect(ctx.arc).toHaveBeenCalled();
+      expect(drawAgentAvatar).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client-react/src/components/home/RightNowPanel.test.tsx
+++ b/client-react/src/components/home/RightNowPanel.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import React from "react";
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { AgentProfile } from "../../agents/types";
+import type { RightNow } from "../../types/focusBrief";
+import { RightNowPanel } from "./RightNowPanel";
+import { useAgentProfiles } from "../../agents/useAgentProfiles";
+
+vi.mock("./FlipCard", () => ({
+  FlipCard: ({ front }: { front: React.ReactNode }) => (
+    <div data-testid="flip-mock">{front}</div>
+  ),
+}));
+
+vi.mock("./TarotCard", () => ({
+  TarotCardFront: ({ children, agent }: { children?: React.ReactNode; agent?: { name: string } }) => (
+    <div data-testid="tarot-front">
+      {agent ? <span data-testid="agent-name">{agent.name}</span> : null}
+      {children}
+    </div>
+  ),
+  TarotCardBack: () => <div data-testid="tarot-back" />,
+}));
+
+vi.mock("./CardBack", () => ({
+  CardBackContent: () => <div data-testid="card-back" />,
+}));
+
+vi.mock("./pixel-art", () => ({
+  FlameArt: () => <span data-testid="flame-art" />,
+}));
+
+vi.mock("../../agents/useAgentProfiles", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../agents/useAgentProfiles")>();
+  return {
+    ...actual,
+    useAgentProfiles: vi.fn(actual.useAgentProfiles),
+  };
+});
+
+const mira: AgentProfile = {
+  id: "mira",
+  name: "Mira",
+  role: "Planner",
+  traits: ["t1", "t2", "t3"],
+  quote: "q",
+  superpower: "sp",
+  quirk: "qk",
+  bestCalledWhen: "planning",
+  colors: {
+    stroke: "#000",
+    bg: "#fff",
+    textDark: "#222",
+    traitBg: "#eee",
+  },
+  voice: {
+    tone: "warm",
+    avgWordsPerSentence: 6,
+    openers: ["o"],
+    closers: ["c"],
+    thinkingLines: ["th"],
+    emptyStateLines: ["e"],
+    errorLines: ["er"],
+  },
+  avatarSeed: 2,
+};
+
+describe("RightNowPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when there is nothing to show", () => {
+    const { container } = render(
+      ce(RightNowPanel, {
+        data: {
+          narrative: "",
+          urgentItems: [],
+          topRecommendation: null,
+        },
+        onTaskClick: vi.fn(),
+      }),
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders when urgent items exist even if narrative is empty", () => {
+    vi.mocked(useAgentProfiles).mockReturnValue({});
+    const data: RightNow = {
+      narrative: "",
+      urgentItems: [
+        { title: "Urgent", dueDate: "2024-01-01", reason: "soon" },
+      ],
+      topRecommendation: null,
+    };
+    render(ce(RightNowPanel, { data, onTaskClick: vi.fn() }));
+    expect(screen.getByTestId("flip-mock")).toBeTruthy();
+  });
+
+  it("renders narrative, recommendation click, and agent chip when profile exists", () => {
+    vi.mocked(useAgentProfiles).mockReturnValue({ mira });
+    const onTaskClick = vi.fn();
+    const data: RightNow = {
+      narrative: "You should focus.",
+      urgentItems: [],
+      topRecommendation: {
+        title: "Ship feature",
+        taskId: "task-99",
+        reasoning: "Highest leverage.",
+      },
+      agentId: "mira",
+    };
+    render(ce(RightNowPanel, { data, onTaskClick }));
+    expect(screen.getByText("You should focus.")).toBeTruthy();
+    expect(screen.getByTestId("agent-name").textContent).toBe("Mira");
+    fireEvent.click(screen.getByRole("button", { name: /Ship feature/i }));
+    expect(onTaskClick).toHaveBeenCalledWith("task-99");
+  });
+});

--- a/client-react/src/components/home/TodayAgendaPanel.test.tsx
+++ b/client-react/src/components/home/TodayAgendaPanel.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import React from "react";
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { AgendaItem } from "../../types/focusBrief";
+import { TodayAgendaPanel } from "./TodayAgendaPanel";
+
+vi.mock("./FlipCard", () => ({
+  FlipCard: ({ front }: { front: React.ReactNode }) => (
+    <div data-testid="flip-mock">{front}</div>
+  ),
+}));
+
+vi.mock("./TarotCard", () => ({
+  TarotCardFront: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="tarot-front">{children}</div>
+  ),
+  TarotCardBack: () => <div data-testid="tarot-back" />,
+}));
+
+vi.mock("./CardBack", () => ({
+  CardBackContent: ({ reason }: { reason: string }) => (
+    <div data-testid="card-back">{reason}</div>
+  ),
+}));
+
+vi.mock("./pixel-art", () => ({
+  SunriseArt: () => <span data-testid="sunrise-art" />,
+}));
+
+describe("TodayAgendaPanel", () => {
+  const onTaskClick = vi.fn();
+  const onToggle = vi.fn();
+
+  it("shows empty agenda copy", () => {
+    render(
+      ce(TodayAgendaPanel, {
+        items: [],
+        onTaskClick,
+        onToggle,
+      }),
+    );
+    expect(screen.getByText("All clear. Enjoy your day.")).toBeTruthy();
+  });
+
+  it("renders timeline items and forwards task clicks", () => {
+    const items: AgendaItem[] = [
+      {
+        id: "1",
+        title: "First task",
+        dueDate: null,
+        estimateMinutes: 10,
+        priority: "normal",
+        overdue: false,
+        completed: false,
+      },
+      {
+        id: "2",
+        title: "Second task",
+        dueDate: null,
+        estimateMinutes: null,
+        priority: "normal",
+        overdue: true,
+        completed: false,
+      },
+    ];
+    render(
+      ce(TodayAgendaPanel, {
+        items,
+        onTaskClick,
+        onToggle,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "First task" }));
+    expect(onTaskClick).toHaveBeenCalledWith("1");
+    expect(screen.getByText("overdue")).toBeTruthy();
+    expect(screen.getByText("10m")).toBeTruthy();
+  });
+
+  it("shows light day hint when there are at most two items", () => {
+    const items: AgendaItem[] = [
+      {
+        id: "1",
+        title: "Only",
+        dueDate: null,
+        estimateMinutes: null,
+        priority: "low",
+        overdue: false,
+        completed: false,
+      },
+    ];
+    render(
+      ce(TodayAgendaPanel, {
+        items,
+        onTaskClick,
+        onToggle,
+      }),
+    );
+    expect(screen.getByText(/Light day/)).toBeTruthy();
+  });
+});

--- a/client-react/src/components/layout/AppShell.test.tsx
+++ b/client-react/src/components/layout/AppShell.test.tsx
@@ -179,11 +179,26 @@ vi.mock("../todos/TodoDrawer", () => ({
 }));
 
 vi.mock("../shared/UndoToast", () => ({
-  UndoToast: ({ action }: { action?: { message?: string } | null }) =>
+  UndoToast: ({
+    action,
+    onDismiss,
+  }: {
+    action?: { message?: string } | null;
+    onDismiss?: () => void;
+  }) =>
     React.createElement(
       "div",
       { "data-testid": "undo-toast" },
       action?.message ?? "",
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          "data-testid": "undo-dismiss",
+          onClick: () => onDismiss?.(),
+        },
+        "Dismiss toast",
+      ),
     ),
 }));
 
@@ -206,7 +221,18 @@ vi.mock("../shared/ConfirmDialog", () => ({
 }));
 
 vi.mock("../shared/CommandPalette", () => ({
-  CommandPalette: ({ isOpen, onExportCalendar, onClose }: any) =>
+  CommandPalette: ({
+    isOpen,
+    onExportCalendar,
+    onClose,
+    onNavigateHorizonSegment,
+    onWeeklyReview,
+    onOpenFeedback,
+    onOpenShortcuts,
+    onTodoClick,
+    onProjectOpen,
+    onLogout,
+  }: any) =>
     isOpen
       ? React.createElement(
           "div",
@@ -222,6 +248,69 @@ vi.mock("../shared/CommandPalette", () => ({
           ),
           React.createElement(
             "button",
+            {
+              type: "button",
+              "data-testid": "cmd-horizon-pending",
+              onClick: () => onNavigateHorizonSegment?.("pending"),
+            },
+            "Horizon pending",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-weekly-review",
+              onClick: onWeeklyReview,
+            },
+            "Weekly review",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-open-feedback",
+              onClick: onOpenFeedback,
+            },
+            "Feedback",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-open-shortcuts",
+              onClick: onOpenShortcuts,
+            },
+            "Shortcuts",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-todo-click",
+              onClick: () => onTodoClick?.("t-palette"),
+            },
+            "Open todo",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-project-open",
+              onClick: () => onProjectOpen?.("p-palette"),
+            },
+            "Open project",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-logout",
+              onClick: onLogout,
+            },
+            "Logout",
+          ),
+          React.createElement(
+            "button",
             { type: "button", "data-testid": "cmd-close", onClick: onClose },
             "Close palette",
           ),
@@ -230,9 +319,22 @@ vi.mock("../shared/CommandPalette", () => ({
 }));
 
 vi.mock("../shared/ShortcutsOverlay", () => ({
-  ShortcutsOverlay: ({ isOpen }: any) => isOpen
-    ? React.createElement("div", { "data-testid": "shortcuts-overlay" })
-    : null,
+  ShortcutsOverlay: ({ isOpen, onClose }: any) =>
+    isOpen
+      ? React.createElement(
+          "div",
+          { "data-testid": "shortcuts-overlay" },
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "shortcuts-overlay-close",
+              onClick: onClose,
+            },
+            "Close shortcuts",
+          ),
+        )
+      : null,
 }));
 
 vi.mock("../todos/FilterPanel", () => ({
@@ -344,9 +446,22 @@ vi.mock("../todos/TaskFullPage", () => ({
 }));
 
 vi.mock("../todos/TaskComposer", () => ({
-  TaskComposer: ({ isOpen }: any) => isOpen
-    ? React.createElement("div", { "data-testid": "task-composer" })
-    : null,
+  TaskComposer: ({ isOpen, onClose }: any) =>
+    isOpen
+      ? React.createElement(
+          "div",
+          { "data-testid": "task-composer" },
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "task-composer-close",
+              onClick: onClose,
+            },
+            "Close composer",
+          ),
+        )
+      : null,
 }));
 
 vi.mock("../projects/ProjectCrud", () => ({
@@ -367,6 +482,15 @@ vi.mock("../tuneup/TuneUpView", () => ({
 
 vi.mock("./WeeklyReview", () => ({
   WeeklyReview: () => React.createElement("div", { "data-testid": "weekly-review" }),
+}));
+
+vi.mock("../feedback/FeedbackForm", () => ({
+  FeedbackForm: ({ onBack }: any) =>
+    React.createElement(
+      "div",
+      { "data-testid": "feedback-form" },
+      React.createElement("button", { type: "button", onClick: onBack }, "Back"),
+    ),
 }));
 
 vi.mock("../activity/AgentActivityView", () => ({
@@ -1104,6 +1228,162 @@ describe("AppShell", () => {
       });
       expect(mockExportIcs).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId("undo-toast").textContent).toMatch(/Exported/);
+    });
+  });
+
+  describe("command palette navigation callbacks", () => {
+    it("navigates horizon segment from palette", async () => {
+      setupOverrides();
+      localStorage.setItem("todos:horizon-segment", "due");
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-horizon-pending"));
+      });
+      await waitFor(() => {
+        expect(localStorage.getItem("todos:horizon-segment")).toBe("pending");
+      });
+    });
+
+    it("opens weekly review page from palette", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-weekly-review"));
+      });
+      expect(screen.getByTestId("weekly-review")).toBeTruthy();
+    });
+
+    it("opens feedback page from palette", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-open-feedback"));
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("feedback-form")).toBeTruthy();
+      });
+    });
+
+    it("opens shortcuts from palette then closes overlay", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-open-shortcuts"));
+      });
+      expect(screen.getByTestId("shortcuts-overlay")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("shortcuts-overlay-close"));
+      });
+      expect(screen.queryByTestId("shortcuts-overlay")).toBeNull();
+    });
+
+    it("opens drawer for todo and closes palette", async () => {
+      setupOverrides({
+        todos: [baseTodo("t-palette", "Palette todo")],
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-todo-click"));
+      });
+      expect(screen.getByTestId("todo-drawer")).toBeTruthy();
+      expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
+
+    it("selects project from palette", async () => {
+      setupOverrides({
+        projects: [
+          {
+            id: "p-palette",
+            name: "Palette Project",
+            slug: "pp",
+            status: "active" as const,
+            archived: false,
+            userId: "u1",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-project-open"));
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("project-editor-view")).toBeTruthy();
+      });
+      expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
+
+    it("logs out from palette", async () => {
+      const logout = vi.fn();
+      setupOverrides();
+      mockUseAuth.mockReturnValue({
+        user: {
+          id: "u1",
+          name: "Test User",
+          email: "test@example.com",
+          onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+        },
+        loading: false,
+        logout,
+        setUser: vi.fn(),
+        setTokens: vi.fn(),
+        refreshUser: vi.fn().mockResolvedValue(null),
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-logout"));
+      });
+      expect(logout).toHaveBeenCalled();
+    });
+  });
+
+  describe("undo toast and composer", () => {
+    it("dismisses undo toast", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        serviceWorkerCallback!(1, 0);
+      });
+      expect(screen.getByTestId("undo-toast").textContent).toMatch(/Synced/);
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("undo-dismiss"));
+      });
+      expect(screen.getByTestId("undo-toast").textContent).not.toMatch(/Synced/);
+    });
+
+    it("closes task composer", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("sidebar-new-task"));
+      });
+      expect(screen.getByTestId("task-composer")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("task-composer-close"));
+      });
+      expect(screen.queryByTestId("task-composer")).toBeNull();
     });
   });
 

--- a/client-react/src/components/layout/AppShell.test.tsx
+++ b/client-react/src/components/layout/AppShell.test.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 import { ce } from "../../test-helpers";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  within,
+  waitFor,
+} from "@testing-library/react";
 import React from "react";
 
 // ─── Mock all heavy dependencies before importing AppShell ──────────
@@ -30,33 +37,24 @@ vi.mock("../../hooks/useGroupBy", () => ({
   useGroupBy: () => ({ groupBy: "none", setGroupBy: vi.fn() }),
 }));
 
-vi.mock("../../hooks/useServiceWorker", () => ({
-  useServiceWorker: () => vi.fn(),
-}));
-
 vi.mock("../../hooks/useIsMobile", () => ({
   useIsMobile: vi.fn(),
 }));
 
+const mockExportIcs = vi.hoisted(() => vi.fn());
+
 vi.mock("../../hooks/useIcsExport", () => ({
-  useIcsExport: () => ({ exportIcs: vi.fn() }),
+  useIcsExport: () => mockExportIcs,
 }));
 
-vi.mock("../../hooks/useTaskNavigation", () => ({
-  useTaskNavigation: () => ({
-    state: { mode: "collapsed" },
-    activeTaskId: null,
-    openQuickEdit: vi.fn(),
-    openDrawer: vi.fn(),
-    openFullPage: vi.fn(),
-    escalate: vi.fn(),
-    deescalate: vi.fn(),
-    collapse: vi.fn(),
-  }),
-}));
+let serviceWorkerCallback:
+  | ((replayed: number, failed: number) => void)
+  | undefined;
 
-vi.mock("../../hooks/useHashRoute", () => ({
-  useHashRoute: () => ({ hashRoute: { taskId: null } }),
+vi.mock("../../hooks/useServiceWorker", () => ({
+  useServiceWorker: (cb: (replayed: number, failed: number) => void) => {
+    serviceWorkerCallback = cb;
+  },
 }));
 
 vi.mock("../../hooks/useViewTransition", () => ({
@@ -77,6 +75,8 @@ vi.mock("../../api/client", () => ({
 
 vi.mock("../../api/todos", () => ({
   reorderTodos: vi.fn().mockResolvedValue(undefined),
+  updateTodo: vi.fn().mockResolvedValue(undefined),
+  deleteTodo: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock child components
@@ -93,28 +93,140 @@ vi.mock("../projects/Sidebar", () => ({
     ),
 }));
 
+vi.mock("../todos/BoardView", () => ({
+  BoardView: ({ todos }: { todos?: unknown[] }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "board-view" },
+      `board:${(todos ?? []).length}`,
+    ),
+}));
+
 vi.mock("../todos/SortableTodoList", () => ({
-  SortableTodoList: () => React.createElement("div", { "data-testid": "todo-list" }),
+  SortableTodoList: ({
+    todos,
+    expandedTodoId,
+    onSelect,
+  }: {
+    todos?: { id: string; title: string }[];
+    expandedTodoId?: string | null;
+    onSelect?: (id: string) => void;
+  }) =>
+    React.createElement(
+      "div",
+      {
+        "data-testid": "todo-list",
+        "data-expanded-todo": expandedTodoId ?? "",
+      },
+      React.createElement(
+        "div",
+        { "data-testid": "todo-list-bulk-triggers" },
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            "data-testid": "todo-select-row-a",
+            onClick: () => onSelect?.("t-a"),
+          },
+          "Select row A",
+        ),
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            "data-testid": "todo-select-row-b",
+            onClick: () => onSelect?.("t-b"),
+          },
+          "Select row B",
+        ),
+      ),
+      (todos ?? []).map((t) =>
+        React.createElement(
+          "div",
+          { key: t.id, "data-todo-id": t.id },
+          t.title,
+        ),
+      ),
+    ),
 }));
 
 vi.mock("../todos/TodoDrawer", () => ({
-  TodoDrawer: ({ todo }: any) => todo
-    ? React.createElement("div", { "data-testid": "todo-drawer" })
-    : null,
+  TodoDrawer: ({ todo, onClose, onOpenFullPage }: any) =>
+    todo
+      ? React.createElement(
+          "div",
+          { "data-testid": "todo-drawer" },
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "drawer-open-full-page",
+              onClick: () => onOpenFullPage?.(todo.id),
+            },
+            "Open full page",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "drawer-close",
+              onClick: () => onClose?.(),
+            },
+            "Close drawer",
+          ),
+        )
+      : null,
 }));
 
 vi.mock("../shared/UndoToast", () => ({
-  UndoToast: () => React.createElement("div", { "data-testid": "undo-toast" }),
+  UndoToast: ({ action }: { action?: { message?: string } | null }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "undo-toast" },
+      action?.message ?? "",
+    ),
 }));
 
 vi.mock("../shared/ConfirmDialog", () => ({
-  ConfirmDialog: () => React.createElement("div", { "data-testid": "confirm-dialog" }),
+  ConfirmDialog: ({ onConfirm, onCancel }: any) =>
+    React.createElement(
+      "div",
+      { "data-testid": "confirm-dialog" },
+      React.createElement(
+        "button",
+        { type: "button", "data-testid": "confirm-delete-ok", onClick: onConfirm },
+        "Delete",
+      ),
+      React.createElement(
+        "button",
+        { type: "button", "data-testid": "confirm-delete-cancel", onClick: onCancel },
+        "Cancel",
+      ),
+    ),
 }));
 
 vi.mock("../shared/CommandPalette", () => ({
-  CommandPalette: ({ isOpen }: any) => isOpen
-    ? React.createElement("div", { "data-testid": "command-palette" })
-    : null,
+  CommandPalette: ({ isOpen, onExportCalendar, onClose }: any) =>
+    isOpen
+      ? React.createElement(
+          "div",
+          { "data-testid": "command-palette" },
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "cmd-export-calendar",
+              onClick: onExportCalendar,
+            },
+            "Export calendar",
+          ),
+          React.createElement(
+            "button",
+            { type: "button", "data-testid": "cmd-close", onClick: onClose },
+            "Close palette",
+          ),
+        )
+      : null,
 }));
 
 vi.mock("../shared/ShortcutsOverlay", () => ({
@@ -142,7 +254,70 @@ vi.mock("./HomeDashboard", () => ({
 }));
 
 vi.mock("./ListViewHeader", () => ({
-  ListViewHeader: () => React.createElement("div", { "data-testid": "list-header" }),
+  ListViewHeader: (props: any) =>
+    React.createElement(
+      "div",
+      { "data-testid": "list-header", "data-active-view": props.activeView },
+      props.activeView === "all" &&
+        React.createElement(
+          React.Fragment,
+          null,
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "hdr-view-board",
+              onClick: () => props.onViewModeChange?.("board"),
+            },
+            "Board",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "hdr-view-list",
+              onClick: () => props.onViewModeChange?.("list"),
+            },
+            "List",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "hdr-select-all",
+              onClick: () => props.onSelectAll?.(),
+            },
+            "Select all",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "hdr-bulk-complete",
+              onClick: () => void props.onBulkComplete?.(),
+            },
+            "Bulk complete",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "hdr-bulk-delete",
+              onClick: () => void props.onBulkDelete?.(),
+            },
+            "Bulk delete",
+          ),
+          React.createElement(
+            "button",
+            {
+              type: "button",
+              "data-testid": "hdr-bulk-cancel",
+              onClick: () => props.onCancelBulk?.(),
+            },
+            "Cancel bulk",
+          ),
+        ),
+    ),
 }));
 
 vi.mock("../../utils/focusTargets", () => ({
@@ -155,7 +330,17 @@ vi.mock("../shared/OnboardingFlow", () => ({
 }));
 
 vi.mock("../todos/TaskFullPage", () => ({
-  TaskFullPage: () => React.createElement("div", { "data-testid": "task-full-page" }),
+  TaskFullPage: ({ todo, onBack }: any) =>
+    React.createElement(
+      "div",
+      { "data-testid": "task-full-page" },
+      React.createElement("span", null, todo?.title ?? ""),
+      React.createElement(
+        "button",
+        { type: "button", "data-testid": "full-page-back", onClick: onBack },
+        "Back",
+      ),
+    ),
 }));
 
 vi.mock("../todos/TaskComposer", () => ({
@@ -209,6 +394,8 @@ import { useProjectsStore } from "../../store/useProjectsStore";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { useDarkMode } from "../../hooks/useDarkMode";
 import { AppShell } from "./AppShell";
+import * as todosApi from "../../api/todos";
+import * as focusTargets from "../../utils/focusTargets";
 
 const mockUseAuth = vi.mocked(useAuth);
 const mockUseTodosStore = vi.mocked(useTodosStore);
@@ -223,9 +410,17 @@ function setupOverrides(overrides: {
   projects?: any[];
   isMobile?: boolean;
   dark?: boolean;
+  removeTodo?: ReturnType<typeof vi.fn>;
+  addTodo?: ReturnType<typeof vi.fn>;
+  loadTodos?: ReturnType<typeof vi.fn>;
 } = {}) {
   mockUseAuth.mockReturnValue({
-    user: overrides.user ?? { id: "u1", name: "Test User", email: "test@example.com" },
+    user: overrides.user ?? {
+      id: "u1",
+      name: "Test User",
+      email: "test@example.com",
+      onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+    },
     loading: false,
     logout: vi.fn(),
     setUser: vi.fn(),
@@ -236,11 +431,17 @@ function setupOverrides(overrides: {
     todos: overrides.todos ?? [],
     loadState: (overrides.loadState ?? "loaded") as "idle" | "loading" | "loaded" | "error",
     errorMessage: "",
-    loadTodos: vi.fn(),
-    addTodo: vi.fn(),
+    loadTodos: (overrides.loadTodos ?? vi.fn()) as ReturnType<
+      typeof useTodosStore
+    >["loadTodos"],
+    addTodo: (overrides.addTodo ?? vi.fn()) as ReturnType<
+      typeof useTodosStore
+    >["addTodo"],
     toggleTodo: vi.fn(),
     editTodo: vi.fn(),
-    removeTodo: vi.fn(),
+    removeTodo: (overrides.removeTodo ?? vi.fn()) as ReturnType<
+      typeof useTodosStore
+    >["removeTodo"],
   });
   mockUseProjectsStore.mockReturnValue({
     projects: overrides.projects ?? [],
@@ -255,6 +456,14 @@ describe("AppShell", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    window.history.replaceState(null, "", "/");
+    window.location.hash = "";
+    serviceWorkerCallback = undefined;
+    Element.prototype.scrollIntoView = vi.fn() as unknown as typeof Element.prototype.scrollIntoView;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    }) as typeof requestAnimationFrame;
     setupOverrides();
   });
 
@@ -453,7 +662,12 @@ describe("AppShell", () => {
     it("logs out when sidebar logout button clicked", async () => {
       const logout = vi.fn();
       mockUseAuth.mockReturnValue({
-        user: { id: "u1", name: "Test User", email: "test@example.com" },
+        user: {
+          id: "u1",
+          name: "Test User",
+          email: "test@example.com",
+          onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+        },
         loading: false,
         logout,
         setUser: vi.fn(),
@@ -650,6 +864,279 @@ describe("AppShell", () => {
       });
       // Project crud should render when editing a project
       // This depends on the routing state
+    });
+  });
+
+  const baseTodo = (id: string, title: string, extra: Record<string, unknown> = {}) => ({
+    id,
+    title,
+    status: "inbox" as const,
+    completed: false,
+    tags: [] as string[],
+    dependsOnTaskIds: [] as string[],
+    order: 0,
+    archived: false,
+    userId: "u1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...extra,
+  });
+
+  describe("keyboard shortcuts and navigation", () => {
+    it("j/k updates quick-edit focus and calls scrollIntoView", async () => {
+      setupOverrides({
+        todos: [baseTodo("t-a", "A"), baseTodo("t-b", "B")],
+      });
+      render(ce(AppShell));
+      const lists = screen.getAllByTestId("todo-list");
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      expect(lists[0].getAttribute("data-expanded-todo")).toBe("t-a");
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      expect(lists[0].getAttribute("data-expanded-todo")).toBe("t-b");
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", bubbles: true });
+      });
+      expect(lists[0].getAttribute("data-expanded-todo")).toBe("t-a");
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
+
+    it("Escape collapses quick edit when a task is focused", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "Only")] });
+      render(ce(AppShell));
+      const list = screen.getAllByTestId("todo-list")[0];
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      expect(list.getAttribute("data-expanded-todo")).toBe("t-a");
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape", bubbles: true });
+      });
+      expect(list.getAttribute("data-expanded-todo")).toBe("");
+    });
+
+    it("Escape cancels bulk selection", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "A"), baseTodo("t-b", "B")] });
+      const { container } = render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("todo-select-row-a")[0]!);
+      });
+      expect(container.querySelector(".is-bulk-selecting")).toBeTruthy();
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape", bubbles: true });
+      });
+      expect(container.querySelector(".is-bulk-selecting")).toBeNull();
+    });
+
+    it("e opens drawer and full-page control shows TaskFullPage", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "Task A")] });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "e", bubbles: true });
+      });
+      expect(screen.getByTestId("todo-drawer")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("drawer-open-full-page"));
+      });
+      expect(screen.getByTestId("task-full-page")).toBeTruthy();
+      expect(
+        within(screen.getByTestId("task-full-page")).getByText("Task A"),
+      ).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("full-page-back"));
+      });
+      expect(screen.queryByTestId("task-full-page")).toBeNull();
+    });
+
+    it("d requests delete and confirm runs removeTodo", async () => {
+      const removeTodo = vi.fn().mockResolvedValue(undefined);
+      setupOverrides({
+        todos: [baseTodo("t-a", "Delete me")],
+        removeTodo,
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "d", bubbles: true });
+      });
+      expect(screen.getByTestId("confirm-dialog")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("confirm-delete-ok"));
+      });
+      expect(removeTodo).toHaveBeenCalledWith("t-a");
+      expect(screen.queryByTestId("confirm-dialog")).toBeNull();
+    });
+
+    it("slash focuses global search", async () => {
+      const spy = vi.mocked(focusTargets.focusGlobalSearchInput);
+      spy.mockClear();
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "/", bubbles: true });
+      });
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+    });
+
+    it("toggles command palette with meta+k", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      expect(screen.getByTestId("command-palette")).toBeTruthy();
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
+  });
+
+  describe("board view and bulk actions", () => {
+    it("switches list routes to board view", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "A")] });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("hdr-view-board"));
+      });
+      const boards = screen.getAllByTestId("board-view");
+      expect(boards.some((el) => el.textContent?.includes("board:1"))).toBe(
+        true,
+      );
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("hdr-view-list"));
+      });
+      expect(screen.queryAllByTestId("board-view").length).toBe(0);
+    });
+
+    it("bulk complete calls todosApi.updateTodo and reloads", async () => {
+      const loadTodos = vi.fn();
+      setupOverrides({
+        todos: [baseTodo("t-a", "A"), baseTodo("t-b", "B")],
+        loadTodos,
+      });
+      vi.mocked(todosApi.updateTodo).mockClear();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("todo-select-row-a")[0]!);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("todo-select-row-b")[0]!);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("hdr-bulk-complete"));
+      });
+      expect(todosApi.updateTodo).toHaveBeenCalled();
+      expect(loadTodos).toHaveBeenCalled();
+    });
+
+    it("bulk delete calls todosApi.deleteTodo", async () => {
+      const loadTodos = vi.fn();
+      setupOverrides({
+        todos: [baseTodo("t-a", "A")],
+        loadTodos,
+      });
+      vi.mocked(todosApi.deleteTodo).mockClear();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("todo-select-row-a")[0]!);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("hdr-bulk-delete"));
+      });
+      expect(todosApi.deleteTodo).toHaveBeenCalledWith("t-a");
+    });
+
+    it("select all toggles full selection then clears via cancel", async () => {
+      setupOverrides({
+        todos: [baseTodo("t-a", "A"), baseTodo("t-b", "B")],
+      });
+      const { container } = render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getAllByTestId("todo-select-row-a")[0]!);
+      });
+      expect(container.querySelector(".is-bulk-selecting")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("hdr-select-all"));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("hdr-bulk-cancel"));
+      });
+      expect(container.querySelector(".is-bulk-selecting")).toBeNull();
+    });
+  });
+
+  describe("command palette export calendar", () => {
+    it("shows toast when no todos have due dates", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "No due")] });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-export-calendar"));
+      });
+      expect(screen.getByTestId("undo-toast").textContent).toMatch(
+        /No tasks with due dates/,
+      );
+      expect(mockExportIcs).not.toHaveBeenCalled();
+    });
+
+    it("exports ICS when tasks have due dates", async () => {
+      mockExportIcs.mockClear();
+      setupOverrides({
+        todos: [baseTodo("t-a", "Due", { dueDate: "2026-04-20T12:00:00.000Z" })],
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("cmd-export-calendar"));
+      });
+      expect(mockExportIcs).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("undo-toast").textContent).toMatch(/Exported/);
+    });
+  });
+
+  describe("service worker offline replay", () => {
+    it("surfaces a toast when offline changes are replayed", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      expect(serviceWorkerCallback).toBeTypeOf("function");
+      await act(async () => {
+        serviceWorkerCallback!(2, 1);
+      });
+      expect(screen.getByTestId("undo-toast").textContent).toMatch(
+        /Synced 2 offline changes \(1 failed\)/,
+      );
+    });
+  });
+
+  describe("mobile escape closes sheet", () => {
+    it("Escape closes mobile nav when open", async () => {
+      setupOverrides({ isMobile: true });
+      const { container } = render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(container.querySelector("#projectsRailMobileOpen")!);
+      });
+      expect(container.querySelector(".mobile-sheet")?.getAttribute("aria-hidden")).toBe(
+        "false",
+      );
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape", bubbles: true });
+      });
+      expect(container.querySelector(".mobile-sheet")?.getAttribute("aria-hidden")).toBe(
+        "true",
+      );
     });
   });
 });

--- a/client-react/src/components/projects/ProjectEditorHeader.test.tsx
+++ b/client-react/src/components/projects/ProjectEditorHeader.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import type { Project } from "../../types";
+import { ProjectEditorHeader } from "./ProjectEditorHeader";
+import type { ProjectEditorStats } from "./projectEditorModels";
+
+vi.mock("./ProjectKebabMenu", () => ({
+  ProjectKebabMenu: ({
+    onRename,
+    onArchive,
+    onDelete,
+  }: {
+    onRename: () => void;
+    onArchive: () => void;
+    onDelete: () => void;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "project-kebab" },
+      React.createElement("button", { type: "button", onClick: onRename }, "Rename"),
+      React.createElement("button", { type: "button", onClick: onArchive }, "Archive"),
+      React.createElement("button", { type: "button", onClick: onDelete }, "Delete"),
+    ),
+}));
+
+const baseProject: Project = {
+  id: "p1",
+  name: "Alpha",
+  status: "active",
+  archived: false,
+  userId: "u1",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const baseStats: ProjectEditorStats = {
+  openCount: 2,
+  completedCount: 1,
+  nextStepTitle: "Ship",
+  progressLabel: "50%",
+  progressPercent: 50,
+};
+
+describe("ProjectEditorHeader", () => {
+  it("renders stats and forwards name and description edits", () => {
+    const onNameChange = vi.fn();
+    const onDescriptionChange = vi.fn();
+    render(
+      ce(ProjectEditorHeader, {
+        project: baseProject,
+        name: "Alpha",
+        onNameChange,
+        description: "Desc",
+        onDescriptionChange,
+        stats: baseStats,
+        onRenameMenu: vi.fn(),
+        onArchiveProject: vi.fn(),
+        onDeleteProject: vi.fn(),
+      }),
+    );
+    expect(screen.getByDisplayValue("Alpha")).toBeTruthy();
+    expect(screen.getByDisplayValue("Desc")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("Ship")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Project name"), {
+      target: { value: "Beta" },
+    });
+    expect(onNameChange).toHaveBeenCalledWith("Beta");
+    fireEvent.change(screen.getByPlaceholderText(/What this project is for/i), {
+      target: { value: "Next" },
+    });
+    expect(onDescriptionChange).toHaveBeenCalledWith("Next");
+  });
+
+  it("shows area pill when project has trimmed area", () => {
+    render(
+      ce(ProjectEditorHeader, {
+        project: { ...baseProject, area: "  Work  " },
+        name: "N",
+        onNameChange: vi.fn(),
+        description: "",
+        onDescriptionChange: vi.fn(),
+        stats: baseStats,
+        onRenameMenu: vi.fn(),
+        onArchiveProject: vi.fn(),
+        onDeleteProject: vi.fn(),
+      }),
+    );
+    expect(screen.getByText("Work")).toBeTruthy();
+  });
+
+  it("omits area pill when area is blank", () => {
+    render(
+      ce(ProjectEditorHeader, {
+        project: { ...baseProject, area: "   " },
+        name: "N",
+        onNameChange: vi.fn(),
+        description: "",
+        onDescriptionChange: vi.fn(),
+        stats: baseStats,
+        onRenameMenu: vi.fn(),
+        onArchiveProject: vi.fn(),
+        onDeleteProject: vi.fn(),
+      }),
+    );
+    expect(screen.queryByText("Work")).toBeNull();
+  });
+
+  it("forwards kebab actions", () => {
+    const onRenameMenu = vi.fn();
+    const onArchiveProject = vi.fn();
+    const onDeleteProject = vi.fn();
+    render(
+      ce(ProjectEditorHeader, {
+        project: baseProject,
+        name: "N",
+        onNameChange: vi.fn(),
+        description: "",
+        onDescriptionChange: vi.fn(),
+        stats: baseStats,
+        onRenameMenu,
+        onArchiveProject,
+        onDeleteProject,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    expect(onRenameMenu).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    expect(onArchiveProject).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDeleteProject).toHaveBeenCalled();
+  });
+});

--- a/client-react/src/components/shared/AnimatedCount.test.tsx
+++ b/client-react/src/components/shared/AnimatedCount.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { createElement } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AnimatedCount } from "./AnimatedCount";
 
@@ -11,7 +11,9 @@ describe("AnimatedCount", () => {
   });
 
   it("applies custom className when provided", () => {
-    render(createElement(AnimatedCount, { value: 10, className: "custom-class" }));
+    render(
+      createElement(AnimatedCount, { value: 10, className: "custom-class" }),
+    );
     expect(screen.getByText("10").className).toBe("custom-class");
   });
 
@@ -23,5 +25,17 @@ describe("AnimatedCount", () => {
   it("renders negative values", () => {
     render(createElement(AnimatedCount, { value: -5 }));
     expect(screen.getByText("-5")).toBeTruthy();
+  });
+
+  it("animates when value increases", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(createElement(AnimatedCount, { value: 0 }));
+    expect(screen.getByText("0")).toBeTruthy();
+    rerender(createElement(AnimatedCount, { value: 10 }));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.getByText("10")).toBeTruthy();
+    vi.useRealTimers();
   });
 });

--- a/client-react/src/components/tuneup/DuplicatesSection.test.tsx
+++ b/client-react/src/components/tuneup/DuplicatesSection.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { DuplicateGroup } from "../../types/tuneup";
+import { DuplicatesSection } from "./DuplicatesSection";
+import { dupGroupKey } from "../../utils/topFinding";
+
+describe("DuplicatesSection", () => {
+  const noop = vi.fn();
+
+  it("shows All clear when nothing visible", () => {
+    render(
+      ce(DuplicatesSection, {
+        groups: [],
+        dismissed: new Set(),
+        patchedTaskIds: new Set(),
+        onMerge: noop,
+        onDismiss: noop,
+      }),
+    );
+    expect(screen.getByText("All clear")).toBeTruthy();
+  });
+
+  it("hides groups that are dismissed or patched", () => {
+    const group: DuplicateGroup = {
+      confidence: 0.96,
+      reason: "r",
+      tasks: [
+        { id: "t1", title: "One", status: "open", projectId: null },
+        { id: "t2", title: "Two", status: "open", projectId: null },
+      ],
+      suggestedAction: "merge",
+    };
+    const key = dupGroupKey(["t1", "t2"]);
+    render(
+      ce(DuplicatesSection, {
+        groups: [group],
+        dismissed: new Set([key]),
+        patchedTaskIds: new Set(),
+        onMerge: noop,
+        onDismiss: noop,
+      }),
+    );
+    expect(screen.getByText("All clear")).toBeTruthy();
+  });
+
+  it("renders exact duplicate row and wires merge and dismiss", () => {
+    const onMerge = vi.fn();
+    const onDismiss = vi.fn();
+    const group: DuplicateGroup = {
+      confidence: 0.96,
+      reason: "r",
+      tasks: [
+        { id: "t1", title: "Keep me", status: "open", projectId: null },
+        { id: "t2", title: "Dup", status: "open", projectId: null },
+      ],
+      suggestedAction: "merge",
+    };
+    const key = dupGroupKey(["t1", "t2"]);
+    render(
+      ce(DuplicatesSection, {
+        groups: [group],
+        dismissed: new Set(),
+        patchedTaskIds: new Set(),
+        onMerge,
+        onDismiss,
+      }),
+    );
+    expect(screen.getByText(/Exact:/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Merge" }));
+    expect(onMerge).toHaveBeenCalledWith(group);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledWith(key);
+  });
+
+  it("labels near-duplicate groups as Similar", () => {
+    const group: DuplicateGroup = {
+      confidence: 0.5,
+      reason: "r",
+      tasks: [
+        { id: "a", title: "A", status: "open", projectId: null },
+        { id: "b", title: "B", status: "open", projectId: null },
+      ],
+      suggestedAction: "review",
+    };
+    render(
+      ce(DuplicatesSection, {
+        groups: [group],
+        dismissed: new Set(),
+        patchedTaskIds: new Set(),
+        onMerge: noop,
+        onDismiss: noop,
+      }),
+    );
+    expect(screen.getByText(/Similar:/)).toBeTruthy();
+  });
+});

--- a/client-react/src/components/tuneup/SectionHeader.test.tsx
+++ b/client-react/src/components/tuneup/SectionHeader.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SectionHeader } from "./SectionHeader";
+
+describe("SectionHeader", () => {
+  it("toggles collapse and shows count badge when idle", () => {
+    const onToggle = vi.fn();
+    render(
+      ce(SectionHeader, {
+        title: "Stale",
+        count: 3,
+        isCollapsed: true,
+        onToggle,
+      }),
+    );
+    const btn = screen.getByRole("button", { name: /Stale/i });
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalled();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("shows expanded chevron when not collapsed", () => {
+    render(
+      ce(SectionHeader, {
+        title: "Quality",
+        count: 0,
+        isCollapsed: false,
+        onToggle: vi.fn(),
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: /Quality/i }).getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
+  it("hides count badge while loading", () => {
+    render(
+      ce(SectionHeader, {
+        title: "Taxonomy",
+        count: 9,
+        isCollapsed: false,
+        onToggle: vi.fn(),
+        loading: true,
+      }),
+    );
+    expect(screen.queryByText("9")).toBeNull();
+  });
+
+  it("shows retry when error and onRetry provided", () => {
+    const onRetry = vi.fn();
+    render(
+      ce(SectionHeader, {
+        title: "Duplicates",
+        count: 1,
+        isCollapsed: false,
+        onToggle: vi.fn(),
+        error: "boom",
+        onRetry,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Retry loading Duplicates/i }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+});

--- a/client-react/src/components/tuneup/StaleSection.test.tsx
+++ b/client-react/src/components/tuneup/StaleSection.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StaleSection } from "./StaleSection";
+
+describe("StaleSection", () => {
+  const noop = vi.fn();
+
+  it("shows All clear when nothing visible", () => {
+    render(
+      ce(StaleSection, {
+        staleTasks: [],
+        staleProjects: [],
+        dismissed: new Set(),
+        patchedTaskIds: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveTask: noop,
+        onSnoozeTask: noop,
+        onArchiveProject: noop,
+        onDismiss: noop,
+        onOpenTask: noop,
+      }),
+    );
+    expect(screen.getByText("All clear")).toBeTruthy();
+  });
+
+  it("hides dismissed and patched tasks", () => {
+    render(
+      ce(StaleSection, {
+        staleTasks: [{ id: "t1", title: "Old task" }],
+        staleProjects: [],
+        dismissed: new Set(["stale:task:t1"]),
+        patchedTaskIds: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveTask: noop,
+        onSnoozeTask: noop,
+        onArchiveProject: noop,
+        onDismiss: noop,
+        onOpenTask: noop,
+      }),
+    );
+    expect(screen.getByText("All clear")).toBeTruthy();
+  });
+
+  it("renders task row actions", () => {
+    const onOpenTask = vi.fn();
+    const onSnoozeTask = vi.fn();
+    const onArchiveTask = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      ce(StaleSection, {
+        staleTasks: [
+          {
+            id: "t1",
+            title: "Stale",
+            status: "inbox",
+            lastUpdated: "2020-01-01T00:00:00.000Z",
+          },
+        ],
+        staleProjects: [],
+        dismissed: new Set(),
+        patchedTaskIds: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveTask,
+        onSnoozeTask,
+        onArchiveProject: noop,
+        onDismiss,
+        onOpenTask,
+      }),
+    );
+    expect(screen.getByText("Stale")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(onOpenTask).toHaveBeenCalledWith("t1");
+    fireEvent.click(screen.getByRole("button", { name: "Snooze 30d" }));
+    expect(onSnoozeTask).toHaveBeenCalledWith("t1");
+    fireEvent.click(screen.getAllByRole("button", { name: "Archive" })[0]!);
+    expect(onArchiveTask).toHaveBeenCalledWith("t1");
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledWith("stale:task:t1");
+  });
+
+  it("renders project row actions", () => {
+    const onArchiveProject = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      ce(StaleSection, {
+        staleTasks: [],
+        staleProjects: [
+          {
+            id: "p1",
+            name: "Old project",
+            lastUpdated: "2020-01-02T00:00:00.000Z",
+          },
+        ],
+        dismissed: new Set(),
+        patchedTaskIds: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveTask: noop,
+        onSnoozeTask: noop,
+        onArchiveProject,
+        onDismiss,
+        onOpenTask: noop,
+      }),
+    );
+    expect(screen.getByText("Old project")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    expect(onArchiveProject).toHaveBeenCalledWith("p1");
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledWith("stale:project:p1");
+  });
+});

--- a/client-react/src/components/tuneup/TaxonomySection.test.tsx
+++ b/client-react/src/components/tuneup/TaxonomySection.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TaxonomySection } from "./TaxonomySection";
+import { taxSimilarKey } from "../../utils/topFinding";
+
+describe("TaxonomySection", () => {
+  const noop = vi.fn();
+
+  it("shows All clear when no visible rows", () => {
+    render(
+      ce(TaxonomySection, {
+        similarProjects: [],
+        smallProjects: [],
+        dismissed: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveProject: noop,
+        onDismiss: noop,
+      }),
+    );
+    expect(screen.getByText("All clear")).toBeTruthy();
+  });
+
+  it("renders similar project pair and dismiss uses stable key", () => {
+    const onDismiss = vi.fn();
+    const pair = {
+      projectAName: "Front",
+      projectBName: "Back",
+      projectAId: "1",
+      projectBId: "2",
+    };
+    const key = taxSimilarKey(
+      pair.projectAId,
+      pair.projectBId,
+      pair.projectAName,
+      pair.projectBName,
+    );
+    render(
+      ce(TaxonomySection, {
+        similarProjects: [pair],
+        smallProjects: [],
+        dismissed: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveProject: noop,
+        onDismiss,
+      }),
+    );
+    expect(screen.getByText(/look similar/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledWith(key);
+  });
+
+  it("renders small project with id including archive", () => {
+    const onArchiveProject = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      ce(TaxonomySection, {
+        similarProjects: [],
+        smallProjects: [{ name: "Tiny", id: "proj-1", taskCount: 2 }],
+        dismissed: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveProject,
+        onDismiss,
+      }),
+    );
+    expect(screen.getByText(/"Tiny" has only 2 tasks/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    expect(onArchiveProject).toHaveBeenCalledWith("proj-1");
+    fireEvent.click(screen.getAllByRole("button", { name: "Dismiss" })[0]!);
+    expect(onDismiss).toHaveBeenCalledWith("tax:low:proj-1");
+  });
+
+  it("omits archive for small project without id and uses name dismiss key", () => {
+    const onDismiss = vi.fn();
+    render(
+      ce(TaxonomySection, {
+        similarProjects: [],
+        smallProjects: [{ name: "Solo", taskCount: 1 }],
+        dismissed: new Set(),
+        patchedProjectIds: new Set(),
+        onArchiveProject: noop,
+        onDismiss,
+      }),
+    );
+    expect(screen.queryByRole("button", { name: "Archive" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledWith("tax:low:name:Solo");
+  });
+});

--- a/client-react/src/components/tuneup/TuneUpTile.test.tsx
+++ b/client-react/src/components/tuneup/TuneUpTile.test.tsx
@@ -1,0 +1,297 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { TuneUpData } from "../../types/tuneup";
+import { TuneUpTile } from "./TuneUpTile";
+import { useTuneUp } from "../../hooks/useTuneUp";
+
+vi.mock("../../hooks/useTuneUp", () => ({
+  useTuneUp: vi.fn(),
+}));
+
+const emptyData: TuneUpData = {
+  duplicates: null,
+  stale: null,
+  quality: null,
+  taxonomy: null,
+};
+
+const idleLoading = {
+  duplicates: false,
+  stale: false,
+  quality: false,
+  taxonomy: false,
+};
+
+function tuneUpStub(partial: Partial<ReturnType<typeof useTuneUp>>) {
+  return {
+    data: emptyData,
+    loading: { ...idleLoading },
+    error: {
+      duplicates: null,
+      stale: null,
+      quality: null,
+      taxonomy: null,
+    },
+    dismissed: new Set<string>(),
+    patchedTaskIds: new Set<string>(),
+    patchedProjectIds: new Set<string>(),
+    hasFetched: false,
+    allSettled: true,
+    lastFetchedAt: null as number | null,
+    load: vi.fn(),
+    refresh: vi.fn(),
+    refreshSection: vi.fn(),
+    dismiss: vi.fn(),
+    patchTaskOut: vi.fn(),
+    unpatchTaskOut: vi.fn(),
+    patchProjectOut: vi.fn(),
+    unpatchProjectOut: vi.fn(),
+    patchQualityResolved: vi.fn(),
+    patchStaleResolved: vi.fn(),
+    restoreStaleTask: vi.fn(),
+    ...partial,
+  } as ReturnType<typeof useTuneUp>;
+}
+
+describe("TuneUpTile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls load on mount", () => {
+    const load = vi.fn();
+    vi.mocked(useTuneUp).mockReturnValue(tuneUpStub({ load }));
+    render(ce(TuneUpTile, {}));
+    expect(load).toHaveBeenCalled();
+  });
+
+  it("shows all-failed empty state when settled without fetch", () => {
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: false,
+        allSettled: true,
+        loading: { ...idleLoading },
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(screen.getByText("Couldn't analyze")).toBeTruthy();
+  });
+
+  it("shows analyzing when loading with no top finding yet", () => {
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: false,
+        loading: { ...idleLoading, duplicates: true },
+        data: emptyData,
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(screen.getByLabelText("Analyzing...")).toBeTruthy();
+  });
+
+  it("shows early finding with danger cue when tier <= 3 while still loading", () => {
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: false,
+        loading: { ...idleLoading, duplicates: true },
+        data: {
+          ...emptyData,
+          duplicates: {
+            groups: [
+              {
+                confidence: 0.96,
+                reason: "test",
+                tasks: [
+                  {
+                    id: "a",
+                    title: "A",
+                    status: "open",
+                    projectId: null,
+                  },
+                  {
+                    id: "b",
+                    title: "B",
+                    status: "open",
+                    projectId: null,
+                  },
+                ],
+                suggestedAction: "merge",
+              },
+            ],
+            totalTasks: 2,
+          },
+        },
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(
+      screen.getByText(/exact duplicate task group found/i),
+    ).toBeTruthy();
+    expect(screen.getByText("Needs attention")).toBeTruthy();
+    expect(screen.getByText(/still analyzing/i)).toBeTruthy();
+  });
+
+  it("shows settled quality finding for mid-tier severity styling", () => {
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: true,
+        allSettled: true,
+        data: {
+          ...emptyData,
+          quality: {
+            results: [
+              {
+                id: "q1",
+                title: "Split me",
+                qualityScore: 0.4,
+                issues: ["typo"],
+                suggestions: ["fix"],
+              },
+            ],
+            totalAnalyzed: 1,
+          },
+        },
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(
+      screen.getByText(/with title quality issues/i),
+    ).toBeTruthy();
+    expect(screen.queryByText("Needs attention")).toBeNull();
+  });
+
+  it("shows settled taxonomy finding with muted styling branch", () => {
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: true,
+        allSettled: true,
+        data: {
+          ...emptyData,
+          taxonomy: {
+            similarProjects: [
+              {
+                projectAName: "Alpha",
+                projectBName: "Beta",
+                projectAId: "p1",
+                projectBId: "p2",
+              },
+            ],
+            smallProjects: [],
+          },
+        },
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(
+      screen.getByText(/project organization suggestion/i),
+    ).toBeTruthy();
+  });
+
+  it("shows settled exact-duplicate finding with freshness", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00.000Z"));
+    const lastFetchedAt = new Date("2024-01-01T11:55:00.000Z").getTime();
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: true,
+        allSettled: true,
+        lastFetchedAt,
+        data: {
+          ...emptyData,
+          duplicates: {
+            groups: [
+              {
+                confidence: 0.96,
+                reason: "test",
+                tasks: [
+                  {
+                    id: "a",
+                    title: "A",
+                    status: "open",
+                    projectId: null,
+                  },
+                  {
+                    id: "b",
+                    title: "B",
+                    status: "open",
+                    projectId: null,
+                  },
+                ],
+                suggestedAction: "merge",
+              },
+            ],
+            totalTasks: 2,
+          },
+        },
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(screen.getByText("Needs attention")).toBeTruthy();
+    expect(screen.getByText(/last checked 5m ago/i)).toBeTruthy();
+  });
+
+  it("shows all clear when settled with no findings", () => {
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: true,
+        allSettled: true,
+        data: emptyData,
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(
+      screen.getByText(/all clear — nothing to clean up/i),
+    ).toBeTruthy();
+  });
+
+  it("labels freshness as just now when last fetch was under a minute ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T12:00:30.000Z"));
+    const lastFetchedAt = new Date("2024-06-01T12:00:00.000Z").getTime();
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: true,
+        allSettled: true,
+        lastFetchedAt,
+        data: emptyData,
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(screen.getByText(/last checked just now/i)).toBeTruthy();
+  });
+
+  it("uses hours label when last fetch was over an hour ago", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T14:00:00.000Z"));
+    const lastFetchedAt = new Date("2024-06-01T12:30:00.000Z").getTime();
+    vi.mocked(useTuneUp).mockReturnValue(
+      tuneUpStub({
+        hasFetched: true,
+        allSettled: true,
+        lastFetchedAt,
+        data: {
+          ...emptyData,
+          taxonomy: {
+            similarProjects: [
+              {
+                projectAName: "X",
+                projectBName: "Y",
+                projectAId: "a",
+                projectBId: "b",
+              },
+            ],
+            smallProjects: [],
+          },
+        },
+      }),
+    );
+    render(ce(TuneUpTile, {}));
+    expect(screen.getByText(/last checked 1h ago/i)).toBeTruthy();
+  });
+});

--- a/client-react/src/mobile/components/FieldPicker.test.tsx
+++ b/client-react/src/mobile/components/FieldPicker.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FieldPicker } from "./FieldPicker";
+
+describe("FieldPicker", () => {
+  const options = [
+    { key: "a" as const, label: "Alpha", color: "#f00" },
+    { key: "b" as const, label: "Beta" },
+  ];
+
+  it("toggles panel and selects an option", () => {
+    const onChange = vi.fn();
+    render(
+      ce(FieldPicker, {
+        label: "Status",
+        value: null,
+        options,
+        onChange,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Status/i }));
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Beta/i }));
+    expect(onChange).toHaveBeenCalledWith("b");
+  });
+
+  it("shows selected label and active styling", () => {
+    const onChange = vi.fn();
+    render(
+      ce(FieldPicker, {
+        label: "Field",
+        value: "a",
+        options,
+        onChange,
+      }),
+    );
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /Field/i }));
+    expect(screen.getByText("✓")).toBeTruthy();
+  });
+
+  it("clears when allowClear and Clear clicked", () => {
+    const onChange = vi.fn();
+    render(
+      ce(FieldPicker, {
+        label: "X",
+        value: "a",
+        options,
+        onChange,
+        allowClear: true,
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /X/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/client-react/src/mobile/components/InstallBanner.test.tsx
+++ b/client-react/src/mobile/components/InstallBanner.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { InstallBanner } from "./InstallBanner";
+
+const DISMISSED_KEY = "mobile:installDismissed";
+
+describe("InstallBanner", () => {
+  beforeEach(() => {
+    localStorage.removeItem(DISMISSED_KEY);
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: "",
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("stays hidden until beforeinstallprompt", () => {
+    render(ce(InstallBanner));
+    expect(screen.queryByText("Add to Home Screen")).toBeNull();
+  });
+
+  it("shows after beforeinstallprompt and dismiss persists", async () => {
+    render(ce(InstallBanner));
+    const prompt = vi.fn().mockResolvedValue(undefined);
+    const ev = new Event("beforeinstallprompt", {
+      cancelable: true,
+    }) as Event & {
+      prompt: () => Promise<void>;
+      userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+    };
+    ev.preventDefault = vi.fn();
+    ev.prompt = prompt;
+    ev.userChoice = Promise.resolve({ outcome: "dismissed" });
+    await act(async () => {
+      window.dispatchEvent(ev);
+    });
+    expect(screen.getByText("Add to Home Screen")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Not now" }));
+    expect(screen.queryByText("Add to Home Screen")).toBeNull();
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe("1");
+  });
+
+  it("install calls prompt and clears when accepted", async () => {
+    render(ce(InstallBanner));
+    const prompt = vi.fn().mockResolvedValue(undefined);
+    const ev = new Event("beforeinstallprompt", {
+      cancelable: true,
+    }) as Event & {
+      prompt: () => Promise<void>;
+      userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+    };
+    ev.preventDefault = vi.fn();
+    ev.prompt = prompt;
+    ev.userChoice = Promise.resolve({ outcome: "accepted" });
+    await act(async () => {
+      window.dispatchEvent(ev);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Install" }));
+    });
+    expect(prompt).toHaveBeenCalled();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByText("Add to Home Screen")).toBeNull();
+  });
+});

--- a/client-react/src/mobile/components/OfflineBanner.test.tsx
+++ b/client-react/src/mobile/components/OfflineBanner.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { ce } from "../../test-helpers";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { OfflineBanner } from "./OfflineBanner";
+
+describe("OfflineBanner", () => {
+  let onLineDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    onLineDescriptor = Object.getOwnPropertyDescriptor(
+      Navigator.prototype,
+      "onLine",
+    );
+  });
+
+  afterEach(() => {
+    if (onLineDescriptor) {
+      Object.defineProperty(Navigator.prototype, "onLine", onLineDescriptor);
+    }
+  });
+
+  it("renders nothing when online", () => {
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => true,
+    });
+    render(ce(OfflineBanner));
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("renders banner when navigator starts offline", () => {
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    render(ce(OfflineBanner));
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText(/You're offline/i)).toBeTruthy();
+  });
+
+  it("shows after offline event", async () => {
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => true,
+    });
+    render(ce(OfflineBanner));
+    expect(screen.queryByRole("status")).toBeNull();
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("hides after online event", async () => {
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => false,
+    });
+    render(ce(OfflineBanner));
+    expect(screen.getByRole("status")).toBeTruthy();
+    Object.defineProperty(Navigator.prototype, "onLine", {
+      configurable: true,
+      get: () => true,
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Closes

_(No linked issue — test coverage only.)_

## Why

Raise **client-react** line coverage with **deterministic Vitest tests** and **minimal churn**: target small, prop- or mock-driven components (home agenda / right-now panels, tune-up sections and tile, agent message) without changing runtime behavior.

## What Changed

- **New tests only** (no production code changes):
  - `AgentMessage` — idle vs streaming, timestamp display, streaming interval with `act` + fake timers.
  - `TuneUpTile` — `useTuneUp` mocked; branches for all-failed, analyzing, early finding, mid-tier quality, taxonomy, freshness labels, all-clear.
  - `DuplicatesSection` / `TaxonomySection` — empty state, dismiss/patch filtering, merge/dismiss/archive callbacks, Similar vs Exact.
  - `TodayAgendaPanel` / `RightNowPanel` — lightweight mocks for FlipCard / Tarot / pixel art / card back; task click, overdue/estimate, agent profile path.
- **Shared contract:** `src/types.ts` unchanged — **no cross-client impact**.

## Architecture

- Target layer/domain: **React client tests** (`client-react/src/**/*.test.tsx`).
- Relevant invariant/ADR: N/A — tests only; behavior preserved.
- [x] I kept routes, entrypoints, and other orchestrators thin. _(N/A — no app code touched.)_
- [x] I reused the canonical code path instead of adding a parallel flow.
- [ ] If I introduced or changed a boundary, I updated the relevant durable doc/ADR. _(N/A.)_

## Verification

- [x] `npx tsc --noEmit`
- [x] `npm run check:architecture`
- [x] `npm run format:check`
- [ ] `npm run lint:html` _(not applicable — no HTML edits)_
- [ ] `npm run lint:css` _(not applicable — no CSS edits)_
- [x] `npm run test:unit`
- [x] `CI=1 npm run test:ui:fast` _(after `npm run build:react`)_
- [x] `npm run test:coverage:check` _(root ratchet)_
- [x] `npm test` in `client-react` _(full Vitest suite)_

**Coverage note:** `client-react` aggregate line coverage from `coverage-summary.json` is **~67.34%** after this batch (prior reported baseline **~66.08%**).

## Brief / Protocol Impact

- [x] No
- [ ] Yes

If yes, which doc changed?
