### PR TITLE
docs(adr): ADR-006 transport contract source of truth (Story 1.1)

### DIFF
--- a/.claude/skills/ios-app/SKILL.md
+++ b/.claude/skills/ios-app/SKILL.md
@@ -23,12 +23,15 @@ description: Conventions for the SwiftUI iOS app in ios/TodosApp/
 
 ## Shared Contract
 
-`src/types.ts` is the source of truth. iOS models live in `ios/TodosApp/TodosApp/Core/Models/`.
+iOS DTOs mirror the backend's **transport contract**, not `src/types.ts` directly. Per [ADR-006](../../../docs/adr/006-transport-contract-source-of-truth.md), transport is defined by Zod schemas in `src/transport/` (backend); date fields are ISO 8601 strings on the wire and `src/types.ts` is canonical for backend domain types only. iOS models live in `ios/TodosApp/TodosApp/Core/Models/` and remain hand-maintained.
 
-When `src/types.ts` changes (new enums, new fields):
+When the transport contract changes (new enums, new fields):
+
 1. Update `Enums.swift` for new enum cases
 2. Update the relevant DTO file for new fields (as optionals to avoid decoding failures)
 3. Verify `swift build` passes
+
+Story 1.3 will add a CI check that compares iOS DTO field names against the generated OpenAPI spec to catch drift before merge.
 
 ## Build & Test
 

--- a/.claude/skills/react-client/SKILL.md
+++ b/.claude/skills/react-client/SKILL.md
@@ -20,6 +20,6 @@ npm run build   # Production build (tsc -b && vite build)
 
 ## Shared Contract
 
-The React client consumes the same REST API as the vanilla client and iOS app. `src/types.ts` is the source of truth for all API types.
+The React client consumes transport DTOs, not backend domain types. Per [ADR-006](../../../docs/adr/006-transport-contract-source-of-truth.md), transport DTOs are defined by Zod schemas in `src/transport/` (backend); their inferred TS types are what the React client imports. `src/types.ts` is canonical for backend domain types only (uses `Date` objects that never cross the wire).
 
-When `src/types.ts` changes, check if React types/interfaces need matching updates.
+When the shared contract changes, check if the React transport types need matching updates. Until Story 1.2 lands, `client-react/src/types/index.ts` still holds duplicated hand-written transport types.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ A `commit-msg` hook enforces conventional commit format. Hooks run after `npm ci
 
 ### Shared contract
 
-`src/types.ts` is the canonical source of truth for all API types and enums. When this file changes, all clients (React, iOS DTOs) must stay in sync. Mention cross-client impact in the PR description. CI will automatically verify that iOS compiles (`swift build`) and React typechecks (`tsc --noEmit`) when `src/types.ts` or `src/validation/constants.ts` change.
+`src/types.ts` is canonical for **backend domain types** (internal shapes used by services — e.g. `createdAt: Date`). Client-facing **transport DTOs** live in `src/transport/` and are defined by Zod schemas; their inferred types are what React, iOS, and Python consume on the wire (ISO strings, not `Date`). See [docs/adr/006-transport-contract-source-of-truth.md](docs/adr/006-transport-contract-source-of-truth.md) for the split and the iOS/Python sync paths. When the shared contract changes, mention cross-client impact in the PR description. CI runs `swift build` and React `tsc --noEmit` when `src/types.ts` or `src/validation/constants.ts` change.
 
 ## Clean Code + Architecture (REQUIRED)
 

--- a/client-react/AGENTS.md
+++ b/client-react/AGENTS.md
@@ -11,4 +11,6 @@ npm run build   # Production build (tsc -b && vite build)
 
 ## Shared Contract
 
-Consumes the same REST API as the vanilla client and iOS app. `src/types.ts` (in repo root) is the source of truth. When API types change, check if React types/interfaces need matching updates.
+Consumes transport DTOs from the backend. Per [ADR-006](../docs/adr/006-transport-contract-source-of-truth.md), transport DTOs are defined by Zod schemas in root `src/transport/` and their inferred TS types are what this client imports. `src/types.ts` is canonical for backend domain types only — never consume it directly from the client (it uses `Date` objects that never cross the wire).
+
+Until Story 1.2 lands, `client-react/src/types/index.ts` still holds duplicated hand-written transport types. When the shared contract changes, check if those need matching updates.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Navigation map for this directory.
 | `agent-ops/`                            | Dual-agent protocol (state machine, review contract)                          |
 | `agent-queue/`                          | Legacy markdown task archive and historical prompts                           |
 | `architecture/`                         | Architecture invariants (structural rules)                                    |
+| `adr/`                                  | Architecture Decision Records (numbered, dated, reviewed)                     |
 | `memory/`                               | Canon / Brief / Index / Archive for context compaction                        |
 
 Task state lives in GitHub Issues and GitHub Projects. Docs are for durable guidance only.

--- a/docs/adr/006-transport-contract-source-of-truth.md
+++ b/docs/adr/006-transport-contract-source-of-truth.md
@@ -1,0 +1,182 @@
+# ADR-006: Transport contract source of truth
+
+## Status
+
+Accepted (2026-04-19)
+
+Implements [Epic 1 / Story 1.1](../engineering-backlog.md) from the repo-grounded engineering backlog.
+
+## Context
+
+The repo currently maintains the same API shape in five places, with real
+drift between them:
+
+| Surface             | File                                        | Date shape                                                       | Source                                                        |
+| ------------------- | ------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| Backend domain      | `src/types.ts`                              | `Date` objects (e.g. `createdAt: Date` at line 85)               | Canonical for backend business logic                          |
+| OpenAPI description | `src/swagger.ts`                            | ISO strings                                                      | Hand-written declarative spec; 507 lines; not route-annotated |
+| Web transport       | `client-react/src/types/index.ts`           | `string \| null` (e.g. `completedAt?: string \| null` at line 8) | Hand-maintained, duplicated                                   |
+| iOS DTOs            | `ios/TodosApp/TodosApp/Core/Models/*.swift` | Decoded to `Date` via ISO8601 formatters                         | Hand-maintained                                               |
+| Python client       | `agent-runner/mcp_client.py`                | Dict access, mostly untyped                                      | No types at all                                               |
+
+This causes three concrete problems:
+
+1. **Transport vs domain conflation.** `src/types.ts` is described as "the
+   source of truth for all API types" across `AGENTS.md`, multiple `SKILL.md`
+   files, and `client-react/AGENTS.md`, but it uses `Date` objects that never
+   cross the wire. Clients cannot consume `src/types.ts` verbatim; they
+   re-declare transport shapes with string dates.
+2. **OpenAPI is decorative, not generated.** `src/swagger.ts` is hand-written
+   and can silently drift from real responses. Nothing in the runtime
+   validates that routes conform to it.
+3. **No defined sync path for iOS or Python.** When backend types change, iOS
+   and Python updates are implicit follow-ups done manually. Cross-client
+   drift is caught only when a reviewer remembers or when a decoder fails at
+   runtime.
+
+Baseline observability (logs, request IDs, route latency) and health probes
+already exist — this ADR does not re-open those. It defines how transport
+contracts are expressed and kept in sync, nothing more.
+
+## Decision
+
+### Source of truth
+
+**Transport DTOs are defined by Zod schemas in a new `src/transport/`
+directory. TypeScript transport types are inferred from those schemas via
+`z.infer`. The OpenAPI spec is generated from the same schemas and replaces
+the hand-written `src/swagger.ts`.**
+
+- `src/types.ts` remains canonical for **backend domain types** (internal
+  shapes used by services and Prisma adapters). It keeps `Date` objects,
+  computed fields, and internal unions. It is not a client-facing contract.
+- `src/transport/` (new, added in Story 1.2) holds Zod schemas for every
+  endpoint's request/response payloads. Inferred types (`z.infer<typeof
+TodoDto>`) are the canonical transport types.
+- Backend request validation and response serialization go through the same
+  Zod schemas at the route boundary. This closes the gap between "the spec"
+  and "what the runtime actually does".
+- OpenAPI is produced by `@asteasolutions/zod-to-openapi` (or an equivalent
+  pure-output library) at build time. `src/swagger.ts` becomes a
+  thin invocation of the generator.
+
+### Date and time handling
+
+**All transport DTOs use ISO 8601 strings** (`z.string().datetime({ offset:
+true })` in Zod) for date/time fields. No `Date` instances, Prisma objects,
+or server-local formats cross the wire.
+
+- Domain types in `src/types.ts` keep `Date` where useful for internal logic.
+- Mapping happens in a thin `src/transport/mappers.ts` (or adjacent to each
+  service) where domain shapes convert to and from DTO shapes.
+- Clients parse ISO strings to their platform's datetime type (React:
+  `new Date(...)` on demand; iOS: `ISO8601DateFormatter`; Python:
+  `datetime.fromisoformat`).
+
+### What each client consumes
+
+| Client                    | What it consumes                                                                                 | Sync guarantee                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| **Backend routes**        | Zod schemas directly                                                                             | Runtime validation — cannot drift                                                                  |
+| **React (client-react)**  | `z.infer`-inferred TS types via path alias `@transport/*` into the root `src/transport/`         | Typecheck fails on drift                                                                           |
+| **iOS (TodosApp)**        | Hand-maintained Swift DTOs, mirrored to the generated OpenAPI spec                               | CI contract-drift check compares Swift struct field names against the OpenAPI JSON (see Story 1.3) |
+| **Python (agent-runner)** | Hand-written typed dataclass wrappers in `mcp_client.py` for the 2–3 endpoints it actually calls | Manual sync with a documented review checklist (see Story 1.3)                                     |
+
+No code generator is introduced for iOS or Python in this phase. Generators
+add meaningful toolchain weight and the repo has not yet felt enough drift
+pain to justify them. Story 1.3 will reassess after Story 1.2 lands.
+
+### Why Zod, not OpenAPI-first
+
+Considered alternatives:
+
+| Option                                                                                 | Pros                                                                                                                                                                                          | Cons                                                                                                                                               | Verdict                                                                                         |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **A. Keep `src/types.ts` + hand-written `swagger.ts`; just document separation.**      | Zero migration cost.                                                                                                                                                                          | Drift keeps happening; OpenAPI stays decorative; no backend validation win.                                                                        | Rejected — does not meet Story 1.1 goal.                                                        |
+| **B. OpenAPI-first with generators for every client.**                                 | Industry-standard; each client gets native generated code.                                                                                                                                    | Heavy multi-generator toolchain; iOS and Python code-gen requires CI investment; migrates all clients at once.                                     | Rejected for now — too much blast radius for Story 1.1. Revisit in Story 1.3 if drift persists. |
+| **C. Zod schemas as source; OpenAPI generated from them; manual sync for iOS/Python.** | Single source covers both static (inferred types) and runtime (validation); OpenAPI stays honest because it is generated; incremental React migration; iOS/Python opt in when pain justifies. | Introduces one new dependency family (`zod`, `@asteasolutions/zod-to-openapi`); requires a migration pass on existing `src/validation/` over time. | **Selected.**                                                                                   |
+| **D. Plain TypeScript transport types in a shared package; no runtime validation.**    | Minimal toolchain.                                                                                                                                                                            | Loses the runtime-validation benefit; OpenAPI still has to be synced manually.                                                                     | Rejected — transport without validation is still a drift vector.                                |
+
+## Migration steps
+
+These map directly to the downstream stories in the backlog. Story 1.1 does
+**not** execute any of them — it only names them.
+
+### Story 1.2 — React consumes generated or shared transport types
+
+1. Add `zod` and `@asteasolutions/zod-to-openapi` to the backend workspace.
+2. Introduce `src/transport/` with one schemas file per resource (start with
+   `todo.ts`, `project.ts`, `user.ts`).
+3. Wire Zod validation into the three affected routers first
+   (`preferencesRouter`, `adaptationRouter`, `agentActivityRouter` — these
+   overlap with Story 4.1's extraction work).
+4. Delete overlapping types from `client-react/src/types/index.ts`. Replace
+   them with `import type { TodoDto } from "@transport/todo"` via a
+   `tsconfig` path alias that resolves to root `src/transport/`.
+5. Replace `src/swagger.ts` internals with a generator invocation that
+   walks the Zod schemas.
+
+### Story 1.3 — iOS and Python sync path
+
+1. **iOS:** keep hand-maintained DTOs. Add a CI job that parses the generated
+   OpenAPI JSON and compares top-level field names of `TodoDTO`,
+   `ProjectDTO`, `UserDTO` against the spec. Fail the job on mismatch. Re-
+   evaluate `swift-openapi-generator` adoption once two or more drift
+   incidents happen in a quarter.
+2. **Python:** keep dict-based consumption in `mcp_client.py`. Add a small
+   typed wrapper layer (plain `dataclass`, no generator) for the specific
+   read/write actions `agent-runner` calls. Document "when backend DTOs
+   change, update the matching Python dataclass" as part of the
+   cross-client checklist in the PR template.
+
+### Explicit non-goals
+
+- **Not** migrating `src/validation/` to Zod wholesale. That layer currently
+  does boundary validation in its own style; it can be converted endpoint by
+  endpoint as Zod schemas are added, or left in place if the duplication
+  stays small. A separate ADR can reopen this once evidence accrues.
+- **Not** introducing a code generator for iOS or Python.
+- **Not** rewriting `src/types.ts`. The domain layer is unchanged; it just
+  stops being described as the client-facing contract.
+- **Not** changing on-the-wire payloads. DTOs should match what the backend
+  currently returns; this ADR is about representation, not protocol.
+
+## Consequences
+
+### Positive
+
+- OpenAPI spec stays honest because it is generated from the same schemas the
+  runtime uses.
+- Transport types are validated at the boundary, not just statically typed.
+- The canonical-source confusion across five docs gets resolved by a single
+  pointer: "domain in `src/types.ts`, transport in `src/transport/`".
+- Story 4.1's router extraction and this migration can move together — new
+  services naturally consume Zod schemas as they are extracted.
+
+### Negative / accepted costs
+
+- One new dependency cluster in the backend (`zod`, `@asteasolutions/zod-to-openapi`).
+  Both are widely maintained and size-appropriate.
+- Temporary duplication while `src/validation/` and `src/transport/` coexist.
+  Acceptable if the coexistence window is measured in sprints, not quarters.
+- iOS and Python continue to hand-sync. This is explicit; Story 1.3 monitors
+  the drift rate and revisits generators if it crosses a threshold.
+
+### Risks mitigated by doing nothing in this ADR
+
+- No behavior change. No wire-format change. No new runtime dependencies in
+  this PR — this ADR is a docs change only. All risk sits in Stories 1.2 and
+  1.3 where implementation lands.
+
+## References
+
+- `docs/engineering-backlog.md` — Epic 1, Stories 1.1 / 1.2 / 1.3
+- `src/types.ts` (backend domain types)
+- `src/swagger.ts` (hand-written OpenAPI, to be replaced by generation in
+  Story 1.2)
+- `client-react/src/types/index.ts` (transport types to be replaced in Story
+  1.2)
+- `ios/TodosApp/TodosApp/Core/Models/TodoDTO.swift` (hand-maintained DTO;
+  target for Story 1.3 CI drift check)
+- `agent-runner/mcp_client.py` (dict-based consumer; target for Story 1.3
+  typed wrappers)

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -11,12 +11,15 @@ SwiftUI (iOS 17+) in `TodosApp/`. Swift Package — zero third-party dependencie
 
 ## Shared Contract
 
-`src/types.ts` (repo root) is the source of truth. iOS DTOs live in `TodosApp/TodosApp/Core/Models/`.
+iOS DTOs mirror the backend's **transport contract**, not `src/types.ts` directly. Per [ADR-006](../docs/adr/006-transport-contract-source-of-truth.md), transport is defined by Zod schemas in `src/transport/` (backend) and date fields are ISO 8601 strings on the wire. iOS DTOs live in `TodosApp/TodosApp/Core/Models/` and remain hand-maintained.
 
-When `src/types.ts` changes:
+When the transport contract changes:
+
 1. Update `Enums.swift` for new enum cases
 2. Update the relevant DTO file for new fields (as optionals)
 3. Verify `swift build` passes
+
+Story 1.3 will add a CI drift check that compares iOS DTO field names against the generated OpenAPI spec.
 
 ## Build
 


### PR DESCRIPTION
## Summary

Implements [Epic 1 / Story 1.1](https://github.com/karthikg80/todos-api/pull/985) from the repo-grounded engineering backlog. Docs-only decision artifact — no runtime or wire-format change.

**Decision in one sentence:** transport DTOs become Zod schemas in a new root `src/transport/`; their `z.infer` types replace the duplicated `client-react/src/types/index.ts`; OpenAPI is generated from the same schemas and replaces the hand-written `src/swagger.ts`; `src/types.ts` keeps its role as canonical for **backend domain types only**.

## Problem

Five surfaces carry the same API shape today with real drift:

| Surface | File | Date shape |
|---|---|---|
| Backend domain | `src/types.ts` | `Date` objects (line 85: `createdAt: Date`) |
| OpenAPI | `src/swagger.ts` | ISO strings, hand-written, not route-annotated |
| Web transport | `client-react/src/types/index.ts` | `string \| null` (line 8: `completedAt?: string \| null`) |
| iOS DTOs | `ios/TodosApp/TodosApp/Core/Models/*.swift` | Decoded to `Date` via ISO8601 formatters |
| Python | `agent-runner/mcp_client.py` | Dict access, untyped |

Docs across `AGENTS.md`, `ios/AGENTS.md`, `client-react/AGENTS.md`, and two `SKILL.md` files described `src/types.ts` as "the source of truth for all API types." That's not accurate once you compare the `Date` vs `string` boundary — clients cannot consume `src/types.ts` verbatim, which is why they re-declare transport shapes.

## What this PR changes

Docs only:
- **New:** `docs/adr/006-transport-contract-source-of-truth.md` with the decision, the Date-vs-string rule, and per-client migration steps (mapped to Stories 1.2 / 1.3).
- **Updated:** The 5 canonical-source mentions in `AGENTS.md`, `ios/AGENTS.md`, `client-react/AGENTS.md`, `.claude/skills/ios-app/SKILL.md`, and `.claude/skills/react-client/SKILL.md` now qualify the claim (`src/types.ts` = domain; `src/transport/` = wire contract).
- **Added:** `docs/adr/` to the `docs/README.md` navigation so ADRs are discoverable.

Does **not** touch `CONTRIBUTING.md` because that file is being added in [PR #984](https://github.com/karthikg80/todos-api/pull/984) and hasn't landed yet; it will need the same qualification after #984 merges (tracked as a trivial follow-up).

## Why Zod-as-source, not OpenAPI-first

| Option | Verdict |
|---|---|
| A. Keep status quo, just document separation | Rejected — doesn't meet Story 1.1 goal |
| B. OpenAPI-first with generators for every client | Rejected for now — too much toolchain blast radius in one step |
| **C. Zod schemas as source; OpenAPI generated from them; iOS/Python hand-sync with guardrails** | **Selected** |
| D. Plain TS transport types, no runtime validation | Rejected — transport without validation is still a drift vector |

The Zod path gives runtime validation + static typing + a generated (always-current) OpenAPI spec from a single source. Existing `src/validation/` can coexist and migrate incrementally. iOS/Python generators stay available as a later Story 1.3 option if drift pressure accumulates.

## Non-goals (explicit)

- Not migrating `src/validation/` to Zod in this ADR.
- Not introducing a code generator for iOS or Python.
- Not rewriting `src/types.ts`.
- Not changing on-the-wire payloads.

All implementation risk sits in the follow-on Stories 1.2 and 1.3.

## Scope relative to backlog

- Story 1.1 → this PR (docs + decision)
- Story 1.2 → next Codex-owned PR (implement React migration + replace `src/swagger.ts` with generator)
- Story 1.3 → Codex/Claude split (iOS CI drift check; Python typed wrappers)

## Test plan

- [x] `npm run format:check` clean (root gate)
- [x] `npx prettier --check` clean on the 5 updated docs + new ADR (root gate doesn't cover those paths, so checked manually)
- [x] No code changes; no typecheck or unit-test impact
- [x] Links in the ADR resolve relatively; `../engineering-backlog.md` will resolve once PR #985 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)