### PR TITLE
feat(ui): design system v2 PR 2 — core component primitives

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,10 @@ Summarize the user-facing and technical changes.
 - [ ] `CI=1 npm run test:ui:fast`
 - [ ] Additional manual validation notes, if applicable
 
+## Design system check
+
+For PRs that add or change a shared UI primitive under `client-react/src/components/ui/`, walk through the [Gallery PR checklist](../UX.md#gallery-pr-checklist) in `UX.md`. Skip otherwise.
+
 ## Brief / Protocol Impact
 
 - [ ] No

--- a/UX.md
+++ b/UX.md
@@ -185,3 +185,16 @@ Use this checklist for UI-affecting changes.
 - In the vanilla web client, prefer extending shared tokens and patterns in `client/styles.css` over adding one-off values
 - In React and iOS, preserve the same product semantics even when platform-native controls differ
 - When a UI change introduces a new repeated pattern, document it here or promote it into the local surface guide
+
+## Gallery PR checklist
+
+Any PR that adds or changes a shared UI primitive in `client-react/src/components/ui/` must walk through the checklist below. Reviewers open `ComponentGalleryPage` and confirm each item.
+
+- [ ] All component states shown in `ComponentGalleryPage` (rest / hover / focus / active / disabled / loading / error)
+- [ ] Dark mode verified — no hardcoded colors leak
+- [ ] Compact + spacious density verified where applicable
+- [ ] Keyboard-only navigation works; `--ring` is visible on focus for every interactive element
+- [ ] No new raw hex codes — every color is a token reference
+- [ ] No body text rendered on `--muted-light` (display-only token, not AA)
+- [ ] If color carries state, a label or icon reinforces it
+- [ ] When tokens change, the iOS catalog is regenerated in the same PR (`npm run tokens:check` stays green, once wired)

--- a/client-react/src/App.tsx
+++ b/client-react/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthPage } from "./auth/AuthPage";
 import { FeedbackView } from "./views/FeedbackView";
 import { AppShell } from "./components/layout/AppShell";
 import { MobileShell } from "./mobile/MobileShell";
+import { ToastProvider } from "./components/ui/ToastProvider";
 import { useIsMobile } from "./hooks/useIsMobile";
 import "./styles/app.css";
 import { navigateWithFade } from "./utils/pageTransitions";
@@ -81,5 +82,9 @@ function AppContent() {
 }
 
 export function App() {
-  return <AppContent />;
+  return (
+    <ToastProvider>
+      <AppContent />
+    </ToastProvider>
+  );
 }

--- a/client-react/src/components/layout/ComponentGalleryPage.test.tsx
+++ b/client-react/src/components/layout/ComponentGalleryPage.test.tsx
@@ -1,8 +1,15 @@
 // @vitest-environment jsdom
-import { createElement } from "react";
+import { createElement, type ComponentProps } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ComponentGalleryPage } from "./ComponentGalleryPage";
+import { ToastProvider } from "../ui/ToastProvider";
+
+function renderGallery(props: ComponentProps<typeof ComponentGalleryPage>) {
+  return render(
+    createElement(ToastProvider, null, createElement(ComponentGalleryPage, props)),
+  );
+}
 
 // Mock complex sub-components
 vi.mock("../home/FlipCard", () => ({
@@ -63,17 +70,17 @@ const defaultProps = {
 
 describe("ComponentGalleryPage", () => {
   it("renders with data-testid='component-gallery-page'", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     expect(screen.getByTestId("component-gallery-page")).toBeTruthy();
   });
 
   it("shows hero title 'Component gallery'", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     expect(screen.getByText("Component gallery")).toBeTruthy();
   });
 
   it("renders navigation preview items (Focus, Today, Upcoming, Tune-up)", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     expect(screen.getByText("Focus")).toBeTruthy();
     expect(screen.getByText("Today")).toBeTruthy();
     expect(screen.getByText("Upcoming")).toBeTruthy();
@@ -81,14 +88,14 @@ describe("ComponentGalleryPage", () => {
   });
 
   it("shows filter input", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     const input = screen.getByPlaceholderText(PLACEHOLDER);
     expect(input).toBeTruthy();
     expect(input.tagName).toBe("INPUT");
   });
 
   it("filters sections when filter text is typed", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     // All 6 sections visible initially (check by counting section cards)
     const initialSections = screen.getAllByText(/Actions and affordances|Workspace rail items|Search and view switching|Task chips and metadata|Live list row specimens|Account launcher and color tokens/);
     expect(initialSections.length).toBeGreaterThan(0);
@@ -103,7 +110,7 @@ describe("ComponentGalleryPage", () => {
   });
 
   it("shows empty state when filter matches nothing", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     const filterInput = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(filterInput, { target: { value: "xyznonexistent" } });
 
@@ -112,7 +119,7 @@ describe("ComponentGalleryPage", () => {
   });
 
   it("clear filter button resets filter", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     const filterInput = screen.getByPlaceholderText(PLACEHOLDER);
     fireEvent.change(filterInput, { target: { value: "xyznonexistent" } });
 
@@ -128,18 +135,18 @@ describe("ComponentGalleryPage", () => {
   });
 
   it("renders task row specimens (TodoRow components)", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     expect(screen.getByTestId("todo-row-preview-rich-row")).toBeTruthy();
     expect(screen.getByTestId("todo-row-preview-done-row")).toBeTruthy();
   });
 
   it("ProfileLauncher renders with sample user", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     expect(screen.getByTestId("mock-profile-launcher")).toBeTruthy();
   });
 
   it("view toggle buttons render (list/board mode)", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     const listButton = screen.getByRole("button", { name: "List preview" });
     const boardButton = screen.getByRole("button", { name: "Board preview" });
     expect(listButton).toBeTruthy();
@@ -147,12 +154,12 @@ describe("ComponentGalleryPage", () => {
   });
 
   it("UndoToast renders", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     expect(screen.getByTestId("mock-undo-toast")).toBeTruthy();
   });
 
   it("section count displays correctly (6)", () => {
-    render(createElement(ComponentGalleryPage, defaultProps));
+    renderGallery(defaultProps);
     // The hero stats show "6" for Live modules
     const stats = screen.getAllByText("6");
     expect(stats.length).toBeGreaterThan(0);

--- a/client-react/src/components/layout/ComponentGalleryPage.tsx
+++ b/client-react/src/components/layout/ComponentGalleryPage.tsx
@@ -13,6 +13,11 @@ import { ProfileLauncher } from "../shared/ProfileLauncher";
 import { SearchBar } from "../shared/SearchBar";
 import { UndoToast, type ToastVariant } from "../shared/UndoToast";
 import { TodoRow } from "../todos/TodoRow";
+import { Button, type ButtonVariant } from "../ui/Button";
+import { Chip, type ChipFamily } from "../ui/Chip";
+import { Input } from "../ui/Input";
+import { Skeleton } from "../ui/Skeleton";
+import { useToast } from "../ui/ToastProvider";
 
 type PreviewMode = "list" | "board";
 
@@ -210,6 +215,24 @@ function SectionCard({
   );
 }
 
+const BUTTON_VARIANTS: ButtonVariant[] = [
+  "primary",
+  "secondary",
+  "ghost",
+  "danger",
+  "ai",
+];
+
+const CHIP_FAMILIES: ChipFamily[] = [
+  "status",
+  "meta",
+  "tag",
+  "danger",
+  "warning",
+  "success",
+  "ai",
+];
+
 export function ComponentGalleryPage({ dark, onBack }: Props) {
   const [filterText, setFilterText] = useState("");
   const [searchPreviewValue, setSearchPreviewValue] = useState("overdue");
@@ -221,6 +244,9 @@ export function ComponentGalleryPage({ dark, onBack }: Props) {
   const [toastAction, setToastAction] = useState<GalleryToastAction | null>(
     null,
   );
+  const [inputValue, setInputValue] = useState("design@todos.app");
+  const [invalidInputValue, setInvalidInputValue] = useState("not-an-email");
+  const toast = useToast();
   const deferredFilter = useDeferredValue(filterText.trim().toLowerCase());
 
   const handlePreviewToast = (
@@ -416,6 +442,198 @@ export function ComponentGalleryPage({ dark, onBack }: Props) {
               }}
             />
           ))}
+        </div>
+      ),
+    },
+    {
+      id: "ds-buttons",
+      eyebrow: "Design System · Buttons",
+      title: "Button variants and states",
+      keywords: [
+        "button",
+        "btn",
+        "primary",
+        "secondary",
+        "ghost",
+        "danger",
+        "ai",
+        "pill",
+        "disabled",
+      ],
+      content: (
+        <div className="component-gallery__ds-grid">
+          <div className="component-gallery__ds-row">
+            {BUTTON_VARIANTS.map((variant) => (
+              <Button key={variant} variant={variant}>
+                {variant[0].toUpperCase() + variant.slice(1)}
+              </Button>
+            ))}
+          </div>
+          <div className="component-gallery__ds-row">
+            {BUTTON_VARIANTS.map((variant) => (
+              <Button key={variant} variant={variant} pill>
+                Pill · {variant}
+              </Button>
+            ))}
+          </div>
+          <div className="component-gallery__ds-row">
+            {BUTTON_VARIANTS.map((variant) => (
+              <Button key={variant} variant={variant} disabled>
+                Disabled · {variant}
+              </Button>
+            ))}
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: "ds-chips",
+      eyebrow: "Design System · Chips",
+      title: "One axis — family drives color, label is content",
+      keywords: [
+        "chip",
+        "chips",
+        "family",
+        "status",
+        "meta",
+        "tag",
+        "danger",
+        "warning",
+        "success",
+        "ai",
+      ],
+      content: (
+        <div className="component-gallery__ds-row">
+          {CHIP_FAMILIES.map((family) => (
+            <Chip key={family} family={family}>
+              {family}
+            </Chip>
+          ))}
+        </div>
+      ),
+    },
+    {
+      id: "ds-inputs",
+      eyebrow: "Design System · Inputs",
+      title: "Input with label, hint, and inline error",
+      keywords: [
+        "input",
+        "field",
+        "label",
+        "error",
+        "aria-invalid",
+        "disabled",
+      ],
+      content: (
+        <div className="component-gallery__ds-grid">
+          <Input
+            label="Email"
+            hint="Used for task assignments and notifications."
+            value={inputValue}
+            onChange={(event) => setInputValue(event.target.value)}
+            placeholder="you@team.app"
+          />
+          <Input
+            label="Email (invalid)"
+            error="Enter a valid email address."
+            value={invalidInputValue}
+            onChange={(event) => setInvalidInputValue(event.target.value)}
+          />
+          <Input
+            label="Disabled"
+            value="read-only handle"
+            disabled
+            readOnly
+          />
+        </div>
+      ),
+    },
+    {
+      id: "ds-skeletons",
+      eyebrow: "Design System · Skeletons",
+      title: "Loading placeholders shaped like the real layout",
+      keywords: ["skeleton", "loading", "shimmer", "placeholder"],
+      content: (
+        <div className="component-gallery__ds-grid">
+          <div className="component-gallery__ds-row">
+            <Skeleton shape="title" />
+            <Skeleton shape="line" />
+            <Skeleton shape="line" style={{ width: "70%" }} />
+          </div>
+          <div className="component-gallery__ds-row">
+            <Skeleton shape="circle" />
+            <Skeleton shape="chip" />
+            <Skeleton shape="chip" />
+            <Skeleton shape="chip" />
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: "ds-toasts",
+      eyebrow: "Design System · Toasts",
+      title: "Variants, action slot, and persistent patterns",
+      keywords: ["toast", "notification", "alert", "success", "warning", "ai"],
+      content: (
+        <div className="component-gallery__ds-row">
+          <Button
+            variant="secondary"
+            onClick={() =>
+              toast.info("Catalog synced", {
+                description: "We refreshed the upcoming view just now.",
+              })
+            }
+          >
+            Info
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() =>
+              toast.success("Task saved", {
+                description: "Your changes are live.",
+                action: {
+                  label: "Undo",
+                  onClick: () => toast.info("Reverted"),
+                },
+              })
+            }
+          >
+            Success · undo
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() =>
+              toast.warning("Check offline", {
+                description: "Some changes may be unsynced.",
+              })
+            }
+          >
+            Warning
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() =>
+              toast.danger("Save failed", {
+                description: "We couldn't reach the server.",
+              })
+            }
+          >
+            Danger
+          </Button>
+          <Button
+            variant="ai"
+            onClick={() =>
+              toast.ai("Planner suggestion", {
+                description: "Move 2 overdue items to tomorrow?",
+                action: {
+                  label: "Apply",
+                  onClick: () => toast.success("Plan applied"),
+                },
+              })
+            }
+          >
+            AI
+          </Button>
         </div>
       ),
     },

--- a/client-react/src/components/ui/Button.test.tsx
+++ b/client-react/src/components/ui/Button.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { createRef } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  it("defaults to primary variant", () => {
+    const { getByRole } = render(<Button>Go</Button>);
+    expect(getByRole("button", { name: "Go" })).toHaveClass("btn", "btn--primary");
+  });
+
+  it.each(["primary", "secondary", "ghost", "danger", "ai"] as const)(
+    "applies the %s variant class",
+    (variant) => {
+      const { getByRole } = render(<Button variant={variant}>X</Button>);
+      expect(getByRole("button")).toHaveClass(`btn--${variant}`);
+    },
+  );
+
+  it("adds the pill modifier when requested", () => {
+    const { getByRole } = render(<Button pill>Pill</Button>);
+    expect(getByRole("button")).toHaveClass("btn--pill");
+  });
+
+  it("merges caller-provided className with the generated classes", () => {
+    const { getByRole } = render(<Button className="extra">Go</Button>);
+    expect(getByRole("button")).toHaveClass("btn", "btn--primary", "extra");
+  });
+
+  it("forwards refs and click handlers", () => {
+    const ref = createRef<HTMLButtonElement>();
+    const onClick = vi.fn();
+    const { getByRole } = render(
+      <Button ref={ref} onClick={onClick}>
+        Go
+      </Button>,
+    );
+    expect(ref.current).toBe(getByRole("button"));
+    fireEvent.click(getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onClick when disabled", () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(
+      <Button disabled onClick={onClick}>
+        Go
+      </Button>,
+    );
+    fireEvent.click(getByRole("button"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("defaults the HTML type to button so it does not submit forms implicitly", () => {
+    const { getByRole } = render(<Button>Go</Button>);
+    expect(getByRole("button")).toHaveAttribute("type", "button");
+  });
+});

--- a/client-react/src/components/ui/Button.tsx
+++ b/client-react/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type ForwardedRef,
+} from "react";
+
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "ghost"
+  | "danger"
+  | "ai";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  pill?: boolean;
+}
+
+const DEFAULT_VARIANT: ButtonVariant = "primary";
+
+export const Button = forwardRef(function Button(
+  { variant = DEFAULT_VARIANT, pill, className, type, ...rest }: ButtonProps,
+  ref: ForwardedRef<HTMLButtonElement>,
+) {
+  const classes = ["btn", `btn--${variant}`];
+  if (pill) classes.push("btn--pill");
+  if (className) classes.push(className);
+
+  return (
+    <button
+      ref={ref}
+      type={type ?? "button"}
+      className={classes.join(" ")}
+      {...rest}
+    />
+  );
+});

--- a/client-react/src/components/ui/Chip.test.tsx
+++ b/client-react/src/components/ui/Chip.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Chip } from "./Chip";
+
+describe("Chip", () => {
+  it.each([
+    "status",
+    "meta",
+    "tag",
+    "danger",
+    "warning",
+    "success",
+    "ai",
+  ] as const)("emits data-family=%s", (family) => {
+    const { getByText } = render(<Chip family={family}>{family}</Chip>);
+    const chip = getByText(family);
+    expect(chip).toHaveClass("chip");
+    expect(chip).toHaveAttribute("data-family", family);
+  });
+
+  it("merges caller-provided className", () => {
+    const { getByText } = render(
+      <Chip family="meta" className="chip--dense">
+        x
+      </Chip>,
+    );
+    expect(getByText("x")).toHaveClass("chip", "chip--dense");
+  });
+});

--- a/client-react/src/components/ui/Chip.tsx
+++ b/client-react/src/components/ui/Chip.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export type ChipFamily =
+  | "status"
+  | "meta"
+  | "tag"
+  | "danger"
+  | "warning"
+  | "success"
+  | "ai";
+
+export interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
+  family: ChipFamily;
+  children: ReactNode;
+}
+
+export function Chip({ family, className, children, ...rest }: ChipProps) {
+  const classes = className ? `chip ${className}` : "chip";
+  return (
+    <span className={classes} data-family={family} {...rest}>
+      {children}
+    </span>
+  );
+}

--- a/client-react/src/components/ui/Input.test.tsx
+++ b/client-react/src/components/ui/Input.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { createRef } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Input } from "./Input";
+
+describe("Input", () => {
+  it("renders a label associated with the input by id", () => {
+    const { getByLabelText } = render(<Input label="Email" />);
+    expect(getByLabelText("Email").tagName).toBe("INPUT");
+  });
+
+  it("hides hint once an error is present and keeps the input marked invalid", () => {
+    const { rerender, queryByText, getByRole } = render(
+      <Input label="Email" hint="We never share it." />,
+    );
+    expect(queryByText("We never share it.")).toBeInTheDocument();
+    expect(getByRole("textbox")).not.toHaveAttribute("aria-invalid");
+
+    rerender(
+      <Input
+        label="Email"
+        hint="We never share it."
+        error="That email is taken."
+      />,
+    );
+    expect(queryByText("We never share it.")).not.toBeInTheDocument();
+    expect(queryByText("That email is taken.")).toBeInTheDocument();
+    expect(getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("forwards onChange and ref", () => {
+    const onChange = vi.fn();
+    const ref = createRef<HTMLInputElement>();
+    const { getByRole } = render(<Input ref={ref} onChange={onChange} />);
+    fireEvent.change(getByRole("textbox"), { target: { value: "hi" } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(ref.current).toBe(getByRole("textbox"));
+  });
+
+  it("wires aria-describedby to the error and hint ids", () => {
+    const { getByRole, rerender } = render(
+      <Input label="Name" hint="Up to 40 characters." />,
+    );
+    const describedByHint = getByRole("textbox").getAttribute("aria-describedby");
+    expect(describedByHint).toBeTruthy();
+    expect(describedByHint).toMatch(/-hint$/);
+
+    rerender(<Input label="Name" error="Required." />);
+    const describedByError = getByRole("textbox").getAttribute("aria-describedby");
+    expect(describedByError).toMatch(/-error$/);
+  });
+});

--- a/client-react/src/components/ui/Input.tsx
+++ b/client-react/src/components/ui/Input.tsx
@@ -1,0 +1,58 @@
+import {
+  forwardRef,
+  useId,
+  type ForwardedRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: ReactNode;
+  error?: ReactNode;
+  hint?: ReactNode;
+}
+
+export const Input = forwardRef(function Input(
+  {
+    label,
+    error,
+    hint,
+    id,
+    className,
+    "aria-describedby": describedByProp,
+    ...rest
+  }: InputProps,
+  ref: ForwardedRef<HTMLInputElement>,
+) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const hintId = hint ? `${inputId}-hint` : undefined;
+  const describedBy =
+    [describedByProp, errorId, hintId].filter(Boolean).join(" ") || undefined;
+  const inputClass = className ? `input ${className}` : "input";
+
+  return (
+    <div className="field">
+      {label && <label htmlFor={inputId}>{label}</label>}
+      <input
+        ref={ref}
+        id={inputId}
+        className={inputClass}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+        {...rest}
+      />
+      {hint && !error && (
+        <span id={hintId} className="field-hint">
+          {hint}
+        </span>
+      )}
+      {error && (
+        <span id={errorId} className="field-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+});

--- a/client-react/src/components/ui/Skeleton.test.tsx
+++ b/client-react/src/components/ui/Skeleton.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("defaults to the line shape", () => {
+    const { container } = render(<Skeleton data-testid="s" />);
+    const el = container.querySelector(".skel")!;
+    expect(el).toHaveClass("skel", "skel--line");
+  });
+
+  it.each(["line", "title", "chip", "circle"] as const)(
+    "applies the %s shape modifier",
+    (shape) => {
+      const { container } = render(<Skeleton shape={shape} />);
+      const el = container.querySelector(".skel")!;
+      expect(el).toHaveClass(`skel--${shape}`);
+    },
+  );
+
+  it("accepts width + height overrides", () => {
+    const { container } = render(<Skeleton width={120} height={24} />);
+    const el = container.querySelector(".skel")! as HTMLElement;
+    expect(el.style.width).toBe("120px");
+    expect(el.style.height).toBe("24px");
+  });
+
+  it("is aria-hidden so assistive tech skips placeholder chrome", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.querySelector(".skel")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+});

--- a/client-react/src/components/ui/Skeleton.tsx
+++ b/client-react/src/components/ui/Skeleton.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties, HTMLAttributes } from "react";
+
+export type SkeletonShape = "line" | "title" | "chip" | "circle";
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  shape?: SkeletonShape;
+  width?: number | string;
+  height?: number | string;
+}
+
+export function Skeleton({
+  shape = "line",
+  width,
+  height,
+  className,
+  style,
+  ...rest
+}: SkeletonProps) {
+  const classes = ["skel", `skel--${shape}`];
+  if (className) classes.push(className);
+
+  const sized: CSSProperties = { ...style };
+  if (width !== undefined) sized.width = width;
+  if (height !== undefined) sized.height = height;
+
+  return (
+    <div
+      className={classes.join(" ")}
+      style={sized}
+      aria-hidden="true"
+      {...rest}
+    />
+  );
+}

--- a/client-react/src/components/ui/Toast.tsx
+++ b/client-react/src/components/ui/Toast.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+
+export type ToastVariant = "info" | "success" | "warning" | "danger" | "ai";
+
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface ToastProps {
+  variant: ToastVariant;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ToastAction;
+  onDismiss?: () => void;
+}
+
+const ICON_BY_VARIANT: Record<ToastVariant, ReactNode> = {
+  info: (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M8 7v4M8 4.5v.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+  success: (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3 8.5l3 3 7-7" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  ),
+  warning: (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 2l6.5 11.5h-13L8 2z" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+      <path d="M8 6v3.5M8 11.5v.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+  danger: (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <path d="M5.5 5.5l5 5m0-5l-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  ),
+  ai: (
+    <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 2l1.8 4.2L14 8l-4.2 1.8L8 14l-1.8-4.2L2 8l4.2-1.8L8 2z" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinejoin="round" />
+    </svg>
+  ),
+};
+
+export function Toast({
+  variant,
+  title,
+  description,
+  action,
+  onDismiss,
+}: ToastProps) {
+  return (
+    <div
+      className="toast"
+      data-variant={variant}
+      role={variant === "danger" || variant === "warning" ? "alert" : "status"}
+      aria-live={variant === "danger" || variant === "warning" ? "assertive" : "polite"}
+    >
+      <span className="toast-icon">{ICON_BY_VARIANT[variant]}</span>
+      <div className="toast-body">
+        <b>{title}</b>
+        {description && <span>{description}</span>}
+      </div>
+      {action && (
+        <button
+          type="button"
+          className="toast-action"
+          onClick={() => {
+            action.onClick();
+            onDismiss?.();
+          }}
+        >
+          {action.label}
+        </button>
+      )}
+      {onDismiss && !action && (
+        <button
+          type="button"
+          className="toast-action"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client-react/src/components/ui/ToastProvider.test.tsx
+++ b/client-react/src/components/ui/ToastProvider.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, useToast } from "./ToastProvider";
+
+function Harness() {
+  const toast = useToast();
+  return (
+    <div>
+      <button type="button" onClick={() => toast.success("Saved", { description: "All good" })}>
+        success
+      </button>
+      <button type="button" onClick={() => toast.warning("Heads up")}>
+        warning
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          toast.info("With action", {
+            action: { label: "Undo", onClick: () => toast.info("Undone") },
+          })
+        }
+      >
+        action
+      </button>
+    </div>
+  );
+}
+
+describe("ToastProvider + useToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders a toast when the API is called", () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "success" }));
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses info/success toasts after 5s", () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "success" }));
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+  });
+
+  it("leaves warning/danger toasts until dismissed explicitly", () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "warning" }));
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(screen.getByText("Heads up")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByText("Heads up")).not.toBeInTheDocument();
+  });
+
+  it("runs the action callback and dismisses when clicked", () => {
+    render(
+      <ToastProvider>
+        <Harness />
+      </ToastProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "action" }));
+    expect(screen.getByText("With action")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+    expect(screen.queryByText("With action")).not.toBeInTheDocument();
+    expect(screen.getByText("Undone")).toBeInTheDocument();
+  });
+
+  it("throws when useToast is called outside the provider", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Harness />)).toThrow(/ToastProvider/);
+    spy.mockRestore();
+  });
+});

--- a/client-react/src/components/ui/ToastProvider.tsx
+++ b/client-react/src/components/ui/ToastProvider.tsx
@@ -1,0 +1,137 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Toast, type ToastAction, type ToastVariant } from "./Toast";
+
+interface ToastRecord {
+  id: number;
+  variant: ToastVariant;
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ToastAction;
+}
+
+export interface ToastOptions {
+  description?: ReactNode;
+  action?: ToastAction;
+  /** Override auto-dismiss. `null` keeps the toast persistent. */
+  duration?: number | null;
+}
+
+type Publish = (
+  variant: ToastVariant,
+  title: ReactNode,
+  options?: ToastOptions,
+) => number;
+
+export interface ToastApi {
+  info: (title: ReactNode, options?: ToastOptions) => number;
+  success: (title: ReactNode, options?: ToastOptions) => number;
+  warning: (title: ReactNode, options?: ToastOptions) => number;
+  danger: (title: ReactNode, options?: ToastOptions) => number;
+  ai: (title: ReactNode, options?: ToastOptions) => number;
+  dismiss: (id: number) => void;
+}
+
+const MAX_VISIBLE = 4;
+const AUTO_DISMISS_MS: Record<ToastVariant, number | null> = {
+  info: 5000,
+  success: 5000,
+  ai: 5000,
+  warning: null,
+  danger: null,
+};
+
+const ToastContext = createContext<ToastApi | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const nextId = useRef(1);
+  const timers = useRef(new Map<number, ReturnType<typeof setTimeout>>());
+
+  const dismiss = useCallback((id: number) => {
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+    setToasts((current) => current.filter((t) => t.id !== id));
+  }, []);
+
+  const publish = useCallback<Publish>(
+    (variant, title, options) => {
+      const id = nextId.current++;
+      const record: ToastRecord = {
+        id,
+        variant,
+        title,
+        description: options?.description,
+        action: options?.action,
+      };
+      setToasts((current) => [...current.slice(-(MAX_VISIBLE - 1)), record]);
+      const duration =
+        options?.duration === undefined
+          ? AUTO_DISMISS_MS[variant]
+          : options.duration;
+      if (duration !== null && duration !== undefined && duration > 0) {
+        const timer = setTimeout(() => dismiss(id), duration);
+        timers.current.set(id, timer);
+      }
+      return id;
+    },
+    [dismiss],
+  );
+
+  useEffect(() => {
+    const snapshot = timers.current;
+    return () => {
+      snapshot.forEach((timer) => clearTimeout(timer));
+      snapshot.clear();
+    };
+  }, []);
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      info: (title, options) => publish("info", title, options),
+      success: (title, options) => publish("success", title, options),
+      warning: (title, options) => publish("warning", title, options),
+      danger: (title, options) => publish("danger", title, options),
+      ai: (title, options) => publish("ai", title, options),
+      dismiss,
+    }),
+    [publish, dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <div className="toast-stack" aria-live="polite">
+        {toasts.map((t) => (
+          <Toast
+            key={t.id}
+            variant={t.variant}
+            title={t.title}
+            description={t.description}
+            action={t.action}
+            onDismiss={() => dismiss(t.id)}
+          />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used within a <ToastProvider>");
+  }
+  return ctx;
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -11141,6 +11141,19 @@ body.dark-mode {
   gap: var(--s-2);
 }
 
+.component-gallery__ds-grid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+}
+
+.component-gallery__ds-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-3);
+  align-items: center;
+}
+
 .component-gallery__rows {
   display: grid;
   gap: var(--s-2);

--- a/client-react/src/styles/components.css
+++ b/client-react/src/styles/components.css
@@ -1,11 +1,353 @@
 /* ════════════════════════════════════════════════════════════════════
    Design System v2 — components layer
-   Reserved for shared component primitives (.btn, .chip, .input, .cbx,
-   .toast, .skel, .todo-row, …). Populated in PR 2; kept as an empty
-   layer today so the cascade order is established and later additions
-   slot in without reshuffling existing view-layer styles.
+   Shared component primitives: .btn, .chip, .input, .field, .toast,
+   .toast-stack, .skel. Rendered by the React primitives under
+   client-react/src/components/ui/.
    ════════════════════════════════════════════════════════════════════ */
 
 @layer components {
-  /* intentionally empty — see PR 2 */
+  /* ── Buttons ─────────────────────────── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--s-2);
+    padding: var(--s-2h) var(--s-4);
+    border: 1px solid transparent;
+    border-radius: var(--r-sm);
+    background: transparent;
+    color: var(--text);
+    font:
+      600 var(--fs-meta) / 1 var(--font-sans);
+    white-space: nowrap;
+    cursor: pointer;
+    min-height: 36px;
+    transition:
+      background var(--dur-base) var(--ease-out),
+      color var(--dur-base) var(--ease-out),
+      border-color var(--dur-base) var(--ease-out),
+      box-shadow var(--dur-base) var(--ease-out),
+      transform var(--dur-base) var(--ease-out);
+  }
+  .btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    transform: none !important;
+    box-shadow: none !important;
+  }
+
+  .btn--primary {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  .btn--primary:hover:not(:disabled) {
+    background: var(--accent-3);
+    border-color: var(--accent-3);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+  }
+  .btn--primary:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: none;
+  }
+
+  .btn--secondary {
+    background: var(--surface);
+    color: var(--text);
+    border-color: var(--border);
+  }
+  .btn--secondary:hover:not(:disabled) {
+    background: var(--surface-2);
+    border-color: var(--border-strong);
+  }
+
+  .btn--ghost {
+    background: transparent;
+    color: var(--muted);
+    border-color: transparent;
+  }
+  .btn--ghost:hover:not(:disabled) {
+    background: var(--surface-2);
+    color: var(--text);
+  }
+
+  .btn--danger {
+    background: var(--danger);
+    color: #fff;
+    border-color: var(--danger);
+  }
+  .btn--danger:hover:not(:disabled) {
+    background: var(--danger-2);
+    border-color: var(--danger-2);
+  }
+
+  .btn--ai {
+    background: var(--accent-secondary);
+    color: #fff;
+    border-color: var(--accent-secondary);
+  }
+  .btn--ai:hover:not(:disabled) {
+    background: var(--accent-secondary-3);
+    border-color: var(--accent-secondary-3);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+  }
+
+  .btn--pill {
+    border-radius: var(--r-full);
+    padding-inline: var(--s-5);
+  }
+
+  /* ── Chips — one axis: family drives color, label is content ─── */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--s-1);
+    padding: 2px var(--s-2);
+    border: 1px solid transparent;
+    border-radius: var(--r-full);
+    font:
+      500 var(--fs-label) / 1.4 var(--font-sans);
+    white-space: nowrap;
+  }
+  .chip[data-family="status"] {
+    background: color-mix(in oklab, var(--accent) 10%, transparent);
+    color: var(--accent-3);
+    border-color: color-mix(in oklab, var(--accent) 22%, transparent);
+  }
+  .chip[data-family="meta"] {
+    background: var(--surface-3);
+    color: var(--muted);
+  }
+  .chip[data-family="tag"] {
+    background: transparent;
+    color: var(--muted);
+    border-color: var(--border);
+    cursor: pointer;
+  }
+  .chip[data-family="tag"]:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+  .chip[data-family="danger"] {
+    background: color-mix(in oklab, var(--danger) 12%, transparent);
+    color: var(--danger-2);
+    border-color: color-mix(in oklab, var(--danger) 25%, transparent);
+  }
+  .chip[data-family="warning"] {
+    background: color-mix(in oklab, var(--warning) 14%, transparent);
+    color: var(--warning);
+    border-color: color-mix(in oklab, var(--warning) 30%, transparent);
+  }
+  .chip[data-family="success"] {
+    background: color-mix(in oklab, var(--success) 12%, transparent);
+    color: var(--success);
+    border-color: color-mix(in oklab, var(--success) 25%, transparent);
+  }
+  .chip[data-family="ai"] {
+    background: color-mix(in oklab, var(--accent-secondary) 12%, transparent);
+    color: var(--accent-secondary-3);
+    border-color: color-mix(in oklab, var(--accent-secondary) 28%, transparent);
+  }
+  body.dark-mode .chip[data-family="warning"] {
+    color: #ffc97a;
+  }
+  body.dark-mode .chip[data-family="ai"] {
+    color: var(--accent-secondary-3);
+  }
+
+  /* ── Inputs ──────────────────────────── */
+  .input {
+    width: 100%;
+    padding: var(--s-2h) var(--s-3);
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    background: var(--surface);
+    color: var(--text);
+    font:
+      400 var(--fs-body) / 1.4 var(--font-sans);
+    transition:
+      border-color var(--dur-fast),
+      box-shadow var(--dur-fast);
+    min-height: 36px;
+  }
+  .input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: var(--ring);
+  }
+  .input::placeholder {
+    color: var(--muted-strong);
+  }
+  .input[aria-invalid="true"] {
+    border-color: var(--danger);
+  }
+  .input[aria-invalid="true"]:focus {
+    box-shadow: var(--ring-danger);
+  }
+  .input:disabled {
+    background: var(--surface-3);
+    color: var(--muted);
+    cursor: not-allowed;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-1);
+  }
+  .field > label {
+    color: var(--muted);
+    font:
+      500 var(--fs-label) / 1 var(--font-sans);
+  }
+  .field-hint {
+    color: var(--muted);
+    font:
+      400 var(--fs-label) / 1.3 var(--font-sans);
+  }
+  .field-error {
+    color: var(--danger-2);
+    font:
+      500 var(--fs-label) / 1.3 var(--font-sans);
+  }
+
+  /* ── Toast ───────────────────────────── */
+  .toast-stack {
+    position: fixed;
+    right: var(--s-4);
+    bottom: var(--s-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-3);
+    z-index: 1000;
+    pointer-events: none;
+  }
+  .toast-stack > .toast {
+    pointer-events: auto;
+  }
+  .toast {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--s-3);
+    padding: var(--s-3) var(--s-4);
+    min-width: 320px;
+    max-width: 420px;
+    background: var(--surface);
+    border: 1px solid var(--border-light);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--r-md);
+    box-shadow: var(--shadow-lg);
+    animation: toast-enter var(--dur-base) var(--ease-out);
+  }
+  .toast[data-variant="success"] {
+    border-left-color: var(--success);
+  }
+  .toast[data-variant="warning"] {
+    border-left-color: var(--warning);
+  }
+  .toast[data-variant="danger"] {
+    border-left-color: var(--danger);
+  }
+  .toast[data-variant="ai"] {
+    border-left-color: var(--accent-secondary);
+  }
+  .toast-icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: var(--accent);
+  }
+  .toast[data-variant="success"] .toast-icon {
+    color: var(--success);
+  }
+  .toast[data-variant="warning"] .toast-icon {
+    color: var(--warning);
+  }
+  .toast[data-variant="danger"] .toast-icon {
+    color: var(--danger);
+  }
+  .toast[data-variant="ai"] .toast-icon {
+    color: var(--accent-secondary);
+  }
+  .toast-body {
+    flex: 1;
+    font-size: var(--fs-meta);
+  }
+  .toast-body b {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--text-strong);
+  }
+  .toast-body span {
+    color: var(--muted);
+  }
+  .toast-action {
+    padding: var(--s-1h) var(--s-2);
+    border: none;
+    border-radius: var(--r-xs);
+    background: none;
+    color: var(--accent);
+    font:
+      600 var(--fs-meta) / 1 var(--font-sans);
+    cursor: pointer;
+  }
+  .toast-action:hover {
+    background: var(--accent-light);
+  }
+  @keyframes toast-enter {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* ── Skeleton ────────────────────────── */
+  @keyframes skel-shimmer {
+    0% {
+      background-position: -200px 0;
+    }
+    100% {
+      background-position: calc(200px + 100%) 0;
+    }
+  }
+  .skel {
+    display: block;
+    background: linear-gradient(
+      90deg,
+      var(--surface-2) 0%,
+      var(--surface-3) 40%,
+      var(--surface-2) 80%
+    );
+    background-size: 200px 100%;
+    background-repeat: no-repeat;
+    border-radius: var(--r-xs);
+    animation: skel-shimmer 1.4s var(--ease-in-out) infinite;
+  }
+  .skel--line {
+    height: 12px;
+  }
+  .skel--title {
+    height: 18px;
+    width: 45%;
+  }
+  .skel--chip {
+    height: 16px;
+    width: 60px;
+    border-radius: var(--r-full);
+  }
+  .skel--circle {
+    width: 18px;
+    height: 18px;
+    border-radius: var(--r-xs);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .skel {
+      animation: none;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `Button`, `Chip`, `Input`, `Skeleton`, `Toast`, `ToastProvider` under `client-react/src/components/ui/` with the classes the v2 spec calls for, and populates `@layer components` in `components.css` with matching styles.
- Mounts `ToastProvider` once at the app root, exposes `useToast()` with variant methods (`info`, `success`, `warning`, `danger`, `ai`), and keeps the existing `UndoToast` in place for the gallery's pre-existing demo.
- Extends `ComponentGalleryPage` with five new design-system sections (buttons / chips / inputs / skeletons / toasts) that exercise every variant and state, and appends the Gallery PR checklist to `UX.md` + references it from the PR template.

## What is **not** in this PR (follow-ups)

The README's PR 2 envelope is broad; the items below are staged for separate PRs so this one stays reviewable and the primitives can land first:

1. **iOS token generator** — `scripts/tokens-to-swift.ts` + `ios/TodosApp/DesignTokens.swift` + `npm run tokens:check` CI drift guard.
2. **Density header segmented control** — promoting density from Settings into the list-view header with per-view `localStorage` persistence.
3. **Data-viz palette wiring** — plumbing `--viz-1..6` / `--viz-seq-*` into the Insights / weekly-review charts.
4. **Product mark redraw** — new sidebar SVG + favicon swap.

## Cross-client impact

None — no changes to `src/types.ts`, validation, or shared contract.

## Test plan

- [x] `npx vite build` (client-react) — 273 kB CSS bundle, no warnings from new CSS
- [x] `npx vitest run` — 1530 passed / 4 skipped / 0 failed across 131 test files (35 new tests for the primitives)
- [x] Dev server smoke — new sections render and toast stack appears
- [ ] CI \`unit\` / \`integration\` / \`ui-quality\` green
- [ ] Gallery PR checklist (open `ComponentGalleryPage`, toggle dark, keyboard focus, etc.) — reviewer step

## Notes on cascade interaction

`app.css` (wrapped in `@layer views` in PR 1) still defines base `.btn`, `.chip`, and some `.input-like` rules. With layer order `views > components`, the existing base styles keep winning for the classes they already cover; the new rules in `@layer components` fill in the v2-only surfaces (`.btn--secondary/ghost/ai/pill`, `.chip[data-family="X"]`, `.field`, `.field-error`, the full `.toast*` and `.skel*` families). A full extraction of the old base rules into `components.css` is its own migration and would inflate this PR beyond the "primitives" scope — flagging for the next pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)