### PR TITLE
chore(client-react): make Vite dev proxy target configurable via env

### DIFF
--- a/client-react/vite.config.ts
+++ b/client-react/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react";
 
 const localAllowedHosts = ["dev.todos.karthikg.in"];
 
+const apiTarget = process.env.API_PROXY_TARGET ?? "http://localhost:3000";
+
 export default defineConfig({
   plugins: [react()],
   base: "/app/",
@@ -22,14 +24,14 @@ export default defineConfig({
     strictPort: true,
     allowedHosts: localAllowedHosts,
     proxy: {
-      "/auth": "http://localhost:3000",
-      "/todos": "http://localhost:3000",
-      "/projects": "http://localhost:3000",
-      "/users": "http://localhost:3000",
-      "/ai": "http://localhost:3000",
-      "/admin": "http://localhost:3000",
-      "/api": "http://localhost:3000",
-      "/agent": "http://localhost:3000",
+      "/auth": apiTarget,
+      "/todos": apiTarget,
+      "/projects": apiTarget,
+      "/users": apiTarget,
+      "/ai": apiTarget,
+      "/admin": apiTarget,
+      "/api": apiTarget,
+      "/agent": apiTarget,
     },
   },
 });


### PR DESCRIPTION
## Summary

Vite's dev proxy was hardcoded to `http://localhost:3000`, which makes the React dev server unusable when port 3000 is occupied by another local service on a contributor's machine. This PR threads the proxy target through an `API_PROXY_TARGET` env var with the existing port-3000 default, so:

```bash
PORT=3003 npm run dev
API_PROXY_TARGET=http://localhost:3003 npm run dev:react
```

works without editing `vite.config.ts`.

The env var is intentionally **not** `VITE_`-prefixed — it is consumed by `vite.config.ts` at server startup, not by the client bundle, so the `VITE_` prefix would be misleading (Vite exposes `VITE_*` vars to client code via `import.meta.env`).

No behavior change for the default flow (`npm run dev:react` with no env override) — proxy target is still `http://localhost:3000`.

## Test plan

- [x] \`npm run format:check\` passes (the file matches Prettier style)
- [x] Diff is minimal: 1 file, +10 -8 lines, no structural refactor
- [ ] CI green on Linux

## Cross-client impact

None — frontend-only change in \`client-react/vite.config.ts\`. iOS app and backend are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)