### PR TITLE
feat(banner): suppressed-banner overflow menu

### DIFF
--- a/client-react/src/components/layout/ListViewHeader.tsx
+++ b/client-react/src/components/layout/ListViewHeader.tsx
@@ -13,6 +13,10 @@ import { QuickEntry } from "../todos/QuickEntry";
 import { SearchBar } from "../shared/SearchBar";
 import { SegmentedControl } from "../shared/SegmentedControl";
 import { VerificationBanner } from "../shared/VerificationBanner";
+import {
+  BannerOverflowMenu,
+  type SuppressedBanner,
+} from "../shared/BannerOverflowMenu";
 import { DensitySegmentedControl } from "../ui/DensitySegmentedControl";
 import { ViewMenu } from "./ViewMenu";
 import { ViewSubtitle } from "./ViewSubtitle";
@@ -337,11 +341,10 @@ export function ListViewHeader({
 
       {/* Banner stack — only one banner ever renders. Priority order:
           VerificationBanner > active-filter > today-coaching. The lower
-          priority banners are suppressed (rather than dismissed) so the
-          user can still act on the highest-priority signal first. */}
+          priority banners are suppressed and surfaced via BannerOverflowMenu. */}
       {(() => {
         const showVerification = !!user && !user.isVerified;
-        const showActiveFilter = !showVerification && !!activeTagFilter;
+        const hasActiveFilter = !!activeTagFilter;
         const overdueToday =
           activeView === "today" && !selectedProjectId
             ? visibleTodos.filter(
@@ -351,30 +354,55 @@ export function ListViewHeader({
                     new Date().toISOString().split("T")[0],
               ).length
             : 0;
+        const hasTodayCoaching = visibleTodos.length > 0 && overdueToday > 0;
+
+        const showActiveFilter = !showVerification && hasActiveFilter;
         const showTodayCoaching =
-          !showVerification &&
-          !showActiveFilter &&
-          visibleTodos.length > 0 &&
-          overdueToday > 0;
+          !showVerification && !showActiveFilter && hasTodayCoaching;
+
+        const suppressed: SuppressedBanner[] = [];
+        if (showVerification && hasActiveFilter) {
+          suppressed.push({
+            id: "active-filter",
+            label: `Filtered by tag: #${activeTagFilter}`,
+            actionLabel: "Clear",
+            onAction: onClearTagFilter,
+          });
+        }
+        if ((showVerification || showActiveFilter) && hasTodayCoaching) {
+          suppressed.push({
+            id: "today-coaching",
+            label:
+              overdueToday === 1
+                ? "1 task rolled over."
+                : `${overdueToday} tasks rolled over.`,
+          });
+        }
 
         if (showVerification && user) {
           return (
-            <VerificationBanner
-              email={user.email}
-              isVerified={!!user.isVerified}
-            />
+            <div className="banner-row">
+              <VerificationBanner
+                email={user.email}
+                isVerified={!!user.isVerified}
+              />
+              <BannerOverflowMenu suppressed={suppressed} />
+            </div>
           );
         }
         if (showActiveFilter) {
           return (
-            <div className="active-filter-bar">
-              Filtered by tag: <strong>#{activeTagFilter}</strong>
-              <button
-                className="active-filter-bar__clear"
-                onClick={onClearTagFilter}
-              >
-                ✕ Clear
-              </button>
+            <div className="banner-row">
+              <div className="active-filter-bar">
+                Filtered by tag: <strong>#{activeTagFilter}</strong>
+                <button
+                  className="active-filter-bar__clear"
+                  onClick={onClearTagFilter}
+                >
+                  ✕ Clear
+                </button>
+              </div>
+              <BannerOverflowMenu suppressed={suppressed} />
             </div>
           );
         }

--- a/client-react/src/components/shared/BannerOverflowMenu.test.tsx
+++ b/client-react/src/components/shared/BannerOverflowMenu.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createElement as ce } from "react";
+import {
+  BannerOverflowMenu,
+  type SuppressedBanner,
+} from "./BannerOverflowMenu";
+
+const tagItem: SuppressedBanner = {
+  id: "tag",
+  label: "Filtered by tag: #work",
+  actionLabel: "Clear",
+  onAction: vi.fn(),
+};
+
+const coachingItem: SuppressedBanner = {
+  id: "coaching",
+  label: "3 tasks rolled over.",
+};
+
+describe("BannerOverflowMenu", () => {
+  it("renders nothing when suppressed list is empty", () => {
+    const { container } = render(ce(BannerOverflowMenu, { suppressed: [] }));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows a trigger button with the count", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem] }));
+    expect(
+      screen.getByRole("button", { name: /1 suppressed banner/i }),
+    ).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy();
+  });
+
+  it("shows +N for multiple suppressed banners", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem, coachingItem] }));
+    expect(screen.getByText("+2")).toBeTruthy();
+  });
+
+  it("panel is hidden by default", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem] }));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("opens panel when trigger is clicked", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem] }));
+    fireEvent.click(screen.getByRole("button", { name: /suppressed/i }));
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(screen.getByText("Filtered by tag: #work")).toBeTruthy();
+  });
+
+  it("closes panel when trigger is clicked again", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem] }));
+    const trigger = screen.getByRole("button", { name: /suppressed/i });
+    fireEvent.click(trigger);
+    fireEvent.click(trigger);
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("shows action button for items that have onAction", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem] }));
+    fireEvent.click(screen.getByRole("button", { name: /suppressed/i }));
+    expect(screen.getByRole("button", { name: "Clear" })).toBeTruthy();
+  });
+
+  it("does not show action button for items without onAction", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [coachingItem] }));
+    fireEvent.click(screen.getByRole("button", { name: /suppressed/i }));
+    expect(screen.queryByRole("button", { name: /clear/i })).toBeNull();
+  });
+
+  it("calls onAction and closes the panel when action is clicked", () => {
+    const onAction = vi.fn();
+    const item = { ...tagItem, onAction };
+    render(ce(BannerOverflowMenu, { suppressed: [item] }));
+    fireEvent.click(screen.getByRole("button", { name: /suppressed/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes panel on Escape key", () => {
+    render(ce(BannerOverflowMenu, { suppressed: [tagItem] }));
+    fireEvent.click(screen.getByRole("button", { name: /suppressed/i }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/client-react/src/components/shared/BannerOverflowMenu.tsx
+++ b/client-react/src/components/shared/BannerOverflowMenu.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface SuppressedBanner {
+  id: string;
+  label: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+interface BannerOverflowMenuProps {
+  suppressed: SuppressedBanner[];
+}
+
+export function BannerOverflowMenu({ suppressed }: BannerOverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        menuRef.current?.contains(target) ||
+        triggerRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  if (suppressed.length === 0) return null;
+
+  return (
+    <div className="banner-overflow" ref={menuRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className="banner-overflow__trigger"
+        aria-label={`${suppressed.length} suppressed banner${suppressed.length > 1 ? "s" : ""}`}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        +{suppressed.length}
+      </button>
+      {open && (
+        <div className="banner-overflow__panel" role="menu">
+          {suppressed.map((item) => (
+            <div
+              key={item.id}
+              className="banner-overflow__item"
+              role="menuitem"
+            >
+              <span className="banner-overflow__item-label">{item.label}</span>
+              {item.actionLabel && item.onAction && (
+                <button
+                  type="button"
+                  className="banner-overflow__item-action"
+                  onClick={() => {
+                    item.onAction?.();
+                    setOpen(false);
+                  }}
+                >
+                  {item.actionLabel}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client-react/src/styles/app.css
+++ b/client-react/src/styles/app.css
@@ -2524,6 +2524,96 @@ body {
 }
 
 /* --- Active filter bar --- */
+/* Wrapper that pairs a banner with the overflow indicator */
+.banner-row {
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid var(--border);
+}
+
+.banner-row .active-filter-bar {
+  border-bottom: none;
+  flex: 1;
+}
+
+.banner-row .verification-banner {
+  flex: 1;
+  border-bottom: none;
+}
+
+/* Overflow indicator — the +N button and its dropdown */
+.banner-overflow {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding-inline: var(--s-2);
+  background: color-mix(in oklab, var(--accent) 6%, var(--surface));
+}
+
+.banner-overflow__trigger {
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: var(--fs-label);
+  font-weight: var(--fw-semibold);
+  padding: 2px var(--s-2);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.banner-overflow__trigger:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.banner-overflow__panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 220px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-md);
+  padding: var(--s-1h);
+  z-index: 50;
+}
+
+.banner-overflow__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+  padding: var(--s-2) var(--s-2h);
+  border-radius: var(--r-sm);
+  font-size: var(--fs-meta);
+}
+
+.banner-overflow__item:hover {
+  background: var(--surface-2);
+}
+
+.banner-overflow__item-label {
+  color: var(--text);
+  flex: 1;
+}
+
+.banner-overflow__item-action {
+  border: none;
+  background: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: var(--fs-meta);
+  padding: 0;
+  white-space: nowrap;
+}
+
+.banner-overflow__item-action:hover {
+  text-decoration: underline;
+}
+
 .active-filter-bar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Follow-up to PR 4 (#1022), which shipped the priority-ordered banner stack and noted the overflow UI as a recommended follow-up.

When a higher-priority banner is active and one or more lower-priority signals are suppressed, a **+N** pill now appears at the right edge of the active banner. Clicking it opens a small dropdown listing the suppressed signals — each optionally has an action button (e.g. "Clear" for the tag-filter signal).

### What renders the overflow indicator

| Active banner | Suppressed signal(s) shown |
|---|---|
| VerificationBanner | active-filter ("Filtered by tag: #…" + Clear) and/or today-coaching ("N tasks rolled over.") |
| active-filter bar | today-coaching only |
| today-coaching | nothing (no lower-priority peers) |

### New files

| File | Purpose |
|---|---|
| `BannerOverflowMenu.tsx` | Generic component — receives `SuppressedBanner[]`, renders trigger + dropdown. Closes on Escape or outside click. |
| `BannerOverflowMenu.test.tsx` | 10 unit tests (empty list, count display, open/close, action callback, keyboard close) |

### Changes

- `ListViewHeader.tsx` — builds the `suppressed` array in the existing banner-stack IIFE and wraps the active banner + overflow in a `.banner-row` flex container.
- `app.css` — `.banner-row`, `.banner-overflow`, `.banner-overflow__trigger`, `.banner-overflow__panel`, `.banner-overflow__item*` styles.

### Test results

- New `BannerOverflowMenu.test.tsx`: 10/10 pass.
- Full vitest: same 1 failure as master (date-flaky `FilterPanel.test.ts > applyFilters > 'next-month'`).
- `npx tsc --noEmit`: clean.

### No cross-client impact

`src/types.ts` untouched. iOS DTOs unaffected.

## Test plan

- [ ] CI **unit** gate.
- [ ] CI **integration** gate.
- [ ] CI **ui-quality** gate.
- [ ] In the Railway preview deploy:
  - Trigger the VerificationBanner (unverified user) while also having an active tag filter → confirm the **+1** pill appears and clicking it shows the tag-filter row with a Clear button.
  - Trigger the VerificationBanner while having both an active tag filter and overdue-today tasks → confirm **+2** pill.
  - On Today view with overdue tasks and an active tag filter (no verification) → confirm **+1** pill shows the today-coaching message.
  - Confirm no overflow indicator appears when today-coaching is the only active banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)