### PR TITLE
refactor(agent): remove stale goal alignment casts

### DIFF
--- a/src/agent/agentExecutor.ts
+++ b/src/agent/agentExecutor.ts
@@ -752,10 +752,10 @@ export class AgentExecutor {
             for (const t of allTasks) {
               if (
                 t.projectId &&
-                (t as any).goalId &&
+                t.goalId &&
                 !planProjectGoalMap.has(t.projectId)
               ) {
-                planProjectGoalMap.set(t.projectId, (t as any).goalId);
+                planProjectGoalMap.set(t.projectId, t.goalId);
               }
             }
           }
@@ -1724,10 +1724,10 @@ export class AgentExecutor {
           for (const t of allTasks) {
             if (
               t.projectId &&
-              (t as any).goalId &&
+              t.goalId &&
               !simProjectGoalMap.has(t.projectId)
             ) {
-              simProjectGoalMap.set(t.projectId, (t as any).goalId);
+              simProjectGoalMap.set(t.projectId, t.goalId);
             }
           }
           const simInsightMap = new Map<string, number>();

--- a/src/domains/agent/services/planScorer.test.ts
+++ b/src/domains/agent/services/planScorer.test.ts
@@ -1,0 +1,66 @@
+import type { Todo } from "../../../types";
+import { scorePlan } from "./planScorer";
+
+function makeTask(
+  id: string,
+  title: string,
+  overrides: Partial<Todo> = {},
+): Todo {
+  return {
+    id,
+    title,
+    status: "next",
+    completed: false,
+    tags: [],
+    dependsOnTaskIds: [],
+    order: 0,
+    priority: "medium",
+    archived: false,
+    recurrence: { type: "none" },
+    userId: "user-1",
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    subtasks: [],
+    ...overrides,
+  };
+}
+
+describe("planScorer", () => {
+  it("applies a larger goal-alignment boost for directly linked goals than project fallback goals", () => {
+    const targetDate = new Date(Date.now() + 7 * 86_400_000);
+    const directTask = makeTask("task-1", "Direct goal task", {
+      projectId: "project-1",
+      goalId: "goal-1",
+      effortScore: 30,
+    });
+    const fallbackTask = makeTask("task-2", "Fallback goal task", {
+      projectId: "project-2",
+      effortScore: 30,
+    });
+
+    const result = scorePlan(
+      [directTask, fallbackTask],
+      "2026-03-12",
+      90,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      new Map([
+        ["goal-1", { targetDate }],
+        ["goal-2", { targetDate }],
+      ]),
+      new Map([["project-2", "goal-2"]]),
+    );
+
+    const selectedById = new Map(
+      result.selected.map((item) => [item.task.id, item]),
+    );
+    const direct = selectedById.get("task-1");
+    const fallback = selectedById.get("task-2");
+
+    expect(direct?.scoreBreakdown.goalAlignment).toBe(20);
+    expect(fallback?.scoreBreakdown.goalAlignment).toBe(15);
+    expect(direct?.score).toBeGreaterThan(fallback?.score ?? 0);
+  });
+});

--- a/src/domains/agent/services/planScorer.ts
+++ b/src/domains/agent/services/planScorer.ts
@@ -179,11 +179,10 @@ export function scorePlan(
 
     // Goal alignment boost
     const taskGoalId =
-      (t as any).goalId ||
-      (t.projectId ? projectGoalMap?.get(t.projectId) : undefined);
+      t.goalId || (t.projectId ? projectGoalMap?.get(t.projectId) : undefined);
     if (taskGoalId && goalIndex?.has(taskGoalId)) {
       const goal = goalIndex.get(taskGoalId)!;
-      const directGoal = !!(t as any).goalId;
+      const directGoal = !!t.goalId;
       const baseBoost = directGoal ? 12 : 9;
       score += baseBoost;
       breakdown.goalAlignment = baseBoost;

--- a/src/plannerHeuristics.test.ts
+++ b/src/plannerHeuristics.test.ts
@@ -7,6 +7,7 @@ import {
   projectHasNextAction,
   projectTasksForProject,
 } from "./services/plannerHeuristics";
+import { scoreTaskForDecision } from "./services/planner/plannerHeuristics";
 
 const USER_ID = "user-1";
 
@@ -186,5 +187,48 @@ describe("plannerHeuristics", () => {
         "follow_up_waiting_task",
       ]),
     );
+  });
+
+  it("scores directly-linked goals higher than project fallback goals", () => {
+    const now = new Date("2026-03-12T12:00:00.000Z");
+    const targetDate = new Date("2026-03-20T12:00:00.000Z");
+    const directTask = makeTask("task-1", "Direct goal task", {
+      projectId: "project-1",
+      goalId: "goal-1",
+      status: "next",
+      priority: "high",
+    });
+    const fallbackTask = makeTask("task-2", "Project goal fallback task", {
+      projectId: "project-2",
+      status: "next",
+      priority: "high",
+    });
+
+    const goalIndex = new Map([
+      ["goal-1", { targetDate }],
+      ["goal-2", { targetDate }],
+    ]);
+    const projectGoalMap = new Map([["project-2", "goal-2"]]);
+
+    const directScore = scoreTaskForDecision({
+      task: directTask,
+      now,
+      blocked: false,
+      contexts: [],
+      dependentCount: 0,
+      goalIndex,
+      projectGoalMap,
+    });
+    const fallbackScore = scoreTaskForDecision({
+      task: fallbackTask,
+      now,
+      blocked: false,
+      contexts: [],
+      dependentCount: 0,
+      goalIndex,
+      projectGoalMap,
+    });
+
+    expect(directScore).toBeGreaterThan(fallbackScore);
   });
 });

--- a/src/services/planner/plannerHeuristics.ts
+++ b/src/services/planner/plannerHeuristics.ts
@@ -366,11 +366,11 @@ export function scoreTaskForDecision(input: {
 
   // Goal alignment boost
   const taskGoalId =
-    (task as any).goalId ||
+    task.goalId ||
     (task.projectId ? projectGoalMap?.get(task.projectId) : undefined);
   if (taskGoalId && goalIndex?.has(taskGoalId)) {
     const goal = goalIndex.get(taskGoalId)!;
-    const direct = !!(task as any).goalId;
+    const direct = !!task.goalId;
     score += direct ? 12 : 9;
     if (goal.targetDate) {
       const daysToGoal =


### PR DESCRIPTION
## Summary
- remove stale runtime `as any` casts from planner scoring and agent execution goal-alignment paths
- switch planner and plan scorer logic to typed `goalId` access now that the shared todo type already carries it
- add narrow tests that lock the direct-goal-vs-project-fallback scoring behavior

## Backlog
- implements Epic 4 / Story 4.2 from `docs/engineering-backlog.md`

## Verification
- `npx tsc --noEmit`
- `npm run format:check`
- `npm run test:unit`
- `CI=1 npm run test:ui:fast`
- `npm run test:coverage:check`

## Notes
- `client-react/dist-*` changed locally from the UI preview build used during verification and were intentionally left out of this PR.