### PR TITLE
fix(ui): correct WorkspaceView keys on inline density control

### DIFF
--- a/client-react/src/components/layout/AppShell.tsx
+++ b/client-react/src/components/layout/AppShell.tsx
@@ -119,12 +119,13 @@ export function AppShell() {
   const { dark, toggle: toggleDarkMode } = useDarkMode();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [activeView, setActiveView] = useState<WorkspaceView>("home");
-  // Per-view density: Today, Inbox, Upcoming each remember their own row
-  // density. Other views share the global key so they behave as before.
+  // Per-view density: list surfaces (today / horizon / all) each remember
+  // their own row density. Other views share the global key so they
+  // behave as before. Values must stay a subset of WorkspaceView.
   const densityViewKey =
     activeView === "today" ||
-    activeView === "inbox" ||
-    activeView === "upcoming"
+    activeView === "horizon" ||
+    activeView === "all"
       ? activeView
       : undefined;
   const { density, setDensity, cycle: cycleDensity } = useDensity(

--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -17,7 +17,10 @@ import { DensitySegmentedControl } from "../ui/DensitySegmentedControl";
 import { ViewMenu } from "./ViewMenu";
 import { ViewSubtitle } from "./ViewSubtitle";
 
-const VIEWS_WITH_INLINE_DENSITY = new Set(["today", "inbox", "upcoming"]);
+// List surfaces where the inline density control is worthwhile. Values
+// must match the active view ids (see WorkspaceView) — "inbox" /
+// "upcoming" are UX names, the actual ids are "all" / "horizon".
+const VIEWS_WITH_INLINE_DENSITY = new Set(["today", "horizon", "all"]);
 
 type UiMode = "normal" | "simple";
 type HorizonSegment = "due" | "planned" | "pending" | "later";


### PR DESCRIPTION
## What broke

PR [#977](https://github.com/karthikg80/todos-api/pull/977) wired a new per-view density key using UX-spelling identifiers (\`today\` / \`inbox\` / \`upcoming\`) but \`WorkspaceView\` is \`\"home\" | \"all\" | \"today\" | \"horizon\" | \"completed\"\`. \`tsc -b\` fails with TS2367 on \`AppShell.tsx\` lines 126–127, which fails the \`build-ui\` CI job and cascades into \`cross-client-sync\` (it runs \`tsc\` as a precondition). Post-merge master CI has been red since that PR landed — I missed it because my \`gh pr checks --watch\` tail printed rollup output truncated *above* the \`build-ui\` line, and the \`mergeStateStatus\` was \`UNSTABLE\` not \`CLEAN\` when I ran \`gh pr merge --squash\`.

## Why it slipped past local verification

- Root \`npx tsc --noEmit\` only type-checks backend — doesn't touch client-react.
- My worktree check was \`npx vite build\`, which skips the \`tsc -b\` prefix the repo's \`"build"\` script runs.
- The same blind spot carried into the three follow-up PRs branched off the broken master (C/D/E) — each \`build-ui\` failure on those PRs was pre-existing from this same regression, so none of them exposed fresh breakage.

## Fix

Use the actual \`WorkspaceView\` identifiers in two places:

- \`AppShell.tsx\` \`densityViewKey\`: \`today | horizon | all\` (was: \`today | inbox | upcoming\`).
- \`ListViewHeader.tsx\` \`VIEWS_WITH_INLINE_DENSITY\` set: same keys, with an explanatory comment mapping UX names to real ids.

No behavior change was ever possible under the broken version (the string comparisons were always false); this PR makes the feature reachable on the three list views the spec called for.

## Related failures that are _not_ fixed here

- \`integration\` has been failing on master since 2026-04-17 (before any of these PRs): 4 tests in \`src/feedback.api.integration.test.ts\`, plus an \`express-rate-limit\` IPv6 warning. Not caused by UI work. Flagging for a separate investigation.
- \`UI Visual\` workflow — depends on \`build-ui\` succeeding, so unblocking it is a side-effect of this PR; any remaining visual-regression deltas from the design revamp will need baseline updates in their own PR.

## Verification

- [x] \`npm run build\` in \`client-react\` — no TS2367 errors (only the pre-existing \`global\` usage in \`src/api/client.test.ts\`, which the same error pattern has shown on master for weeks).
- [x] \`npx vitest run\` — 1541 passed / 4 skipped / 0 failed across 133 files.
- [ ] CI \`build-ui\` green on this branch
- [ ] CI \`cross-client-sync\` green on this branch
- [ ] Will **wait for \`mergeStateStatus=CLEAN\`** before merging this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)