### PR TITLE
refactor(api): extract adaptation project inference service

### DIFF
--- a/jest.unit.config.js
+++ b/jest.unit.config.js
@@ -29,5 +29,6 @@ module.exports = {
     "**/src/services/adaptationLlmInference.test.ts",
     "**/src/services/adaptationFlags.test.ts",
     "**/src/services/planningPreferencesService.test.ts",
+    "**/src/services/adaptationProjectInferenceService.test.ts",
   ],
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -74,6 +74,7 @@ import { AgentActivityService } from "./services/agentActivityService";
 import { DayPlanService } from "./services/dayPlanService";
 import { UserAdaptationService } from "./services/userAdaptationService";
 import { AdaptationLlmInferenceService } from "./services/adaptationLlmInference";
+import { AdaptationProjectInferenceService } from "./services/adaptationProjectInferenceService";
 import { AreaService } from "./services/areaService";
 import { GoalService } from "./services/goalService";
 import {
@@ -554,12 +555,16 @@ export function createApp(deps: AppDependencies = {}) {
       activityEventService,
     );
     const llmInferenceService = new AdaptationLlmInferenceService();
+    const projectInferenceService = new AdaptationProjectInferenceService(
+      persistencePrisma,
+      adaptationService,
+      llmInferenceService,
+    );
     app.use(
       "/adaptation",
       createAdaptationRouter({
         adaptationService,
-        llmInferenceService,
-        prisma: persistencePrisma,
+        projectInferenceService,
         resolveUserId: resolveAiUserId,
       }),
     );

--- a/src/routes/adaptationRouter.ts
+++ b/src/routes/adaptationRouter.ts
@@ -1,7 +1,6 @@
 import { Router, Request, Response, NextFunction } from "express";
-import { PrismaClient } from "@prisma/client";
 import { UserAdaptationService } from "../services/userAdaptationService";
-import { AdaptationLlmInferenceService } from "../services/adaptationLlmInference";
+import { AdaptationProjectInferenceService } from "../services/adaptationProjectInferenceService";
 import {
   AdaptationFlags,
   getDefaultFlags,
@@ -16,8 +15,7 @@ const log = createLogger("adaptationRouter");
 
 interface AdaptationRouterDeps {
   adaptationService: UserAdaptationService;
-  llmInferenceService?: AdaptationLlmInferenceService;
-  prisma?: PrismaClient;
+  projectInferenceService?: AdaptationProjectInferenceService;
   flags?: AdaptationFlags;
   resolveUserId: (req: Request, res: Response) => string | null;
 }
@@ -26,8 +24,7 @@ interface AdaptationRouterDeps {
 
 export function createAdaptationRouter({
   adaptationService,
-  llmInferenceService,
-  prisma,
+  projectInferenceService,
   flags,
   resolveUserId,
 }: AdaptationRouterDeps): Router {
@@ -132,78 +129,18 @@ export function createAdaptationRouter({
           return res.status(400).json({ error: "Invalid project ID" });
         }
 
-        if (!llmInferenceService || !prisma) {
+        if (!projectInferenceService) {
           return res.status(503).json({
             error: "LLM inference not configured",
             inference: null,
           });
         }
 
-        // Fetch project data for inference
-        const project = await prisma.project.findFirst({
-          where: { id: projectId, userId },
-          select: {
-            id: true,
-            name: true,
-            description: true,
-            targetDate: true,
-            createdAt: true,
-          },
-        });
-
-        if (!project) {
-          return res.status(404).json({ error: "Project not found" });
-        }
-
-        // Fetch tasks and headings
-        const [todos, headings] = await Promise.all([
-          prisma.todo.findMany({
-            where: { userId, projectId, archived: false },
-            select: { title: true, headingId: true, dueDate: true },
-            take: 50,
-          }),
-          prisma.heading.findMany({
-            where: { projectId },
-            select: { name: true },
-          }),
-        ]);
-
-        // Check behavioral confidence — only use LLM when low
-        const profileResult =
-          await adaptationService.getOrCreateProfile(userId);
-        if (profileResult.profile.confidence >= 0.4) {
-          // Behavioral data is sufficient — don't use LLM
-          return res.json({
-            inference: null,
-            reason: "behavioral confidence sufficient — LLM inference skipped",
-            behavioralConfidence: profileResult.profile.confidence,
-          });
-        }
-
-        // Run LLM inference
-        const inference = await llmInferenceService.inferProjectIntent({
-          projectName: project.name,
-          projectDescription: project.description,
-          taskTitles: todos.map((t) => t.title),
-          existingSectionNames: headings.map((h) => h.name),
-        });
-
-        log.info("Soft inference result", {
+        const result = await projectInferenceService.getSoftInference(
           userId,
           projectId,
-          projectName: project.name,
-          behavioralConfidence: profileResult.profile.confidence,
-          llmConfidence: inference?.confidence ?? 0,
-          inferredType: inference?.inferredProjectType,
-        });
-
-        res.json({
-          inference,
-          reason: inference
-            ? "llm soft inference"
-            : "llm provider not available",
-          behavioralConfidence: profileResult.profile.confidence,
-        });
+        );
+        res.status(result.status).json(result.body);
       } catch (error) {
         next(error);
       }

--- a/src/services/adaptationProjectInferenceService.test.ts
+++ b/src/services/adaptationProjectInferenceService.test.ts
@@ -1,0 +1,129 @@
+import type { PrismaClient } from "@prisma/client";
+import { AdaptationProjectInferenceService } from "./adaptationProjectInferenceService";
+
+function createMockPrisma(
+  overrides: Record<string, unknown> = {},
+): PrismaClient {
+  return {
+    project: { findFirst: jest.fn() },
+    todo: { findMany: jest.fn() },
+    heading: { findMany: jest.fn() },
+    ...overrides,
+  } as unknown as PrismaClient;
+}
+
+describe("AdaptationProjectInferenceService", () => {
+  it("returns 404 when the project is missing", async () => {
+    const service = new AdaptationProjectInferenceService(
+      createMockPrisma({
+        project: { findFirst: jest.fn().mockResolvedValue(null) },
+      }),
+      { getOrCreateProfile: jest.fn() } as any,
+      { inferProjectIntent: jest.fn() } as any,
+    );
+
+    await expect(
+      service.getSoftInference("user-1", "project-1"),
+    ).resolves.toEqual({
+      status: 404,
+      body: { error: "Project not found" },
+    });
+  });
+
+  it("skips todo and heading fetches when behavioral confidence is already high", async () => {
+    const projectFindFirst = jest.fn().mockResolvedValue({
+      id: "project-1",
+      name: "Project",
+      description: "Description",
+      targetDate: null,
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    const todoFindMany = jest.fn();
+    const headingFindMany = jest.fn();
+    const getOrCreateProfile = jest.fn().mockResolvedValue({
+      profile: { confidence: 0.82 },
+    });
+    const inferProjectIntent = jest.fn();
+    const service = new AdaptationProjectInferenceService(
+      createMockPrisma({
+        project: { findFirst: projectFindFirst },
+        todo: { findMany: todoFindMany },
+        heading: { findMany: headingFindMany },
+      }),
+      { getOrCreateProfile } as any,
+      { inferProjectIntent } as any,
+    );
+
+    await expect(
+      service.getSoftInference("user-1", "project-1"),
+    ).resolves.toEqual({
+      status: 200,
+      body: {
+        inference: null,
+        reason: "behavioral confidence sufficient — LLM inference skipped",
+        behavioralConfidence: 0.82,
+      },
+    });
+    expect(todoFindMany).not.toHaveBeenCalled();
+    expect(headingFindMany).not.toHaveBeenCalled();
+    expect(inferProjectIntent).not.toHaveBeenCalled();
+  });
+
+  it("loads project context and returns soft inference when behavioral confidence is low", async () => {
+    const inferProjectIntent = jest.fn().mockResolvedValue({
+      inferredProjectType: "commitment",
+      confidence: 0.61,
+    });
+    const service = new AdaptationProjectInferenceService(
+      createMockPrisma({
+        project: {
+          findFirst: jest.fn().mockResolvedValue({
+            id: "project-1",
+            name: "Launch plan",
+            description: "Coordinate the rollout",
+            targetDate: null,
+            createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          }),
+        },
+        todo: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              title: "Write launch checklist",
+              headingId: null,
+              dueDate: null,
+            },
+          ]),
+        },
+        heading: {
+          findMany: jest.fn().mockResolvedValue([{ name: "Milestones" }]),
+        },
+      }),
+      {
+        getOrCreateProfile: jest
+          .fn()
+          .mockResolvedValue({ profile: { confidence: 0.18 } }),
+      } as any,
+      { inferProjectIntent } as any,
+    );
+
+    await expect(
+      service.getSoftInference("user-1", "project-1"),
+    ).resolves.toEqual({
+      status: 200,
+      body: {
+        inference: {
+          inferredProjectType: "commitment",
+          confidence: 0.61,
+        },
+        reason: "llm soft inference",
+        behavioralConfidence: 0.18,
+      },
+    });
+    expect(inferProjectIntent).toHaveBeenCalledWith({
+      projectName: "Launch plan",
+      projectDescription: "Coordinate the rollout",
+      taskTitles: ["Write launch checklist"],
+      existingSectionNames: ["Milestones"],
+    });
+  });
+});

--- a/src/services/adaptationProjectInferenceService.ts
+++ b/src/services/adaptationProjectInferenceService.ts
@@ -1,0 +1,92 @@
+import { PrismaClient } from "@prisma/client";
+import { createLogger } from "../infra/logging/logger";
+import { AdaptationLlmInferenceService } from "./adaptationLlmInference";
+import { UserAdaptationService } from "./userAdaptationService";
+
+const log = createLogger("adaptationProjectInferenceService");
+
+export interface AdaptationProjectInferenceResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export class AdaptationProjectInferenceService {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly adaptationService: UserAdaptationService,
+    private readonly llmInferenceService: AdaptationLlmInferenceService,
+  ) {}
+
+  async getSoftInference(
+    userId: string,
+    projectId: string,
+  ): Promise<AdaptationProjectInferenceResult> {
+    const project = await this.prisma.project.findFirst({
+      where: { id: projectId, userId },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        targetDate: true,
+        createdAt: true,
+      },
+    });
+
+    if (!project) {
+      return {
+        status: 404,
+        body: { error: "Project not found" },
+      };
+    }
+
+    const profileResult =
+      await this.adaptationService.getOrCreateProfile(userId);
+    if (profileResult.profile.confidence >= 0.4) {
+      return {
+        status: 200,
+        body: {
+          inference: null,
+          reason: "behavioral confidence sufficient — LLM inference skipped",
+          behavioralConfidence: profileResult.profile.confidence,
+        },
+      };
+    }
+
+    const [todos, headings] = await Promise.all([
+      this.prisma.todo.findMany({
+        where: { userId, projectId, archived: false },
+        select: { title: true, headingId: true, dueDate: true },
+        take: 50,
+      }),
+      this.prisma.heading.findMany({
+        where: { projectId },
+        select: { name: true },
+      }),
+    ]);
+
+    const inference = await this.llmInferenceService.inferProjectIntent({
+      projectName: project.name,
+      projectDescription: project.description,
+      taskTitles: todos.map((todo) => todo.title),
+      existingSectionNames: headings.map((heading) => heading.name),
+    });
+
+    log.info("Soft inference result", {
+      userId,
+      projectId,
+      projectName: project.name,
+      behavioralConfidence: profileResult.profile.confidence,
+      llmConfidence: inference?.confidence ?? 0,
+      inferredType: inference?.inferredProjectType,
+    });
+
+    return {
+      status: 200,
+      body: {
+        inference,
+        reason: inference ? "llm soft inference" : "llm provider not available",
+        behavioralConfidence: profileResult.profile.confidence,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- extract `/adaptation/projects/:projectId/soft-inference` persistence + LLM orchestration into `AdaptationProjectInferenceService`
- keep `adaptationRouter` focused on auth/param handling and HTTP response wiring
- add focused unit coverage for missing-project, high-confidence short-circuit, and low-confidence inference paths

## Architecture
- This is the third narrow follow-up slice from the closed broad route-service extraction PR.
- The service preserves the existing API shape while improving the query order: it now checks behavioral confidence before loading todos/headings, so high-confidence users skip those extra queries.
- `jest.unit.config.js` now includes the new adaptation inference service test.
- No API contract changes.

## Verification
- `npx tsc --noEmit` ✅
- `npm run test:unit` ✅
- `npm run test:coverage:check` ✅
- `NODE_ENV=test npx jest --runInBand --testPathPatterns=src/adaptation.api.integration.test.ts` ✅
- `npm run format:check` ⚠️ existing repo baseline failure: Prettier cannot parse unchanged `.github/workflows/ci.yml`
- `CI=1 npm run test:ui:fast` ⚠️ existing local harness issue: `scripts/ui-static-server.mjs` serves `500 Internal Server Error` for `/app/`, so the smoke runner never reaches a Playwright browser process
