### PR TITLE
fix(ui): Escape closes palette and delete confirm in AppShell

### DIFF
--- a/client-react/src/components/layout/AppShell.test.tsx
+++ b/client-react/src/components/layout/AppShell.test.tsx
@@ -81,8 +81,40 @@ vi.mock("../../api/todos", () => ({
 
 // Mock child components
 vi.mock("../projects/Sidebar", () => ({
-  Sidebar: ({ onNewTask, onOpenSettings, onOpenActivity, onToggleTheme, onOpenShortcuts, onLogout, onSearchChange, searchQuery, isCollapsed }: any) =>
-    React.createElement("aside", { "data-testid": "sidebar", "data-collapsed": isCollapsed ? "true" : "false" },
+  Sidebar: ({
+    onNewTask,
+    onOpenSettings,
+    onOpenActivity,
+    onToggleTheme,
+    onOpenShortcuts,
+    onLogout,
+    onSearchChange,
+    searchQuery,
+    isCollapsed,
+    onSelectView,
+  }: any) =>
+    React.createElement(
+      "aside",
+      {
+        "data-testid": "sidebar",
+        "data-collapsed": isCollapsed ? "true" : "false",
+      },
+      React.createElement(
+        "button",
+        {
+          "data-testid": "sidebar-view-home",
+          onClick: () => onSelectView?.("home"),
+        },
+        "Focus",
+      ),
+      React.createElement(
+        "button",
+        {
+          "data-testid": "sidebar-view-all",
+          onClick: () => onSelectView?.("all"),
+        },
+        "Everything",
+      ),
       React.createElement("button", { "data-testid": "sidebar-new-task", onClick: onNewTask }, "New Task"),
       React.createElement("button", { "data-testid": "sidebar-settings", onClick: onOpenSettings }, "Settings"),
       React.createElement("button", { "data-testid": "sidebar-activity", onClick: onOpenActivity }, "Activity"),
@@ -537,6 +569,7 @@ function setupOverrides(overrides: {
   removeTodo?: ReturnType<typeof vi.fn>;
   addTodo?: ReturnType<typeof vi.fn>;
   loadTodos?: ReturnType<typeof vi.fn>;
+  toggleTodo?: ReturnType<typeof vi.fn>;
 } = {}) {
   mockUseAuth.mockReturnValue({
     user: overrides.user ?? {
@@ -561,7 +594,9 @@ function setupOverrides(overrides: {
     addTodo: (overrides.addTodo ?? vi.fn()) as ReturnType<
       typeof useTodosStore
     >["addTodo"],
-    toggleTodo: vi.fn(),
+    toggleTodo: (overrides.toggleTodo ?? vi.fn()) as ReturnType<
+      typeof useTodosStore
+    >["toggleTodo"],
     editTodo: vi.fn(),
     removeTodo: (overrides.removeTodo ?? vi.fn()) as ReturnType<
       typeof useTodosStore
@@ -820,6 +855,19 @@ describe("AppShell", () => {
         fireEvent.click(screen.getByTestId("sidebar-new-task"));
       });
       expect(screen.getByTestId("task-composer")).toBeTruthy();
+    });
+  });
+
+  describe("workspace navigation from sidebar", () => {
+    it("switching to Everything surfaces list vs board controls for the todo workspace", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "One task")] });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("sidebar-view-all"));
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("hdr-view-board")).toBeTruthy();
+      });
     });
   });
 
@@ -1121,6 +1169,112 @@ describe("AppShell", () => {
         fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
       });
       expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
+
+    it("Escape closes the command palette without a second shortcut", async () => {
+      setupOverrides();
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true, bubbles: true });
+      });
+      expect(screen.getByTestId("command-palette")).toBeTruthy();
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape", bubbles: true });
+      });
+      expect(screen.queryByTestId("command-palette")).toBeNull();
+    });
+
+    it("Escape dismisses delete confirmation before touching task navigation", async () => {
+      const removeTodo = vi.fn().mockResolvedValue(undefined);
+      setupOverrides({
+        todos: [baseTodo("t-a", "Do not delete")],
+        removeTodo,
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "d", bubbles: true });
+      });
+      expect(screen.getByTestId("confirm-dialog")).toBeTruthy();
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape", bubbles: true });
+      });
+      expect(screen.queryByTestId("confirm-dialog")).toBeNull();
+      expect(removeTodo).not.toHaveBeenCalled();
+      const list = screen.getAllByTestId("todo-list")[0]!;
+      expect(list.getAttribute("data-expanded-todo")).toBe("t-a");
+    });
+
+    it("Cancel on delete confirmation leaves the task in place", async () => {
+      const removeTodo = vi.fn().mockResolvedValue(undefined);
+      setupOverrides({
+        todos: [baseTodo("t-a", "Keep me")],
+        removeTodo,
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "d", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("confirm-delete-cancel"));
+      });
+      expect(screen.queryByTestId("confirm-dialog")).toBeNull();
+      expect(removeTodo).not.toHaveBeenCalled();
+    });
+
+    it("x marks the focused task complete via the store", async () => {
+      const toggleTodo = vi.fn().mockResolvedValue(undefined);
+      setupOverrides({
+        todos: [baseTodo("t-a", "Do it")],
+        toggleTodo,
+      });
+      render(ce(AppShell));
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "x", bubbles: true });
+      });
+      expect(toggleTodo).toHaveBeenCalledWith("t-a", true);
+    });
+
+    it("Escape from drawer returns to quick edit with the same task focused", async () => {
+      setupOverrides({ todos: [baseTodo("t-a", "In drawer")] });
+      render(ce(AppShell));
+      const list = screen.getAllByTestId("todo-list")[0]!;
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "j", bubbles: true });
+      });
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "e", bubbles: true });
+      });
+      expect(screen.getByTestId("todo-drawer")).toBeTruthy();
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "Escape", bubbles: true });
+      });
+      expect(screen.queryByTestId("todo-drawer")).toBeNull();
+      expect(list.getAttribute("data-expanded-todo")).toBe("t-a");
+    });
+
+    it("n focuses quick entry when the primary control exists, otherwise opens composer", async () => {
+      const trigger = vi.mocked(focusTargets.triggerPrimaryNewTask);
+      setupOverrides();
+      render(ce(AppShell));
+      trigger.mockReturnValueOnce(true);
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "n", bubbles: true });
+      });
+      expect(screen.queryByTestId("task-composer")).toBeNull();
+      trigger.mockReturnValueOnce(false);
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "n", bubbles: true });
+      });
+      expect(screen.getByTestId("task-composer")).toBeTruthy();
     });
   });
 

--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -660,11 +660,18 @@ export function AppShell() {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      // Escape: close palette, close drawer, cancel bulk, close mobile nav
+      // Escape: close palette, cancel delete confirm, de-escalate task UI,
+      // cancel bulk, close mobile nav
       if (e.key === "Escape") {
         if (paletteOpen) {
+          setPaletteOpen(false);
           return;
-        } else if (activeTodoId) {
+        }
+        if (deleteTarget) {
+          setDeleteTarget(null);
+          return;
+        }
+        if (activeTodoId) {
           taskNav.deescalate();
         } else if (bulkMode) {
           handleCancelBulk();
@@ -759,6 +766,7 @@ export function AppShell() {
     bulkMode,
     mobileNavOpen,
     paletteOpen,
+    deleteTarget,
     viewMenuOpen,
     handleCancelBulk,
     focusQuickEntryOrOpenComposer,


### PR DESCRIPTION
Add regression tests for palette/delete escape, delete cancel, x toggle, drawer de-escalation, n new-task path, and sidebar workspace switch.

Made-with: Cursor

## Closes

Closes #<issue>

## Why

Explain why this change is needed.

## What Changed

Summarize the user-facing and technical changes.

## Architecture

- Target layer/domain:
- Relevant invariant/ADR:
- [ ] I kept routes, entrypoints, and other orchestrators thin.
- [ ] I reused the canonical code path instead of adding a parallel flow.
- [ ] If I introduced or changed a boundary, I updated the relevant durable doc/ADR.

## Verification

- [ ] `npx tsc --noEmit`
- [ ] `npm run check:architecture`
- [ ] `npm run format:check`
- [ ] `npm run lint:html`
- [ ] `npm run lint:css`
- [ ] `npm run test:unit`
- [ ] `CI=1 npm run test:ui:fast`
- [ ] Additional manual validation notes, if applicable

## Brief / Protocol Impact

- [ ] No
- [ ] Yes

If yes, which doc changed?
