### PR TITLE
[codex] recover local https dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ artifacts/harness/
 .codex/context-ack.json
 .codex/progress.md
 .codex/feature-checklist.json
+.local/
 
 src/generated/prisma/
 .worktrees/

--- a/Caddyfile.local
+++ b/Caddyfile.local
@@ -5,6 +5,8 @@ http://dev.todos.karthikg.in {
 https://dev.todos.karthikg.in {
 	tls ./.local/certs/dev.todos.karthikg.in.pem ./.local/certs/dev.todos.karthikg.in-key.pem
 
+	redir /app /app/ 308
+
 	@vite path /app* /@vite* /@id/* /@fs/* /src/* /node_modules/* /vite.svg /__vite_ping
 	reverse_proxy @vite 127.0.0.1:5173
 

--- a/Caddyfile.local
+++ b/Caddyfile.local
@@ -1,0 +1,12 @@
+http://dev.todos.karthikg.in {
+	redir https://dev.todos.karthikg.in{uri} permanent
+}
+
+https://dev.todos.karthikg.in {
+	tls ./.local/certs/dev.todos.karthikg.in.pem ./.local/certs/dev.todos.karthikg.in-key.pem
+
+	@vite path /app* /@vite* /@id/* /@fs/* /src/* /node_modules/* /vite.svg /__vite_ping
+	reverse_proxy @vite 127.0.0.1:5173
+
+	reverse_proxy 127.0.0.1:3000
+}

--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ https://dev.todos.karthikg.in/app/
 
 The local proxy routes `/app` and Vite dev assets to `http://127.0.0.1:5173`, and routes `/auth`, `/todos`, `/users`, and the rest of the backend surface to `http://127.0.0.1:3000`.
 
+If you want one command after the one-time setup steps above, use:
+
+```bash
+npm run dev:https
+```
+
+That helper starts the local DB, backend, React dev server, and Caddy proxy together with:
+
+- `BASE_URL=https://dev.todos.karthikg.in`
+- `GOOGLE_REDIRECT_URI=https://dev.todos.karthikg.in/auth/google/callback`
+
 ### Testing
 
 - `npm test` - Run all tests

--- a/README.md
+++ b/README.md
@@ -214,6 +214,53 @@ BASE_URL=http://dev.todos.karthikg.in:3000
 GOOGLE_REDIRECT_URI=http://dev.todos.karthikg.in:3000/auth/google/callback
 ```
 
+### Local HTTPS Routing
+
+For a trusted local HTTPS endpoint on this laptop, use `mkcert` plus the repo-local Caddy proxy:
+
+1. Install local tools once:
+
+```bash
+brew install mkcert caddy
+mkcert -install
+```
+
+2. Add the host alias once:
+
+```bash
+echo '127.0.0.1 dev.todos.karthikg.in' | sudo tee -a /etc/hosts
+```
+
+3. Generate the local cert:
+
+```bash
+npm run https:certs
+```
+
+4. Start the backend and React dev server:
+
+```bash
+BASE_URL=https://dev.todos.karthikg.in \
+GOOGLE_REDIRECT_URI=https://dev.todos.karthikg.in/auth/google/callback \
+npm run dev
+
+npm run dev:react
+```
+
+5. Start the HTTPS reverse proxy:
+
+```bash
+npm run https:proxy
+```
+
+6. Open:
+
+```text
+https://dev.todos.karthikg.in/app/
+```
+
+The local proxy routes `/app` and Vite dev assets to `http://127.0.0.1:5173`, and routes `/auth`, `/todos`, `/users`, and the rest of the backend surface to `http://127.0.0.1:3000`.
+
 ### Testing
 
 - `npm test` - Run all tests

--- a/README.md
+++ b/README.md
@@ -177,6 +177,43 @@ Important current limitations:
 - `npm run docker:reset` - Reset Docker volumes (deletes all data)
 - `npm run docker:logs` - View PostgreSQL logs
 
+### Local Domain Routing
+
+To use a stable local host alias on this laptop without touching production or staging:
+
+1. Add an `/etc/hosts` entry:
+
+```bash
+echo '127.0.0.1 dev.todos.karthikg.in' | sudo tee -a /etc/hosts
+```
+
+2. Start the API on port `3000`:
+
+```bash
+npm run dev
+```
+
+3. Start the React dev server on port `5173`:
+
+```bash
+npm run dev:react
+```
+
+4. Open the app at:
+
+```text
+http://dev.todos.karthikg.in:5173/app/
+```
+
+The Vite config explicitly allows `dev.todos.karthikg.in`, and API requests continue to proxy to the backend on `http://localhost:3000`.
+
+If you need the backend to generate links for the local host alias, set:
+
+```bash
+BASE_URL=http://dev.todos.karthikg.in:3000
+GOOGLE_REDIRECT_URI=http://dev.todos.karthikg.in:3000/auth/google/callback
+```
+
 ### Testing
 
 - `npm test` - Run all tests

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ That helper starts the local DB, backend, React dev server, and Caddy proxy toge
 
 - `BASE_URL=https://dev.todos.karthikg.in`
 - `GOOGLE_REDIRECT_URI=https://dev.todos.karthikg.in/auth/google/callback`
+- `EMAIL_FEATURES_ENABLED=false` unless you explicitly override it
 
 ### Testing
 

--- a/client-react/src/auth/RegisterForm.test.tsx
+++ b/client-react/src/auth/RegisterForm.test.tsx
@@ -30,7 +30,8 @@ vi.mock("./authApi", () => ({
 
 // Mock SocialButtons
 vi.mock("./SocialButtons", () => ({
-  SocialButtons: () => createElement("div", { "data-testid": "social-buttons" }),
+  SocialButtons: () =>
+    createElement("div", { "data-testid": "social-buttons" }),
 }));
 
 // Mock pageTransitions
@@ -73,7 +74,9 @@ describe("RegisterForm", () => {
 
   it("updates name input value on change", () => {
     render(createElement(RegisterForm, defaultProps));
-    const nameInput = screen.getByLabelText("Name (optional)") as HTMLInputElement;
+    const nameInput = screen.getByLabelText(
+      "Name (optional)",
+    ) as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "Jane Doe" } });
     expect(nameInput.value).toBe("Jane Doe");
   });
@@ -139,7 +142,9 @@ describe("RegisterForm", () => {
 
   it("has correct autocomplete attributes", () => {
     render(createElement(RegisterForm, defaultProps));
-    const nameInput = screen.getByLabelText("Name (optional)") as HTMLInputElement;
+    const nameInput = screen.getByLabelText(
+      "Name (optional)",
+    ) as HTMLInputElement;
     const emailInput = screen.getByLabelText("Email") as HTMLInputElement;
     const passwordInput = screen.getByLabelText("Password") as HTMLInputElement;
     expect(nameInput.autocomplete).toBe("name");
@@ -149,12 +154,33 @@ describe("RegisterForm", () => {
 
   it("renders with 'Create your account' heading", () => {
     render(createElement(RegisterForm, defaultProps));
-    expect(screen.getByRole("heading", { name: "Create your account" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Create your account" }),
+    ).toBeTruthy();
   });
 
   it("has password minLength attribute", () => {
     render(createElement(RegisterForm, defaultProps));
     const passwordInput = screen.getByLabelText("Password") as HTMLInputElement;
     expect(passwordInput.minLength).toBe(8);
+  });
+
+  it("shows the backend error when registration fails", async () => {
+    vi.mocked(authApi.register).mockRejectedValueOnce(
+      new Error("Email already registered"),
+    );
+
+    render(createElement(RegisterForm, defaultProps));
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "taken@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Account" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toBe("Email already registered");
   });
 });

--- a/client-react/src/auth/RegisterForm.tsx
+++ b/client-react/src/auth/RegisterForm.tsx
@@ -15,10 +15,16 @@ export function RegisterForm({ onSwitchToLogin, onSwitchToPhone }: Props) {
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [providers, setProviders] = useState<AuthProviders>({ google: false, apple: false, phone: false });
+  const [providers, setProviders] = useState<AuthProviders>({
+    google: false,
+    apple: false,
+    phone: false,
+  });
 
   useEffect(() => {
-    fetchProviders().then(setProviders).catch(() => {});
+    fetchProviders()
+      .then(setProviders)
+      .catch(() => {});
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -26,10 +32,15 @@ export function RegisterForm({ onSwitchToLogin, onSwitchToPhone }: Props) {
     setError(null);
     setSubmitting(true);
     try {
-      const result = await register({ email, password, name: name || undefined });
+      const result = await register({
+        email,
+        password,
+        name: name || undefined,
+      });
       setTokens(result.token, result.refreshToken, result.user);
       const next = new URLSearchParams(window.location.search).get("next");
-      const target = (next === "/app" || next?.startsWith("/app/")) ? next : "/app";
+      const target =
+        next === "/app" || next?.startsWith("/app/") ? next : "/app";
       window.location.href = target;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");
@@ -78,15 +89,32 @@ export function RegisterForm({ onSwitchToLogin, onSwitchToPhone }: Props) {
         />
       </div>
       <div className="auth-form__actions">
-        <button type="submit" className="auth-form__submit" disabled={submitting}>
+        <button
+          type="submit"
+          className="auth-form__submit"
+          disabled={submitting}
+        >
           {submitting ? "Creating account…" : "Create Account"}
         </button>
       </div>
-      <button type="button" className="auth-form__link" onClick={onSwitchToLogin}>
+      {error && (
+        <p className="auth-form__error" role="alert">
+          {error}
+        </p>
+      )}
+      <button
+        type="button"
+        className="auth-form__link"
+        onClick={onSwitchToLogin}
+      >
         Already have an account? Log in
       </button>
       {providers.phone && (
-        <button type="button" className="auth-form__link" onClick={onSwitchToPhone}>
+        <button
+          type="button"
+          className="auth-form__link"
+          onClick={onSwitchToPhone}
+        >
           Sign up with phone
         </button>
       )}

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
     strictPort: true,
   },
   server: {
+    host: "127.0.0.1",
+    port: 5173,
+    strictPort: true,
     allowedHosts: localAllowedHosts,
     proxy: {
       "/auth": "http://localhost:3000",

--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const localAllowedHosts = ["dev.todos.karthikg.in"];
+
 export default defineConfig({
   plugins: [react()],
   base: "/app/",
@@ -10,10 +12,12 @@ export default defineConfig({
   },
   preview: {
     host: "127.0.0.1",
+    allowedHosts: localAllowedHosts,
     port: 4173,
     strictPort: true,
   },
   server: {
+    allowedHosts: localAllowedHosts,
     proxy: {
       "/auth": "http://localhost:3000",
       "/todos": "http://localhost:3000",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: todos-api
+
 version: "3.9"
 
 services:

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "db:setup": "npm run docker:up && npm run db:wait && npm run prisma:migrate",
     "db:seed": "ts-node prisma/seed.ts",
     "dev:react": "npm --prefix client-react run dev",
+    "dev:https": "bash scripts/dev-https.sh",
     "https:certs": "bash scripts/generate-local-https-certs.sh",
     "https:proxy": "caddy run --config Caddyfile.local",
     "build:react": "npm --prefix client-react install --include=dev && npm --prefix client-react run build:all",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "db:setup": "npm run docker:up && npm run db:wait && npm run prisma:migrate",
     "db:seed": "ts-node prisma/seed.ts",
     "dev:react": "npm --prefix client-react run dev",
+    "https:certs": "bash scripts/generate-local-https-certs.sh",
+    "https:proxy": "caddy run --config Caddyfile.local",
     "build:react": "npm --prefix client-react install --include=dev && npm --prefix client-react run build:all",
     "preview:react": "UI_PORT=4173 node scripts/ui-static-server.mjs",
     "prepare": "husky || true"

--- a/scripts/dev-https.sh
+++ b/scripts/dev-https.sh
@@ -69,4 +69,12 @@ echo "  mkcert -install"
 echo "  echo '127.0.0.1 dev.todos.karthikg.in' | sudo tee -a /etc/hosts"
 echo
 
-wait -n "${PIDS[@]}"
+while true; do
+  for pid in "${PIDS[@]}"; do
+    if ! kill -0 "$pid" >/dev/null 2>&1; then
+      wait "$pid" || true
+      exit 1
+    fi
+  done
+  sleep 1
+done

--- a/scripts/dev-https.sh
+++ b/scripts/dev-https.sh
@@ -41,11 +41,15 @@ npm run db:start
 
 BASE_URL="${BASE_URL:-https://dev.todos.karthikg.in}"
 GOOGLE_REDIRECT_URI="${GOOGLE_REDIRECT_URI:-https://dev.todos.karthikg.in/auth/google/callback}"
+EMAIL_FEATURES_ENABLED="${EMAIL_FEATURES_ENABLED:-false}"
 
 declare -a PIDS=()
 
 echo "Starting backend on :3000..."
-BASE_URL="$BASE_URL" GOOGLE_REDIRECT_URI="$GOOGLE_REDIRECT_URI" npm run dev &
+BASE_URL="$BASE_URL" \
+GOOGLE_REDIRECT_URI="$GOOGLE_REDIRECT_URI" \
+EMAIL_FEATURES_ENABLED="$EMAIL_FEATURES_ENABLED" \
+npm run dev &
 PIDS+=($!)
 
 echo "Starting React dev server on :5173..."

--- a/scripts/dev-https.sh
+++ b/scripts/dev-https.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT INT TERM
+
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+
+  wait "${PIDS[@]:-}" 2>/dev/null || true
+  exit "$exit_code"
+}
+
+trap cleanup EXIT INT TERM
+
+if ! command -v caddy >/dev/null 2>&1; then
+  echo "caddy is required. Install it first with: brew install caddy"
+  exit 1
+fi
+
+if ! command -v mkcert >/dev/null 2>&1; then
+  echo "mkcert is required. Install it first with: brew install mkcert"
+  exit 1
+fi
+
+if [[ ! -f ".local/certs/dev.todos.karthikg.in.pem" || ! -f ".local/certs/dev.todos.karthikg.in-key.pem" ]]; then
+  echo "Local HTTPS certs are missing. Generate them first with: npm run https:certs"
+  exit 1
+fi
+
+echo "Starting local Postgres..."
+npm run db:start
+
+BASE_URL="${BASE_URL:-https://dev.todos.karthikg.in}"
+GOOGLE_REDIRECT_URI="${GOOGLE_REDIRECT_URI:-https://dev.todos.karthikg.in/auth/google/callback}"
+
+declare -a PIDS=()
+
+echo "Starting backend on :3000..."
+BASE_URL="$BASE_URL" GOOGLE_REDIRECT_URI="$GOOGLE_REDIRECT_URI" npm run dev &
+PIDS+=($!)
+
+echo "Starting React dev server on :5173..."
+npm run dev:react &
+PIDS+=($!)
+
+echo "Starting HTTPS proxy on :443..."
+npm run https:proxy &
+PIDS+=($!)
+
+echo
+echo "Local HTTPS dev environment is starting."
+echo "Open: https://dev.todos.karthikg.in/app/"
+echo
+echo "One-time prerequisites on this machine:"
+echo "  mkcert -install"
+echo "  echo '127.0.0.1 dev.todos.karthikg.in' | sudo tee -a /etc/hosts"
+echo
+
+wait -n "${PIDS[@]}"

--- a/scripts/generate-local-https-certs.sh
+++ b/scripts/generate-local-https-certs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CERT_DIR="$ROOT_DIR/.local/certs"
+CERT_FILE="$CERT_DIR/dev.todos.karthikg.in.pem"
+KEY_FILE="$CERT_DIR/dev.todos.karthikg.in-key.pem"
+
+if ! command -v mkcert >/dev/null 2>&1; then
+  echo "mkcert is required. Install it first with: brew install mkcert"
+  exit 1
+fi
+
+mkdir -p "$CERT_DIR"
+
+mkcert -cert-file "$CERT_FILE" -key-file "$KEY_FILE" \
+  dev.todos.karthikg.in localhost 127.0.0.1 ::1
+
+echo "Generated local TLS certs:"
+echo "  $CERT_FILE"
+echo "  $KEY_FILE"

--- a/src/routes/usersRouter.ts
+++ b/src/routes/usersRouter.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from "express";
-import rateLimit from "express-rate-limit";
+import rateLimit, { ipKeyGenerator } from "express-rate-limit";
 import { AuthService } from "../services/authService";
 import { isValidEmail } from "../validation/authValidation";
 import { DataExportService } from "../services/dataExportService";
@@ -21,7 +21,7 @@ export function createUsersRouter({
       windowMs: 60 * 60 * 1000,
       max: 1,
       keyGenerator: (req: Request) =>
-        (req as any).user?.userId || req.ip || "anon",
+        (req as any).user?.userId || ipKeyGenerator(req.ip || "anon"),
       message: { error: "Export limited to once per hour" },
     });
     const exportService = new DataExportService(persistencePrisma);


### PR DESCRIPTION
## Summary

Recover the local HTTPS and persistent local Postgres development workflow on top of current master.

This PR restores the local dev scripts and config that were previously merged but are no longer present on current origin/master. It brings back the local HTTPS proxy, mkcert-based cert generation, the one-command `dev:https` helper, the Vite host binding needed for the proxy, and the small auth/register and rate-limit fixes discovered while validating the flow locally.

## Validation

- `npx tsc --noEmit`
- `npm --prefix client-react run build`
- `npm --prefix client-react run test -- src/auth/RegisterForm.test.tsx`
- `caddy validate --config Caddyfile.local`
- local stack validation during recovery: Postgres + backend + Vite + Caddy wiring
