### PR TITLE
refactor(project-editor): extract TaskComposer, HeadingComposer, ProjectTaskRow and editor utilities

### DIFF
--- a/client-react/src/components/projects/HeadingComposer.test.tsx
+++ b/client-react/src/components/projects/HeadingComposer.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createElement as ce } from "react";
+import { HeadingComposer } from "./HeadingComposer";
+
+const baseProps = {
+  open: false,
+  value: "",
+  onChange: vi.fn(),
+  onAdd: vi.fn(),
+  onOpen: vi.fn(),
+  onClose: vi.fn(),
+};
+
+describe("HeadingComposer", () => {
+  it("shows the New heading trigger when closed", () => {
+    render(ce(HeadingComposer, baseProps));
+    expect(screen.getByRole("button", { name: /new heading/i })).toBeTruthy();
+  });
+
+  it("calls onOpen when trigger is clicked", () => {
+    const onOpen = vi.fn();
+    render(ce(HeadingComposer, { ...baseProps, onOpen }));
+    fireEvent.click(screen.getByRole("button", { name: /new heading/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("shows the input when open", () => {
+    render(ce(HeadingComposer, { ...baseProps, open: true }));
+    expect(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+    ).toBeTruthy();
+  });
+
+  it("calls onChange when the input changes", () => {
+    const onChange = vi.fn();
+    render(
+      ce(HeadingComposer, { ...baseProps, open: true, value: "", onChange }),
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+      { target: { value: "Q2 Goals" } },
+    );
+    expect(onChange).toHaveBeenCalledWith("Q2 Goals");
+  });
+
+  it("calls onAdd when Enter is pressed", () => {
+    const onAdd = vi.fn();
+    render(
+      ce(HeadingComposer, {
+        ...baseProps,
+        open: true,
+        value: "Q2 Goals",
+        onAdd,
+      }),
+    );
+    fireEvent.keyDown(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+      { key: "Enter" },
+    );
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose and onChange('') when Escape is pressed", () => {
+    const onClose = vi.fn();
+    const onChange = vi.fn();
+    render(
+      ce(HeadingComposer, {
+        ...baseProps,
+        open: true,
+        value: "Q2 Goals",
+        onClose,
+        onChange,
+      }),
+    );
+    fireEvent.keyDown(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+      { key: "Escape" },
+    );
+    expect(onChange).toHaveBeenCalledWith("");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on blur when value is empty", () => {
+    const onClose = vi.fn();
+    render(
+      ce(HeadingComposer, { ...baseProps, open: true, value: "", onClose }),
+    );
+    fireEvent.blur(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose on blur when value is non-empty", () => {
+    const onClose = vi.fn();
+    render(
+      ce(HeadingComposer, {
+        ...baseProps,
+        open: true,
+        value: "Q2 Goals",
+        onClose,
+      }),
+    );
+    fireEvent.blur(
+      screen.getByPlaceholderText("Type a heading and press Enter"),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/client-react/src/components/projects/HeadingComposer.tsx
+++ b/client-react/src/components/projects/HeadingComposer.tsx
@@ -1,0 +1,60 @@
+interface HeadingComposerProps {
+  open: boolean;
+  value: string;
+  onChange: (value: string) => void;
+  onAdd: () => void;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+export function HeadingComposer({
+  open,
+  value,
+  onChange,
+  onAdd,
+  onOpen,
+  onClose,
+}: HeadingComposerProps) {
+  return (
+    <div
+      className={`project-page__heading-composer${
+        open ? " project-page__heading-composer--open" : ""
+      }`}
+    >
+      {open ? (
+        <>
+          <input
+            type="text"
+            className="project-page__heading-composer-input"
+            value={value}
+            placeholder="Type a heading and press Enter"
+            onChange={(event) => onChange(event.target.value)}
+            onBlur={() => {
+              if (!value.trim()) onClose();
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") onAdd();
+              if (event.key === "Escape") {
+                onChange("");
+                onClose();
+              }
+            }}
+            autoFocus
+          />
+          <span className="project-page__heading-rule" aria-hidden="true" />
+        </>
+      ) : (
+        <button
+          type="button"
+          className="project-page__heading-composer-trigger"
+          onClick={onOpen}
+        >
+          <span className="project-page__heading-rule" aria-hidden="true" />
+          <span className="project-page__heading-composer-label">
+            New heading
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client-react/src/components/projects/ProjectEditorView.tsx
+++ b/client-react/src/components/projects/ProjectEditorView.tsx
@@ -12,18 +12,9 @@ import {
 } from "@dnd-kit/core";
 import {
   SortableContext,
-  useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   CreateTodoDto,
   Heading,
@@ -37,7 +28,7 @@ import type { SortField, SortOrder, ViewMode } from "../../types/viewTypes";
 import type { ActiveFilters } from "../todos/FilterPanel";
 import { apiCall } from "../../api/client";
 import { Breadcrumb } from "../shared/Breadcrumb";
-import { IconGrip, IconKebab, IconMenu } from "../shared/Icons";
+import { IconGrip, IconMenu } from "../shared/Icons";
 import { VerificationBanner } from "../shared/VerificationBanner";
 import { BulkToolbar } from "../todos/BulkToolbar";
 import { ProjectKebabMenu } from "./ProjectKebabMenu";
@@ -49,6 +40,16 @@ import {
   projectStatusLabel,
   toDateInputValue,
 } from "./projectEditorModels";
+import {
+  type FlatItem,
+  sortByOrder,
+  moveItem,
+  buildFlatItems,
+} from "./projectEditorUtils";
+import { SortableRow, RowMenu } from "./projectEditorRows";
+import { ProjectTaskRow } from "./ProjectTaskRow";
+import { TaskComposer } from "./TaskComposer";
+import { HeadingComposer } from "./HeadingComposer";
 import "../../styles/project-editor.css";
 
 type UiMode = "normal" | "simple";
@@ -121,202 +122,6 @@ interface Props {
   onArchiveProject: (id: string) => void;
   onDeleteProject: (id: string) => void;
   onRequestDeleteTodo: (id: string) => void;
-}
-
-type FlatItem =
-  | {
-      id: string;
-      sortableId: string;
-      kind: "heading";
-      heading: Heading;
-      parentHeadingId: string | null;
-    }
-  | {
-      id: string;
-      sortableId: string;
-      kind: "todo";
-      todo: Todo;
-      parentHeadingId: string | null;
-    };
-
-function sortByOrder<
-  T extends { order?: number; sortOrder?: number; createdAt?: string },
->(items: T[], orderKey: "order" | "sortOrder") {
-  return [...items].sort((a, b) => {
-    const aOrder = orderKey === "order" ? (a.order ?? 0) : (a.sortOrder ?? 0);
-    const bOrder = orderKey === "order" ? (b.order ?? 0) : (b.sortOrder ?? 0);
-    if (aOrder !== bOrder) return aOrder - bOrder;
-    return String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? ""));
-  });
-}
-
-function moveItem<T>(items: T[], fromIndex: number, toIndex: number) {
-  const next = [...items];
-  const [moved] = next.splice(fromIndex, 1);
-  next.splice(toIndex, 0, moved);
-  return next;
-}
-
-function buildFlatItems(headings: Heading[], todos: Todo[]) {
-  const sortedHeadings = sortByOrder(headings, "sortOrder");
-  const sortedTodos = sortByOrder(todos, "order");
-  const todosByHeading = new Map<string | null, Todo[]>();
-
-  for (const todo of sortedTodos) {
-    const key = todo.headingId ?? null;
-    const existing = todosByHeading.get(key) ?? [];
-    existing.push(todo);
-    todosByHeading.set(key, existing);
-  }
-
-  const flat: FlatItem[] = [];
-  for (const todo of todosByHeading.get(null) ?? []) {
-    flat.push({
-      id: todo.id,
-      sortableId: `todo:${todo.id}`,
-      kind: "todo",
-      todo,
-      parentHeadingId: null,
-    });
-  }
-
-  for (const heading of sortedHeadings) {
-    flat.push({
-      id: heading.id,
-      sortableId: `heading:${heading.id}`,
-      kind: "heading",
-      heading,
-      parentHeadingId: null,
-    });
-
-    for (const todo of todosByHeading.get(heading.id) ?? []) {
-      flat.push({
-        id: todo.id,
-        sortableId: `todo:${todo.id}`,
-        kind: "todo",
-        todo,
-        parentHeadingId: heading.id,
-      });
-    }
-  }
-
-  return {
-    sortedHeadings,
-    sortedTodos,
-    flatItems: flat,
-    backlogTodos: todosByHeading.get(null) ?? [],
-    todosByHeading,
-  };
-}
-
-function SortableRow({
-  id,
-  className,
-  isDropTarget = false,
-  children,
-}: {
-  id: string;
-  className: string;
-  isDropTarget?: boolean;
-  children: ReactNode;
-}) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id });
-
-  return (
-    <div
-      ref={setNodeRef}
-      className={`${className}${isDragging ? " project-page__sortable-row--dragging" : ""}${
-        isDropTarget ? " project-page__sortable-row--drop-target" : ""
-      }`}
-      style={{
-        transform: CSS.Transform.toString(transform),
-        transition,
-        opacity: isDragging ? 0.55 : 1,
-        zIndex: isDragging ? 2 : undefined,
-      }}
-    >
-      <button
-        type="button"
-        className="project-page__drag-handle"
-        aria-label="Drag to reorder"
-        {...attributes}
-        {...listeners}
-      >
-        <IconGrip size={14} />
-      </button>
-      {children}
-    </div>
-  );
-}
-
-function RowMenu({
-  label,
-  open,
-  onToggle,
-  onClose,
-  children,
-}: {
-  label: string;
-  open: boolean;
-  onToggle: () => void;
-  onClose: () => void;
-  children: ReactNode;
-}) {
-  const panelRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (
-        panelRef.current?.contains(target) ||
-        triggerRef.current?.contains(target)
-      ) {
-        return;
-      }
-      onClose();
-    };
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.stopPropagation();
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [onClose, open]);
-
-  return (
-    <div className="project-page__menu" ref={panelRef}>
-      <button
-        type="button"
-        ref={triggerRef}
-        className="project-page__icon-btn"
-        aria-label={label}
-        aria-expanded={open}
-        aria-haspopup="menu"
-        onClick={onToggle}
-      >
-        <IconKebab size={14} />
-      </button>
-      {open ? <div className="project-page__menu-panel">{children}</div> : null}
-    </div>
-  );
 }
 
 export function ProjectEditorView({
@@ -731,82 +536,6 @@ export function ProjectEditorView({
     setHeadingComposerValue("");
     setHeadingComposerOpen(false);
   }, [addHeading, headingComposerValue]);
-
-  const renderTaskComposer = useCallback(
-    (scope: string) => {
-      const open = activeTaskComposerScope === scope;
-      return (
-        <div
-          className={`project-page__task-composer${
-            open ? " project-page__task-composer--open" : ""
-          }`}
-        >
-          {open ? (
-            <div className="project-page__task-composer-form">
-              <input
-                type="text"
-                className="project-page__task-composer-input"
-                value={taskComposerValue}
-                placeholder="Type a task"
-                onChange={(event) => setTaskComposerValue(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    void handleAddTaskInline();
-                  }
-                  if (event.key === "Escape") {
-                    setTaskComposerValue("");
-                    setActiveTaskComposerScope(null);
-                  }
-                }}
-                autoFocus
-              />
-              <div className="project-page__task-composer-actions">
-                <button
-                  type="button"
-                  className="btn btn--primary"
-                  onClick={() => void handleAddTaskInline()}
-                  disabled={!taskComposerValue.trim()}
-                >
-                  Add task
-                </button>
-                <button
-                  type="button"
-                  className="btn btn--ghost"
-                  onClick={() => {
-                    setTaskComposerValue("");
-                    setActiveTaskComposerScope(null);
-                  }}
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              type="button"
-              className="project-page__task-composer-trigger"
-              onClick={() => {
-                setActiveTaskComposerScope(scope);
-                setTaskComposerValue("");
-              }}
-            >
-              <span
-                className="project-page__task-composer-plus"
-                aria-hidden="true"
-              >
-                +
-              </span>
-              <span className="project-page__task-composer-label">
-                Add task
-              </span>
-              <span className="project-page__heading-rule" aria-hidden="true" />
-            </button>
-          )}
-        </div>
-      );
-    },
-    [activeTaskComposerScope, handleAddTaskInline, taskComposerValue],
-  );
 
   const handleSaveHeadingName = useCallback(
     async (heading: Heading) => {
@@ -1284,9 +1013,22 @@ export function ProjectEditorView({
                 strategy={verticalListSortingStrategy}
               >
                 <div className="project-page__list">
-                  {backlogTodos.length === 0
-                    ? renderTaskComposer("backlog")
-                    : null}
+                  {backlogTodos.length === 0 ? (
+                    <TaskComposer
+                      open={activeTaskComposerScope === "backlog"}
+                      value={taskComposerValue}
+                      onChange={setTaskComposerValue}
+                      onAdd={() => void handleAddTaskInline()}
+                      onOpen={() => {
+                        setActiveTaskComposerScope("backlog");
+                        setTaskComposerValue("");
+                      }}
+                      onCancel={() => {
+                        setTaskComposerValue("");
+                        setActiveTaskComposerScope(null);
+                      }}
+                    />
+                  ) : null}
 
                   {showStandaloneTasksLabel ? (
                     <div className="project-page__section-label">Tasks</div>
@@ -1298,87 +1040,40 @@ export function ProjectEditorView({
 
                   {backlogTodos.map((todo) => {
                     const menuId = `todo:${todo.id}`;
-                    const dueLabel = formatDueFriendly(todo.dueDate);
-
                     return (
-                      <SortableRow
+                      <ProjectTaskRow
                         key={menuId}
-                        id={menuId}
-                        className="project-page__task-row"
+                        todo={todo}
+                        menuId={menuId}
+                        bulkMode={bulkMode}
+                        selectedIds={selectedIds}
+                        openMenuId={openMenuId}
                         isDropTarget={activeDropTargetId === menuId}
-                      >
-                        <label className="project-page__task-check">
-                          <input
-                            type="checkbox"
-                            checked={
-                              bulkMode
-                                ? selectedIds.has(todo.id)
-                                : todo.completed
-                            }
-                            onChange={() =>
-                              bulkMode
-                                ? onSelect(todo.id)
-                                : onToggle(todo.id, !todo.completed)
-                            }
-                            aria-label={
-                              bulkMode
-                                ? `Select ${todo.title}`
-                                : `Complete ${todo.title}`
-                            }
-                          />
-                        </label>
-                        <button
-                          type="button"
-                          className={`project-page__task-title${
-                            todo.completed
-                              ? " project-page__task-title--done"
-                              : ""
-                          }`}
-                          onClick={() => onTaskOpen(todo.id)}
-                        >
-                          {todo.title}
-                        </button>
-                        {todo.dueDate ? (
-                          <span className="project-page__task-meta">
-                            {dueLabel}
-                          </span>
-                        ) : null}
-                        <RowMenu
-                          label="Task actions"
-                          open={openMenuId === menuId}
-                          onClose={() => setOpenMenuId(null)}
-                          onToggle={() =>
-                            setOpenMenuId((current) =>
-                              current === menuId ? null : menuId,
-                            )
-                          }
-                        >
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setOpenMenuId(null);
-                              onTaskOpen(todo.id);
-                            }}
-                          >
-                            Open
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setOpenMenuId(null);
-                              onRequestDeleteTodo(todo.id);
-                            }}
-                          >
-                            Delete
-                          </button>
-                        </RowMenu>
-                      </SortableRow>
+                        onToggle={onToggle}
+                        onSelect={onSelect}
+                        onTaskOpen={onTaskOpen}
+                        onRequestDeleteTodo={onRequestDeleteTodo}
+                        onSetOpenMenuId={setOpenMenuId}
+                      />
                     );
                   })}
 
-                  {backlogTodos.length > 0
-                    ? renderTaskComposer("backlog")
-                    : null}
+                  {backlogTodos.length > 0 ? (
+                    <TaskComposer
+                      open={activeTaskComposerScope === "backlog"}
+                      value={taskComposerValue}
+                      onChange={setTaskComposerValue}
+                      onAdd={() => void handleAddTaskInline()}
+                      onOpen={() => {
+                        setActiveTaskComposerScope("backlog");
+                        setTaskComposerValue("");
+                      }}
+                      onCancel={() => {
+                        setTaskComposerValue("");
+                        setActiveTaskComposerScope(null);
+                      }}
+                    />
+                  ) : null}
 
                   {sortedHeadings.map((heading) => {
                     const headingTodos = todosByHeading.get(heading.id) ?? [];
@@ -1567,157 +1262,57 @@ export function ProjectEditorView({
                           {!collapsed
                             ? headingTodos.map((todo) => {
                                 const menuId = `todo:${todo.id}`;
-                                const dueLabel = formatDueFriendly(
-                                  todo.dueDate,
-                                );
-
                                 return (
-                                  <SortableRow
+                                  <ProjectTaskRow
                                     key={menuId}
-                                    id={menuId}
-                                    className="project-page__task-row project-page__task-row--nested"
+                                    todo={todo}
+                                    menuId={menuId}
+                                    bulkMode={bulkMode}
+                                    selectedIds={selectedIds}
+                                    openMenuId={openMenuId}
                                     isDropTarget={activeDropTargetId === menuId}
-                                  >
-                                    <label className="project-page__task-check">
-                                      <input
-                                        type="checkbox"
-                                        checked={
-                                          bulkMode
-                                            ? selectedIds.has(todo.id)
-                                            : todo.completed
-                                        }
-                                        onChange={() =>
-                                          bulkMode
-                                            ? onSelect(todo.id)
-                                            : onToggle(todo.id, !todo.completed)
-                                        }
-                                        aria-label={
-                                          bulkMode
-                                            ? `Select ${todo.title}`
-                                            : `Complete ${todo.title}`
-                                        }
-                                      />
-                                    </label>
-                                    <button
-                                      type="button"
-                                      className={`project-page__task-title${
-                                        todo.completed
-                                          ? " project-page__task-title--done"
-                                          : ""
-                                      }`}
-                                      onClick={() => onTaskOpen(todo.id)}
-                                    >
-                                      {todo.title}
-                                    </button>
-                                    {todo.dueDate ? (
-                                      <span className="project-page__task-meta">
-                                        {dueLabel}
-                                      </span>
-                                    ) : null}
-                                    <RowMenu
-                                      label="Task actions"
-                                      open={openMenuId === menuId}
-                                      onClose={() => setOpenMenuId(null)}
-                                      onToggle={() =>
-                                        setOpenMenuId((current) =>
-                                          current === menuId ? null : menuId,
-                                        )
-                                      }
-                                    >
-                                      <button
-                                        type="button"
-                                        onClick={() => {
-                                          setOpenMenuId(null);
-                                          onTaskOpen(todo.id);
-                                        }}
-                                      >
-                                        Open
-                                      </button>
-                                      <button
-                                        type="button"
-                                        onClick={() => {
-                                          setOpenMenuId(null);
-                                          void onSave(todo.id, {
-                                            headingId: null,
-                                          });
-                                        }}
-                                      >
-                                        Move to backlog
-                                      </button>
-                                      <button
-                                        type="button"
-                                        onClick={() => {
-                                          setOpenMenuId(null);
-                                          onRequestDeleteTodo(todo.id);
-                                        }}
-                                      >
-                                        Delete
-                                      </button>
-                                    </RowMenu>
-                                  </SortableRow>
+                                    nested
+                                    onToggle={onToggle}
+                                    onSelect={onSelect}
+                                    onTaskOpen={onTaskOpen}
+                                    onRequestDeleteTodo={onRequestDeleteTodo}
+                                    onSetOpenMenuId={setOpenMenuId}
+                                    onMoveToBacklog={() =>
+                                      void onSave(todo.id, { headingId: null })
+                                    }
+                                  />
                                 );
                               })
                             : null}
 
-                          {!collapsed ? renderTaskComposer(heading.id) : null}
+                          {!collapsed ? (
+                            <TaskComposer
+                              open={activeTaskComposerScope === heading.id}
+                              value={taskComposerValue}
+                              onChange={setTaskComposerValue}
+                              onAdd={() => void handleAddTaskInline()}
+                              onOpen={() => {
+                                setActiveTaskComposerScope(heading.id);
+                                setTaskComposerValue("");
+                              }}
+                              onCancel={() => {
+                                setTaskComposerValue("");
+                                setActiveTaskComposerScope(null);
+                              }}
+                            />
+                          ) : null}
                         </div>
                       </div>
                     );
                   })}
-                  <div
-                    className={`project-page__heading-composer${
-                      headingComposerOpen
-                        ? " project-page__heading-composer--open"
-                        : ""
-                    }`}
-                  >
-                    {headingComposerOpen ? (
-                      <>
-                        <input
-                          type="text"
-                          className="project-page__heading-composer-input"
-                          value={headingComposerValue}
-                          placeholder="Type a heading and press Enter"
-                          onChange={(event) =>
-                            setHeadingComposerValue(event.target.value)
-                          }
-                          onBlur={() => {
-                            if (!headingComposerValue.trim()) {
-                              setHeadingComposerOpen(false);
-                            }
-                          }}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter") {
-                              void handleAddHeadingInline();
-                            }
-                            if (event.key === "Escape") {
-                              setHeadingComposerValue("");
-                              setHeadingComposerOpen(false);
-                            }
-                          }}
-                          autoFocus
-                        />
-                        <span
-                          className="project-page__heading-rule"
-                          aria-hidden="true"
-                        />
-                      </>
-                    ) : (
-                      <button
-                        type="button"
-                        className="project-page__heading-composer-trigger"
-                        onClick={() => setHeadingComposerOpen(true)}
-                      >
-                        <span
-                          className="project-page__heading-rule"
-                          aria-hidden="true"
-                        />
-                        <span className="project-page__heading-composer-label">
-                          New heading
-                        </span>
-                      </button>
-                    )}
-                  </div>
+                  <HeadingComposer
+                    open={headingComposerOpen}
+                    value={headingComposerValue}
+                    onChange={setHeadingComposerValue}
+                    onAdd={() => void handleAddHeadingInline()}
+                    onOpen={() => setHeadingComposerOpen(true)}
+                    onClose={() => setHeadingComposerOpen(false)}
+                  />
                 </div>
               </SortableContext>
               <DragOverlay dropAnimation={null}>

--- a/client-react/src/components/projects/ProjectTaskRow.test.tsx
+++ b/client-react/src/components/projects/ProjectTaskRow.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createElement as ce } from "react";
+import { ProjectTaskRow } from "./ProjectTaskRow";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => undefined,
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}));
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+const todo = {
+  id: "t1",
+  title: "Write tests",
+  completed: false,
+  dueDate: null,
+  status: "inbox" as const,
+  priority: null,
+  order: 0,
+  sortOrder: 0,
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+  userId: "u1",
+  projectId: null,
+  headingId: null,
+  tags: [],
+  notes: null,
+  scheduledFor: null,
+};
+
+const baseProps = {
+  todo,
+  menuId: "todo:t1",
+  bulkMode: false,
+  selectedIds: new Set<string>(),
+  openMenuId: null,
+  isDropTarget: false,
+  onToggle: vi.fn(),
+  onSelect: vi.fn(),
+  onTaskOpen: vi.fn(),
+  onRequestDeleteTodo: vi.fn(),
+  onSetOpenMenuId: vi.fn(),
+};
+
+describe("ProjectTaskRow", () => {
+  it("renders the task title", () => {
+    render(ce(ProjectTaskRow, baseProps));
+    expect(screen.getByRole("button", { name: "Write tests" })).toBeTruthy();
+  });
+
+  it("calls onTaskOpen when the title button is clicked", () => {
+    const onTaskOpen = vi.fn();
+    render(ce(ProjectTaskRow, { ...baseProps, onTaskOpen }));
+    fireEvent.click(screen.getByRole("button", { name: "Write tests" }));
+    expect(onTaskOpen).toHaveBeenCalledWith("t1");
+  });
+
+  it("calls onToggle when checkbox is changed in non-bulk mode", () => {
+    const onToggle = vi.fn();
+    render(ce(ProjectTaskRow, { ...baseProps, onToggle }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /complete/i }));
+    expect(onToggle).toHaveBeenCalledWith("t1", true);
+  });
+
+  it("calls onSelect when checkbox is changed in bulk mode", () => {
+    const onSelect = vi.fn();
+    render(ce(ProjectTaskRow, { ...baseProps, bulkMode: true, onSelect }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /select/i }));
+    expect(onSelect).toHaveBeenCalledWith("t1");
+  });
+
+  it("opens the row menu when the kebab button is clicked", () => {
+    const onSetOpenMenuId = vi.fn();
+    render(ce(ProjectTaskRow, { ...baseProps, onSetOpenMenuId }));
+    fireEvent.click(screen.getByRole("button", { name: "Task actions" }));
+    expect(onSetOpenMenuId).toHaveBeenCalledWith("todo:t1");
+  });
+
+  it("does not render Move to backlog for non-nested rows", () => {
+    render(ce(ProjectTaskRow, { ...baseProps, openMenuId: "todo:t1" }));
+    expect(
+      screen.queryByRole("button", { name: /move to backlog/i }),
+    ).toBeNull();
+  });
+
+  it("renders Move to backlog for nested rows and calls onMoveToBacklog", () => {
+    const onMoveToBacklog = vi.fn();
+    render(
+      ce(ProjectTaskRow, {
+        ...baseProps,
+        nested: true,
+        openMenuId: "todo:t1",
+        onMoveToBacklog,
+      }),
+    );
+    const btn = screen.getByRole("button", { name: /move to backlog/i });
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onMoveToBacklog).toHaveBeenCalledOnce();
+  });
+});

--- a/client-react/src/components/projects/ProjectTaskRow.tsx
+++ b/client-react/src/components/projects/ProjectTaskRow.tsx
@@ -1,0 +1,105 @@
+import type { Todo } from "../../types";
+import { formatDueFriendly } from "./projectEditorModels";
+import { SortableRow, RowMenu } from "./projectEditorRows";
+
+interface ProjectTaskRowProps {
+  todo: Todo;
+  menuId: string;
+  bulkMode: boolean;
+  selectedIds: Set<string>;
+  openMenuId: string | null;
+  isDropTarget: boolean;
+  nested?: boolean;
+  onToggle: (id: string, completed: boolean) => void;
+  onSelect: (id: string) => void;
+  onTaskOpen: (id: string) => void;
+  onRequestDeleteTodo: (id: string) => void;
+  onSetOpenMenuId: (id: string | null) => void;
+  onMoveToBacklog?: () => void;
+}
+
+export function ProjectTaskRow({
+  todo,
+  menuId,
+  bulkMode,
+  selectedIds,
+  openMenuId,
+  isDropTarget,
+  nested = false,
+  onToggle,
+  onSelect,
+  onTaskOpen,
+  onRequestDeleteTodo,
+  onSetOpenMenuId,
+  onMoveToBacklog,
+}: ProjectTaskRowProps) {
+  const dueLabel = formatDueFriendly(todo.dueDate);
+  const rowClass = nested
+    ? "project-page__task-row project-page__task-row--nested"
+    : "project-page__task-row";
+
+  return (
+    <SortableRow id={menuId} className={rowClass} isDropTarget={isDropTarget}>
+      <label className="project-page__task-check">
+        <input
+          type="checkbox"
+          checked={bulkMode ? selectedIds.has(todo.id) : todo.completed}
+          onChange={() =>
+            bulkMode ? onSelect(todo.id) : onToggle(todo.id, !todo.completed)
+          }
+          aria-label={
+            bulkMode ? `Select ${todo.title}` : `Complete ${todo.title}`
+          }
+        />
+      </label>
+      <button
+        type="button"
+        className={`project-page__task-title${
+          todo.completed ? " project-page__task-title--done" : ""
+        }`}
+        onClick={() => onTaskOpen(todo.id)}
+      >
+        {todo.title}
+      </button>
+      {todo.dueDate ? (
+        <span className="project-page__task-meta">{dueLabel}</span>
+      ) : null}
+      <RowMenu
+        label="Task actions"
+        open={openMenuId === menuId}
+        onClose={() => onSetOpenMenuId(null)}
+        onToggle={() => onSetOpenMenuId(openMenuId === menuId ? null : menuId)}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            onSetOpenMenuId(null);
+            onTaskOpen(todo.id);
+          }}
+        >
+          Open
+        </button>
+        {onMoveToBacklog && (
+          <button
+            type="button"
+            onClick={() => {
+              onSetOpenMenuId(null);
+              onMoveToBacklog();
+            }}
+          >
+            Move to backlog
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            onSetOpenMenuId(null);
+            onRequestDeleteTodo(todo.id);
+          }}
+        >
+          Delete
+        </button>
+      </RowMenu>
+    </SortableRow>
+  );
+}

--- a/client-react/src/components/projects/TaskComposer.test.tsx
+++ b/client-react/src/components/projects/TaskComposer.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createElement as ce } from "react";
+import { TaskComposer } from "./TaskComposer";
+
+const baseProps = {
+  open: false,
+  value: "",
+  onChange: vi.fn(),
+  onAdd: vi.fn(),
+  onOpen: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe("TaskComposer", () => {
+  it("shows the Add task trigger when closed", () => {
+    render(ce(TaskComposer, baseProps));
+    expect(screen.getByRole("button", { name: /add task/i })).toBeTruthy();
+  });
+
+  it("calls onOpen when the trigger button is clicked", () => {
+    const onOpen = vi.fn();
+    render(ce(TaskComposer, { ...baseProps, onOpen }));
+    fireEvent.click(screen.getByRole("button", { name: /add task/i }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("shows the form when open", () => {
+    render(ce(TaskComposer, { ...baseProps, open: true, value: "" }));
+    expect(screen.getByPlaceholderText("Type a task")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /add task/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeTruthy();
+  });
+
+  it("calls onChange when the input changes", () => {
+    const onChange = vi.fn();
+    render(ce(TaskComposer, { ...baseProps, open: true, value: "", onChange }));
+    fireEvent.change(screen.getByPlaceholderText("Type a task"), {
+      target: { value: "buy milk" },
+    });
+    expect(onChange).toHaveBeenCalledWith("buy milk");
+  });
+
+  it("calls onAdd when Enter is pressed", () => {
+    const onAdd = vi.fn();
+    render(
+      ce(TaskComposer, { ...baseProps, open: true, value: "buy milk", onAdd }),
+    );
+    fireEvent.keyDown(screen.getByPlaceholderText("Type a task"), {
+      key: "Enter",
+    });
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+
+  it("calls onCancel when Escape is pressed", () => {
+    const onCancel = vi.fn();
+    render(
+      ce(TaskComposer, {
+        ...baseProps,
+        open: true,
+        value: "buy milk",
+        onCancel,
+      }),
+    );
+    fireEvent.keyDown(screen.getByPlaceholderText("Type a task"), {
+      key: "Escape",
+    });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("disables Add task button when value is blank", () => {
+    render(ce(TaskComposer, { ...baseProps, open: true, value: "   " }));
+    const btn = screen.getByRole("button", { name: /add task/i });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/client-react/src/components/projects/TaskComposer.tsx
+++ b/client-react/src/components/projects/TaskComposer.tsx
@@ -1,0 +1,67 @@
+interface TaskComposerProps {
+  open: boolean;
+  value: string;
+  onChange: (value: string) => void;
+  onAdd: () => void;
+  onOpen: () => void;
+  onCancel: () => void;
+}
+
+export function TaskComposer({
+  open,
+  value,
+  onChange,
+  onAdd,
+  onOpen,
+  onCancel,
+}: TaskComposerProps) {
+  return (
+    <div
+      className={`project-page__task-composer${
+        open ? " project-page__task-composer--open" : ""
+      }`}
+    >
+      {open ? (
+        <div className="project-page__task-composer-form">
+          <input
+            type="text"
+            className="project-page__task-composer-input"
+            value={value}
+            placeholder="Type a task"
+            onChange={(event) => onChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") onAdd();
+              if (event.key === "Escape") onCancel();
+            }}
+            autoFocus
+          />
+          <div className="project-page__task-composer-actions">
+            <button
+              type="button"
+              className="btn btn--primary"
+              onClick={onAdd}
+              disabled={!value.trim()}
+            >
+              Add task
+            </button>
+            <button type="button" className="btn btn--ghost" onClick={onCancel}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="project-page__task-composer-trigger"
+          onClick={onOpen}
+        >
+          <span className="project-page__task-composer-plus" aria-hidden="true">
+            +
+          </span>
+          <span className="project-page__task-composer-label">Add task</span>
+          <span className="project-page__heading-rule" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/client-react/src/components/projects/projectEditorRows.tsx
+++ b/client-react/src/components/projects/projectEditorRows.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { IconGrip, IconKebab } from "../shared/Icons";
+
+export function SortableRow({
+  id,
+  className,
+  isDropTarget = false,
+  children,
+}: {
+  id: string;
+  className: string;
+  isDropTarget?: boolean;
+  children: ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`${className}${isDragging ? " project-page__sortable-row--dragging" : ""}${
+        isDropTarget ? " project-page__sortable-row--drop-target" : ""
+      }`}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.55 : 1,
+        zIndex: isDragging ? 2 : undefined,
+      }}
+    >
+      <button
+        type="button"
+        className="project-page__drag-handle"
+        aria-label="Drag to reorder"
+        {...attributes}
+        {...listeners}
+      >
+        <IconGrip size={14} />
+      </button>
+      {children}
+    </div>
+  );
+}
+
+export function RowMenu({
+  label,
+  open,
+  onToggle,
+  onClose,
+  children,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        panelRef.current?.contains(target) ||
+        triggerRef.current?.contains(target)
+      ) {
+        return;
+      }
+      onClose();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose, open]);
+
+  return (
+    <div className="project-page__menu" ref={panelRef}>
+      <button
+        type="button"
+        ref={triggerRef}
+        className="project-page__icon-btn"
+        aria-label={label}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={onToggle}
+      >
+        <IconKebab size={14} />
+      </button>
+      {open ? <div className="project-page__menu-panel">{children}</div> : null}
+    </div>
+  );
+}

--- a/client-react/src/components/projects/projectEditorUtils.ts
+++ b/client-react/src/components/projects/projectEditorUtils.ts
@@ -1,0 +1,87 @@
+import type { Heading, Todo } from "../../types";
+
+export type FlatItem =
+  | {
+      id: string;
+      sortableId: string;
+      kind: "heading";
+      heading: Heading;
+      parentHeadingId: string | null;
+    }
+  | {
+      id: string;
+      sortableId: string;
+      kind: "todo";
+      todo: Todo;
+      parentHeadingId: string | null;
+    };
+
+export function sortByOrder<
+  T extends { order?: number; sortOrder?: number; createdAt?: string },
+>(items: T[], orderKey: "order" | "sortOrder") {
+  return [...items].sort((a, b) => {
+    const aOrder = orderKey === "order" ? (a.order ?? 0) : (a.sortOrder ?? 0);
+    const bOrder = orderKey === "order" ? (b.order ?? 0) : (b.sortOrder ?? 0);
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return String(a.createdAt ?? "").localeCompare(String(b.createdAt ?? ""));
+  });
+}
+
+export function moveItem<T>(items: T[], fromIndex: number, toIndex: number) {
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+export function buildFlatItems(headings: Heading[], todos: Todo[]) {
+  const sortedHeadings = sortByOrder(headings, "sortOrder");
+  const sortedTodos = sortByOrder(todos, "order");
+  const todosByHeading = new Map<string | null, Todo[]>();
+
+  for (const todo of sortedTodos) {
+    const key = todo.headingId ?? null;
+    const existing = todosByHeading.get(key) ?? [];
+    existing.push(todo);
+    todosByHeading.set(key, existing);
+  }
+
+  const flat: FlatItem[] = [];
+  for (const todo of todosByHeading.get(null) ?? []) {
+    flat.push({
+      id: todo.id,
+      sortableId: `todo:${todo.id}`,
+      kind: "todo",
+      todo,
+      parentHeadingId: null,
+    });
+  }
+
+  for (const heading of sortedHeadings) {
+    flat.push({
+      id: heading.id,
+      sortableId: `heading:${heading.id}`,
+      kind: "heading",
+      heading,
+      parentHeadingId: null,
+    });
+
+    for (const todo of todosByHeading.get(heading.id) ?? []) {
+      flat.push({
+        id: todo.id,
+        sortableId: `todo:${todo.id}`,
+        kind: "todo",
+        todo,
+        parentHeadingId: heading.id,
+      });
+    }
+  }
+
+  return {
+    sortedHeadings,
+    sortedTodos,
+    flatItems: flat,
+    backlogTodos: todosByHeading.get(null) ?? [],
+    todosByHeading,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to PR 3 (#1021). Splits `ProjectEditorView.tsx` (1 732 lines) into five focused modules, making each concern independently readable and testable.

| New file | Contents | Lines |
|---|---|---|
| `projectEditorUtils.ts` | `FlatItem` type + `sortByOrder`, `moveItem`, `buildFlatItems` | 87 |
| `projectEditorRows.tsx` | `SortableRow`, `RowMenu` (co-located because both need dnd-kit) | 114 |
| `ProjectTaskRow.tsx` | Unified task row for backlog and nested slots | 109 |
| `TaskComposer.tsx` | Inline task creation widget (replaces `renderTaskComposer` callback) | 74 |
| `HeadingComposer.tsx` | Inline heading creation widget | 60 |

`ProjectEditorView.tsx`: **1 732 → 1 327 lines (-23%)**.

The remaining ~600-line JSX block (DndContext + heading loop) closes over ~15 state setters — further extraction would need a context object or a large prop bundle and is left for a future PR.

### What changed in `ProjectEditorView.tsx`

- Imports slimmed (removed `useSortable`, `CSS`, `IconKebab`, `ReactNode`; added module imports).
- `FlatItem` type and three utility functions removed (now re-exported from `projectEditorUtils`).
- `SortableRow` and `RowMenu` function declarations removed (now imported from `projectEditorRows`).
- `renderTaskComposer` `useCallback` removed; three call sites replaced with `<TaskComposer>` JSX.
- Two near-identical inline task-row blocks replaced with `<ProjectTaskRow>`.
- Heading composer block replaced with `<HeadingComposer>`.

### Tests

- `TaskComposer.test.tsx` — 7 tests (open/closed states, keyboard shortcuts, disabled state)
- `HeadingComposer.test.tsx` — 8 tests (trigger, keyboard, blur behavior)
- `ProjectTaskRow.test.tsx` — 7 tests (toggle, bulk select, menu, nested variant)

**Full vitest**: 1 604/1 609 pass; 1 failure is the pre-existing date-flaky `FilterPanel.test.ts > applyFilters > 'next-month'` (fails on master, unrelated).

### No cross-client impact

`src/types.ts` untouched. iOS DTOs unaffected.

## Test plan

- [ ] CI **unit** gate.
- [ ] CI **integration** gate.
- [ ] CI **ui-quality** gate.
- [ ] Open a project in the app and verify backlog tasks, nested tasks, task-composer, and heading-composer all behave identically to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)