### PR TITLE
fix(deps): migrate Prisma client to v7 driver-adapter API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@sentry/node": "^8.55.1",
         "@types/bcrypt": "^6.0.0",
@@ -2215,6 +2216,38 @@
         "node": ">=18"
       }
     },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.8.0.tgz",
+      "integrity": "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.8.0",
+        "@types/pg": "^8.16.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
+    "node_modules/@prisma/adapter-pg/node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@prisma/adapter-pg/node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.8.0.tgz",
@@ -2286,6 +2319,15 @@
         "std-env": "3.10.0",
         "valibot": "1.2.0",
         "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.8.0.tgz",
+      "integrity": "sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/engines": {
@@ -8617,6 +8659,46 @@
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -8624,6 +8706,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
@@ -8646,6 +8737,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -9705,6 +9805,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "node": ">=20.19.0 <23"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@sentry/node": "^8.55.1",
     "@types/bcrypt": "^6.0.0",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,12 @@
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: env("DATABASE_URL"),
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 enum UserRole {

--- a/src/prismaClient.ts
+++ b/src/prismaClient.ts
@@ -1,10 +1,12 @@
+import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 import { config } from "./config";
 
 // Singleton Prisma Client instance
 const prismaClientSingleton = () => {
+  const adapter = new PrismaPg({ connectionString: config.databaseUrl });
   return new PrismaClient({
-    datasourceUrl: config.databaseUrl,
+    adapter,
     log:
       config.nodeEnv === "development" ? ["query", "error", "warn"] : ["error"],
   });


### PR DESCRIPTION
## Summary

PR #1004 bumped Prisma to 7.8.0 but Prisma 7 removed `datasource.url` from schema files and removed the `datasourceUrl` runtime option. Master CI and local `prisma generate` have been failing on every fresh install since.

This PR completes the v6→v7 migration:

- Add `@prisma/adapter-pg` and construct `PrismaClient` with `PrismaPg({ connectionString })` in `src/prismaClient.ts` (replaces the removed `datasourceUrl` option).
- Move the migrate/generate connection URL into a new `prisma.config.ts` (`datasource.url: env("DATABASE_URL")`).
- Drop `url = env("DATABASE_URL")` from `prisma/schema.prisma` (no longer allowed in v7).

The 55 service files that import `PrismaClient` as a type are unchanged — they all use the singleton from `src/prismaClient.ts`. Test bootstrap (`test/setup.ts`) keeps working unchanged because it mutates `process.env.DATABASE_URL` before the singleton is constructed; both `PrismaPg` and `prisma.config.ts` resolve the URL from env at construction time.

Fixes the CI break introduced in #1004.

## Test plan

- [x] \`prisma generate\` succeeds (v7.8.0 client emitted)
- [x] \`prisma migrate status\` reads the new config and reports the dev DB up to date
- [x] \`npm run dev\` boots the backend; \`/healthz\` → 200, \`/todos\` → 401 (auth gate intact)
- [x] \`tsc --noEmit\` passes (run with \`node --stack-size=16384\` locally on macOS due to a separate, pre-existing deep-generic recursion issue; CI's larger Linux stack should pass without the override)
- [x] \`npm run test:unit\` — 419/424 passing; 5 failures in known-flaky suites (\`api.contract.test.ts\` is called out in CLAUDE.md as a typical flake to rerun before judging)
- [ ] CI green on Linux

## Cross-client impact

None — this PR does not touch \`src/types.ts\` or \`src/transport/\`. iOS and React clients are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)