### PR TITLE
refactor(api): extract planning preferences service

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -28,5 +28,6 @@ module.exports = {
     "**/src/services/surfacePolicy.test.ts",
     "**/src/services/adaptationLlmInference.test.ts",
     "**/src/services/adaptationFlags.test.ts",
+    "**/src/services/planningPreferencesService.test.ts",
   ],
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,7 @@ import { createMcpPublicRouter } from "./routes/mcpPublicRouter";
 import { CaptureService } from "./services/captureService";
 import { createCaptureRouter } from "./routes/captureRouter";
 import { createPreferencesRouter } from "./routes/preferencesRouter";
+import { PlanningPreferencesService } from "./services/planningPreferencesService";
 import { createAgentEnrollmentRouter } from "./routes/agentEnrollmentRouter";
 import {
   createAgentProfileRouter,
@@ -492,7 +493,13 @@ export function createApp(deps: AppDependencies = {}) {
   }
 
   if (persistencePrisma) {
-    app.use("/preferences", createPreferencesRouter(persistencePrisma));
+    const planningPreferencesService = new PlanningPreferencesService(
+      persistencePrisma,
+    );
+    app.use(
+      "/preferences",
+      createPreferencesRouter(planningPreferencesService),
+    );
 
     const areaService = new AreaService(persistencePrisma);
     app.use(

--- a/src/routes/preferencesRouter.ts
+++ b/src/routes/preferencesRouter.ts
@@ -1,65 +1,10 @@
 import { Router, Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
+import { PlanningPreferencesService } from "../services/planningPreferencesService";
 
-const VALID_LIFE_AREAS = [
-  "work",
-  "personal",
-  "family",
-  "health",
-  "side_projects",
-] as const;
-const VALID_FAILURE_MODES = [
-  "overwhelmed",
-  "forgetful",
-  "perfectionist",
-  "overcommitted",
-  "inconsistent",
-] as const;
-const VALID_PLANNING_STYLES = ["structure", "flexibility", "both"] as const;
-const VALID_ENERGY_PATTERNS = [
-  "morning",
-  "afternoon",
-  "evening",
-  "variable",
-] as const;
-const VALID_GOOD_DAY_THEMES = [
-  "important_work",
-  "life_admin",
-  "avoid_overload",
-  "visible_progress",
-  "protect_rest",
-] as const;
-const VALID_TONES = ["calm", "focused", "encouraging", "direct"] as const;
-const VALID_DAILY_RITUALS = [
-  "morning_plan",
-  "evening_reset",
-  "both",
-  "neither",
-] as const;
-
-const soulDefaults = {
-  lifeAreas: [] as string[],
-  failureModes: [] as string[],
-  planningStyle: "both",
-  energyPattern: "variable",
-  goodDayThemes: [] as string[],
-  tone: "calm",
-  dailyRitual: "neither",
-};
-
-export function createPreferencesRouter(prisma: PrismaClient): Router {
+export function createPreferencesRouter(
+  planningPreferencesService: PlanningPreferencesService,
+): Router {
   const router = Router();
-
-  const defaults = {
-    maxDailyTasks: null,
-    preferredChunkMinutes: null,
-    deepWorkPreference: null,
-    weekendsActive: true,
-    preferredContexts: [] as string[],
-    waitingFollowUpDays: 7,
-    workWindowsJson: null,
-    soulProfile: { ...soulDefaults },
-  };
 
   router.get("/", async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -68,10 +13,7 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
         res.status(401).json({ error: "Unauthorized" });
         return;
       }
-      const prefs = await prisma.userPlanningPreferences.findUnique({
-        where: { userId },
-      });
-      res.json(prefs ? toDto(prefs) : { ...defaults });
+      res.json(await planningPreferencesService.getForUser(userId));
     } catch (error) {
       next(error);
     }
@@ -84,169 +26,13 @@ export function createPreferencesRouter(prisma: PrismaClient): Router {
         res.status(401).json({ error: "Unauthorized" });
         return;
       }
-
-      const existing = await prisma.userPlanningPreferences.findUnique({
-        where: { userId },
-      });
-      const update = buildUpdate(req.body, existing?.soulProfile ?? null);
-      const prefs = await prisma.userPlanningPreferences.upsert({
-        where: { userId },
-        create: { userId, ...update },
-        update,
-      });
-      res.json(toDto(prefs));
+      res.json(
+        await planningPreferencesService.updateForUser(userId, req.body),
+      );
     } catch (error) {
       next(error);
     }
   });
-
-  function buildUpdate(
-    body: Record<string, unknown>,
-    currentSoulProfile: unknown,
-  ) {
-    const update: Record<string, unknown> = {};
-    if (body.maxDailyTasks !== undefined) {
-      update.maxDailyTasks = body.maxDailyTasks;
-    }
-    if (body.preferredChunkMinutes !== undefined) {
-      update.preferredChunkMinutes = body.preferredChunkMinutes;
-    }
-    if (body.deepWorkPreference !== undefined) {
-      update.deepWorkPreference = body.deepWorkPreference;
-    }
-    if (body.weekendsActive !== undefined) {
-      update.weekendsActive = body.weekendsActive;
-    }
-    if (body.preferredContexts !== undefined) {
-      update.preferredContexts = body.preferredContexts;
-    }
-    if (body.waitingFollowUpDays !== undefined) {
-      update.waitingFollowUpDays = body.waitingFollowUpDays;
-    }
-    if (body.workWindowsJson !== undefined) {
-      update.workWindowsJson = body.workWindowsJson;
-    }
-    if (body.soulProfile !== undefined) {
-      update.soulProfile = mergeSoulProfile(
-        currentSoulProfile,
-        body.soulProfile,
-      );
-    }
-    return update;
-  }
-
-  function toStringList<T extends string>(
-    value: unknown,
-    valid: readonly T[],
-    maxItems: number,
-  ): T[] {
-    if (!Array.isArray(value)) return [];
-    return value
-      .map(
-        (item) =>
-          String(item || "")
-            .trim()
-            .toLowerCase() as T,
-      )
-      .filter(
-        (item, index, items) =>
-          !!item && valid.includes(item) && items.indexOf(item) === index,
-      )
-      .slice(0, maxItems);
-  }
-
-  function toEnumValue<T extends string>(
-    value: unknown,
-    valid: readonly T[],
-    fallback: T,
-  ): T {
-    const normalized = String(value || "")
-      .trim()
-      .toLowerCase() as T;
-    return valid.includes(normalized) ? normalized : fallback;
-  }
-
-  function mergeSoulProfile(current: unknown, incoming: unknown) {
-    const currentValue =
-      current && typeof current === "object"
-        ? (current as Record<string, unknown>)
-        : {};
-    const nextValue =
-      incoming && typeof incoming === "object"
-        ? (incoming as Record<string, unknown>)
-        : {};
-    return {
-      lifeAreas:
-        nextValue.lifeAreas !== undefined
-          ? toStringList(nextValue.lifeAreas, VALID_LIFE_AREAS, 6)
-          : toStringList(currentValue.lifeAreas, VALID_LIFE_AREAS, 6),
-      failureModes:
-        nextValue.failureModes !== undefined
-          ? toStringList(nextValue.failureModes, VALID_FAILURE_MODES, 6)
-          : toStringList(currentValue.failureModes, VALID_FAILURE_MODES, 6),
-      planningStyle:
-        nextValue.planningStyle !== undefined
-          ? toEnumValue(nextValue.planningStyle, VALID_PLANNING_STYLES, "both")
-          : toEnumValue(
-              currentValue.planningStyle,
-              VALID_PLANNING_STYLES,
-              soulDefaults.planningStyle,
-            ),
-      energyPattern:
-        nextValue.energyPattern !== undefined
-          ? toEnumValue(
-              nextValue.energyPattern,
-              VALID_ENERGY_PATTERNS,
-              "variable",
-            )
-          : toEnumValue(
-              currentValue.energyPattern,
-              VALID_ENERGY_PATTERNS,
-              soulDefaults.energyPattern,
-            ),
-      goodDayThemes:
-        nextValue.goodDayThemes !== undefined
-          ? toStringList(nextValue.goodDayThemes, VALID_GOOD_DAY_THEMES, 6)
-          : toStringList(currentValue.goodDayThemes, VALID_GOOD_DAY_THEMES, 6),
-      tone:
-        nextValue.tone !== undefined
-          ? toEnumValue(nextValue.tone, VALID_TONES, "calm")
-          : toEnumValue(currentValue.tone, VALID_TONES, soulDefaults.tone),
-      dailyRitual:
-        nextValue.dailyRitual !== undefined
-          ? toEnumValue(nextValue.dailyRitual, VALID_DAILY_RITUALS, "neither")
-          : toEnumValue(
-              currentValue.dailyRitual,
-              VALID_DAILY_RITUALS,
-              soulDefaults.dailyRitual,
-            ),
-    };
-  }
-
-  function toDto(p: {
-    maxDailyTasks: number | null;
-    preferredChunkMinutes: number | null;
-    deepWorkPreference: string | null;
-    weekendsActive: boolean;
-    preferredContexts: string[];
-    waitingFollowUpDays: number;
-    workWindowsJson: unknown;
-    soulProfile: unknown;
-  }) {
-    return {
-      maxDailyTasks: p.maxDailyTasks,
-      preferredChunkMinutes: p.preferredChunkMinutes,
-      deepWorkPreference: p.deepWorkPreference,
-      weekendsActive: p.weekendsActive,
-      preferredContexts: p.preferredContexts,
-      waitingFollowUpDays: p.waitingFollowUpDays,
-      workWindowsJson: p.workWindowsJson,
-      soulProfile: {
-        ...soulDefaults,
-        ...mergeSoulProfile(null, p.soulProfile),
-      },
-    };
-  }
 
   return router;
 }

--- a/src/services/planningPreferencesService.test.ts
+++ b/src/services/planningPreferencesService.test.ts
@@ -1,0 +1,105 @@
+import type { PrismaClient } from "@prisma/client";
+import { PlanningPreferencesService } from "./planningPreferencesService";
+
+function createMockPrisma(
+  overrides: Record<string, unknown> = {},
+): PrismaClient {
+  return {
+    userPlanningPreferences: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      upsert: jest.fn(),
+    },
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+describe("PlanningPreferencesService", () => {
+  it("returns defaults when a user has no saved preferences", async () => {
+    const service = new PlanningPreferencesService(createMockPrisma());
+
+    await expect(service.getForUser("user-1")).resolves.toEqual({
+      maxDailyTasks: null,
+      preferredChunkMinutes: null,
+      deepWorkPreference: null,
+      weekendsActive: true,
+      preferredContexts: [],
+      waitingFollowUpDays: 7,
+      workWindowsJson: null,
+      soulProfile: {
+        lifeAreas: [],
+        failureModes: [],
+        planningStyle: "both",
+        energyPattern: "variable",
+        goodDayThemes: [],
+        tone: "calm",
+        dailyRitual: "neither",
+      },
+    });
+  });
+
+  it("sanitizes and merges soul profile updates before upserting", async () => {
+    const findUnique = jest.fn().mockResolvedValue({
+      soulProfile: {
+        tone: "focused",
+        lifeAreas: ["work"],
+        planningStyle: "flexibility",
+      },
+    });
+    const upsert = jest.fn().mockImplementation(({ create }) =>
+      Promise.resolve({
+        id: "pref-1",
+        userId: create.userId,
+        maxDailyTasks: null,
+        preferredChunkMinutes: null,
+        deepWorkPreference: null,
+        weekendsActive: true,
+        preferredContexts: [],
+        waitingFollowUpDays: 7,
+        workWindowsJson: null,
+        soulProfile: create.soulProfile,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      }),
+    );
+    const service = new PlanningPreferencesService(
+      createMockPrisma({
+        userPlanningPreferences: { findUnique, upsert },
+      }),
+    );
+
+    const result = await service.updateForUser("user-1", {
+      soulProfile: {
+        tone: "LOUD",
+        planningStyle: "Structure",
+        lifeAreas: ["work", "health", "work", "invalid"],
+      },
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1" },
+        create: expect.objectContaining({
+          userId: "user-1",
+          soulProfile: {
+            tone: "calm",
+            planningStyle: "structure",
+            lifeAreas: ["work", "health"],
+            failureModes: [],
+            energyPattern: "variable",
+            goodDayThemes: [],
+            dailyRitual: "neither",
+          },
+        }),
+      }),
+    );
+    expect(result.soulProfile).toEqual({
+      tone: "calm",
+      planningStyle: "structure",
+      lifeAreas: ["work", "health"],
+      failureModes: [],
+      energyPattern: "variable",
+      goodDayThemes: [],
+      dailyRitual: "neither",
+    });
+  });
+});

--- a/src/services/planningPreferencesService.ts
+++ b/src/services/planningPreferencesService.ts
@@ -1,0 +1,263 @@
+import { PrismaClient, UserPlanningPreferences } from "@prisma/client";
+
+const VALID_LIFE_AREAS = [
+  "work",
+  "personal",
+  "family",
+  "health",
+  "side_projects",
+] as const;
+const VALID_FAILURE_MODES = [
+  "overwhelmed",
+  "forgetful",
+  "perfectionist",
+  "overcommitted",
+  "inconsistent",
+] as const;
+const VALID_PLANNING_STYLES = ["structure", "flexibility", "both"] as const;
+const VALID_ENERGY_PATTERNS = [
+  "morning",
+  "afternoon",
+  "evening",
+  "variable",
+] as const;
+const VALID_GOOD_DAY_THEMES = [
+  "important_work",
+  "life_admin",
+  "avoid_overload",
+  "visible_progress",
+  "protect_rest",
+] as const;
+const VALID_TONES = ["calm", "focused", "encouraging", "direct"] as const;
+const VALID_DAILY_RITUALS = [
+  "morning_plan",
+  "evening_reset",
+  "both",
+  "neither",
+] as const;
+
+const soulDefaults = {
+  lifeAreas: [] as string[],
+  failureModes: [] as string[],
+  planningStyle: "both",
+  energyPattern: "variable",
+  goodDayThemes: [] as string[],
+  tone: "calm",
+  dailyRitual: "neither",
+};
+
+export interface SoulProfileDto {
+  lifeAreas: string[];
+  failureModes: string[];
+  planningStyle: string;
+  energyPattern: string;
+  goodDayThemes: string[];
+  tone: string;
+  dailyRitual: string;
+}
+
+export interface PlanningPreferencesDto {
+  maxDailyTasks: number | null;
+  preferredChunkMinutes: number | null;
+  deepWorkPreference: string | null;
+  weekendsActive: boolean;
+  preferredContexts: string[];
+  waitingFollowUpDays: number;
+  workWindowsJson: unknown;
+  soulProfile: SoulProfileDto;
+}
+
+const defaults: PlanningPreferencesDto = {
+  maxDailyTasks: null,
+  preferredChunkMinutes: null,
+  deepWorkPreference: null,
+  weekendsActive: true,
+  preferredContexts: [] as string[],
+  waitingFollowUpDays: 7,
+  workWindowsJson: null,
+  soulProfile: { ...soulDefaults },
+};
+
+export class PlanningPreferencesService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getForUser(userId: string): Promise<PlanningPreferencesDto> {
+    const prefs = await this.prisma.userPlanningPreferences.findUnique({
+      where: { userId },
+    });
+
+    return prefs ? this.toDto(prefs) : { ...defaults };
+  }
+
+  async updateForUser(
+    userId: string,
+    body: Record<string, unknown>,
+  ): Promise<PlanningPreferencesDto> {
+    const existing = await this.prisma.userPlanningPreferences.findUnique({
+      where: { userId },
+    });
+    const update = this.buildUpdate(body, existing?.soulProfile ?? null);
+    const prefs = await this.prisma.userPlanningPreferences.upsert({
+      where: { userId },
+      create: { userId, ...update },
+      update,
+    });
+
+    return this.toDto(prefs);
+  }
+
+  private buildUpdate(
+    body: Record<string, unknown>,
+    currentSoulProfile: unknown,
+  ) {
+    const update: Record<string, unknown> = {};
+    if (body.maxDailyTasks !== undefined) {
+      update.maxDailyTasks = body.maxDailyTasks;
+    }
+    if (body.preferredChunkMinutes !== undefined) {
+      update.preferredChunkMinutes = body.preferredChunkMinutes;
+    }
+    if (body.deepWorkPreference !== undefined) {
+      update.deepWorkPreference = body.deepWorkPreference;
+    }
+    if (body.weekendsActive !== undefined) {
+      update.weekendsActive = body.weekendsActive;
+    }
+    if (body.preferredContexts !== undefined) {
+      update.preferredContexts = body.preferredContexts;
+    }
+    if (body.waitingFollowUpDays !== undefined) {
+      update.waitingFollowUpDays = body.waitingFollowUpDays;
+    }
+    if (body.workWindowsJson !== undefined) {
+      update.workWindowsJson = body.workWindowsJson;
+    }
+    if (body.soulProfile !== undefined) {
+      update.soulProfile = this.mergeSoulProfile(
+        currentSoulProfile,
+        body.soulProfile,
+      );
+    }
+    return update;
+  }
+
+  private toStringList<T extends string>(
+    value: unknown,
+    valid: readonly T[],
+    maxItems: number,
+  ): T[] {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map(
+        (item) =>
+          String(item || "")
+            .trim()
+            .toLowerCase() as T,
+      )
+      .filter(
+        (item, index, items) =>
+          !!item && valid.includes(item) && items.indexOf(item) === index,
+      )
+      .slice(0, maxItems);
+  }
+
+  private toEnumValue<T extends string>(
+    value: unknown,
+    valid: readonly T[],
+    fallback: T,
+  ): T {
+    const normalized = String(value || "")
+      .trim()
+      .toLowerCase() as T;
+    return valid.includes(normalized) ? normalized : fallback;
+  }
+
+  private mergeSoulProfile(current: unknown, incoming: unknown) {
+    const currentValue =
+      current && typeof current === "object"
+        ? (current as Record<string, unknown>)
+        : {};
+    const nextValue =
+      incoming && typeof incoming === "object"
+        ? (incoming as Record<string, unknown>)
+        : {};
+    return {
+      lifeAreas:
+        nextValue.lifeAreas !== undefined
+          ? this.toStringList(nextValue.lifeAreas, VALID_LIFE_AREAS, 6)
+          : this.toStringList(currentValue.lifeAreas, VALID_LIFE_AREAS, 6),
+      failureModes:
+        nextValue.failureModes !== undefined
+          ? this.toStringList(nextValue.failureModes, VALID_FAILURE_MODES, 6)
+          : this.toStringList(
+              currentValue.failureModes,
+              VALID_FAILURE_MODES,
+              6,
+            ),
+      planningStyle:
+        nextValue.planningStyle !== undefined
+          ? this.toEnumValue(
+              nextValue.planningStyle,
+              VALID_PLANNING_STYLES,
+              "both",
+            )
+          : this.toEnumValue(
+              currentValue.planningStyle,
+              VALID_PLANNING_STYLES,
+              soulDefaults.planningStyle,
+            ),
+      energyPattern:
+        nextValue.energyPattern !== undefined
+          ? this.toEnumValue(
+              nextValue.energyPattern,
+              VALID_ENERGY_PATTERNS,
+              "variable",
+            )
+          : this.toEnumValue(
+              currentValue.energyPattern,
+              VALID_ENERGY_PATTERNS,
+              soulDefaults.energyPattern,
+            ),
+      goodDayThemes:
+        nextValue.goodDayThemes !== undefined
+          ? this.toStringList(nextValue.goodDayThemes, VALID_GOOD_DAY_THEMES, 6)
+          : this.toStringList(
+              currentValue.goodDayThemes,
+              VALID_GOOD_DAY_THEMES,
+              6,
+            ),
+      tone:
+        nextValue.tone !== undefined
+          ? this.toEnumValue(nextValue.tone, VALID_TONES, "calm")
+          : this.toEnumValue(currentValue.tone, VALID_TONES, soulDefaults.tone),
+      dailyRitual:
+        nextValue.dailyRitual !== undefined
+          ? this.toEnumValue(
+              nextValue.dailyRitual,
+              VALID_DAILY_RITUALS,
+              "neither",
+            )
+          : this.toEnumValue(
+              currentValue.dailyRitual,
+              VALID_DAILY_RITUALS,
+              soulDefaults.dailyRitual,
+            ),
+    };
+  }
+
+  private toDto(prefs: UserPlanningPreferences): PlanningPreferencesDto {
+    return {
+      maxDailyTasks: prefs.maxDailyTasks,
+      preferredChunkMinutes: prefs.preferredChunkMinutes,
+      deepWorkPreference: prefs.deepWorkPreference,
+      weekendsActive: prefs.weekendsActive,
+      preferredContexts: prefs.preferredContexts,
+      waitingFollowUpDays: prefs.waitingFollowUpDays,
+      workWindowsJson: prefs.workWindowsJson,
+      soulProfile: {
+        ...soulDefaults,
+        ...this.mergeSoulProfile(null, prefs.soulProfile),
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- extract `/preferences` persistence and soul-profile normalization into `PlanningPreferencesService`
- keep `preferencesRouter` focused on auth, HTTP orchestration, and error delegation
- add focused unit coverage for defaults plus soul-profile sanitization/merge behavior

## Architecture
- This is the second narrow follow-up slice from the closed broad route-service extraction PR.
- The router no longer owns Prisma lookups, upsert logic, or DTO shaping.
- `jest.unit.config.js` now includes the new service unit test so the coverage gate actually exercises the new service.
- No API contract changes.

## Verification
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅
- `npm run test:coverage:check` ✅
- `NODE_ENV=test npx jest --runInBand --testPathPatterns=src/preferences.api.integration.test.ts` ✅
- `npm run format:check` ⚠️ existing repo baseline failure: Prettier cannot parse unchanged `.github/workflows/ci.yml`
- `CI=1 npm run test:ui:fast` ⚠️ existing local harness issue: `scripts/ui-static-server.mjs` serves `500 Internal Server Error` for `/app/`, so the smoke runner never gets to a Playwright browser process
