### PR TITLE
docs(adr): ADR-007 iOS + Python contract sync mechanism (Story 1.3)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,15 @@ Summarize the user-facing and technical changes.
 - [ ] I reused the canonical code path instead of adding a parallel flow.
 - [ ] If I introduced or changed a boundary, I updated the relevant durable doc/ADR.
 
+## Shared contract
+
+Check all that apply. Skip this section if the change does not touch the API wire format or transport DTOs. See [ADR-006](../docs/adr/006-transport-contract-source-of-truth.md) and [ADR-007](../docs/adr/007-ios-python-contract-sync.md) for context.
+
+- [ ] My change does not affect transport DTOs. (Skip the rest.)
+- [ ] If transport DTOs changed, I updated the iOS DTOs in `ios/TodosApp/TodosApp/Core/Models/*.swift`.
+- [ ] If transport DTOs changed, I updated the affected `@dataclass` entries in `agent-runner/agent_api_types.py` (or flagged that the change does not touch any action `agent-runner` consumes).
+- [ ] If transport DTOs changed, I mentioned the cross-client impact in the PR description so reviewers can flag any client that needs a follow-up.
+
 ## Verification
 
 - [ ] `npx tsc --noEmit`

--- a/docs/adr/007-ios-python-contract-sync.md
+++ b/docs/adr/007-ios-python-contract-sync.md
@@ -1,0 +1,108 @@
+# ADR-007: iOS and Python contract sync mechanism
+
+## Status
+
+Accepted (2026-04-19)
+
+Implements [Epic 1 / Story 1.3](../engineering-backlog.md). Follows [ADR-006](006-transport-contract-source-of-truth.md), which set the higher-level direction (transport defined by Zod schemas; iOS and Python hand-maintained with documented sync paths).
+
+## Context
+
+ADR-006 committed to hand-maintained iOS DTOs and Python typed wrappers rather than introducing code generators for those surfaces. It did not specify _how_ those hand-maintained layers stay in sync with the transport contract. This ADR fills that gap.
+
+### Verified current state
+
+**iOS (`ios/TodosApp/TodosApp/Core/Models/`):**
+
+- `TodoDTO.swift`, `ProjectDTO.swift`, `SubtaskDTO.swift`, `HeadingDTO.swift`, `UserDTO.swift`, `AuthModels.swift`, `Enums.swift` — seven hand-maintained files decoding JSON responses via `ISO8601DateFormatter` into Swift structs.
+- CI runs `swift build` in the `cross-client-sync` job on `macos-latest` when shared contracts change (`.github/workflows/ci.yml` L347–377). There is no property-level drift check — a Swift struct missing a field the backend returns compiles fine and only fails at decode time.
+
+**Python (`agent-runner/`):**
+
+- `mcp_client.py` is a generic action dispatcher: `client.read(action, params)` and `client.write(action, params)` return `dict[str, Any]`. No typed response shapes anywhere.
+- Inventory of actions actually consumed across `agent-runner/jobs/*.py`:
+  - Reads (4): `analyze_project_health`, `suggest_next_actions`, `list_projects_without_next_action`, `plan_today`
+  - Writes (6): `triage_inbox`, `generate_morning_brief`, `project_health_intervention`, `run_data_retention`, `send_task_reminder`, `create_task`
+  - Non-agent: `post_api("/insights/compute", ...)` from `jobs/insights.py`
+
+These are the surfaces that need a sync mechanism.
+
+## Decision
+
+### iOS: hand-maintained DTOs + automated CI drift check
+
+**Mechanism:** A new script at `scripts/check-ios-dto-drift.mjs` runs in CI and compares the top-level property names of each Swift DTO struct against the OpenAPI spec's schema definitions for the equivalent type.
+
+- **Swift parsing:** regex-based, scanning `ios/TodosApp/TodosApp/Core/Models/*.swift` for `struct <Name>DTO` / `struct <Name>` blocks and their `let <name>:` / `var <name>:` property declarations. A full Swift parser is out of scope; property-name-level drift catches the failure mode that matters (new or renamed wire fields).
+- **OpenAPI source:** the spec currently lives in `src/swagger.ts` (hand-written). Story 1.2 will replace that with a generator over Zod schemas. Until the generator lands, the drift check runs in **warning mode** (non-fatal) because `src/swagger.ts` is itself known to drift from the runtime and would produce false positives. It flips to **failing mode** the moment Story 1.2 lands a generated OpenAPI JSON that the runtime validates against.
+- **CI wiring:** extend the existing `cross-client-sync` job (already runs on `macos-latest` for `swift build`). Add the drift check after the Swift build step. Update the job's path filter so it also triggers on `ios/TodosApp/TodosApp/Core/Models/**` and (post-1.2) `src/transport/**`.
+
+**What this does not catch (accepted):**
+
+- **Optionality mismatches** (e.g., backend-required vs Swift optional). Property names are sufficient to catch the failure modes that routinely bite us; typed optionality drift is rarer and is better caught by runtime decode tests.
+- **Nested type drift** (e.g., an enum value added on the server). This is caught by `swift build` when the enum type changes in `Enums.swift` via the standard shared-contract path; the drift check doesn't replicate it.
+
+### Python (agent-runner): typed facade over the action dispatcher
+
+**Mechanism:** a new `agent-runner/agent_api_types.py` (or equivalent) with plain `@dataclass` request and response types for each consumed action.
+
+- **No runtime validation.** Types are documentation + statically checkable when Story 2.1 lands `mypy` in CI. Adopting `pydantic` or `msgspec` would solve validation but adds toolchain cost disproportionate to the 10-action surface.
+- **Typed facade pattern** rather than a rewrite of `mcp_client.py`. New methods on `AgentClient` (or a thin subclass) take a dataclass and return a parsed dataclass, delegating to the existing `self.read(action, params)` / `self.write(action, params)` under the hood. Call sites in `agent-runner/jobs/*.py` migrate incrementally — the generic dispatcher remains available for one-off or experimental actions.
+- **Scope:** type the 10 actions above and the `/insights/compute` helper. Everything else stays dict-based until its volume grows.
+
+### What's manual vs automated
+
+| Surface                 | Authoring                  | Drift detection                                                                                         |
+| ----------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| React (Story 1.2)       | Generated from Zod         | Runtime validation (Zod at route boundary) + typecheck on inferred types                                |
+| iOS                     | Manual DTO files           | Automated `scripts/check-ios-dto-drift.mjs` in `cross-client-sync` (warning-only pre-1.2, failing post) |
+| Python (`agent-runner`) | Manual `@dataclass` facade | `mypy` at author time (once Story 2.1 lands); PR-template checklist for cross-client-affecting changes  |
+
+### PR template update
+
+Add a "Shared contract" subsection to `.github/pull_request_template.md` so reviewers ask the right question when a transport schema changes. See the diff in this PR.
+
+### Triggers to revisit
+
+- **iOS → `swift-openapi-generator`:** adopt if (a) two or more drift incidents occur in a quarter despite the CI check, or (b) `swift-openapi-generator` matures enough that the toolchain cost of adding a Swift codegen step into CI becomes negligible.
+- **Python → `pydantic` / `msgspec`:** adopt if `agent-runner` starts consuming more than ~15 actions, or if runtime validation of agent responses becomes important for debugging.
+
+## Implementation phasing
+
+This ADR is the decision artifact. Code lands in separate PRs:
+
+1. **Phase B — iOS drift check.** Can ship in warning-only mode before Story 1.2; flips to failing mode once the generated OpenAPI JSON is in place.
+2. **Phase C — Python typed facade.** Add `agent-runner/agent_api_types.py`, migrate one representative job (probably `daily.py`) to the typed facade as a template, and document the sync checklist.
+
+Neither phase is blocked on the other.
+
+## Non-goals (explicit)
+
+- Not adopting `swift-openapi-generator`.
+- Not adopting `pydantic` or `msgspec`.
+- Not moving `agent-runner` off the action-dispatcher `mcp_client.py` structure.
+- Not changing any on-the-wire payloads.
+- Not implementing the drift check or typed facade in this PR — that's Phase B and Phase C.
+
+## Consequences
+
+### Positive
+
+- iOS drift becomes visible at CI time rather than at runtime decode failure.
+- Python job code reads with typed call sites even though the transport layer remains dict-based.
+- Both sync paths are explicit, documented, and have named upgrade triggers.
+
+### Negative / accepted costs
+
+- Regex-based Swift parsing is approximate. The check catches the property-name failure mode, not every possible drift. Accepted because the alternatives (full Swift parser dependency or `swift-openapi-generator`) cost more than they save at the current drift rate.
+- The typed facade and the generic dispatcher coexist in `agent-runner`. Acceptable if the coexistence window is measured in sprints; revisit if it persists past mid-2026.
+- Pre-Story-1.2 the drift check can warn-only, which is weaker than failing. This is a feature, not a bug — a failing check against a known-stale hand-written spec would produce noise rather than signal.
+
+## References
+
+- [ADR-006](006-transport-contract-source-of-truth.md) — transport contract source of truth
+- `ios/TodosApp/TodosApp/Core/Models/*.swift` — hand-maintained Swift DTOs
+- `agent-runner/mcp_client.py` — action dispatcher
+- `agent-runner/jobs/*.py` — action consumers (10 distinct actions + one direct API path)
+- `.github/workflows/ci.yml` — `cross-client-sync` job (L347–377)
+- `.github/pull_request_template.md` — updated with shared-contract checklist in this PR


### PR DESCRIPTION
## Summary

Implements [Epic 1 / Story 1.3](https://github.com/karthikg80/todos-api/pull/985) from the repo-grounded engineering backlog. Follows [ADR-006](https://github.com/karthikg80/todos-api/pull/986) (now on master). **Docs-only** decision artifact plus a PR-template update; no runtime change.

**Decision in one sentence:** iOS stays hand-maintained with an automated CI drift check comparing Swift DTO property names to the OpenAPI spec; Python `agent-runner` gets a typed `@dataclass` facade over the existing generic action dispatcher for the 10 actions it actually consumes.

## Problem

ADR-006 named iOS and Python as hand-maintained — explicitly rejecting `swift-openapi-generator` and `pydantic` for now — but didn't specify _how_ either surface stays in sync with the transport contract. This ADR fills that gap.

## Grounded inventory

**iOS (`ios/TodosApp/TodosApp/Core/Models/`):** 7 hand-maintained files (`TodoDTO`, `ProjectDTO`, `SubtaskDTO`, `HeadingDTO`, `UserDTO`, `AuthModels`, `Enums`). Today's CI: `swift build` only, in `cross-client-sync` on `macos-latest`. Missing-field drift compiles fine and only fails at decode time.

**Python (`agent-runner/`):** `mcp_client.py` is a generic action dispatcher (`read(action, params)` / `write(action, params) → dict[str, Any]`). Grepping `agent-runner/jobs/*.py` shows **10 distinct actions consumed**:

- Reads: `analyze_project_health`, `suggest_next_actions`, `list_projects_without_next_action`, `plan_today`
- Writes: `triage_inbox`, `generate_morning_brief`, `project_health_intervention`, `run_data_retention`, `send_task_reminder`, `create_task`
- Plus direct `post_api("/insights/compute", ...)` from `jobs/insights.py`

## What this PR changes

- **New:** [docs/adr/007-ios-python-contract-sync.md](docs/adr/007-ios-python-contract-sync.md) — the decision, mechanism details, and phasing.
- **Updated:** [.github/pull_request_template.md](.github/pull_request_template.md) — adds a **Shared contract** checklist section so reviewers ask the right question when a transport DTO changes. This is the PR-template half of the Story 1.3 acceptance criterion called out in ADR-006.

## Mechanism highlights

### iOS drift check (Phase B, follow-on PR)

- New `scripts/check-ios-dto-drift.mjs` — regex-scans `ios/TodosApp/TodosApp/Core/Models/*.swift` for `struct <Name>DTO` property names and diffs them against the OpenAPI spec's schemas.
- Runs inside the existing `cross-client-sync` CI job (already on `macos-latest` for `swift build`).
- **Pre-Story-1.2** runs in **warning mode** — the current `src/swagger.ts` is hand-written and drifty; failing on it would produce noise rather than signal.
- **Post-Story-1.2** flips to **failing mode** once the generated OpenAPI JSON exists.
- Does not catch optionality drift or nested enum drift — both have existing mitigations (decode tests; `swift build` on `Enums.swift`).

### Python typed facade (Phase C, follow-on PR)

- New `agent-runner/agent_api_types.py` with `@dataclass` request + response shapes for the 10 actions above.
- Typed methods on `AgentClient` (or a thin subclass) delegate to the existing `self.read(...)` / `self.write(...)` — no rewrite of the dispatcher.
- No pydantic / msgspec; `mypy` (once Story 2.1 lands) is the authoring-time check.
- Call-site migration is incremental; start with one representative job (likely `daily.py`) as a template.

### Triggers to reopen the decision

- iOS → `swift-openapi-generator` if ≥2 drift incidents / quarter despite the CI check, or when the toolchain cost becomes negligible.
- Python → `pydantic` / `msgspec` if `agent-runner` consumes >15 actions or needs runtime validation.

## Non-goals (explicit)

- Not adopting `swift-openapi-generator` or `pydantic` / `msgspec`.
- Not implementing the drift check (Phase B) or typed facade (Phase C) in this PR.
- Not changing any on-the-wire payloads.
- Not moving `agent-runner` off its action-dispatcher structure.

## Phasing and ownership

- **Phase A — this PR** (docs + PR template).
- **Phase B — iOS drift check**: Codex-appropriate; can ship in warning-only mode independent of Story 1.2 timeline.
- **Phase C — Python typed facade**: either owner; independent of Story 1.2.

## Test plan

- [x] `npm run format:check` clean
- [x] No code changes; no typecheck or unit-test impact
- [x] Action inventory grounded in `grep -rh '\.read("\|\.write("' agent-runner/jobs/*.py`
- [x] iOS DTO file list verified against `ls ios/TodosApp/TodosApp/Core/Models/`
- [x] `cross-client-sync` job location verified at `.github/workflows/ci.yml:347`

🤖 Generated with [Claude Code](https://claude.com/claude-code)