### PR TITLE
feat(ui): wire --viz-* palette into home dashboard charts

### DIFF
--- a/client-react/src/components/home/PanelRenderer.tsx
+++ b/client-react/src/components/home/PanelRenderer.tsx
@@ -185,8 +185,8 @@ function DueSoonPanel({
                   width: `${Math.round((group.items.length / maxCount) * 100)}%`,
                   height: "100%",
                   background: group.items.some((i: any) => i.overdue)
-                    ? "var(--tarot-red)"
-                    : "var(--tarot-amber)",
+                    ? "var(--viz-4)"
+                    : "var(--viz-2)",
                   borderRadius: 2,
                 }}
               />

--- a/client-react/src/components/home/TodayAgendaPanel.tsx
+++ b/client-react/src/components/home/TodayAgendaPanel.tsx
@@ -12,10 +12,15 @@ interface Props {
   onToggle: (id: string, completed: boolean) => void;
 }
 
+// Data-viz palette (Okabe-Ito adapted, colorblind-safe) — categorical
+// token mapping: overdue → viz-4 (red), quick-win → viz-3 (green),
+// regular → viz-2 (amber). Pulled from tokens.css so light/dark and
+// cross-platform iOS stay in lockstep.
 function dotColor(item: AgendaItem): string {
-  if (item.overdue) return "var(--tarot-red)";
-  if (item.estimateMinutes != null && item.estimateMinutes <= 15) return "var(--tarot-sage)";
-  return "var(--tarot-gold)";
+  if (item.overdue) return "var(--viz-4)";
+  if (item.estimateMinutes != null && item.estimateMinutes <= 15)
+    return "var(--viz-3)";
+  return "var(--viz-2)";
 }
 
 export function TodayAgendaPanel({ items, provenance, onTaskClick, onToggle: _onToggle }: Props) {

--- a/client-react/src/components/layout/ComponentGalleryPage.tsx
+++ b/client-react/src/components/layout/ComponentGalleryPage.tsx
@@ -233,6 +233,23 @@ const CHIP_FAMILIES: ChipFamily[] = [
   "ai",
 ];
 
+const VIZ_CATEGORICAL = [
+  { token: "--viz-1", label: "viz-1 · accent" },
+  { token: "--viz-2", label: "viz-2 · amber" },
+  { token: "--viz-3", label: "viz-3 · green" },
+  { token: "--viz-4", label: "viz-4 · red" },
+  { token: "--viz-5", label: "viz-5 · purple" },
+  { token: "--viz-6", label: "viz-6 · teal" },
+];
+
+const VIZ_SEQUENTIAL = [
+  "--viz-seq-1",
+  "--viz-seq-2",
+  "--viz-seq-3",
+  "--viz-seq-4",
+  "--viz-seq-5",
+];
+
 export function ComponentGalleryPage({ dark, onBack }: Props) {
   const [filterText, setFilterText] = useState("");
   const [searchPreviewValue, setSearchPreviewValue] = useState("overdue");
@@ -566,6 +583,87 @@ export function ComponentGalleryPage({ dark, onBack }: Props) {
             <Skeleton shape="chip" />
             <Skeleton shape="chip" />
           </div>
+        </div>
+      ),
+    },
+    {
+      id: "ds-dataviz",
+      eyebrow: "Design System · Data-viz",
+      title: "Categorical + sequential palettes",
+      keywords: [
+        "data-viz",
+        "chart",
+        "palette",
+        "viz",
+        "sequential",
+        "categorical",
+        "colorblind",
+        "okabe-ito",
+      ],
+      content: (
+        <div className="component-gallery__ds-grid">
+          <div
+            className="component-gallery__ds-row"
+            style={{ alignItems: "flex-end", gap: "var(--s-2)" }}
+          >
+            {VIZ_CATEGORICAL.map((swatch, index) => (
+              <div
+                key={swatch.token}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: "var(--s-1)",
+                }}
+              >
+                <div
+                  aria-hidden="true"
+                  style={{
+                    width: 32,
+                    height: 16 + index * 12,
+                    background: `var(${swatch.token})`,
+                    borderRadius: "var(--r-xs)",
+                  }}
+                />
+                <span
+                  style={{
+                    color: "var(--muted-strong)",
+                    fontSize: "var(--fs-xs)",
+                    fontFamily: "var(--font-mono)",
+                  }}
+                >
+                  {swatch.label}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div
+            className="component-gallery__ds-row"
+            style={{ gap: 0, borderRadius: "var(--r-xs)", overflow: "hidden" }}
+            aria-label="Sequential palette"
+          >
+            {VIZ_SEQUENTIAL.map((token) => (
+              <div
+                key={token}
+                aria-hidden="true"
+                style={{
+                  flex: 1,
+                  height: 20,
+                  background: `var(${token})`,
+                }}
+              />
+            ))}
+          </div>
+          <span
+            style={{
+              color: "var(--muted)",
+              fontSize: "var(--fs-label)",
+            }}
+          >
+            Categorical palette is Okabe-Ito adapted — colorblind-safe for
+            comparing up to six series. Sequential steps follow the accent hue
+            for magnitude-ordered data (heatmaps, gradients).
+          </span>
         </div>
       ),
     },


### PR DESCRIPTION
## Summary

- Replaces the tarot-palette color encodings on the home dashboard's data-viz surfaces with the colorblind-safe \`--viz-*\` tokens introduced in PR 1.
- \`TodayAgendaPanel\` timeline dots: overdue → \`--viz-4\`, quick-win (≤15 min) → \`--viz-3\`, default → \`--viz-2\`.
- \`PanelRenderer\` urgency-bars fill: overdue → \`--viz-4\`, otherwise → \`--viz-2\`.
- Adds a "Data-viz" section to \`ComponentGalleryPage\` showing both the categorical and sequential swatches so reviewers can verify contrast and sequence from the gallery.

## Why

The tarot palette was designed for illustration / card chrome, not for encoding data. The v2 \`--viz-*\` tokens are Okabe-Ito adapted, so users with the most common color-vision differences can still separate the categories. Tarot colors stay in place for card backgrounds, frames, and decorative elements — the swap only touches the *data-encoding* surfaces.

## Verification

- [x] \`npx vite build\` — clean
- [x] \`npx vitest run\` — 1532 passed / 4 skipped / 0 failed across 132 test files
- [ ] CI \`react-tests\` / \`ui-quality\` green

## Follow-ups

No other production charts exist in the web client today (Insights / weekly-review scaffolds are unrendered); when they land, they should read the same \`--viz-*\` tokens directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)