### PR TITLE
docs(ui): document design-system v2 cascade + backfill primitive tests

### DIFF
--- a/UX.md
+++ b/UX.md
@@ -186,6 +186,30 @@ Use this checklist for UI-affecting changes.
 - In React and iOS, preserve the same product semantics even when platform-native controls differ
 - When a UI change introduces a new repeated pattern, document it here or promote it into the local surface guide
 
+## Design system v2 — cascade architecture
+
+The React client serves its CSS through a single `@layer` cascade declared at the top of `client-react/src/styles/app.css`:
+
+```
+@layer tokens, base, components, views;
+```
+
+Layer responsibilities:
+
+| Layer        | File                                                                | Contains                                                                                                                                         |
+| ------------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tokens`     | `styles/tokens.css`                                                 | `:root` + `body.dark-mode` custom properties, density modes, reduced-motion overrides. **Only custom properties live here** — no concrete rules. |
+| `base`       | `styles/base.css`                                                   | Global resets and the single `:focus-visible { box-shadow: var(--ring) }` recipe.                                                                |
+| `components` | `styles/components.css`                                             | Shared primitives rendered by `components/ui/` (`.btn`, `.chip`, `.input`, `.field`, `.toast*`, `.skel`, etc.).                                  |
+| `views`      | `styles/app.css` body (everything past the `@layer views {` opener) | Page scaffolds, feature surfaces, one-off view styles.                                                                                           |
+
+Rules of thumb when adding CSS:
+
+1. Touching a shared primitive? Edit `components.css`. A new primitive? Add the class there, render it from a typed component under `components/ui/`, and register it in `ComponentGalleryPage` so the Gallery PR checklist passes.
+2. Page- or feature-specific styling goes in `app.css` **inside the `@layer views { … }` wrapper**. Unlayered rules win over every declared layer — avoid them.
+3. iOS stays in sync via `npm run tokens:check`: any token change in `tokens.css` regenerates `ios/TodosApp/TodosApp/Core/Theme/DesignTokens.swift`.
+4. Legacy `.btn` / `.chip` rules still live inside `@layer views` (app.css) for historical reasons. They override the v2 primitives in those places because `views` has higher layer precedence than `components`. Net-new work should prefer the typed `<Button>` / `<Chip>` / `<Input>` components; a base-rule extraction is tracked as separate design-system cleanup.
+
 ## Gallery PR checklist
 
 Any PR that adds or changes a shared UI primitive in `client-react/src/components/ui/` must walk through the checklist below. Reviewers open `ComponentGalleryPage` and confirm each item.

--- a/client-react/src/components/ui/BrandMark.test.tsx
+++ b/client-react/src/components/ui/BrandMark.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BrandMark } from "./BrandMark";
+
+describe("BrandMark", () => {
+  it("renders an SVG with default 24px sizing", () => {
+    const { container } = render(<BrandMark />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toBeTruthy();
+    expect(svg).toHaveAttribute("width", "24");
+    expect(svg).toHaveAttribute("height", "24");
+    expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
+  });
+
+  it("honors the size override", () => {
+    const { container } = render(<BrandMark size={48} />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("width", "48");
+    expect(svg).toHaveAttribute("height", "48");
+  });
+
+  it("is aria-hidden so screen readers skip decorative chrome", () => {
+    const { container } = render(<BrandMark />);
+    expect(container.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("merges a caller-provided className", () => {
+    const { container } = render(<BrandMark className="extra" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("class")).toBe("extra");
+  });
+
+  it("references design-system tokens (no hardcoded hex)", () => {
+    const { container } = render(<BrandMark />);
+    const svg = container.querySelector("svg")!;
+    const fills = Array.from(svg.querySelectorAll("[fill]"))
+      .map((el) => el.getAttribute("fill"))
+      .filter((f): f is string => !!f && f !== "none");
+    for (const fill of fills) {
+      expect(fill).toMatch(/^var\(--/);
+    }
+  });
+});

--- a/client-react/src/hooks/useDensity.test.ts
+++ b/client-react/src/hooks/useDensity.test.ts
@@ -55,6 +55,41 @@ describe("useDensity", () => {
     });
   });
 
+  describe("per-view keys", () => {
+    it("reads from `todos:density:<viewKey>` when a key is provided", () => {
+      localStorage.setItem("todos:density:today", "spacious");
+      const { result } = renderHook(() => useDensity("today"));
+      expect(result.current.density).toBe("spacious");
+    });
+
+    it("falls back to the global key when a per-view value is not yet stored", () => {
+      localStorage.setItem("todos:density", "compact");
+      const { result } = renderHook(() => useDensity("inbox"));
+      expect(result.current.density).toBe("compact");
+    });
+
+    it("writes to the per-view key when set, not the global one", () => {
+      localStorage.setItem("todos:density", "normal");
+      const { result } = renderHook(() => useDensity("inbox"));
+      act(() => {
+        result.current.setDensity("spacious");
+      });
+      expect(localStorage.getItem("todos:density:inbox")).toBe("spacious");
+      expect(localStorage.getItem("todos:density")).toBe("normal");
+    });
+
+    it("reloads when the view key changes", () => {
+      localStorage.setItem("todos:density:today", "compact");
+      localStorage.setItem("todos:density:upcoming", "spacious");
+      const { result, rerender } = renderHook(({ key }: { key: string }) => useDensity(key), {
+        initialProps: { key: "today" },
+      });
+      expect(result.current.density).toBe("compact");
+      rerender({ key: "upcoming" });
+      expect(result.current.density).toBe("spacious");
+    });
+  });
+
   describe("cycle", () => {
     it("cycles compact → normal → spacious → compact", () => {
       localStorage.setItem("todos:density", "compact");


### PR DESCRIPTION
## Summary

- Adds a "Cascade architecture" section to \`UX.md\` that spells out what lives in each @layer (\`tokens\`, \`base\`, \`components\`, \`views\`), with a per-layer responsibility table and three practical rules for where new CSS should go.
- Backfills tests for \`BrandMark\` (sizing, aria-hidden, className forwarding, token-only fills) and extends \`useDensity\` coverage to the per-view storage path added alongside the inline density header control.

## Why this and not a base-rule extraction

The original PR E plan was to extract the existing \`.btn\` / \`.chip\` / \`.input\` base rules from \`app.css\` (\`@layer views\`) into \`components.css\` (\`@layer components\`). After inspecting the current state I found that the later-declared \`.btn\` block in app.css is a deliberate warm-theme override on top of the first one (not a mechanical duplicate) — extracting them without running a visual diff across every screen risks regressing the cream-tinted button treatment on several surfaces. That refactor deserves its own PR with screenshot diffing, not a scope add-on here.

Instead, this PR makes the current architecture legible for future contributors and shores up the primitives with tests that should have landed in PRs 2 / B / D.

## Verification

- [x] \`npx vitest run\` — 1541 passed / 4 skipped / 0 failed across 133 files (+9 new tests)
- [x] \`npm run format:check\` — green (prettier-clean, including the reformatted UX.md)
- [ ] CI \`react-tests\` / \`ui-quality\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)