### PR TITLE
docs: unstale top-level summaries re: removed vanilla client (Story 6.1)

### DIFF
--- a/ARCHITECTURE_SUMMARY.md
+++ b/ARCHITECTURE_SUMMARY.md
@@ -3,29 +3,31 @@
 **Repository:** `todos-api`  
 **Version:** 1.6.0  
 **Last Updated:** 2026-03-25  
-**Stack:** Express 5 + TypeScript + Prisma + PostgreSQL + Vanilla JS (no framework)
+**Stack:** Express 5 + TypeScript + Prisma + PostgreSQL backend; React + Vite web client in `client-react/`; SwiftUI iOS app in `ios/TodosApp/`; Python agent-runner on Railway cron
 
 ---
 
 ## Quick Reference
 
-| Aspect       | Value                                                                    |
-| ------------ | ------------------------------------------------------------------------ |
-| **Frontend** | `client/` — Multi-page vanilla ES6 modules, no build step, no framework  |
-| **Backend**  | `src/` — TypeScript, Express 5, Prisma ORM                               |
-| **Database** | PostgreSQL 16 (26 models, 15+ enums)                                     |
-| **Testing**  | Jest (unit/integration/MCP), Playwright (UI), Custom (AI evals)          |
-| **Auth**     | JWT + refresh rotation, Google OAuth, Apple Sign-In, Phone SMS OTP       |
-| **AI**       | OpenAI-compatible API (planning, critique, suggestions, decision assist) |
-| **MCP**      | Remote Model Context Protocol for AI assistant connectors                |
-| **Worker**   | Python (`agent-runner/`) — scheduled automation jobs on Railway cron     |
-| **API Docs** | Swagger/OpenAPI at `/api-docs`                                           |
+| Aspect       | Value                                                                                                                                                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Frontend** | `client-react/` — Vite + React + TypeScript (primary). iOS app in `ios/TodosApp/` consumes the same API. The legacy vanilla JS client at `client/` has been removed; see `docs/reference/vanilla-client-archive.md` for history. |
+| **Backend**  | `src/` — TypeScript, Express 5, Prisma ORM                                                                                                                                                                                       |
+| **Database** | PostgreSQL 16 (26 models, 15+ enums)                                                                                                                                                                                             |
+| **Testing**  | Jest (unit/integration/MCP), Playwright (UI), Custom (AI evals)                                                                                                                                                                  |
+| **Auth**     | JWT + refresh rotation, Google OAuth, Apple Sign-In, Phone SMS OTP                                                                                                                                                               |
+| **AI**       | OpenAI-compatible API (planning, critique, suggestions, decision assist)                                                                                                                                                         |
+| **MCP**      | Remote Model Context Protocol for AI assistant connectors                                                                                                                                                                        |
+| **Worker**   | Python (`agent-runner/`) — scheduled automation jobs on Railway cron                                                                                                                                                             |
+| **API Docs** | Swagger/OpenAPI at `/api-docs`                                                                                                                                                                                                   |
 
 ---
 
 ## Load-Bearing Patterns (DO NOT BREAK)
 
-### Frontend
+### Frontend (Historical — vanilla JS client)
+
+> **Historical.** The patterns in this subsection describe the removed vanilla JS web client (previously in `client/`). They are preserved here for context on legacy code and prior ADRs (001–004). For the current web client, see `client-react/` and `.claude/skills/react-client/SKILL.md`. Full archive: [`docs/reference/vanilla-client-archive.md`](docs/reference/vanilla-client-archive.md).
 
 1. **Event Delegation** — `app.js` uses delegated listeners via `data-onclick` attributes. Never attach listeners directly to dynamic child elements.
 
@@ -59,35 +61,20 @@
 
 ## Directory Structure
 
+> The tree below summarizes top-level directories; it is not exhaustive. The legacy `client/` vanilla JS tree has been removed; for its historical layout see [`docs/reference/vanilla-client-archive.md`](docs/reference/vanilla-client-archive.md).
+
 ```
 todos-api/
-├── client/                          # Frontend (static, no build step)
-│   ├── app.js                       # Main composition root (1,733 lines)
-│   ├── index.html                   # Landing page with embedded auth (4,010 lines)
-│   ├── styles.css                   # All styles (10,778 lines, 216KB)
-│   ├── manifest.json                # PWA manifest
-│   ├── service-worker.js            # PWA service worker
-│   ├── public/                      # Standalone pages (added Mar 2026)
-│   │   ├── app.html                 # Standalone app workspace (3,241 lines)
-│   │   ├── app-page.js              # App page bootstrap shim (139 lines)
-│   │   ├── auth.html                # Standalone auth page (392 lines)
-│   │   ├── auth-page.js             # Auth page handlers (779 lines)
-│   │   └── auth-page.css            # Auth page styles (89 lines)
-│   ├── bootstrap/                   # App initialization modules
-│   │   └── initGlobalListeners.js   # Global event listeners (5.5KB)
-│   ├── features/                    # Feature-domain modules (6 dirs)
-│   │   ├── agent/                   # Agent polling, store, actions
-│   │   ├── assistant/               # AI assistant surfaces
-│   │   ├── command-palette/         # Ctrl+K navigation
-│   │   ├── drawer/                  # Todo edit drawer
-│   │   ├── projects/                # Project management
-│   │   └── todos/                   # Todo CRUD, filtering
-│   ├── modules/                     # Domain JS modules (38 files, 1.5MB)
-│   ├── utils/                       # Shared utilities (14 files)
-│   ├── platform/                    # Platform abstractions (events, state)
-│   ├── images/                      # Static assets
-│   ├── illustrations-preview.html   # Illustration preview (dev only)
-│   └── vendor/                      # Synced vendor assets (chrono-node)
+├── client-react/                    # Primary web client — Vite + React + TypeScript
+│   ├── src/                         # Components, features, hooks, mobile, views
+│   ├── public/                      # Static assets
+│   └── vite*.config.ts              # Separate build targets (main, landing, auth)
+│
+├── ios/TodosApp/                    # SwiftUI iOS app (iOS 17+), zero third-party deps
+│   ├── TodosApp/                    # App/Core/Features/Components
+│   └── TodosAppTests/               # XCTest suites
+│
+├── cli/                             # `td` CLI package wrapper
 │
 ├── src/                             # Backend TypeScript source (175 files)
 │   ├── server.ts                    # Entry point
@@ -110,8 +97,12 @@ todos-api/
 │   ├── schema.prisma                # Database schema (26 models, 15+ enums)
 │   └── migrations/                  # Database migrations
 │
-├── agent-runner/                    # Python worker (scheduled jobs)
-│   └── agent_runner/                # 7 job types: daily, weekly, inbox, etc.
+├── agent-runner/                    # Python worker (scheduled jobs, Railway cron)
+│   ├── main.py                      # Command router
+│   ├── jobs/                        # Job modules: daily, weekly, inbox, decomposer,
+│   │                                # watchdog, evaluators, project_health, retention, etc.
+│   ├── storage/                     # Enrollment, state, audit
+│   └── mcp_client.py                # Backend API client
 │
 ├── tests/
 │   └── ui/                          # Playwright specs (40+ files)

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,43 +1,61 @@
-# Todos API - Project Summary
+# Todos API — Project Summary
 
 ## Status
 
-Active and production-oriented. The repository contains:
+Active and production-oriented. The repository is a multi-client monorepo sharing one Express/Prisma/PostgreSQL backend.
 
-- An Express + TypeScript backend with Prisma/PostgreSQL persistence.
-- A static frontend (`client/`) that consumes the API.
-- Auth, project management, todo CRUD/reordering, and AI-assist flows.
-- Unit, integration, and Playwright UI test suites.
+## Surfaces
 
-## Current Architecture Snapshot
+- **Backend API** — Express + TypeScript + Prisma in `src/`. Route modules in `src/routes/`, business logic in `src/services/` and `src/domains/`. Prisma-backed persistence against PostgreSQL (see `prisma/schema.prisma`).
+- **Web client** — Vite + React + TypeScript in `client-react/`. Separate `package.json`, consumes the REST API. See `.claude/skills/react-client/SKILL.md`.
+- **iOS app** — SwiftUI (iOS 17+) in `ios/TodosApp/`. Zero third-party dependencies, actor-based networking (`APIClient`, `SessionCoordinator`), Keychain-backed token storage. See `.claude/skills/ios-app/SKILL.md`.
+- **CLI (`td`)** — Commander.js-based TypeScript CLI in `cli/` + `src/cli/`. Distributed as an npm `bin` entry.
+- **Agent runner** — Python 3 worker in `agent-runner/`. Deployed on Railway cron. Hosts scheduled job modules (daily planning, weekly review, inbox triage, decomposer, evaluators, watchdog, project health, retention, and others — see `agent-runner/jobs/`).
+- **Remote MCP surface** — OAuth-gated Model Context Protocol endpoint (at `/mcp/*`) for ChatGPT/Claude connector integrations.
 
-- `src/server.ts` boots the API; `src/app.ts` composes middleware and routes.
-- Route modules live in `src/routes/` (`auth`, `todos`, `projects`, `ai`, `users`, `admin`).
-- Persistence is Prisma-backed (`src/services/prismaTodoService.ts`, `src/services/projectService.ts`) with interfaces in `src/interfaces/`.
-- A deterministic in-memory todo service exists for focused unit flows (`src/services/todoService.ts`).
-- Data model is defined in `prisma/schema.prisma` and includes `User`, `RefreshToken`, `Project`, `Todo`, `Subtask`, and AI suggestion tables.
-- Frontend UI is framework-free (`client/index.html`, `client/app.js`, `client/styles.css`).
+The legacy vanilla JS web client previously in `client/` has been removed. See `docs/reference/vanilla-client-archive.md` for historical context.
 
-## Testing Snapshot
+## Shared Contract
 
-The test footprint is no longer the original small in-memory-only set. Current coverage includes:
+- `src/types.ts` is canonical for **backend domain types** (internal shapes used by services).
+- Transport DTOs are a separate concern — see [ADR-006](docs/adr/006-transport-contract-source-of-truth.md) for the domain-vs-transport split and the per-client sync path.
+- CI runs `swift build` and React `tsc --noEmit` when `src/types.ts` or `src/validation/constants.ts` change.
 
-- Unit tests (`npm run test:unit`)
-- Integration API tests (`npm run test:integration`)
-- UI regression tests with Playwright (`npm run test:ui:fast` and `npm run test:ui`)
+## Testing
 
-For exact test counts, use current command output instead of fixed numbers in docs.
+- **Unit** — `npm run test:unit` (Jest, `jest.unit.config.js`)
+- **Integration** — `npm run test:integration` (Jest, real Postgres via Docker Compose)
+- **MCP** — `npm run test:mcp` (MCP-surface tests)
+- **UI regression** — `CI=1 npm run test:ui:fast` (Playwright, 4-way sharded in CI)
+- **React** — `cd client-react && npm test` (Vitest)
+- **iOS** — `cd ios/TodosApp && swift test` (XCTest, macOS SPM build)
+- **AI evals** — `npm run eval:all` (custom evaluator under `evals/` + `eval-lab/`)
 
-## Operational Checks Used in Practice
+Coverage ratchet enforced via `npm run test:coverage:check` and `.coverage-baseline.json`.
 
-- `npx tsc --noEmit`
-- `npm run format:check`
-- `npm run lint:html`
-- `npm run lint:css`
-- `npm run test:unit`
-- `CI=1 npm run test:ui:fast`
+## Day-to-day verification checks
 
-## Notes
+```bash
+npx tsc --noEmit
+npm run format:check
+npm run test:unit
+CI=1 npm run test:ui:fast
+```
 
-- AI provider integration is optional and controlled via environment flags.
-- The codebase uses explicit docs/task protocols under `docs/agent-queue/` for planning and delivery.
+See [CLAUDE.md](CLAUDE.md) for the full verification matrix, worktree workflow, and husky hook behavior.
+
+## Operational
+
+- Deployment: Railway (NIXPACKS builder). `/readyz` serves as the platform health probe.
+- Release cadence: daily fast-forward release-train workflow (`.github/workflows/release-train.yml`) on weekdays; manual staging/UAT promotion.
+- Observability: structured JSON logs, request-ID middleware, route-latency logging, optional Sentry (backend + React) gated on `SENTRY_DSN`.
+- Local Postgres: `npm run docker:up` + `npm run db:setup`.
+
+## Docs
+
+- [README.md](README.md) — setup, scripts, endpoints, directory map.
+- [CLAUDE.md](CLAUDE.md) — developer workflow and verification matrix.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — single entry point that links the rest.
+- [ARCHITECTURE_SUMMARY.md](ARCHITECTURE_SUMMARY.md) — deeper architecture reference (some sub-sections still describe the removed vanilla client and are marked historical).
+- [docs/adr/](docs/adr/) — numbered Architecture Decision Records.
+- [docs/engineering-backlog.md](docs/engineering-backlog.md) — repo-grounded engineering backlog.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ A calm workspace for turning scattered tasks into focused days, reviewed weeks, 
 
 ## Technical Stack
 
-- Static single-page frontend in `client/` (vanilla HTML/CSS/JS, no build step)
-- Express + Prisma + PostgreSQL backend in `src/`
+- Express + Prisma + PostgreSQL backend in `src/` (TypeScript, input validation, structured errors)
+- Vite + React + TypeScript web client in `client-react/`
+- SwiftUI iOS app (iOS 17+) in `ios/TodosApp/` — zero third-party dependencies
+- `td` CLI (Commander.js) in `cli/` + `src/cli/`
+- Python agent runner in `agent-runner/` (scheduled jobs on Railway cron)
 - JWT auth with refresh-token rotation, email verification, Google/Apple/phone login
 - Remote MCP surface and internal `/agent` surface for assistant connectors
-- TypeScript backend with input validation, structured errors, and automated tests
 - Docker Compose for local PostgreSQL development
+- Legacy vanilla JS web client in `client/` has been removed; see [`docs/reference/vanilla-client-archive.md`](docs/reference/vanilla-client-archive.md) for context
 
 ## Prerequisites
 
@@ -514,24 +517,30 @@ Tests automatically use a separate test database (`todos_test`) to avoid affecti
 
 ```
 todos-api/
-├── client/                  # Static frontend shell + modular vanilla JS
-│   ├── modules/             # Domain JS modules
-│   ├── utils/               # Shared frontend utilities
-│   └── vendor/              # Synced vendor assets
-├── prisma/                  # Prisma schema + migrations
-├── src/
-│   ├── services/            # Domain/services (todos, projects, auth, AI)
-│   ├── middleware/          # Express middleware modules
-│   ├── validation/          # Validation/contracts
-│   ├── routes/              # Express routers (auth/todos/projects/ai/users/admin)
+├── src/                     # Express + Prisma backend (TypeScript)
+│   ├── routes/              # Express routers
+│   ├── services/            # Domain services (todos, projects, auth, AI)
+│   ├── domains/             # Domain-oriented backend modules
+│   ├── middleware/          # Express middleware
+│   ├── validation/          # Request validation
 │   ├── interfaces/          # Service contracts
+│   ├── cli/                 # `td` CLI implementation
 │   ├── app.ts               # App composition
 │   └── server.ts            # Entrypoint
+├── client-react/            # Vite + React + TypeScript web client
+├── ios/TodosApp/            # SwiftUI iOS app (iOS 17+), zero third-party deps
+├── cli/                     # `td` CLI package wrapper
+├── agent-runner/            # Python worker (Railway cron) — scheduled jobs
+├── prisma/                  # Prisma schema + migrations
 ├── test/                    # Jest setup/teardown helpers
 ├── tests/ui/                # Playwright UI specs
-├── scripts/                 # Utility scripts (lint/test helpers)
-└── docs/                    # Architecture + agent protocol docs
+├── evals/ + eval-lab/       # AI evaluator suites
+├── scripts/                 # Build, deploy, workflow-guard scripts
+├── docs/                    # Architecture, runbooks, ADRs, agent protocol
+└── .github/workflows/       # CI, release-train, secret-scan, eval-lab
 ```
+
+The legacy vanilla JS web client previously in `client/` has been removed; its historical structure is preserved in [`docs/reference/vanilla-client-archive.md`](docs/reference/vanilla-client-archive.md).
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Implements [Epic 6 / Story 6.1](https://github.com/karthikg80/todos-api/pull/985) from the repo-grounded engineering backlog. Docs-only; no runtime or wire-format change.

**Problem:** three top-level summaries describe the removed vanilla `client/` app as though it were current, and PROJECT_SUMMARY.md also misses the React, iOS, CLI, and agent-runner surfaces entirely. That makes onboarding noisier than it needs to be and made my own earlier audit sloppier than it should have been.

## What changed

- **PROJECT_SUMMARY.md** — rewritten. Previously described only a backend + `client/` vanilla frontend. Now lists the actual 5-surface monorepo (backend, `client-react/`, `ios/TodosApp/`, `cli/`, `agent-runner/`) plus the MCP surface, shared-contract pointer to ADR-006, testing matrix, and ops/docs links.
- **README.md** — two surgical edits:
  - Technical Stack: replaced the "Static single-page frontend in `client/`" bullet with current stack (React web + iOS + CLI + agent-runner); added explicit pointer to `docs/reference/vanilla-client-archive.md`.
  - Directory tree: `client/` root replaced with real top-level directories (`client-react/`, `ios/TodosApp/`, `cli/`, `agent-runner/`, `evals/` + `eval-lab/`, `scripts/`, `.github/workflows/`).
- **ARCHITECTURE_SUMMARY.md** — minimally-invasive:
  - Stack line at top now names React + iOS + agent-runner alongside the Express backend.
  - Quick Reference "Frontend" row rewritten to point at `client-react/` and call out the removed `client/` with archive link.
  - "Load-Bearing Patterns / Frontend" subsection still describes the vanilla-client patterns (event delegation, filter pipeline, hooks registry, etc.) — **retained** but clearly marked **Historical** with a banner and a link to the archive; kept because ADRs 001–004 reference them.
  - Replaced the stale `client/` tree block in Directory Structure with current `client-react/` / `ios/TodosApp/` / `cli/` entries. Corrected the outdated "7 job types" agent-runner line to reference the actual job modules under `agent-runner/jobs/`.

## Out of scope (explicit)

- **Not** a full refresh of ARCHITECTURE_SUMMARY.md. It's 38 KB; rewriting more than the vanilla-client-as-current references is broader than Story 6.1 asks for. Deeper sub-sections (diagrams, file-size tables) that still reference `app.js` / `filterLogic.js` remain — they're now contextually covered by the historical banner at the top of the Frontend subsection.
- **Not** touching HANDOFF.md — that's a completed-task handoff note, not an architecture summary describing `client/` as current.
- **Not** archiving plan.md (a 638-line historical auth-feature spec from Feb 2026). That fits Story 6.2's docs-consolidation scope better than 6.1.

## Link caveats

Some links in the rewritten files point at files that are still in-flight on companion open PRs, so they will 404 from this branch until those merge:

- `CONTRIBUTING.md` — lands with [PR #984](https://github.com/karthikg80/todos-api/pull/984)
- `docs/adr/006-transport-contract-source-of-truth.md` — lands with [PR #986](https://github.com/karthikg80/todos-api/pull/986)
- `docs/engineering-backlog.md` — lands with [PR #985](https://github.com/karthikg80/todos-api/pull/985)

All three are open and CLEAN.

## Test plan

- [x] `npm run format:check` clean
- [x] No code changes; no typecheck or unit-test impact
- [x] All referenced directories in the new README.md tree exist in the worktree (`client-react/`, `ios/TodosApp/`, `cli/`, `agent-runner/`, `scripts/`, `eval-lab/`, `evals/`)
- [x] Directory-tree claim that `client/` no longer exists: verified (`ls client/` fails)
- [x] Agent-runner "jobs/" list matches actual modules (verified via `ls agent-runner/jobs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)