### PR TITLE
refactor(api): extract agent activity service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -69,6 +69,7 @@ import { createDayPlanRouter } from "./routes/dayPlanRouter";
 import { createStaticPagesRouter } from "./routes/staticPagesRouter";
 import { createAdaptationRouter } from "./routes/adaptationRouter";
 import { createAgentActivityRouter } from "./routes/agentActivityRouter";
+import { AgentActivityService } from "./services/agentActivityService";
 import { DayPlanService } from "./services/dayPlanService";
 import { UserAdaptationService } from "./services/userAdaptationService";
 import { AdaptationLlmInferenceService } from "./services/adaptationLlmInference";
@@ -565,7 +566,8 @@ export function createApp(deps: AppDependencies = {}) {
       }),
     );
 
-    app.use(createAgentActivityRouter(persistencePrisma));
+    const agentActivityService = new AgentActivityService(persistencePrisma);
+    app.use(createAgentActivityRouter(agentActivityService));
   }
 
   app.use(errorHandler);

--- a/src/routes/agentActivityRouter.ts
+++ b/src/routes/agentActivityRouter.ts
@@ -1,56 +1,29 @@
-import { Router, Request, Response } from "express";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Router, Request, Response, NextFunction } from "express";
+import { AgentActivityService } from "../services/agentActivityService";
 
-interface ActivityRow {
-  agent_id: string;
-  job_name: string;
-  job_period_key: string;
-  narration: string;
-  metadata: Prisma.JsonValue;
-  created_at: Date;
-}
-
-export function createAgentActivityRouter(prisma: PrismaClient): Router {
+export function createAgentActivityRouter(
+  agentActivityService: AgentActivityService,
+): Router {
   const router = Router();
 
-  router.get("/agent-activity", async (req: Request, res: Response) => {
-    const userId = req.user?.userId;
-    if (!userId) {
-      res.status(401).json({ error: "Unauthorized" });
-      return;
-    }
+  router.get(
+    "/agent-activity",
+    async (req: Request, res: Response, next: NextFunction) => {
+      const userId = req.user?.userId;
+      if (!userId) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
 
-    const sevenDaysAgo = new Date();
-    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-
-    try {
-      const rows = await prisma.$queryRaw<ActivityRow[]>`
-        SELECT DISTINCT ON (agent_id, job_name, job_period_key)
-          agent_id, job_name, job_period_key, narration, metadata, created_at
-        FROM agent_action_audits
-        WHERE user_id = ${userId}
-          AND narration IS NOT NULL
-          AND created_at >= ${sevenDaysAgo}
-        ORDER BY agent_id, job_name, job_period_key, created_at DESC
-      `;
-
-      const entries = rows
-        .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
-        .map((row) => ({
-          agentId: row.agent_id,
-          jobName: row.job_name,
-          periodKey: row.job_period_key,
-          narration: row.narration,
-          metadata: row.metadata ?? {},
-          createdAt: row.created_at.toISOString(),
-        }));
-
-      res.json({ entries });
-    } catch (err) {
-      console.error("Failed to fetch agent activity:", err);
-      res.status(500).json({ error: "Internal server error" });
-    }
-  });
+      try {
+        res.json({
+          entries: await agentActivityService.listRecentActivity(userId),
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
 
   return router;
 }

--- a/src/services/agentActivityService.test.ts
+++ b/src/services/agentActivityService.test.ts
@@ -1,0 +1,58 @@
+import type { PrismaClient } from "@prisma/client";
+import { AgentActivityService } from "./agentActivityService";
+
+function createMockPrisma(overrides: Record<string, any> = {}): PrismaClient {
+  return {
+    $queryRaw: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+describe("AgentActivityService", () => {
+  it("maps recent activity rows into API entries and sorts newest-first", async () => {
+    const queryRaw = jest.fn().mockResolvedValue([
+      {
+        agent_id: "agent-b",
+        job_name: "daily",
+        job_period_key: "2026-04-18",
+        narration: "Second entry",
+        metadata: null,
+        created_at: new Date("2026-04-18T10:00:00.000Z"),
+      },
+      {
+        agent_id: "agent-a",
+        job_name: "inbox",
+        job_period_key: "2026-04-19",
+        narration: "Newest entry",
+        metadata: { source: "runner" },
+        created_at: new Date("2026-04-19T12:00:00.000Z"),
+      },
+    ]);
+    const service = new AgentActivityService(
+      createMockPrisma({ $queryRaw: queryRaw }),
+    );
+
+    await expect(service.listRecentActivity("user-1")).resolves.toEqual([
+      {
+        agentId: "agent-a",
+        jobName: "inbox",
+        periodKey: "2026-04-19",
+        narration: "Newest entry",
+        metadata: { source: "runner" },
+        createdAt: "2026-04-19T12:00:00.000Z",
+      },
+      {
+        agentId: "agent-b",
+        jobName: "daily",
+        periodKey: "2026-04-18",
+        narration: "Second entry",
+        metadata: {},
+        createdAt: "2026-04-18T10:00:00.000Z",
+      },
+    ]);
+
+    const [, userIdArg, dateArg] = queryRaw.mock.calls[0];
+    expect(userIdArg).toBe("user-1");
+    expect(dateArg).toBeInstanceOf(Date);
+  });
+});

--- a/src/services/agentActivityService.ts
+++ b/src/services/agentActivityService.ts
@@ -1,0 +1,49 @@
+import { PrismaClient, Prisma } from "@prisma/client";
+
+interface ActivityRow {
+  agent_id: string;
+  job_name: string;
+  job_period_key: string;
+  narration: string;
+  metadata: Prisma.JsonValue;
+  created_at: Date;
+}
+
+export interface AgentActivityEntry {
+  agentId: string;
+  jobName: string;
+  periodKey: string;
+  narration: string;
+  metadata: Prisma.JsonValue | Record<string, never>;
+  createdAt: string;
+}
+
+export class AgentActivityService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listRecentActivity(userId: string): Promise<AgentActivityEntry[]> {
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const rows = await this.prisma.$queryRaw<ActivityRow[]>`
+      SELECT DISTINCT ON (agent_id, job_name, job_period_key)
+        agent_id, job_name, job_period_key, narration, metadata, created_at
+      FROM agent_action_audits
+      WHERE user_id = ${userId}
+        AND narration IS NOT NULL
+        AND created_at >= ${sevenDaysAgo}
+      ORDER BY agent_id, job_name, job_period_key, created_at DESC
+    `;
+
+    return rows
+      .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+      .map((row) => ({
+        agentId: row.agent_id,
+        jobName: row.job_name,
+        periodKey: row.job_period_key,
+        narration: row.narration,
+        metadata: row.metadata ?? {},
+        createdAt: row.created_at.toISOString(),
+      }));
+  }
+}


### PR DESCRIPTION
## Summary
- extract `/agent-activity` persistence and mapping logic into `AgentActivityService`
- keep the router focused on auth, response shaping, and error delegation
- add focused service coverage for row mapping and newest-first ordering

## Architecture
- This is the first narrow follow-up slice from the closed broad route-service extraction PR.
- The router now coordinates request/user concerns only; the raw query and wire-shape mapping live in `src/services/agentActivityService.ts`.
- No API contract or schema changes.

## Verification
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅
- `npm run test:coverage:check` ✅
- `npm run format:check` ⚠️ existing repo baseline failure: Prettier cannot parse unchanged `.github/workflows/ci.yml`
- `CI=1 npm run test:ui:fast` ⚠️ existing local harness issue: `scripts/ui-static-server.mjs` serves `500 Internal Server Error` for `/app/`, causing the smoke run to stall before Playwright reports test results
