### PR TITLE
PR 4: Board mobile + status palette + density polish

### DIFF
--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -289,25 +289,29 @@ export function ListViewHeader({
                 )}
               </button>
             </Tooltip>
-            {filtersOpen && filtersButtonRef.current && (() => {
-              const rect = filtersButtonRef.current!.getBoundingClientRect();
-              return (
-                <div
-                  className="filter-menu__panel"
-                  style={{
-                    position: "fixed",
-                    top: rect.bottom + 8,
-                    right: window.innerWidth - rect.right,
-                  } as CSSProperties}
-                >
-                  <FilterPanel
-                    filters={activeFilters}
-                    onChange={onFilterChange}
-                    onClose={onToggleFilters}
-                  />
-                </div>
-              );
-            })()}
+            {filtersOpen &&
+              filtersButtonRef.current &&
+              (() => {
+                const rect = filtersButtonRef.current!.getBoundingClientRect();
+                return (
+                  <div
+                    className="filter-menu__panel"
+                    style={
+                      {
+                        position: "fixed",
+                        top: rect.bottom + 8,
+                        right: window.innerWidth - rect.right,
+                      } as CSSProperties
+                    }
+                  >
+                    <FilterPanel
+                      filters={activeFilters}
+                      onChange={onFilterChange}
+                      onClose={onToggleFilters}
+                    />
+                  </div>
+                );
+              })()}
           </div>
           <Tooltip content={dark ? "Light mode" : "Dark mode"}>
             <button
@@ -331,21 +335,63 @@ export function ListViewHeader({
         </header>
       )}
 
-      {user && !user.isVerified && (
-        <VerificationBanner email={user.email} isVerified={!!user.isVerified} />
-      )}
+      {/* Banner stack — only one banner ever renders. Priority order:
+          VerificationBanner > active-filter > today-coaching. The lower
+          priority banners are suppressed (rather than dismissed) so the
+          user can still act on the highest-priority signal first. */}
+      {(() => {
+        const showVerification = !!user && !user.isVerified;
+        const showActiveFilter = !showVerification && !!activeTagFilter;
+        const overdueToday =
+          activeView === "today" && !selectedProjectId
+            ? visibleTodos.filter(
+                (t) =>
+                  t.dueDate &&
+                  t.dueDate.split("T")[0] <
+                    new Date().toISOString().split("T")[0],
+              ).length
+            : 0;
+        const showTodayCoaching =
+          !showVerification &&
+          !showActiveFilter &&
+          visibleTodos.length > 0 &&
+          overdueToday > 0;
 
-      {activeTagFilter && (
-        <div className="active-filter-bar">
-          Filtered by tag: <strong>#{activeTagFilter}</strong>
-          <button
-            className="active-filter-bar__clear"
-            onClick={onClearTagFilter}
-          >
-            ✕ Clear
-          </button>
-        </div>
-      )}
+        if (showVerification && user) {
+          return (
+            <VerificationBanner
+              email={user.email}
+              isVerified={!!user.isVerified}
+            />
+          );
+        }
+        if (showActiveFilter) {
+          return (
+            <div className="active-filter-bar">
+              Filtered by tag: <strong>#{activeTagFilter}</strong>
+              <button
+                className="active-filter-bar__clear"
+                onClick={onClearTagFilter}
+              >
+                ✕ Clear
+              </button>
+            </div>
+          );
+        }
+        if (showTodayCoaching) {
+          return (
+            <div className="today-coaching-banner">
+              <span>
+                {overdueToday === 1
+                  ? "1 task rolled over."
+                  : `${overdueToday} tasks rolled over.`}{" "}
+                Let&apos;s make the day smaller.
+              </span>
+            </div>
+          );
+        }
+        return null;
+      })()}
 
       {showHorizonSegments && (
         <SegmentedControl
@@ -357,7 +403,9 @@ export function ListViewHeader({
             value: key,
             label,
             buttonId: `horizonSegment${label}`,
-            badge: horizonSegmentCounts?.[key] ? horizonSegmentCounts[key] : undefined,
+            badge: horizonSegmentCounts?.[key]
+              ? horizonSegmentCounts[key]
+              : undefined,
           }))}
         />
       )}
@@ -374,28 +422,6 @@ export function ListViewHeader({
             />
           </div>
         )}
-
-      {/* Today view coaching */}
-      {activeView === "today" &&
-        !selectedProjectId &&
-        visibleTodos.length > 0 &&
-        (() => {
-          const overdue = visibleTodos.filter(
-            (t) =>
-              t.dueDate &&
-              t.dueDate.split("T")[0] < new Date().toISOString().split("T")[0],
-          ).length;
-          return overdue > 0 ? (
-            <div className="today-coaching-banner">
-              <span>
-                {overdue === 1
-                  ? "1 task rolled over."
-                  : `${overdue} tasks rolled over.`}{" "}
-                Let&apos;s make the day smaller.
-              </span>
-            </div>
-          ) : null;
-        })()}
 
       {/* Bulk actions toolbar */}
       {bulkMode && (

--- a/client-react/src/components/todos/BoardView.statusPalette.test.tsx
+++ b/client-react/src/components/todos/BoardView.statusPalette.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { BoardView } from "./BoardView";
+
+vi.mock("../shared/Illustrations", () => ({
+  IllustrationBoardEmpty: () =>
+    createElement("div", { "data-testid": "empty" }),
+}));
+
+const defaultProps = {
+  todos: [],
+  loadState: "loaded" as const,
+  onToggle: vi.fn(),
+  onClick: vi.fn(),
+  onStatusChange: vi.fn(),
+};
+
+describe("BoardView status palette", () => {
+  it("paints each column dot with the matching status token", () => {
+    const { container } = render(createElement(BoardView, defaultProps));
+    const expected: Record<string, string> = {
+      inbox: "var(--status-inbox)",
+      next: "var(--status-next)",
+      in_progress: "var(--status-in-progress)",
+      waiting: "var(--status-waiting)",
+      done: "var(--status-done)",
+    };
+    for (const [status, token] of Object.entries(expected)) {
+      const column = container.querySelector(
+        `.board__column[data-status="${status}"]`,
+      );
+      expect(column, `expected column for ${status}`).toBeTruthy();
+      const dot = column!.querySelector(".board__column-dot") as HTMLElement;
+      expect(dot.style.background).toContain(token);
+    }
+  });
+
+  it("collapses a column body when its collapse button is clicked", () => {
+    const { container } = render(createElement(BoardView, defaultProps));
+    const inbox = container.querySelector(
+      '.board__column[data-status="inbox"]',
+    ) as HTMLElement;
+    expect(inbox.querySelector(".board__column-body")).toBeTruthy();
+    const button = inbox.querySelector(
+      ".board__column-collapse",
+    ) as HTMLButtonElement;
+    fireEvent.click(button);
+    expect(inbox.querySelector(".board__column-body")).toBeNull();
+  });
+});

--- a/client-react/src/components/todos/BoardView.tsx
+++ b/client-react/src/components/todos/BoardView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import type { Todo, TodoStatus, UpdateTodoDto } from "../../types";
 import type { LoadState } from "../../store/useTodosStore";
 import { IllustrationBoardEmpty } from "../shared/Illustrations";
@@ -12,12 +12,22 @@ interface Props {
   onStatusChange: (id: string, dto: UpdateTodoDto) => Promise<unknown>;
 }
 
-const BOARD_COLUMNS: { status: TodoStatus; label: string; color: string }[] = [
-  { status: "inbox", label: "Inbox", color: "var(--muted)" },
-  { status: "next", label: "Next", color: "var(--accent)" },
-  { status: "in_progress", label: "In Progress", color: "var(--warning)" },
-  { status: "waiting", label: "Waiting", color: "var(--muted)" },
-  { status: "done", label: "Done", color: "var(--success)" },
+interface BoardColumn {
+  status: TodoStatus;
+  label: string;
+  token: string;
+}
+
+const BOARD_COLUMNS: ReadonlyArray<BoardColumn> = [
+  { status: "inbox", label: "Inbox", token: "var(--status-inbox)" },
+  { status: "next", label: "Next", token: "var(--status-next)" },
+  {
+    status: "in_progress",
+    label: "In Progress",
+    token: "var(--status-in-progress)",
+  },
+  { status: "waiting", label: "Waiting", token: "var(--status-waiting)" },
+  { status: "done", label: "Done", token: "var(--status-done)" },
 ];
 
 export function BoardView({
@@ -27,6 +37,10 @@ export function BoardView({
   onClick,
   onStatusChange,
 }: Props) {
+  const [collapsed, setCollapsed] = useState<
+    Partial<Record<TodoStatus, boolean>>
+  >({});
+
   const columns = useMemo(() => {
     const map = new Map<TodoStatus, Todo[]>();
     for (const col of BOARD_COLUMNS) {
@@ -36,7 +50,6 @@ export function BoardView({
       const list = map.get(todo.status);
       if (list) list.push(todo);
       else {
-        // Statuses not in BOARD_COLUMNS go to inbox
         map.get("inbox")?.push(todo);
       }
     }
@@ -58,7 +71,11 @@ export function BoardView({
     return (
       <div className="board loading">
         {BOARD_COLUMNS.map((col) => (
-          <div key={col.status} className="board__column">
+          <div
+            key={col.status}
+            className="board__column"
+            data-status={col.status}
+          >
             <div className="board__column-header">{col.label}</div>
             <Skeleton
               variant="board-column"
@@ -74,85 +91,124 @@ export function BoardView({
     <div className="board">
       {BOARD_COLUMNS.map((col) => {
         const items = columns.get(col.status) || [];
+        const isCollapsed = !!collapsed[col.status];
         return (
           <div
             key={col.status}
             className="board__column"
+            data-status={col.status}
             onDragOver={(e) => e.preventDefault()}
             onDrop={(e) => handleDrop(e, col.status)}
           >
             <div className="board__column-header">
               <span
                 className="board__column-dot"
-                style={{ background: col.color }}
+                style={{ background: col.token }}
+                aria-hidden="true"
               />
-              {col.label}
+              <span className="board__column-label">{col.label}</span>
               <span className="board__column-count">{items.length}</span>
-            </div>
-            <div className="board__column-body">
-              {items.map((todo) => (
-                <div
-                  key={todo.id}
-                  className={`board__card${todo.completed ? " board__card--done" : ""}`}
-                  data-todo-id={todo.id}
-                  draggable
-                  tabIndex={0}
-                  role="button"
-                  aria-label={`Open task ${todo.title}`}
-                  onDragStart={(e) =>
-                    e.dataTransfer.setData("text/plain", todo.id)
-                  }
-                  onClick={() => onClick(todo.id)}
-                  onKeyDown={(e) => {
-                    if (e.target !== e.currentTarget) return;
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      onClick(todo.id);
-                    }
+              <button
+                type="button"
+                className="board__column-collapse"
+                aria-expanded={!isCollapsed}
+                aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${col.label}`}
+                onClick={() =>
+                  setCollapsed((prev) => ({
+                    ...prev,
+                    [col.status]: !prev[col.status],
+                  }))
+                }
+              >
+                <span
+                  className="board__column-chevron"
+                  aria-hidden="true"
+                  style={{
+                    transform: isCollapsed ? "rotate(0deg)" : "rotate(90deg)",
                   }}
                 >
-                  <input
-                    type="checkbox"
-                    className="todo-checkbox"
-                    checked={todo.completed}
-                    aria-label={`Mark "${todo.title}" as ${todo.completed ? "incomplete" : "complete"}`}
-                    onChange={(e) => {
-                      e.stopPropagation();
-                      onToggle(todo.id, e.target.checked);
-                    }}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                  <div className="board__card-content">
-                    <span className="board__card-title">{todo.title}</span>
-                    {todo.dueDate && (
-                      <span className="board__card-meta">
-                        {new Date(todo.dueDate).toLocaleDateString(undefined, {
-                          month: "short",
-                          day: "numeric",
-                        })}
-                      </span>
-                    )}
-                    {todo.priority &&
-                      todo.priority !== "low" &&
-                      todo.priority !== "medium" && (
-                        <span
-                          className={`todo-chip todo-chip--priority ${todo.priority}`}
-                        >
-                          {todo.priority}
-                        </span>
-                      )}
-                  </div>
-                </div>
-              ))}
-              {items.length === 0 && (
-                <div className="board__empty">
-                  <IllustrationBoardEmpty />
-                </div>
-              )}
+                  ›
+                </span>
+              </button>
             </div>
+            {!isCollapsed && (
+              <div className="board__column-body">
+                {items.map((todo) => (
+                  <BoardCard
+                    key={todo.id}
+                    todo={todo}
+                    onClick={onClick}
+                    onToggle={onToggle}
+                  />
+                ))}
+                {items.length === 0 && (
+                  <div className="board__empty">
+                    <IllustrationBoardEmpty />
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         );
       })}
+    </div>
+  );
+}
+
+interface BoardCardProps {
+  todo: Todo;
+  onClick: (id: string) => void;
+  onToggle: (id: string, completed: boolean) => void;
+}
+
+function BoardCard({ todo, onClick, onToggle }: BoardCardProps) {
+  const showHighPriority =
+    todo.priority && todo.priority !== "low" && todo.priority !== "medium";
+  return (
+    <div
+      className={`board__card${todo.completed ? " board__card--done" : ""}`}
+      data-todo-id={todo.id}
+      draggable
+      tabIndex={0}
+      role="button"
+      aria-label={`Open task ${todo.title}`}
+      onDragStart={(e) => e.dataTransfer.setData("text/plain", todo.id)}
+      onClick={() => onClick(todo.id)}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick(todo.id);
+        }
+      }}
+    >
+      <input
+        type="checkbox"
+        className="todo-checkbox"
+        checked={todo.completed}
+        aria-label={`Mark "${todo.title}" as ${todo.completed ? "incomplete" : "complete"}`}
+        onChange={(e) => {
+          e.stopPropagation();
+          onToggle(todo.id, e.target.checked);
+        }}
+        onClick={(e) => e.stopPropagation()}
+      />
+      <div className="board__card-content">
+        <span className="board__card-title">{todo.title}</span>
+        {todo.dueDate && (
+          <span className="board__card-meta">
+            {new Date(todo.dueDate).toLocaleDateString(undefined, {
+              month: "short",
+              day: "numeric",
+            })}
+          </span>
+        )}
+        {showHighPriority && (
+          <span className={`todo-chip todo-chip--priority ${todo.priority}`}>
+            {todo.priority}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2586,6 +2586,8 @@ body {
   overflow-x: auto;
   padding-bottom: var(--s-4);
   min-height: 380px;
+  container-type: inline-size;
+  container-name: board-surface;
 }
 
 .board__column {
@@ -2608,6 +2610,22 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
+.board__column-collapse {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--muted);
+  font-size: var(--fs-lg);
+  line-height: 1;
+}
+
+.board__column-chevron {
+  display: inline-block;
+  transition: transform var(--dur-fast) var(--ease-out);
+}
+
 .board__column-dot {
   width: 8px;
   height: 8px;
@@ -2615,11 +2633,69 @@ body {
   flex-shrink: 0;
 }
 
+.board__column-label {
+  flex: 1;
+  min-width: 0;
+}
+
 .board__column-count {
   margin-left: auto;
   font-size: var(--fs-label);
   color: var(--muted);
   font-weight: var(--fw-regular);
+}
+
+.board__column[data-status="inbox"] {
+  border-top: 2px solid var(--status-inbox);
+}
+.board__column[data-status="next"] {
+  border-top: 2px solid var(--status-next);
+}
+.board__column[data-status="in_progress"] {
+  border-top: 2px solid var(--status-in-progress);
+}
+.board__column[data-status="waiting"] {
+  border-top: 2px solid var(--status-waiting);
+}
+.board__column[data-status="done"] {
+  border-top: 2px solid var(--status-done);
+}
+
+/* Mobile: collapse the board into vertical stacked sections. The
+   container query lets the board respond to its own surface width
+   even when the viewport itself is wider. */
+@container board-surface (max-width: 640px) {
+  .board {
+    flex-direction: column;
+    overflow-x: hidden;
+  }
+
+  .board__column {
+    flex: 1 1 auto;
+  }
+
+  .board__column-collapse {
+    display: inline-flex;
+  }
+}
+
+/* Density-aware board card content: compact = title only,
+   normal = title + meta, spacious = title + meta + first chip. */
+[data-density="compact"] .board__card-meta,
+[data-density="compact"] .board__card .todo-chip {
+  display: none;
+}
+
+[data-density="normal"] .board__card .todo-chip {
+  display: none;
+}
+
+[data-density="compact"] .board__card {
+  padding: var(--s-2);
+}
+
+[data-density="spacious"] .board__card {
+  padding: var(--s-4);
 }
 
 .board__column-body {

--- a/client-react/src/styles/tokens.css
+++ b/client-react/src/styles/tokens.css
@@ -38,6 +38,23 @@
     --danger: #e05260;
     --danger-2: #c94855;
 
+    /* ── Task status palette ─────────────── */
+    --status-inbox: #6b7280;
+    --status-next: #4f6ef7;
+    --status-in-progress: #d97706;
+    --status-waiting: #7b5bc7;
+    --status-done: #2f9e6a;
+
+    --status-inbox-bg: color-mix(in oklab, var(--status-inbox) 10%, white);
+    --status-next-bg: color-mix(in oklab, var(--status-next) 10%, white);
+    --status-in-progress-bg: color-mix(
+      in oklab,
+      var(--status-in-progress) 10%,
+      white
+    );
+    --status-waiting-bg: color-mix(in oklab, var(--status-waiting) 10%, white);
+    --status-done-bg: color-mix(in oklab, var(--status-done) 10%, white);
+
     --overlay: rgb(15 23 42 / 55%);
     --scrim: rgb(15 23 42 / 35%);
 
@@ -113,15 +130,16 @@
     --shadow-0: none;
     --shadow-xs: 0 1px 2px rgb(15 23 42 / 0.05);
     --shadow-sm: 0 1px 3px rgb(15 23 42 / 0.08), 0 1px 2px rgb(15 23 42 / 0.04);
-    --shadow-md: 0 4px 12px rgb(15 23 42 / 0.08), 0 2px 4px rgb(15 23 42 / 0.04);
-    --shadow-lg: 0 12px 24px rgb(15 23 42 / 0.1), 0 4px 8px rgb(15 23 42 / 0.06);
+    --shadow-md:
+      0 4px 12px rgb(15 23 42 / 0.08), 0 2px 4px rgb(15 23 42 / 0.04);
+    --shadow-lg:
+      0 12px 24px rgb(15 23 42 / 0.1), 0 4px 8px rgb(15 23 42 / 0.06);
     --shadow-xl:
       0 20px 40px rgb(15 23 42 / 0.14), 0 8px 16px rgb(15 23 42 / 0.08);
 
     /* ── Focus ring (single recipe) ───────── */
     --ring: 0 0 0 3px color-mix(in oklab, var(--accent) 25%, transparent);
-    --ring-danger: 0 0 0 3px
-      color-mix(in oklab, var(--danger) 25%, transparent);
+    --ring-danger: 0 0 0 3px color-mix(in oklab, var(--danger) 25%, transparent);
 
     /* ── Motion ──────────────────────────── */
     --ease-spring: cubic-bezier(0.22, 1, 0.36, 1);
@@ -163,6 +181,39 @@
     --success: #5dd99f;
     --warning: #ffb74d;
 
+    /* Task status palette — dark mode tints land on surface, not white. */
+    --status-inbox: #9ca3af;
+    --status-next: #7fa8ff;
+    --status-in-progress: #ffb74d;
+    --status-waiting: #b89fdf;
+    --status-done: #5dd99f;
+
+    --status-inbox-bg: color-mix(
+      in oklab,
+      var(--status-inbox) 14%,
+      var(--surface)
+    );
+    --status-next-bg: color-mix(
+      in oklab,
+      var(--status-next) 14%,
+      var(--surface)
+    );
+    --status-in-progress-bg: color-mix(
+      in oklab,
+      var(--status-in-progress) 14%,
+      var(--surface)
+    );
+    --status-waiting-bg: color-mix(
+      in oklab,
+      var(--status-waiting) 14%,
+      var(--surface)
+    );
+    --status-done-bg: color-mix(
+      in oklab,
+      var(--status-done) 14%,
+      var(--surface)
+    );
+
     --overlay: rgb(2 6 23 / 75%);
     --scrim: rgb(2 6 23 / 60%);
 
@@ -173,8 +224,7 @@
     --shadow-xl: 0 20px 40px rgb(0 0 0 / 0.4), 0 8px 16px rgb(0 0 0 / 0.3);
 
     --ring: 0 0 0 3px color-mix(in oklab, var(--accent) 35%, transparent);
-    --ring-danger: 0 0 0 3px
-      color-mix(in oklab, var(--danger) 35%, transparent);
+    --ring-danger: 0 0 0 3px color-mix(in oklab, var(--danger) 35%, transparent);
   }
 
   /* ── Density modes ────────────────────── */
@@ -209,7 +259,6 @@
       --dur-slow: 0ms;
     }
   }
-
 }
 
 /* NOTE: the card/dashboard palette (previously inside :root here) has


### PR DESCRIPTION
## Summary

Adds the **task-status palette tokens**, paints the board column dots and top borders from those tokens, makes the board responsive via a container query, wires density to board card content, and reduces the banner stack so only one banner ever shows at a time.

This is **PR 4 of 4** in the View Consistency refactor. PR 1 (#1017) shipped header primitives, PR 2 (#1020) shipped state primitives, PR 3 (#1021) split Settings into tabs and added Field. PR 4 closes the audit.

### Token additions (`styles/tokens.css`)

```css
--status-inbox: #6b7280;
--status-next: #4f6ef7;
--status-in-progress: #d97706;
--status-waiting: #7b5bc7;
--status-done: #2f9e6a;

--status-inbox-bg: color-mix(in oklab, var(--status-inbox) 10%, white);
/* …matching bg variants for each status. */
```

Dark mode redefines all five core hues plus their `-bg` variants — the dark `-bg` tints land on `var(--surface)` instead of pure white so they stay legible.

### Migrations

| Area | Change |
|---|---|
| `BoardView.tsx` | Column dots now use the matching `--status-*` token. Each column carries a `data-status` attribute and a 2px top border in its own status color. Cards extracted into a small `BoardCard` component for clarity. |
| Mobile board | `.board` becomes a `container-type: inline-size` element with `container-name: board-surface`. A `@container board-surface (max-width: 640px)` query stacks columns vertically and reveals a collapse button per column. The board responds to its own surface width even when the viewport itself is wider. |
| Density | `[data-density="compact"]` hides board-card meta and chips (title only); `normal` hides the chip and shows meta; `spacious` shows everything plus extra padding. The density attribute is already managed centrally by `useDensity`, so list cards and the new board cards now respond to the same setting. |
| Banner stack | `ListViewHeader` evaluates the three banners in priority order — VerificationBanner > active-filter > today-coaching — and only the highest-priority one renders. Lower-priority signals are suppressed; the user surfaces them by acting on the higher-priority one. |

### Acceptance

| Acceptance | Status |
|---|---|
| Board renders cleanly at viewport width 375px (no horizontal scroll) | ✓ via `@container` query that stacks columns vertically below 640px |
| Density changes affect both list cards and board cards | ✓ board cards now respond to `[data-density]` |
| Only one banner ever visible at a time | ✓ single-render branching in `ListViewHeader` |

**Out-of-scope follow-up**: the README mentioned a "dismissed-banner overflow menu" for restoring suppressed banners. PR 4 implements priority suppression but not the overflow UI — recommended as a small follow-up if it proves useful in production.

### Test results

- New `BoardView.statusPalette.test.tsx`: 2/2 tests pass (column → token mapping, collapse toggle behavior).
- Existing `BoardView.test.tsx`: 14/14 tests pass without changes.
- Full vitest: 1577/1578 pass; 1 failure is the pre-existing date-flaky `FilterPanel.test.ts > applyFilters > 'next-month'` (also fails on master, unrelated to PR 4).
- `npx tsc --noEmit` (root + client-react): clean.
- Production build (`tsc -b && vite build`): clean.
- Format check on touched files: clean.
- UI tests (`CI=1 npm run test:ui:fast`): 35/35 pass.

### No-cross-client impact

`src/types.ts` and the transport contract are untouched. iOS DTOs unaffected. No backend changes.

## Test plan

- [ ] CI **unit** gate.
- [ ] CI **integration** gate.
- [ ] CI **ui-quality** gate.
- [ ] In the Railway preview deploy, open the Board view and:
  - Confirm column dots and top borders use the new status palette in both light and dark mode.
  - Resize down to ~375px wide; confirm columns stack vertically and each can be collapsed.
  - Toggle density (compact / normal / spacious) and confirm board cards trim/expand alongside the list cards.
  - On Today, confirm the today-coaching banner gets suppressed when the verification banner or active-filter bar is showing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
