### PR TITLE
test(api): cover backend confidence gaps

### DIFF
--- a/src/authService.test.ts
+++ b/src/authService.test.ts
@@ -5,6 +5,7 @@ import jwt from "jsonwebtoken";
 
 describe("AuthService", () => {
   let authService: AuthService;
+  let dispatchVerificationEmailSpy: jest.SpyInstance;
   const TEST_JWT_SECRET = "test-secret-key";
 
   beforeAll(() => {
@@ -16,6 +17,13 @@ describe("AuthService", () => {
   beforeEach(async () => {
     // Clean up users before each test
     await prisma.user.deleteMany();
+    dispatchVerificationEmailSpy = jest
+      .spyOn(authService, "dispatchVerificationEmail")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    dispatchVerificationEmailSpy.mockRestore();
   });
 
   describe("register", () => {
@@ -95,6 +103,7 @@ describe("AuthService", () => {
     });
 
     it("should not block registration on verification email delivery", async () => {
+      dispatchVerificationEmailSpy.mockRestore();
       let resolveEmail!: () => void;
       const emailDeferred = new Promise<void>((resolve) => {
         resolveEmail = resolve;
@@ -308,6 +317,47 @@ describe("AuthService", () => {
       resolveEmail();
       await emailDeferred;
       sendPasswordResetEmailSpy.mockRestore();
+    });
+  });
+
+  describe("resetPassword", () => {
+    it("should update the password and revoke active refresh tokens", async () => {
+      const user = await prisma.user.create({
+        data: {
+          email: "reset-revokes-sessions@example.com",
+          password: await bcrypt.hash("old-password", 10),
+          resetToken: "valid-reset-token",
+          resetTokenExpiry: new Date(Date.now() + 60 * 60 * 1000),
+        },
+      });
+      const firstSession = await authService.issueTokens(user.id, user.email);
+      const secondSession = await authService.issueTokens(user.id, user.email);
+
+      await authService.resetPassword("valid-reset-token", "new-password");
+
+      await expect(
+        authService.login({
+          email: "reset-revokes-sessions@example.com",
+          password: "old-password",
+        }),
+      ).rejects.toThrow("Invalid credentials");
+      await expect(
+        authService.login({
+          email: "reset-revokes-sessions@example.com",
+          password: "new-password",
+        }),
+      ).resolves.toMatchObject({
+        user: { id: user.id, email: "reset-revokes-sessions@example.com" },
+      });
+      await expect(
+        authService.refreshAccessToken(firstSession.refreshToken),
+      ).rejects.toThrow("Invalid refresh token");
+      await expect(
+        authService.refreshAccessToken(secondSession.refreshToken),
+      ).rejects.toThrow("Invalid refresh token");
+      await expect(
+        prisma.refreshToken.count({ where: { userId: user.id } }),
+      ).resolves.toBe(1);
     });
   });
 

--- a/src/services/planner/decisionEngine.test.ts
+++ b/src/services/planner/decisionEngine.test.ts
@@ -82,4 +82,62 @@ describe("DecisionEngine", () => {
     expect(result.recommendedTasks[0].reason).toContain("overdue");
     expect(result.recommendedTasks[0].impact).toBe("high");
   });
+
+  it("excludes blocked, future, and unavailable tasks from next-work recommendations", () => {
+    const engine = new DecisionEngine();
+    const project = makeProject("project-1", "Platform");
+    const now = new Date("2026-03-12T12:00:00.000Z");
+    const dependency = makeTask("task-1", "Open dependency", {
+      projectId: project.id,
+      status: "next",
+      priority: "low",
+    });
+
+    const result = engine.decideNextWork({
+      projects: [project],
+      tasks: [
+        dependency,
+        makeTask("task-2", "Blocked launch task", {
+          projectId: project.id,
+          status: "next",
+          priority: "urgent",
+          dependsOnTaskIds: [dependency.id],
+        }),
+        makeTask("task-3", "Future start task", {
+          projectId: project.id,
+          status: "next",
+          priority: "urgent",
+          startDate: new Date("2026-03-13T12:00:00.000Z"),
+        }),
+        makeTask("task-4", "Future scheduled task", {
+          projectId: project.id,
+          status: "scheduled",
+          priority: "urgent",
+          scheduledDate: new Date("2026-03-13T12:00:00.000Z"),
+        }),
+        makeTask("task-5", "Wrong context task", {
+          projectId: project.id,
+          status: "next",
+          priority: "urgent",
+          context: "office",
+        }),
+        makeTask("task-6", "Available task", {
+          projectId: project.id,
+          status: "next",
+          priority: "high",
+          context: "computer",
+          energy: "medium",
+          estimateMinutes: 30,
+        }),
+      ],
+      now,
+      availableMinutes: 45,
+      energy: "medium",
+      context: ["computer"],
+    });
+
+    expect(result.recommendedTasks.map((task) => task.taskId)).toEqual([
+      "task-6",
+    ]);
+  });
 });

--- a/src/services/planningPreferencesService.test.ts
+++ b/src/services/planningPreferencesService.test.ts
@@ -102,4 +102,74 @@ describe("PlanningPreferencesService", () => {
       dailyRitual: "neither",
     });
   });
+
+  it("preserves existing soul profile fields during partial updates", async () => {
+    const existing = {
+      id: "pref-1",
+      userId: "user-1",
+      maxDailyTasks: 4,
+      preferredChunkMinutes: 45,
+      deepWorkPreference: "morning",
+      weekendsActive: false,
+      preferredContexts: ["office"],
+      waitingFollowUpDays: 3,
+      workWindowsJson: null,
+      soulProfile: {
+        lifeAreas: ["work", "personal"],
+        failureModes: ["overcommitted"],
+        planningStyle: "structure",
+        energyPattern: "morning",
+        goodDayThemes: ["important_work", "protect_rest"],
+        tone: "direct",
+        dailyRitual: "morning_plan",
+      },
+      createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    };
+    const findUnique = jest.fn().mockResolvedValue(existing);
+    const upsert = jest.fn().mockImplementation(({ update }) =>
+      Promise.resolve({
+        ...existing,
+        ...update,
+      }),
+    );
+    const service = new PlanningPreferencesService(
+      createMockPrisma({
+        userPlanningPreferences: { findUnique, upsert },
+      }),
+    );
+
+    const result = await service.updateForUser("user-1", {
+      soulProfile: {
+        tone: "focused",
+        failureModes: ["forgetful", "unknown", "forgetful"],
+      },
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1" },
+        update: {
+          soulProfile: {
+            lifeAreas: ["work", "personal"],
+            failureModes: ["forgetful"],
+            planningStyle: "structure",
+            energyPattern: "morning",
+            goodDayThemes: ["important_work", "protect_rest"],
+            tone: "focused",
+            dailyRitual: "morning_plan",
+          },
+        },
+      }),
+    );
+    expect(result.soulProfile).toEqual({
+      lifeAreas: ["work", "personal"],
+      failureModes: ["forgetful"],
+      planningStyle: "structure",
+      energyPattern: "morning",
+      goodDayThemes: ["important_work", "protect_rest"],
+      tone: "focused",
+      dailyRitual: "morning_plan",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Refreshes Story 5.1 backend confidence coverage on a fresh task worktree from current master.
- Adds auth/session coverage for password reset revoking active refresh-token sessions while allowing the new password.
- Adds planning preferences coverage for partial soul-profile updates preserving existing valid fields while sanitizing changed fields.
- Adds planner decision-engine coverage that excludes blocked, future, and unavailable tasks from next-work recommendations.

## Architecture notes
- Scope is test-only and limited to backend confidence surfaces.
- No transport contract, Prisma schema, CI workflow, dependency, or client behavior changes.
- Existing auth/planner/preferences tests from the prior branch are already present on current master via #1015 and still align with current behavior.

## Verification
- `npx tsc --noEmit` ✅
- `npx prettier --check src/authService.test.ts src/services/planningPreferencesService.test.ts src/services/planner/decisionEngine.test.ts` ✅
- `npm run test:unit` ✅ (424 passed)
- `npm run build:react` ✅ (needed locally because `/app/` static artifact was absent before UI fast)
- `CI=1 npm run test:ui:fast` ✅ (35 passed, 35 skipped)
- `npm run test:coverage:check` ✅ (ratchet passed: statements +0.08, branches +0.26, functions +0.36, lines +0.08)

## Known unrelated issue
- `npm run format:check` currently fails before reaching touched files because Prettier cannot parse `.github/workflows/ci.yml` on current master. That workflow file is outside this task scope and was not modified.