### PR TITLE
test(api): cover auth and planner edge cases

### DIFF
--- a/src/auth.api.test.ts
+++ b/src/auth.api.test.ts
@@ -29,6 +29,17 @@ describe("Authentication API", () => {
     await prisma.todo.deleteMany();
     await prisma.project.deleteMany();
     await prisma.user.deleteMany();
+
+    jest
+      .spyOn(authService, "dispatchVerificationEmail")
+      .mockImplementation(() => {});
+    jest
+      .spyOn((authService as any).emailService, "sendPasswordResetEmail")
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   describe("POST /auth/register", () => {
@@ -228,6 +239,26 @@ describe("Authentication API", () => {
       expect(response.body.error).toBe("Invalid credentials");
     });
 
+    it("should return 401 for passwordless accounts", async () => {
+      await prisma.user.create({
+        data: {
+          email: "social-only@example.com",
+          password: null,
+          name: "Social Only",
+        },
+      });
+
+      const response = await request(app)
+        .post("/auth/login")
+        .send({
+          email: "social-only@example.com",
+          password: "password123",
+        })
+        .expect(401);
+
+      expect(response.body.error).toBe("Invalid credentials");
+    });
+
     it("should return 400 for missing email", async () => {
       const response = await request(app)
         .post("/auth/login")
@@ -334,6 +365,33 @@ describe("Authentication API", () => {
         .expect(401);
 
       expect(refreshAfterLogout.body.error).toBe("Invalid refresh token");
+    });
+
+    it("should reject refresh tokens with an invalid signature without revoking the stored token", async () => {
+      const register = await request(app).post("/auth/register").send({
+        email: "tampered-refresh@example.com",
+        password: "password123",
+      });
+      const userId = register.body.user.id as string;
+      const refreshToken = register.body.refreshToken as string;
+      const [header, payload, signature] = refreshToken.split(".");
+      const tamperedToken = [
+        header,
+        payload,
+        `${signature.slice(0, -1)}${signature.endsWith("a") ? "b" : "a"}`,
+      ].join(".");
+
+      const response = await request(app)
+        .post("/auth/refresh")
+        .send({ refreshToken: tamperedToken })
+        .expect(401);
+
+      expect(response.body.error).toBe("Invalid refresh token");
+      await expect(
+        prisma.refreshToken.count({
+          where: { userId },
+        }),
+      ).resolves.toBe(1);
     });
 
     it("should return 409 and remove token when refresh token is expired", async () => {

--- a/src/plannerHeuristics.test.ts
+++ b/src/plannerHeuristics.test.ts
@@ -7,7 +7,12 @@ import {
   projectHasNextAction,
   projectTasksForProject,
 } from "./services/plannerHeuristics";
-import { scoreTaskForDecision } from "./services/planner/plannerHeuristics";
+import {
+  buildCriticalPath,
+  buildDecisionReason,
+  clampHealthScore,
+  scoreTaskForDecision,
+} from "./services/planner/plannerHeuristics";
 
 const USER_ID = "user-1";
 
@@ -125,6 +130,56 @@ describe("plannerHeuristics", () => {
     expect(suggestion?.status).toBe("next");
   });
 
+  it("derives a review action from the oldest open task when nothing is waiting", () => {
+    const project = makeProject("project-1", "Platform");
+    const tasks = [
+      makeTask("task-1", "Recently updated task", {
+        projectId: project.id,
+        category: project.name,
+        status: "scheduled",
+        updatedAt: new Date("2026-03-10T12:00:00.000Z"),
+        priority: "low",
+      }),
+      makeTask("task-2", "Oldest task", {
+        projectId: project.id,
+        category: project.name,
+        status: "scheduled",
+        updatedAt: new Date("2026-03-01T12:00:00.000Z"),
+        priority: "high",
+      }),
+    ];
+
+    const suggestion = deriveNextAction(project, tasks);
+
+    expect(suggestion).toEqual({
+      title: "Review Oldest task and choose the next step",
+      description:
+        "Use the current project state to turn Oldest task into one concrete action for Platform.",
+      priority: "high",
+      status: "next",
+      reason:
+        "The project has open work but nothing explicitly actionable right now.",
+    });
+  });
+
+  it("creates a first-step suggestion when the project has no open tasks", () => {
+    const project = makeProject("project-1", "Platform", {
+      goal: "Ship planner improvements",
+      priority: "urgent",
+    });
+
+    const suggestion = deriveNextAction(project, []);
+
+    expect(suggestion).toEqual({
+      title: "Define the first concrete step for Ship planner improvements",
+      description:
+        "Capture the first action that would move Platform forward this week.",
+      priority: "urgent",
+      status: "next",
+      reason: "The project has no open tasks yet and needs a starting action.",
+    });
+  });
+
   it("uses canonical projectId when matching project tasks", () => {
     const project = makeProject("project-1", "Platform");
     const matchingTask = makeTask("task-1", "Canonical task", {
@@ -230,5 +285,90 @@ describe("plannerHeuristics", () => {
     });
 
     expect(directScore).toBeGreaterThan(fallbackScore);
+  });
+
+  it("scores decision candidates higher when they fit context, time, and project goals", () => {
+    const now = new Date("2026-03-12T12:00:00.000Z");
+    const project = makeProject("project-1", "Platform");
+    const alignedTask = makeTask("task-1", "Ship planner update", {
+      projectId: project.id,
+      status: "next",
+      priority: "high",
+      dueDate: new Date("2026-03-13T12:00:00.000Z"),
+      context: "office",
+      energy: "medium",
+      estimateMinutes: 30,
+    });
+    const blockedTask = makeTask("task-2", "Unblock analytics", {
+      status: "scheduled",
+      priority: "high",
+      dueDate: new Date("2026-03-20T12:00:00.000Z"),
+      context: "home",
+      energy: "high",
+      estimateMinutes: 120,
+    });
+
+    const alignedScore = scoreTaskForDecision({
+      task: alignedTask,
+      now,
+      blocked: false,
+      availableMinutes: 45,
+      availableEnergy: "medium",
+      contexts: ["office"],
+      dependentCount: 2,
+      goalIndex: new Map([
+        ["goal-1", { targetDate: new Date("2026-03-20T12:00:00.000Z") }],
+      ]),
+      projectGoalMap: new Map([[project.id, "goal-1"]]),
+      soulModifiers: {
+        statusBoosts: {
+          next: 7,
+        },
+      },
+    });
+    const blockedScore = scoreTaskForDecision({
+      task: blockedTask,
+      now,
+      blocked: true,
+      availableMinutes: 45,
+      availableEnergy: "medium",
+      contexts: ["office"],
+      dependentCount: 0,
+    });
+
+    expect(alignedScore).toBeGreaterThan(blockedScore);
+  });
+
+  it("explains why a task is recommended and computes the critical path", () => {
+    const blockedTask = makeTask("task-1", "Blocked dependency", {
+      status: "next",
+      priority: "high",
+      dueDate: new Date("2026-03-13T12:00:00.000Z"),
+    });
+    const middleTask = makeTask("task-2", "Middle task", {
+      dependsOnTaskIds: ["task-1"],
+    });
+    const endTask = makeTask("task-3", "End task", {
+      dependsOnTaskIds: ["task-2"],
+    });
+
+    expect(
+      buildDecisionReason({
+        task: blockedTask,
+        now: new Date("2026-03-12T12:00:00.000Z"),
+        blocked: true,
+        dependentCount: 2,
+      }),
+    ).toBe(
+      "It is still blocked by an open dependency and it is due soon, it unblocks 2 other tasks, it has elevated priority.",
+    );
+    expect(
+      buildCriticalPath([blockedTask, middleTask, endTask]).map(
+        (task) => task.id,
+      ),
+    ).toEqual(["task-1", "task-2", "task-3"]);
+    expect(clampHealthScore(-4.6)).toBe(0);
+    expect(clampHealthScore(42.4)).toBe(42);
+    expect(clampHealthScore(120)).toBe(100);
   });
 });

--- a/src/preferences.api.integration.test.ts
+++ b/src/preferences.api.integration.test.ts
@@ -7,11 +7,12 @@ import { prisma } from "./prismaClient";
 describe("Preferences API Integration", () => {
   let app: ReturnType<typeof createApp>;
   let authToken: string;
+  let authService: AuthService;
 
   beforeAll(() => {
     process.env.JWT_SECRET = "test-secret-for-preferences-api-tests";
     const todoService = new PrismaTodoService(prisma);
-    const authService = new AuthService(prisma);
+    authService = new AuthService(prisma);
     app = createApp({ todoService, authService });
   });
 
@@ -20,6 +21,10 @@ describe("Preferences API Integration", () => {
     await prisma.refreshToken.deleteMany();
     await prisma.user.deleteMany();
 
+    jest
+      .spyOn(authService, "dispatchVerificationEmail")
+      .mockImplementation(() => {});
+
     const registerResponse = await request(app).post("/auth/register").send({
       email: "prefs-test@example.com",
       password: "password123",
@@ -27,6 +32,10 @@ describe("Preferences API Integration", () => {
     });
 
     authToken = registerResponse.body.token;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("GET /preferences returns defaults when none set", async () => {
@@ -108,6 +117,34 @@ describe("Preferences API Integration", () => {
       energyPattern: "variable",
       goodDayThemes: [],
       tone: "focused",
+      dailyRitual: "neither",
+    });
+  });
+
+  it("PATCH /preferences sanitizes soul profile values and falls back invalid enums", async () => {
+    const response = await request(app)
+      .patch("/preferences")
+      .set("Authorization", `Bearer ${authToken}`)
+      .send({
+        soulProfile: {
+          lifeAreas: ["WORK", "invalid", "personal", "work", "health"],
+          failureModes: ["forgetful", "unknown", "forgetful"],
+          planningStyle: "chaos",
+          energyPattern: "night",
+          goodDayThemes: ["important_work", "made_up", "avoid_overload"],
+          tone: "LOUD",
+          dailyRitual: "sometimes",
+        },
+      })
+      .expect(200);
+
+    expect(response.body.soulProfile).toEqual({
+      lifeAreas: ["work", "personal", "health"],
+      failureModes: ["forgetful"],
+      planningStyle: "both",
+      energyPattern: "variable",
+      goodDayThemes: ["important_work", "avoid_overload"],
+      tone: "calm",
       dailyRitual: "neither",
     });
   });


### PR DESCRIPTION
## Summary
- add auth failure-path coverage for passwordless login and tampered refresh tokens
- add preferences coverage for soul-profile sanitization and invalid enum fallback behavior
- add planner heuristic coverage for oldest-open-task fallback, first-step suggestions, decision scoring, decision reasoning, critical-path derivation, and health-score clamping

## Backlog
- resurrects closed PR #991
- implements Epic 5 / Story 5.1 from `docs/engineering-backlog.md`

## Verification
- `npx tsc --noEmit` ✅
- `npx prettier --check src/auth.api.test.ts src/preferences.api.integration.test.ts src/plannerHeuristics.test.ts` ✅
- `npm run test:unit` ✅
- `npm run test:coverage:check` ✅
- `npm run format:check` ⚠️ blocked by existing parse failure in `.github/workflows/ci.yml` on the current baseline
- `CI=1 npm run test:ui:fast` ⚠️ blocked by the existing static preview server returning `500` at `/app/` and never launching Playwright in this environment
