### PR TITLE
feat(ui): redraw product mark and favicon (stacked horizons + sun)

### DIFF
--- a/client-react/dist-auth/favicon.svg
+++ b/client-react/dist-auth/favicon.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#4f6ef7"/>
-  <path d="M10 16l4 4 8-8" stroke="#fff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Todos">
+  <rect width="32" height="32" rx="8" fill="#f4f7fb"/>
+  <line x1="6" y1="24" x2="26" y2="24" stroke="#6b7280" stroke-width="1.6" stroke-linecap="round"/>
+  <line x1="8" y1="19" x2="24" y2="19" stroke="#9ca3af" stroke-width="1.2" stroke-linecap="round"/>
+  <circle cx="16" cy="19" r="5.3" fill="#b8892f"/>
+  <path d="M16 19 A5.3 5.3 0 0 1 21.3 24 L10.7 24 A5.3 5.3 0 0 1 16 19 Z" fill="#4f6ef7"/>
 </svg>

--- a/client-react/dist-landing/favicon.svg
+++ b/client-react/dist-landing/favicon.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#4f6ef7"/>
-  <path d="M10 16l4 4 8-8" stroke="#fff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Todos">
+  <rect width="32" height="32" rx="8" fill="#f4f7fb"/>
+  <line x1="6" y1="24" x2="26" y2="24" stroke="#6b7280" stroke-width="1.6" stroke-linecap="round"/>
+  <line x1="8" y1="19" x2="24" y2="19" stroke="#9ca3af" stroke-width="1.2" stroke-linecap="round"/>
+  <circle cx="16" cy="19" r="5.3" fill="#b8892f"/>
+  <path d="M16 19 A5.3 5.3 0 0 1 21.3 24 L10.7 24 A5.3 5.3 0 0 1 16 19 Z" fill="#4f6ef7"/>
 </svg>

--- a/client-react/public/favicon.svg
+++ b/client-react/public/favicon.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="8" fill="#4f6ef7"/>
-  <path d="M10 16l4 4 8-8" stroke="#fff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Todos">
+  <rect width="32" height="32" rx="8" fill="#f4f7fb"/>
+  <line x1="6" y1="24" x2="26" y2="24" stroke="#6b7280" stroke-width="1.6" stroke-linecap="round"/>
+  <line x1="8" y1="19" x2="24" y2="19" stroke="#9ca3af" stroke-width="1.2" stroke-linecap="round"/>
+  <circle cx="16" cy="19" r="5.3" fill="#b8892f"/>
+  <path d="M16 19 A5.3 5.3 0 0 1 21.3 24 L10.7 24 A5.3 5.3 0 0 1 16 19 Z" fill="#4f6ef7"/>
 </svg>

--- a/client-react/src/components/projects/Sidebar.tsx
+++ b/client-react/src/components/projects/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   IconSidebar,
   IconSearch,
 } from "../shared/Icons";
+import { BrandMark } from "../ui/BrandMark";
 import { ProfileLauncher } from "../shared/ProfileLauncher";
 import {
   groupProjectsByArea,
@@ -155,7 +156,10 @@ export function Sidebar({
     <>
       {/* Sidebar header: app name + collapse toggle (like Claude.ai) */}
       <div className="sidebar-header">
-        <span className="sidebar-header__logo">Todos</span>
+        <div className="sidebar-header__brand">
+          <BrandMark size={24} className="sidebar-header__mark" />
+          <span className="sidebar-header__logo">Todos</span>
+        </div>
         <button
           className="sidebar-header__collapse"
           onClick={onToggleCollapse}

--- a/client-react/src/components/ui/BrandMark.tsx
+++ b/client-react/src/components/ui/BrandMark.tsx
@@ -1,0 +1,54 @@
+import type { SVGProps } from "react";
+
+export interface BrandMarkProps extends SVGProps<SVGSVGElement> {
+  size?: number;
+}
+
+/**
+ * Product mark — stacked horizons + rising sun motif. Planning by
+ * day (the sun rising over horizon lines), reflection by the
+ * layered horizons. Uses design-system tokens so light/dark follow
+ * the current theme. Lifted from the v2 spec brand-mark SVG.
+ */
+export function BrandMark({
+  size = 24,
+  className,
+  ...rest
+}: BrandMarkProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      role="img"
+      aria-hidden="true"
+      {...rest}
+    >
+      <line
+        x1="4"
+        y1="18"
+        x2="20"
+        y2="18"
+        stroke="var(--muted)"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      <line
+        x1="6"
+        y1="14"
+        x2="18"
+        y2="14"
+        stroke="var(--muted-light)"
+        strokeWidth="1"
+        strokeLinecap="round"
+      />
+      <circle cx="12" cy="14" r="4" fill="var(--accent-secondary)" />
+      <path
+        d="M12 14 A4 4 0 0 1 16 18 L8 18 A4 4 0 0 1 12 14 Z"
+        fill="var(--accent)"
+      />
+    </svg>
+  );
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -131,11 +131,23 @@ body {
   padding-bottom: var(--s-2);
 }
 
+.sidebar-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2h);
+  min-width: 0;
+}
+
+.sidebar-header__mark {
+  flex-shrink: 0;
+}
+
 .sidebar-header__logo {
   font-size: var(--fs-md);
   font-weight: var(--fw-bold);
   letter-spacing: var(--tracking-tight);
   color: var(--text-strong);
+  font-family: var(--font-display, inherit);
 }
 
 .sidebar-header__collapse {


### PR DESCRIPTION
## Summary

- Adds \`BrandMark\` (components/ui/) — the v2 sidebar mark (stacked horizon lines + rising sun), colored through design tokens so light/dark mode follow the active theme.
- Renders the mark next to the \"Todos\" wordmark in the sidebar header; the wordmark still hides in collapsed mode so the mark alone identifies the app when the rail is pinned narrow.
- Replaces the blue-check \`favicon.svg\` with the same motif at 32×32 using hex literals (favicons can't resolve CSS custom properties). Synchronized across \`public/\`, \`dist-auth/\`, and \`dist-landing/\`.

## Visual notes

The favicon bakes in a light-theme fallback (\`#f4f7fb\` background) because favicons render outside the document context. Browsers render a dark-themed app on dark OSes via \`prefers-color-scheme\` in the favicon SVG itself if we want it later; for now the light-theme fallback is consistent with how every browser already displays it.

## Verification

- [x] \`npx vite build\` — clean
- [x] \`npx vitest run\` — 1532 passed / 4 skipped / 0 failed across 132 files
- [ ] CI \`react-tests\` / \`ui-quality\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)