### PR TITLE
feat(ui): design system v2 PR 1 — tokens and @layer architecture

### DIFF
--- a/client-react/src/auth/auth.css
+++ b/client-react/src/auth/auth.css
@@ -63,7 +63,7 @@
 .auth-message {
   padding: var(--s-2) var(--s-3);
   border-radius: var(--r-sm);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   margin-bottom: var(--s-3);
   display: none;
 }
@@ -117,7 +117,7 @@
   border: none;
   border-bottom: 2px solid transparent;
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   cursor: pointer;
   transition: color var(--dur-base), border-color var(--dur-base);
@@ -155,7 +155,7 @@
 
 .auth-form__field label {
   display: block;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   margin-bottom: var(--s-1);
   color: var(--text);
@@ -176,7 +176,7 @@
 .auth-form__field input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
 }
 
 .auth-form__field input::placeholder {
@@ -219,7 +219,7 @@
   background: none;
   border: none;
   color: var(--accent);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   cursor: pointer;
   font-family: inherit;
@@ -269,7 +269,7 @@
   border-radius: var(--r-sm);
   background: var(--surface);
   color: var(--text);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   font-family: inherit;
   cursor: pointer;
@@ -326,7 +326,7 @@
 }
 
 .otp-phone-display {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--muted);
   text-align: center;
   margin-bottom: var(--s-3);
@@ -352,7 +352,7 @@
 /* ── Reset Password Info ────────────────────────────────────────────── */
 
 .auth-reset-info {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--muted);
   margin-bottom: var(--s-3);
   text-align: center;

--- a/client-react/src/components/home/TarotCard.tsx
+++ b/client-react/src/components/home/TarotCard.tsx
@@ -40,7 +40,7 @@ export function TarotCardFront({
 
   return (
     <div
-      className="tarot-frame"
+      className="tarot-card tarot-frame"
       style={
         agent
           ? { borderColor: agent.colors.stroke, background: agent.colors.bg }
@@ -130,7 +130,7 @@ export function TarotCardBack({
 
   return (
     <div
-      className="tarot-frame"
+      className="tarot-card tarot-frame"
       style={
         agent
           ? { borderColor: agent.colors.stroke, background: agent.colors.bg }

--- a/client-react/src/landing/landing.css
+++ b/client-react/src/landing/landing.css
@@ -56,7 +56,7 @@
 .landing-nav__link {
   color: var(--muted);
   text-decoration: none;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   background: none;
   border: none;
@@ -76,7 +76,7 @@
   border-radius: var(--r-full);
   background: var(--accent);
   color: #fff;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-semibold);
   text-decoration: none;
   border: none;

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -1,19 +1,25 @@
+/* ════════════════════════════════════════════════════════════════════
+   Design System v2 — cascade entry point
+   Layer order (low → high precedence): tokens → base → components → views.
+   Token declarations, global resets and the focus-ring recipe live in
+   their own layers; this file wraps view / page styling in @layer views.
+   ════════════════════════════════════════════════════════════════════ */
+
+@layer tokens, base, components, views;
+
 @import "./tokens.css";
+@import "./base.css";
+@import "./components.css";
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-}
+@layer views {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+    margin: 0;
+  }
 
-/* Global focus-visible — consistent accent ring on keyboard nav */
-:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* Smooth scrollbars */
+  /* Smooth scrollbars */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -444,7 +450,7 @@ body {
 .todo-item:focus-visible {
   outline: none;
   border-color: color-mix(in oklab, var(--accent) 30%, transparent);
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
 }
 
 /* Custom checkbox — replaces native browser checkbox */
@@ -490,7 +496,7 @@ body {
 
 .todo-checkbox:focus-visible {
   outline: none;
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
   outline-offset: 2px;
 }
 
@@ -826,7 +832,7 @@ body {
 .todo-drawer__textarea:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
   background: var(--accent-light);
 }
 
@@ -1232,7 +1238,7 @@ body {
 
 .btn:focus-visible {
   outline: none;
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
 }
 
 .btn:disabled {
@@ -1264,7 +1270,7 @@ body {
 }
 
 .btn--danger:focus-visible {
-  box-shadow: var(--shadow-focus-danger);
+  box-shadow: var(--ring-danger);
 }
 
 /* --- Filter bar --- */
@@ -1447,7 +1453,7 @@ body {
   color: #fff;
   padding: var(--s-3) var(--s-5);
   border-radius: var(--r-sm);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   display: flex;
   align-items: center;
   gap: var(--s-4);
@@ -2077,7 +2083,7 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   z-index: 200;
   overflow: hidden;
   animation: profilePanelIn var(--dur-base) var(--ease-spring);
@@ -2199,7 +2205,7 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   animation: viewMenuIn var(--dur-base) var(--ease-spring);
   overflow: hidden;
 }
@@ -2215,7 +2221,7 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   z-index: 200;
   overflow: hidden;
   animation: viewMenuIn var(--dur-base) var(--ease-spring);
@@ -2361,7 +2367,7 @@ body {
   background: var(--surface);
   border-radius: var(--r-md);
   width: min(420px, calc(100vw - var(--s-6)));
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
 
@@ -2639,7 +2645,7 @@ body {
   padding: var(--s-3);
   background: var(--surface);
   border-radius: var(--r-sm);
-  box-shadow: var(--shadow-hover);
+  box-shadow: var(--shadow-sm);
   cursor: grab;
   transition:
     transform var(--dur-fast) var(--ease-spring),
@@ -2647,12 +2653,12 @@ body {
 }
 
 .board__card:hover {
-  box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-md);
 }
 
 .board__card:focus-visible {
   outline: none;
-  box-shadow: var(--shadow-focus), var(--shadow-card);
+  box-shadow: var(--ring), var(--shadow-md);
 }
 
 .board__card:active {
@@ -3058,7 +3064,7 @@ body {
 .focus-panel {
   background: var(--surface);
   border-radius: var(--r-lg);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   padding: var(--s-4);
 }
 
@@ -3160,6 +3166,28 @@ body {
   inset: 0;
   background: var(--tarot-parchment-dark);
   overflow-y: auto;
+}
+
+/* ── Tarot-card palette (scoped) ───────────
+   Previously global in tokens.css; moved here to keep the palette
+   bounded to the tarot card surface and the home-dashboard container
+   so descendants (`.tarot-*`, `.flip-card`, `.timeline`, `.dog-ear`, …)
+   still resolve, without leaking colors into generic UI. */
+.tarot-card,
+.home-dashboard {
+  --tarot-parchment: #faf8f5;
+  --tarot-parchment-dark: #f7f4ee;
+  --tarot-frame: #e0dbd3;
+  --tarot-border: #e8e4de;
+  --tarot-text: #3d3730;
+  --tarot-muted: #8a7e6e;
+  --tarot-gold: #b8a080;
+  --tarot-sage: #8a9a8e;
+  --tarot-red: #c45a3c;
+  --tarot-amber: #d4864a;
+  --tarot-warm: #daa85c;
+  --tarot-faint: #d0c8b8;
+  --tarot-tabletop: #f0ece4;
 }
 
 /* Inner frame — printed margin effect */
@@ -4007,7 +4035,7 @@ body {
   background: var(--surface);
   border-radius: var(--r-md);
   width: min(560px, calc(100vw - var(--s-6)));
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
 }
@@ -4114,7 +4142,7 @@ body {
   padding: var(--s-7) var(--s-6);
   max-width: 480px;
   width: calc(100% - var(--s-6));
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   text-align: center;
 }
 
@@ -4678,7 +4706,7 @@ body {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-lg);
   z-index: 200;
   overflow: hidden;
   animation: viewMenuIn var(--dur-base) var(--ease-spring);
@@ -8108,7 +8136,7 @@ body {
 .task-picker__search:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
 }
 
 .task-picker__dropdown {
@@ -8503,12 +8531,12 @@ body {
 .chip {
   padding: 3px 10px;
   border-radius: 20px;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 500;
   cursor: pointer;
   border: 1.5px solid transparent;
   background: var(--surface-3);
-  color: var(--text-2);
+  color: var(--muted);
   transition:
     background var(--dur-fast),
     color var(--dur-fast),
@@ -8529,7 +8557,7 @@ body {
 
 /* Chip tone colors */
 .chip--muted {
-  color: var(--text-2);
+  color: var(--muted);
 }
 .chip--muted.chip--selected {
   background: var(--surface-3);
@@ -8601,12 +8629,12 @@ body {
 .date-shortcut {
   padding: 2px 8px;
   border-radius: var(--r-sm);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 500;
   cursor: pointer;
   border: 1.5px solid var(--border);
   background: var(--surface-2);
-  color: var(--text-2);
+  color: var(--muted);
   transition:
     background var(--dur-fast),
     border-color var(--dur-fast),
@@ -8624,7 +8652,7 @@ body {
   flex: 1;
   min-width: 120px;
   padding: 3px 6px;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   border: 1.5px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface);
@@ -8635,7 +8663,7 @@ body {
 .field-date-shortcuts__clear {
   padding: 2px 6px;
   border-radius: var(--r-sm);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   cursor: pointer;
   border: none;
   background: none;
@@ -8663,7 +8691,7 @@ body {
   background: none;
   padding: var(--s-1) 0;
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   text-align: left;
   transition: color var(--dur-fast);
 }
@@ -8692,7 +8720,7 @@ body {
 .field-collapsible__textarea {
   width: 100%;
   padding: var(--s-2) var(--s-3);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   border: 1.5px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface);
@@ -8739,12 +8767,12 @@ body {
 .estimate-preset {
   padding: 2px 8px;
   border-radius: var(--r-sm);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 500;
   cursor: pointer;
   border: 1.5px solid var(--border);
   background: var(--surface-2);
-  color: var(--text-2);
+  color: var(--muted);
   transition:
     background var(--dur-fast),
     border-color var(--dur-fast),
@@ -8761,7 +8789,7 @@ body {
 .field-estimate-presets__input {
   width: 70px;
   padding: 3px 6px;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   border: 1.5px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface);
@@ -8770,7 +8798,7 @@ body {
 }
 
 .field-estimate-presets__unit {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--muted);
 }
 
@@ -8807,8 +8835,8 @@ body {
   border: none;
   background: none;
   cursor: pointer;
-  color: var(--text-2);
-  font-size: var(--fs-sm);
+  color: var(--muted);
+  font-size: var(--fs-meta);
   font-weight: 500;
   transition:
     background var(--dur-fast),
@@ -8822,7 +8850,7 @@ body {
 
 .task-full-page__save-status {
   margin-left: auto;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--muted);
 }
 
@@ -8887,7 +8915,7 @@ body {
 .task-full-page__textarea {
   width: 100%;
   padding: var(--s-3) var(--s-4);
-  font-size: var(--fs-base);
+  font-size: var(--fs-body);
   border: 1.5px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface);
@@ -8916,7 +8944,7 @@ body {
 .task-full-page__input {
   width: 100%;
   padding: var(--s-2) var(--s-3);
-  font-size: var(--fs-base);
+  font-size: var(--fs-body);
   border: 1.5px solid var(--border);
   border-radius: var(--r-sm);
   background: var(--surface);
@@ -8966,7 +8994,7 @@ body {
 }
 
 .task-full-page__meta {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--muted);
 }
 
@@ -9029,7 +9057,7 @@ body {
   border: 1.5px solid var(--border);
   background: var(--surface);
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   font-family: inherit;
   cursor: pointer;
@@ -9223,7 +9251,7 @@ body {
 
 .field-preset-custom:focus {
   outline: none;
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
 }
 
 /* ── Collapsible prompt variant ─────────────────────────────────── */
@@ -9443,7 +9471,7 @@ body {
 }
 
 .tuneup-view__refresh {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--accent);
   background: none;
   border: 1px solid var(--accent);
@@ -9482,7 +9510,7 @@ body {
   border: none;
   cursor: pointer;
   text-align: left;
-  font-size: var(--fs-base);
+  font-size: var(--fs-body);
   color: var(--text);
 }
 
@@ -9537,7 +9565,7 @@ body {
 .tuneup-section__retry {
   padding: var(--s-1) var(--s-3);
   margin-right: var(--s-2);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--accent);
   background: none;
   border: 1px solid var(--accent);
@@ -9555,13 +9583,13 @@ body {
 
 .tuneup-section__error {
   color: var(--danger);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   padding: var(--s-2) 0;
 }
 
 .tuneup-section__placeholder {
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   padding: var(--s-2) 0;
 }
 
@@ -9572,7 +9600,7 @@ body {
   align-items: center;
   gap: var(--s-2);
   color: var(--success, #27ae60);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   padding: var(--s-2) 0;
 }
 
@@ -9630,7 +9658,7 @@ body {
 
 .tuneup-row__title {
   flex: 1;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--text);
   line-height: var(--lh-snug);
   min-width: 0;
@@ -9673,7 +9701,7 @@ body {
 
 .tuneup-row__edit-input {
   flex: 1;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--text);
   background: var(--surface-1);
   border: 1px solid var(--accent);
@@ -9729,12 +9757,12 @@ body {
   align-items: center;
   gap: var(--s-2);
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   animation: tuneup-pulse 1.4s ease-in-out infinite;
 }
 
 .tuneup-tile__finding {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--text);
   line-height: var(--lh-snug);
 }
@@ -9783,11 +9811,11 @@ body {
   align-items: center;
   gap: var(--s-2);
   color: var(--success, #27ae60);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
 }
 
 .tuneup-tile__error {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--danger);
 }
 
@@ -11300,7 +11328,7 @@ body.dark-mode {
 }
 
 .project-workspace-card__next-effort-value {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -11383,7 +11411,7 @@ body.dark-mode {
 }
 
 .panel-right-now__title {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 600;
   color: var(--text);
 }
@@ -11407,7 +11435,7 @@ body.dark-mode {
 }
 
 .panel-today-agenda__title {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 600;
   color: var(--text);
 }
@@ -11442,7 +11470,7 @@ body.dark-mode {
 .panel-nudge__title,
 .panel-track__title,
 .panel-rescue__title {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: 600;
   color: var(--text);
 }
@@ -11729,3 +11757,5 @@ body.dark-mode {
   opacity: 0.7;
   margin-top: 4px;
 }
+}
+/* ── end @layer views ───────────────────── */

--- a/client-react/src/styles/base.css
+++ b/client-react/src/styles/base.css
@@ -1,0 +1,23 @@
+/* ════════════════════════════════════════════════════════════════════
+   Design System v2 — base layer
+   Global focus-ring recipe + element resets that pair with tokens.css.
+   The box-shadow-based ring clips cleanly on rounded corners and
+   supersedes the earlier outline-based rule.
+   ════════════════════════════════════════════════════════════════════ */
+
+@layer base {
+  :focus-visible {
+    outline: none;
+    box-shadow: var(--ring);
+    border-radius: var(--r-xs);
+  }
+
+  button:focus-visible,
+  a:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible,
+  .cbx:focus-visible {
+    box-shadow: var(--ring);
+  }
+}

--- a/client-react/src/styles/components.css
+++ b/client-react/src/styles/components.css
@@ -1,0 +1,11 @@
+/* ════════════════════════════════════════════════════════════════════
+   Design System v2 — components layer
+   Reserved for shared component primitives (.btn, .chip, .input, .cbx,
+   .toast, .skel, .todo-row, …). Populated in PR 2; kept as an empty
+   layer today so the cascade order is established and later additions
+   slot in without reshuffling existing view-layer styles.
+   ════════════════════════════════════════════════════════════════════ */
+
+@layer components {
+  /* intentionally empty — see PR 2 */
+}

--- a/client-react/src/styles/feedback.css
+++ b/client-react/src/styles/feedback.css
@@ -41,7 +41,7 @@
 .feedback-standalone__back {
   color: var(--muted);
   text-decoration: none;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   background: none;
   border: none;
   cursor: pointer;
@@ -67,7 +67,7 @@
 
 .feedback-standalone__lede {
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   margin: 0 0 var(--s-5);
   line-height: var(--lh-relaxed);
 }
@@ -80,7 +80,7 @@
   justify-content: center;
   padding: var(--s-2) var(--s-4);
   border-radius: var(--r-sm);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-semibold);
   font-family: inherit;
   cursor: pointer;
@@ -127,7 +127,7 @@
   text-align: center;
   color: var(--muted);
   padding: var(--s-8) 0;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
 }
 
 .feedback-list__item {
@@ -168,7 +168,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   color: var(--text);
 }
 
@@ -232,7 +232,7 @@
 }
 
 .feedback-form__label {
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   color: var(--text);
 }
@@ -256,7 +256,7 @@
 .feedback-form__textarea:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: var(--shadow-focus);
+  box-shadow: var(--ring);
 }
 
 .feedback-form__input::placeholder,
@@ -283,7 +283,7 @@
   background: color-mix(in oklab, var(--danger) 10%, transparent);
   color: var(--danger);
   border: 1px solid color-mix(in oklab, var(--danger) 20%, transparent);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
 }
 
 .feedback-form__context {
@@ -350,7 +350,7 @@
   background: none;
   border: none;
   color: var(--accent);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   font-weight: var(--fw-medium);
   cursor: pointer;
   font-family: inherit;
@@ -372,7 +372,7 @@
 .feedback-confirmation p {
   margin: 0 0 var(--s-3);
   color: var(--muted);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-meta);
   line-height: var(--lh-relaxed);
 }
 

--- a/client-react/src/styles/tokens.css
+++ b/client-react/src/styles/tokens.css
@@ -1,192 +1,217 @@
-:root {
-  /* --- Colors (light) --- */
-  --bg: #f4f7fb;
-  --surface: #ffffff;
-  --surface-2: #f8fafc;
-  --surface-3: #edf1f5;
-  --text: #1f2937;
-  --text-strong: #111827;
-  --muted: #6b7280;
-  --muted-light: #9ca3af;
-  --border: #dbe3ed;
-  --border-light: color-mix(in oklab, #dbe3ed 60%, transparent);
-  --accent: #4f6ef7;
-  --accent-2: #6983ff;
-  --accent-3: #3b5cdb;
-  --accent-light: color-mix(in oklab, #4f6ef7 8%, #ffffff);
-  --danger: #e05260;
-  --danger-2: #c94855;
-  --success: #2f9e6a;
-  --warning: #d97706;
-  --overlay: rgb(15 23 42 / 55%);
-  --scrim: rgb(15 23 42 / 35%);
+/* ════════════════════════════════════════════════════════════════════
+   Design System v2 — tokens
+   One source of truth, no legacy aliases, deterministic cascade via
+   the layer order declared in app.css: tokens → base → components → views.
+   ════════════════════════════════════════════════════════════════════ */
 
-  /* --- Radius --- */
-  --r-xs: 4px;
-  --r-sm: 8px;
-  --r-md: 12px;
-  --r-lg: 16px;
-  --r-xl: 20px;
-  --r-2xl: 24px;
-  --r-full: 999px;
-
-  /* --- Spacing --- */
-  --s-0: 2px;
-  --s-1: 4px;
-  --s-1h: 6px;
-  --s-2: 8px;
-  --s-2h: 10px;
-  --s-3: 12px;
-  --s-3h: 14px;
-  --s-4: 16px;
-  --s-5: 24px;
-  --s-6: 32px;
-  --s-7: 40px;
-  --s-8: 48px;
-
-  /* --- Typography --- */
-  --font-sans:
-    "Inter", "Avenir Next", "Segoe UI", -apple-system, BlinkMacSystemFont,
-    "Helvetica Neue", Arial, sans-serif;
-  --fs-xs: 0.688rem;
-  --fs-label: 0.75rem;
-  --fs-meta: 0.8125rem;
-  --fs-body: 1rem;
-  --fs-md: 1.125rem;
-  --fs-section: 1.25rem;
-  --fs-lg: 1.375rem;
-  --fs-xl: 1.75rem;
-  --lh-tight: 1.25;
-  --lh-base: 1.5;
-  --lh-relaxed: 1.7;
-  --fw-regular: 400;
-  --fw-medium: 500;
-  --fw-semibold: 600;
-  --fw-bold: 700;
-  --tracking-tight: -0.01em;
-  --tracking-normal: 0;
-  --tracking-wide: 0.025em;
-
-  /* --- Aliases (used by FieldRenderer variants) --- */
-  --fs-sm: 0.75rem;
-  --fs-base: var(--fs-body);
-  --text-2: var(--muted);
-  --border-strong: color-mix(in oklab, var(--border) 70%, var(--text));
-
-  /* --- Controls --- */
-  --control-sm: 32px;
-  --control-md: 40px;
-  --row-height: 48px;
-
-  /* --- Shadows (6-level system) --- */
-  --shadow-0: none;
-  --shadow-xs: 0 1px 2px rgb(15 23 42 / 0.05);
-  --shadow-sm: 0 1px 3px rgb(15 23 42 / 0.08), 0 1px 2px rgb(15 23 42 / 0.04);
-  --shadow-md: 0 4px 12px rgb(15 23 42 / 0.08), 0 2px 4px rgb(15 23 42 / 0.04);
-  --shadow-lg: 0 12px 24px rgb(15 23 42 / 0.1), 0 4px 8px rgb(15 23 42 / 0.06);
-  --shadow-xl:
-    0 20px 40px rgb(15 23 42 / 0.14), 0 8px 16px rgb(15 23 42 / 0.08);
-  /* Backward compat aliases */
-  --shadow-hover: var(--shadow-sm);
-  --shadow-card: var(--shadow-md);
-  --shadow-elevated: var(--shadow-lg);
-  /* Focus ring */
-  --shadow-focus: 0 0 0 3px color-mix(in oklab, var(--accent) 20%, transparent);
-  --shadow-focus-danger: 0 0 0 3px
-    color-mix(in oklab, var(--danger) 20%, transparent);
-
-  /* --- Motion --- */
-  --ease-spring: cubic-bezier(0.22, 1, 0.36, 1);
-  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
-  --ease-in-out: cubic-bezier(0.45, 0.05, 0.55, 0.95);
-  --dur-fast: 120ms;
-  --dur-base: 180ms;
-  --dur-slow: 280ms;
-  --dur-view: var(--dur-slow);
-
-  /* ── Tarot Card Design System ──────────────── */
-  --tarot-parchment: #faf8f5;
-  --tarot-parchment-dark: #f7f4ee;
-  --tarot-frame: #e0dbd3;
-  --tarot-border: #e8e4de;
-  --tarot-text: #3d3730;
-  --tarot-muted: #8a7e6e;
-  --tarot-gold: #b8a080;
-  --tarot-sage: #8a9a8e;
-  --tarot-red: #c45a3c;
-  --tarot-amber: #d4864a;
-  --tarot-warm: #daa85c;
-  --tarot-faint: #d0c8b8;
-  --tarot-tabletop: #f0ece4;
-}
-
-/* --- Dark mode (warmer, more vibrant) --- */
-body.dark-mode {
-  --bg: #0f1419;
-  --surface: #1a232f;
-  --surface-2: #232f3d;
-  --surface-3: #2d3d4d;
-  --text: #f1f3f5;
-  --text-strong: #ffffff;
-  --muted: #a0a8b3;
-  --muted-light: #6b7580;
-  --border: #3a4a5a;
-  --border-light: color-mix(in oklab, #3a4a5a 60%, transparent);
-  --accent: #7fa8ff;
-  --accent-2: #5f89ff;
-  --accent-3: #a0c0ff;
-  --accent-light: color-mix(in oklab, #7fa8ff 12%, #1a232f);
-  --danger: #ff8a96;
-  --danger-2: #ef6f7b;
-  --success: #5dd99f;
-  --warning: #ffb74d;
-  --overlay: rgb(2 6 23 / 75%);
-  --scrim: rgb(2 6 23 / 60%);
-
-  --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.2);
-  --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.25), 0 1px 2px rgb(0 0 0 / 0.15);
-  --shadow-md: 0 4px 12px rgb(0 0 0 / 0.3), 0 2px 4px rgb(0 0 0 / 0.2);
-  --shadow-lg: 0 12px 24px rgb(0 0 0 / 0.35), 0 4px 8px rgb(0 0 0 / 0.25);
-  --shadow-xl: 0 20px 40px rgb(0 0 0 / 0.4), 0 8px 16px rgb(0 0 0 / 0.3);
-  --shadow-hover: var(--shadow-sm);
-  --shadow-card: var(--shadow-md);
-  --shadow-elevated: var(--shadow-lg);
-  --shadow-focus: 0 0 0 3px color-mix(in oklab, var(--accent) 30%, transparent);
-  --shadow-focus-danger: 0 0 0 3px
-    color-mix(in oklab, var(--danger) 30%, transparent);
-  --text-2: var(--muted);
-  --border-strong: color-mix(in oklab, var(--border) 70%, var(--text));
-}
-
-/* --- Density modes --- */
-[data-density="compact"] {
-  --row-height: 36px;
-  --control-sm: 28px;
-  --control-md: 34px;
-  --s-3: 10px;
-  --s-4: 12px;
-  --s-5: 18px;
-  --fs-body: 0.875rem;
-  --fs-meta: 0.75rem;
-  --fs-label: 0.688rem;
-}
-
-[data-density="spacious"] {
-  --row-height: 56px;
-  --control-sm: 36px;
-  --control-md: 44px;
-  --s-3: 14px;
-  --s-4: 20px;
-  --s-5: 28px;
-  --fs-body: 1.0625rem;
-  --fs-meta: 0.875rem;
-}
-
-/* --- Reduced motion --- */
-@media (prefers-reduced-motion: reduce) {
+@layer tokens {
   :root {
-    --dur-fast: 0ms;
-    --dur-base: 0ms;
-    --dur-slow: 0ms;
+    /* ── Neutrals (light) ─────────────────── */
+    --bg: #f4f7fb;
+    --surface: #ffffff;
+    --surface-2: #f8fafc;
+    --surface-3: #edf1f5;
+    --text: #1f2937;
+    --text-strong: #111827;
+    --muted: #6b7280;
+    --muted-strong: #858b93; /* AA on white for small text (3.6:1) */
+    --muted-light: #9ca3af; /* display-only: ≥14pt semibold */
+    --border: #dbe3ed;
+    --border-light: color-mix(in oklab, #dbe3ed 60%, transparent);
+    --border-strong: color-mix(in oklab, var(--border) 70%, var(--text));
+
+    /* ── Accent primary ─────────────────────── */
+    --accent: #4f6ef7;
+    --accent-2: #6983ff;
+    --accent-3: #3b5cdb;
+    --accent-light: color-mix(in oklab, #4f6ef7 8%, #ffffff);
+
+    /* ── Accent secondary (AI / planning) ───── */
+    --accent-secondary: #b8892f;
+    --accent-secondary-2: #cfa04b;
+    --accent-secondary-3: #9a7124;
+    --accent-secondary-light: color-mix(in oklab, #b8892f 9%, #ffffff);
+
+    /* ── Semantic ────────────────────────── */
+    --success: #2f9e6a;
+    --warning: #d97706;
+    --danger: #e05260;
+    --danger-2: #c94855;
+
+    --overlay: rgb(15 23 42 / 55%);
+    --scrim: rgb(15 23 42 / 35%);
+
+    /* ── Data-viz palette ────────────────── */
+    /* Categorical — colorblind-safe (Okabe-Ito adapted) */
+    --viz-1: #4f6ef7; /* accent blue */
+    --viz-2: #b8892f; /* amber */
+    --viz-3: #2f9e6a; /* green */
+    --viz-4: #c94855; /* red */
+    --viz-5: #7b5bc7; /* purple */
+    --viz-6: #2e7a8a; /* teal */
+    /* Sequential (5-step on accent hue) */
+    --viz-seq-1: #e6ecff;
+    --viz-seq-2: #b8c7ff;
+    --viz-seq-3: #8aa2ff;
+    --viz-seq-4: #4f6ef7;
+    --viz-seq-5: #2a42a8;
+
+    /* ── Radius ──────────────────────────── */
+    --r-xs: 4px;
+    --r-sm: 8px;
+    --r-md: 12px;
+    --r-lg: 16px;
+    --r-xl: 20px;
+    --r-2xl: 24px;
+    --r-full: 999px;
+
+    /* ── Spacing (4pt) ───────────────────── */
+    --s-0: 2px;
+    --s-1: 4px;
+    --s-1h: 6px;
+    --s-2: 8px;
+    --s-2h: 10px;
+    --s-3: 12px;
+    --s-3h: 14px;
+    --s-4: 16px;
+    --s-5: 24px;
+    --s-6: 32px;
+    --s-7: 40px;
+    --s-8: 48px;
+
+    /* ── Typography ──────────────────────── */
+    --font-sans:
+      "Inter", "Avenir Next", "Segoe UI", -apple-system, BlinkMacSystemFont,
+      "Helvetica Neue", Arial, sans-serif;
+    --font-display: "Fraunces", "Iowan Old Style", Georgia, serif;
+    --font-mono: "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
+    --fs-xs: 0.688rem;
+    --fs-label: 0.75rem;
+    --fs-meta: 0.8125rem;
+    --fs-body: 1rem;
+    --fs-md: 1.125rem;
+    --fs-section: 1.25rem;
+    --fs-lg: 1.375rem;
+    --fs-xl: 1.75rem;
+    --lh-tight: 1.25;
+    --lh-base: 1.5;
+    --lh-relaxed: 1.7;
+    --fw-regular: 400;
+    --fw-medium: 500;
+    --fw-semibold: 600;
+    --fw-bold: 700;
+    --tracking-tight: -0.01em;
+    --tracking-normal: 0;
+    --tracking-wide: 0.025em;
+
+    /* ── Controls ─────────────────────────── */
+    --control-sm: 32px;
+    --control-md: 40px;
+    --row-height: 48px;
+
+    /* ── Shadows (6-level system) ─────────── */
+    --shadow-0: none;
+    --shadow-xs: 0 1px 2px rgb(15 23 42 / 0.05);
+    --shadow-sm: 0 1px 3px rgb(15 23 42 / 0.08), 0 1px 2px rgb(15 23 42 / 0.04);
+    --shadow-md: 0 4px 12px rgb(15 23 42 / 0.08), 0 2px 4px rgb(15 23 42 / 0.04);
+    --shadow-lg: 0 12px 24px rgb(15 23 42 / 0.1), 0 4px 8px rgb(15 23 42 / 0.06);
+    --shadow-xl:
+      0 20px 40px rgb(15 23 42 / 0.14), 0 8px 16px rgb(15 23 42 / 0.08);
+
+    /* ── Focus ring (single recipe) ───────── */
+    --ring: 0 0 0 3px color-mix(in oklab, var(--accent) 25%, transparent);
+    --ring-danger: 0 0 0 3px
+      color-mix(in oklab, var(--danger) 25%, transparent);
+
+    /* ── Motion ──────────────────────────── */
+    --ease-spring: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-in-out: cubic-bezier(0.45, 0.05, 0.55, 0.95);
+    --dur-fast: 120ms;
+    --dur-base: 180ms;
+    --dur-slow: 280ms;
+    --dur-view: var(--dur-slow);
   }
+
+  /* ── Dark mode (warmer, more vibrant) ───── */
+  body.dark-mode {
+    --bg: #0f1419;
+    --surface: #1a232f;
+    --surface-2: #232f3d;
+    --surface-3: #2d3d4d;
+    --text: #f1f3f5;
+    --text-strong: #ffffff;
+    --muted: #a0a8b3;
+    --muted-strong: #b8bec7;
+    --muted-light: #6b7580;
+    --border: #3a4a5a;
+    --border-light: color-mix(in oklab, #3a4a5a 60%, transparent);
+    --border-strong: color-mix(in oklab, var(--border) 80%, #ffffff);
+
+    --accent: #7fa8ff;
+    --accent-2: #5f89ff;
+    --accent-3: #a0c0ff;
+    --accent-light: color-mix(in oklab, #7fa8ff 12%, #1a232f);
+
+    --accent-secondary: #e0b468;
+    --accent-secondary-2: #c99a45;
+    --accent-secondary-3: #f0cd8a;
+    --accent-secondary-light: color-mix(in oklab, #e0b468 14%, #1a232f);
+
+    --danger: #ff8a96;
+    --danger-2: #ef6f7b;
+    --success: #5dd99f;
+    --warning: #ffb74d;
+
+    --overlay: rgb(2 6 23 / 75%);
+    --scrim: rgb(2 6 23 / 60%);
+
+    --shadow-xs: 0 1px 2px rgb(0 0 0 / 0.2);
+    --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.25), 0 1px 2px rgb(0 0 0 / 0.15);
+    --shadow-md: 0 4px 12px rgb(0 0 0 / 0.3), 0 2px 4px rgb(0 0 0 / 0.2);
+    --shadow-lg: 0 12px 24px rgb(0 0 0 / 0.35), 0 4px 8px rgb(0 0 0 / 0.25);
+    --shadow-xl: 0 20px 40px rgb(0 0 0 / 0.4), 0 8px 16px rgb(0 0 0 / 0.3);
+
+    --ring: 0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
+    --ring-danger: 0 0 0 3px
+      color-mix(in oklab, var(--danger) 35%, transparent);
+  }
+
+  /* ── Density modes ────────────────────── */
+  [data-density="compact"] {
+    --row-height: 36px;
+    --control-sm: 28px;
+    --control-md: 34px;
+    --s-3: 10px;
+    --s-4: 12px;
+    --s-5: 18px;
+    --fs-body: 0.875rem;
+    --fs-meta: 0.75rem;
+    --fs-label: 0.688rem;
+  }
+
+  [data-density="spacious"] {
+    --row-height: 56px;
+    --control-sm: 36px;
+    --control-md: 44px;
+    --s-3: 14px;
+    --s-4: 20px;
+    --s-5: 28px;
+    --fs-body: 1.0625rem;
+    --fs-meta: 0.875rem;
+  }
+
+  /* ── Reduced motion ───────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    :root {
+      --dur-fast: 0ms;
+      --dur-base: 0ms;
+      --dur-slow: 0ms;
+    }
+  }
+
 }
+
+/* NOTE: the card/dashboard palette (previously inside :root here) has
+   been relocated to app.css next to its consuming selectors so it is
+   scoped to a single surface and no longer leaks into generic UI. */


### PR DESCRIPTION
## Summary

- Rewrites `tokens.css` inside `@layer tokens` with new v2 tokens (`--muted-strong`, `--accent-secondary-*`, `--viz-*`, `--ring`/`--ring-danger`) and drops every legacy alias.
- Establishes the v2 cascade `tokens → base → components → views` via a new `base.css`, a stub `components.css`, and a `@layer views` wrapper around the existing `app.css`.
- Scopes the tarot palette to `.tarot-card, .home-dashboard` so it no longer leaks into generic UI; `TarotCard.tsx` now renders with `tarot-card tarot-frame`.

## Acceptance criteria (README PR 1)

- `grep -R "shadow-card\|shadow-elevated\|shadow-hover\|--text-2\|--fs-sm\|--fs-base" client-react/src` → **0 hits** ✓
- `grep -R "tarot-" client-react/src/styles/tokens.css` → **0 hits** ✓
- Vite build green, no console warnings from the new CSS, cascade declared via `@layer tokens, base, components, views;`.

## Judgment calls (worth flagging for review)

1. **Dark-mode selector** stays `body.dark-mode` (repo's `useDarkMode` hook writes that class). The spec's `body.dark` would have required a cross-client rename outside PR 1's scope.
2. **`--shadow-hover` → `--shadow-sm`** instead of the README's `--shadow-md`. The only call site is `.board__card` in its default state; remapping to `--shadow-md` would flatten the hover transition to the same shadow.
3. **Tarot palette scoped to `.tarot-card, .home-dashboard`**, not `.tarot-card` alone. `--tarot-tabletop`, `--tarot-gold`, etc. are referenced by `.home-dashboard`, `.flip-card`, `.timeline`, `.dog-ear` — a strict single-selector scope would have caused visual regressions. The "no generic-UI leak" goal is still met: tokens are out of `:root` and bounded to two surfaces.
4. **`app.css` body is wrapped in `@layer views`**, not rule-by-rule split into base/components/views. The cascade order the README calls for is established; the deeper reorganization belongs with the component work in PR 2.

## Cross-client impact

None — no changes to `src/types.ts` or shared contract.

## Test plan

- [x] \`npx vite build\` (client-react) green
- [x] \`npx vitest run\` — 1495 passed / 4 skipped / 0 failed across 126 files
- [x] Acceptance greps clean
- [ ] CI \`unit\` / \`integration\` / \`ui-quality\` green
- [ ] Quick manual spot-check: Home, Today, Inbox, Settings, TarotCard look unchanged
- [ ] Keyboard focus still visible (now via \`box-shadow: var(--ring)\` instead of \`outline\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)