### PR TITLE
fix(mcp): extend idempotency retention

### DIFF
--- a/docs/agent-accessibility.md
+++ b/docs/agent-accessibility.md
@@ -124,6 +124,7 @@ Current behavior:
 - same key + same input => replay the original success response
 - same key + different input => structured conflict error
 - production/runtime storage is durable across restarts and multiple app instances
+- idempotency records expire after 30 days
 
 Current limitation:
 
@@ -150,7 +151,6 @@ This is enough for operational debugging without introducing a separate analytic
 - add destructive confirmation patterns before exposing broader delete or bulk write actions
 - add richer audit reporting or revocation UI if operational needs outgrow the current trace tables
 - keep the new MCP assistant-session revoke APIs aligned with any future in-app assistant management UI
-
 
 ## Manifest action index (mechanical doc-sync)
 

--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -236,6 +236,7 @@ Current behavior:
 - same key + same input => replay the original success response
 - same key + different input => structured conflict error
 - production/runtime storage is durable across restarts and multiple app instances
+- idempotency records expire after 30 days
 
 Current limitation:
 
@@ -258,7 +259,6 @@ Those docs also record what remains manual from this sandboxed environment.
 - persisted audit records are lightweight operational traces, not a full analytics platform
 - the public deployment and real ChatGPT/Claude connector validation must be completed from a networked environment with Railway access
 - the MCP catalog is broader than the end-user UI today; some control-plane and evaluation tools are intended for trusted agents and automation flows more than for conversational end-user prompting
-
 
 ## Manifest action index (mechanical doc-sync)
 

--- a/src/agentIdempotencyService.test.ts
+++ b/src/agentIdempotencyService.test.ts
@@ -4,6 +4,7 @@ function createMockPrisma() {
   const records = new Map<string, any>();
 
   return {
+    records,
     agentIdempotencyRecord: {
       findUnique: jest.fn(async ({ where }) => {
         const key = `${where.action_userId_idempotencyKey.userId}:${where.action_userId_idempotencyKey.action}:${where.action_userId_idempotencyKey.idempotencyKey}`;
@@ -24,6 +25,10 @@ function createMockPrisma() {
 }
 
 describe("AgentIdempotencyService durability", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
   it("replays matching create-flow input across service instances when backed by Prisma", async () => {
     const prisma = createMockPrisma();
     const first = new AgentIdempotencyService(prisma as any);
@@ -47,5 +52,23 @@ describe("AgentIdempotencyService durability", () => {
       status: 201,
       body: { ok: true, data: { task: { id: "task-1" } } },
     });
+  });
+
+  it("retains persisted idempotency records for 30 days", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-05-02T12:00:00.000Z"));
+    const prisma = createMockPrisma();
+    const service = new AgentIdempotencyService(prisma as any);
+
+    await service.store(
+      "create_task",
+      "user-1",
+      "idem-30-day",
+      { title: "Durable task" },
+      201,
+      { ok: true, data: { task: { id: "task-1" } } },
+    );
+
+    const record = prisma.records.get("user-1:create_task:idem-30-day");
+    expect(record.expiresAt).toEqual(new Date("2026-06-01T12:00:00.000Z"));
   });
 });

--- a/src/services/agentIdempotencyService.ts
+++ b/src/services/agentIdempotencyService.ts
@@ -49,7 +49,7 @@ function cloneJsonSafe<T>(value: T): T {
 export class AgentIdempotencyService {
   constructor(private readonly prisma?: PrismaClient) {}
 
-  private readonly ttlMs = 24 * 60 * 60 * 1000;
+  private readonly ttlMs = 30 * 24 * 60 * 60 * 1000;
   private readonly entries = new Map<string, CachedAgentResponse>();
 
   private makeCacheKey(action: string, userId: string, idempotencyKey: string) {


### PR DESCRIPTION
## Summary

Extends agent/MCP idempotency retention from 24 hours to 30 days so Homebase approval retries remain protected against duplicate task creation for a longer operational window. Adds a focused unit test that freezes time and asserts persisted idempotency records expire exactly 30 days after storage. Documents the 30-day expiry in the MCP and agent accessibility docs.

## Verification

- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/todos_dev npx prisma generate
- npm run test:unit -- src/agentIdempotencyService.test.ts
- npm run test:mcp -- src/mcpRouter.test.ts
- npx tsc --noEmit
- npx prettier --check src/services/agentIdempotencyService.ts src/agentIdempotencyService.test.ts docs/assistant-mcp.md docs/agent-accessibility.md

## Notes

The repo-wide npm run format:check is currently blocked by an unrelated existing syntax issue in .github/workflows/ci.yml containing conflict markers around line 351; this PR does not touch workflow files.