### PR TITLE
feat(ui): promote density to inline segmented control in list headers

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -117,11 +117,21 @@ export function AppShell() {
   const { user, logout } = useAuth();
   const isMobile = useIsMobile();
   const { dark, toggle: toggleDarkMode } = useDarkMode();
-  const { density, setDensity, cycle: cycleDensity } = useDensity();
-  const { groupBy, setGroupBy } = useGroupBy();
-  const { startTransition } = useViewTransition();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [activeView, setActiveView] = useState<WorkspaceView>("home");
+  // Per-view density: Today, Inbox, Upcoming each remember their own row
+  // density. Other views share the global key so they behave as before.
+  const densityViewKey =
+    activeView === "today" ||
+    activeView === "inbox" ||
+    activeView === "upcoming"
+      ? activeView
+      : undefined;
+  const { density, setDensity, cycle: cycleDensity } = useDensity(
+    densityViewKey,
+  );
+  const { groupBy, setGroupBy } = useGroupBy();
+  const { startTransition } = useViewTransition();
   const [horizonSegment, setHorizonSegment] = useState<HorizonSegment>(() => {
     const stored = localStorage.getItem("todos:horizon-segment");
     return stored === "due" ||

--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -13,8 +13,11 @@ import { QuickEntry } from "../todos/QuickEntry";
 import { SearchBar } from "../shared/SearchBar";
 import { SegmentedControl } from "../shared/SegmentedControl";
 import { VerificationBanner } from "../shared/VerificationBanner";
+import { DensitySegmentedControl } from "../ui/DensitySegmentedControl";
 import { ViewMenu } from "./ViewMenu";
 import { ViewSubtitle } from "./ViewSubtitle";
+
+const VIEWS_WITH_INLINE_DENSITY = new Set(["today", "inbox", "upcoming"]);
 
 type UiMode = "normal" | "simple";
 type HorizonSegment = "due" | "planned" | "pending" | "later";
@@ -355,6 +358,19 @@ export function ListViewHeader({
           }))}
         />
       )}
+
+      {!isMobile &&
+        !selectedProjectId &&
+        VIEWS_WITH_INLINE_DENSITY.has(activeView) && (
+          <div className="list-header-density-bar">
+            <span className="list-header-density-bar__label">Density</span>
+            <DensitySegmentedControl
+              value={density}
+              onChange={onDensityChange}
+              className="list-header-density-bar__control"
+            />
+          </div>
+        )}
 
       {/* Today view coaching */}
       {activeView === "today" &&

--- a/client-react/src/components/ui/DensitySegmentedControl.test.tsx
+++ b/client-react/src/components/ui/DensitySegmentedControl.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DensitySegmentedControl } from "./DensitySegmentedControl";
+
+describe("DensitySegmentedControl", () => {
+  it("renders all three density options", () => {
+    render(<DensitySegmentedControl value="normal" onChange={() => {}} />);
+    expect(screen.getByRole("tab", { name: "Compact" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Default" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Spacious" })).toBeInTheDocument();
+  });
+
+  it("invokes onChange with the clicked density", () => {
+    const onChange = vi.fn();
+    render(<DensitySegmentedControl value="normal" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Compact" }));
+    expect(onChange).toHaveBeenCalledWith("compact");
+    fireEvent.click(screen.getByRole("tab", { name: "Spacious" }));
+    expect(onChange).toHaveBeenLastCalledWith("spacious");
+  });
+});

--- a/client-react/src/components/ui/DensitySegmentedControl.tsx
+++ b/client-react/src/components/ui/DensitySegmentedControl.tsx
@@ -1,0 +1,41 @@
+import type { Density } from "../../hooks/useDensity";
+import { SegmentedControl } from "../shared/SegmentedControl";
+
+const DENSITY_OPTIONS: ReadonlyArray<{ value: Density; label: string }> = [
+  { value: "compact", label: "Compact" },
+  { value: "normal", label: "Default" },
+  { value: "spacious", label: "Spacious" },
+];
+
+export interface DensitySegmentedControlProps {
+  value: Density;
+  onChange: (next: Density) => void;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Inline segmented control for switching the list-view density.
+ * Thin wrapper over the existing `SegmentedControl` primitive so
+ * header chrome can promote the setting out of the view menu.
+ */
+export function DensitySegmentedControl({
+  value,
+  onChange,
+  ariaLabel = "Row density",
+  className,
+}: DensitySegmentedControlProps) {
+  return (
+    <SegmentedControl
+      value={value}
+      onChange={(next) => onChange(next as Density)}
+      ariaLabel={ariaLabel}
+      className={className}
+      options={DENSITY_OPTIONS.map(({ value: v, label }) => ({
+        value: v,
+        label,
+        buttonId: `densitySegment-${v}`,
+      }))}
+    />
+  );
+}

--- a/client-react/src/hooks/useDensity.ts
+++ b/client-react/src/hooks/useDensity.ts
@@ -2,15 +2,65 @@ import { useState, useEffect, useCallback } from "react";
 
 export type Density = "compact" | "normal" | "spacious";
 
-export function useDensity() {
-  const [density, setDensity] = useState<Density>(
-    () => (localStorage.getItem("todos:density") as Density) || "normal",
+const LEGACY_GLOBAL_KEY = "todos:density";
+
+function storageKeyFor(viewKey: string | undefined): string {
+  return viewKey ? `todos:density:${viewKey}` : LEGACY_GLOBAL_KEY;
+}
+
+function readStoredDensity(storageKey: string): Density {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (raw === "compact" || raw === "normal" || raw === "spacious") {
+      return raw;
+    }
+  } catch {
+    // localStorage can throw in privacy modes; fall back below.
+  }
+  // Per-view keys fall back to the global default when unset so a
+  // brand-new view inherits the user's preferred density.
+  if (storageKey !== LEGACY_GLOBAL_KEY) {
+    try {
+      const fallback = localStorage.getItem(LEGACY_GLOBAL_KEY);
+      if (fallback === "compact" || fallback === "normal" || fallback === "spacious") {
+        return fallback;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return "normal";
+}
+
+/**
+ * Read / write the active density token.
+ *
+ * When `viewKey` is omitted the hook uses the historical single
+ * `todos:density` key so existing callers keep their behavior. Pass a
+ * stable `viewKey` ("today", "inbox", "upcoming", …) to persist a
+ * distinct density per view; switching views re-loads that view's
+ * stored preference and reflects it on `<html data-density="…">` so
+ * the density tokens in `tokens.css` pick it up.
+ */
+export function useDensity(viewKey?: string) {
+  const storageKey = storageKeyFor(viewKey);
+  const [density, setDensity] = useState<Density>(() =>
+    readStoredDensity(storageKey),
   );
+
+  // Reload whenever the storage key changes (i.e. the active view flips).
+  useEffect(() => {
+    setDensity(readStoredDensity(storageKey));
+  }, [storageKey]);
 
   useEffect(() => {
     document.documentElement.dataset.density = density;
-    localStorage.setItem("todos:density", density);
-  }, [density]);
+    try {
+      localStorage.setItem(storageKey, density);
+    } catch {
+      // ignore — ephemeral storage failures shouldn't break the UI.
+    }
+  }, [density, storageKey]);
 
   const cycle = useCallback(() => {
     setDensity((d) => {

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -10397,6 +10397,23 @@ body.dark-mode {
   min-width: 0;
 }
 
+.list-header-density-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-2) var(--s-5);
+}
+.list-header-density-bar__label {
+  color: var(--muted);
+  font:
+    500 var(--fs-label) / 1 var(--font-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.list-header-density-bar__control {
+  min-width: 0;
+}
+
 .toggle-switch {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Adds a \`DensitySegmentedControl\` primitive (components/ui/) and renders it inline beneath the Today / Inbox / Upcoming headers on desktop.
- Extends \`useDensity(viewKey?)\` to persist per-view in \`localStorage\` (\`todos:density:<viewKey>\`) while keeping the legacy single \`todos:density\` key for every other surface, with per-view reads falling back to the global default for first visits.
- Wires \`AppShell\` to pass the active view's key into the hook so switching between Today / Inbox / Upcoming re-loads that view's stored density.

## Behavior

- Mobile keeps the existing \`ViewMenu\` path unchanged (space-constrained).
- Projects and horizon subviews stay on the global key; the inline control only appears on the three list views the spec calls out.
- Writing density cycles through \`compact → normal → spacious\` as before via \`useDensity().cycle\`.

## Verification

- [x] \`npx vitest run\` — 1532 passed / 4 skipped / 0 failed across 132 test files (+2 new tests for the segmented control)
- [x] \`npx vite build\` — clean
- [ ] CI \`unit\` / \`react-tests\` / \`ui-quality\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)