### PR TITLE
feat(mcp): add Phase 4 OIDC identity contract

### DIFF
--- a/docs/assistant-mcp.md
+++ b/docs/assistant-mcp.md
@@ -31,6 +31,12 @@ Runtime endpoints:
   `/mcp/app` endpoint.
 - `GET /.well-known/oauth-authorization-server`
   Authorization server metadata.
+- `GET /.well-known/openid-configuration`
+  OIDC discovery advertising `openid`, `email`, and UserInfo for verified
+  workspace-domain identity.
+- `GET|POST /oauth/userinfo`
+  Audience-bound verified-email identity for access tokens carrying both
+  identity scopes. These scopes never authorize Todos tools.
 - `POST /oauth/register`
   Dynamic client registration for public PKCE clients.
 - `GET /oauth/authorize`

--- a/docs/remote-mcp-auth.md
+++ b/docs/remote-mcp-auth.md
@@ -11,6 +11,8 @@ Public flow:
 1. The connector discovers metadata from:
    - `GET /.well-known/oauth-protected-resource`
    - `GET /.well-known/oauth-authorization-server`
+   - `GET /.well-known/openid-configuration` when verified identity claims
+     are needed
 2. The connector registers a public PKCE client at `POST /oauth/register`.
 3. The user is sent to `GET /oauth/authorize`.
 4. The user signs in with their existing Todos account and approves scopes.
@@ -48,6 +50,43 @@ Returns:
 - `token_endpoint_auth_methods_supported`
 - `code_challenge_methods_supported`
 - `scopes_supported`
+
+The authorization server advertises both Todos application scopes and the
+standard `openid` and `email` identity scopes. The protected-resource metadata
+continues to advertise only the permissions accepted by its MCP resource.
+
+### `GET /.well-known/openid-configuration`
+
+OpenID Connect discovery for ChatGPT workspace-domain restrictions. It
+advertises the same authorization, token, revocation, registration, and PKCE
+capabilities as the OAuth metadata plus:
+
+- `userinfo_endpoint`
+- `openid` and `email` in `scopes_supported`
+- `sub`, `email`, and `email_verified` in `claims_supported`
+
+This contract intentionally does not advertise ID-token or JWKS capabilities;
+the authorization-code response remains an OAuth access-token response and
+verified identity is exposed through UserInfo.
+
+### `GET|POST /oauth/userinfo`
+
+Returns the linked account's verified identity for an audience-bound
+`/mcp/app` access token carrying both `openid` and `email`:
+
+```json
+{
+  "sub": "<stable-user-subject>",
+  "email": "person@example.com",
+  "email_verified": true
+}
+```
+
+The endpoint revalidates token signature, issuer, audience, expiry, revocation,
+assistant-session state, current user existence, current email, and current
+verification state. It returns `401 invalid_token` for invalid identity and
+`403 insufficient_scope` when either identity scope is absent. Responses are
+never cached.
 
 ### `POST /oauth/register`
 
@@ -167,51 +206,61 @@ No MCP tool trusts a client-provided user ID.
 
 ## Supported Scopes
 
-Initial assistant-facing scopes:
+Todos application-authorization scopes:
 
 - `tasks.read`
 - `tasks.write`
 - `projects.read`
 - `projects.write`
 
+Identity scopes:
+
+- `openid`
+- `email` (requires `openid`)
+
+Identity scopes are persisted through authorization-code exchange and refresh
+rotation, but they grant no task or project permission. Tool authorization
+extracts and checks only the four Todos application scopes above. An
+identity-only token therefore cannot call any MCP tool.
+
 The older `read` / `write` aliases are still accepted by validation and expanded to explicit scopes, but new connector setup should use the explicit names above.
 
 ## Tool to Scope Mapping
 
-| Tool             | Read only | Required scopes  |
-| ---------------- | --------- | ---------------- |
-| `list_tasks`     | Yes       | `tasks.read`     |
-| `search_tasks`   | Yes       | `tasks.read`     |
-| `get_task`       | Yes       | `tasks.read`     |
-| `list_today`     | Yes       | `tasks.read`     |
-| `list_next_actions` | Yes    | `tasks.read`     |
-| `list_waiting_on` | Yes      | `tasks.read`     |
-| `list_upcoming`  | Yes       | `tasks.read`     |
-| `list_stale_tasks` | Yes     | `tasks.read`     |
-| `create_task`    | No        | `tasks.write`    |
-| `update_task`    | No        | `tasks.write`    |
-| `complete_task`  | No        | `tasks.write`    |
-| `archive_task`   | No        | `tasks.write`    |
-| `delete_task`    | No        | `tasks.write`    |
-| `add_subtask`    | No        | `tasks.write`    |
-| `update_subtask` | No        | `tasks.write`    |
-| `delete_subtask` | No        | `tasks.write`    |
-| `move_task_to_project` | No  | `tasks.write`    |
-| `list_projects`  | Yes       | `projects.read`  |
-| `get_project`    | Yes       | `projects.read`  |
-| `review_projects` | Yes      | `projects.read`  |
-| `list_projects_without_next_action` | Yes | `projects.read`, `tasks.read` |
-| `plan_project` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
-| `ensure_next_action` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
-| `weekly_review` | No | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
-| `decide_next_work` | Yes | `projects.read`, `tasks.read` |
-| `analyze_project_health` | Yes | `projects.read`, `tasks.read` |
-| `analyze_work_graph` | Yes | `projects.read`, `tasks.read` |
-| `create_project` | No        | `projects.write` |
-| `update_project` | No        | `projects.write` |
-| `rename_project` | No        | `projects.write` |
-| `delete_project` | No        | `projects.write` |
-| `archive_project` | No       | `projects.write` |
+| Tool                                | Read only | Required scopes                                                                                 |
+| ----------------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `list_tasks`                        | Yes       | `tasks.read`                                                                                    |
+| `search_tasks`                      | Yes       | `tasks.read`                                                                                    |
+| `get_task`                          | Yes       | `tasks.read`                                                                                    |
+| `list_today`                        | Yes       | `tasks.read`                                                                                    |
+| `list_next_actions`                 | Yes       | `tasks.read`                                                                                    |
+| `list_waiting_on`                   | Yes       | `tasks.read`                                                                                    |
+| `list_upcoming`                     | Yes       | `tasks.read`                                                                                    |
+| `list_stale_tasks`                  | Yes       | `tasks.read`                                                                                    |
+| `create_task`                       | No        | `tasks.write`                                                                                   |
+| `update_task`                       | No        | `tasks.write`                                                                                   |
+| `complete_task`                     | No        | `tasks.write`                                                                                   |
+| `archive_task`                      | No        | `tasks.write`                                                                                   |
+| `delete_task`                       | No        | `tasks.write`                                                                                   |
+| `add_subtask`                       | No        | `tasks.write`                                                                                   |
+| `update_subtask`                    | No        | `tasks.write`                                                                                   |
+| `delete_subtask`                    | No        | `tasks.write`                                                                                   |
+| `move_task_to_project`              | No        | `tasks.write`                                                                                   |
+| `list_projects`                     | Yes       | `projects.read`                                                                                 |
+| `get_project`                       | Yes       | `projects.read`                                                                                 |
+| `review_projects`                   | Yes       | `projects.read`                                                                                 |
+| `list_projects_without_next_action` | Yes       | `projects.read`, `tasks.read`                                                                   |
+| `plan_project`                      | No        | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
+| `ensure_next_action`                | No        | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
+| `weekly_review`                     | No        | `suggest`: `projects.read`, `tasks.read`; `apply`: `projects.read`, `tasks.read`, `tasks.write` |
+| `decide_next_work`                  | Yes       | `projects.read`, `tasks.read`                                                                   |
+| `analyze_project_health`            | Yes       | `projects.read`, `tasks.read`                                                                   |
+| `analyze_work_graph`                | Yes       | `projects.read`, `tasks.read`                                                                   |
+| `create_project`                    | No        | `projects.write`                                                                                |
+| `update_project`                    | No        | `projects.write`                                                                                |
+| `rename_project`                    | No        | `projects.write`                                                                                |
+| `delete_project`                    | No        | `projects.write`                                                                                |
+| `archive_project`                   | No        | `projects.write`                                                                                |
 
 `tools/list` only returns tools the token is allowed to use.
 

--- a/src/mcp/mcpScopes.ts
+++ b/src/mcp/mcpScopes.ts
@@ -2,6 +2,8 @@ import { McpScope } from "../types";
 import { ValidationError } from "../validation/validation";
 
 export type McpScopeAlias = "read" | "write";
+export type McpIdentityScope = "openid" | "email";
+export type McpOAuthScope = McpScope | McpIdentityScope;
 
 export const TASK_READ_SCOPE: McpScope = "tasks.read";
 export const TASK_WRITE_SCOPE: McpScope = "tasks.write";
@@ -13,6 +15,13 @@ export const ALL_MCP_SCOPES: McpScope[] = [
   TASK_WRITE_SCOPE,
   PROJECT_READ_SCOPE,
   PROJECT_WRITE_SCOPE,
+];
+
+export const ALL_MCP_IDENTITY_SCOPES: McpIdentityScope[] = ["openid", "email"];
+
+export const ALL_MCP_OAUTH_SCOPES: McpOAuthScope[] = [
+  ...ALL_MCP_IDENTITY_SCOPES,
+  ...ALL_MCP_SCOPES,
 ];
 
 export const DEFAULT_MCP_SCOPES: McpScope[] = [
@@ -27,6 +36,10 @@ const LEGACY_SCOPE_ALIASES: Record<McpScopeAlias, McpScope[]> = {
 
 function isExplicitMcpScope(value: string): value is McpScope {
   return ALL_MCP_SCOPES.includes(value as McpScope);
+}
+
+function isMcpIdentityScope(value: string): value is McpIdentityScope {
+  return ALL_MCP_IDENTITY_SCOPES.includes(value as McpIdentityScope);
 }
 
 export function normalizeMcpScopes(
@@ -76,13 +89,74 @@ export function normalizeMcpScopes(
   return uniqueScopes;
 }
 
+export function normalizeMcpOAuthScopes(
+  value: unknown,
+  options?: { defaultScopes?: McpOAuthScope[]; requireNonEmpty?: boolean },
+): McpOAuthScope[] {
+  if (value === undefined) {
+    const defaults = options?.defaultScopes || DEFAULT_MCP_SCOPES;
+    return [...defaults];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new ValidationError("scopes must be an array");
+  }
+
+  const expandedScopes = value.flatMap((entry) => {
+    if (typeof entry !== "string") {
+      throw new ValidationError("scopes entries must be strings");
+    }
+
+    const normalized = entry.trim().toLowerCase();
+    if (!normalized) {
+      throw new ValidationError("scopes entries cannot be empty");
+    }
+
+    if (normalized in LEGACY_SCOPE_ALIASES) {
+      return LEGACY_SCOPE_ALIASES[normalized as McpScopeAlias];
+    }
+
+    if (isExplicitMcpScope(normalized) || isMcpIdentityScope(normalized)) {
+      return [normalized];
+    }
+
+    throw new ValidationError(
+      `Unsupported scope "${entry}". Use openid, email, or explicit scopes like tasks.read or projects.write.`,
+    );
+  });
+
+  const uniqueScopes = Array.from(new Set(expandedScopes)).sort((left, right) =>
+    left.localeCompare(right),
+  ) as McpOAuthScope[];
+
+  if ((options?.requireNonEmpty ?? true) && uniqueScopes.length === 0) {
+    throw new ValidationError("scopes cannot be empty");
+  }
+
+  if (uniqueScopes.includes("email") && !uniqueScopes.includes("openid")) {
+    throw new ValidationError('scope "email" requires scope "openid"');
+  }
+
+  return uniqueScopes;
+}
+
+export function getMcpApplicationScopes(
+  scopes: readonly McpOAuthScope[],
+): McpScope[] {
+  return scopes.filter(isExplicitMcpScope);
+}
+
 export function hasAllMcpScopes(
-  availableScopes: McpScope[],
-  requiredScopes: McpScope[],
+  availableScopes: readonly McpOAuthScope[],
+  requiredScopes: readonly McpScope[],
 ): boolean {
   return requiredScopes.every((scope) => availableScopes.includes(scope));
 }
 
 export function formatMcpScopes(scopes: McpScope[]): string {
+  return [...scopes].sort((left, right) => left.localeCompare(right)).join(" ");
+}
+
+export function formatMcpOAuthScopes(scopes: McpOAuthScope[]): string {
   return [...scopes].sort((left, right) => left.localeCompare(right)).join(" ");
 }

--- a/src/mcpAppRouter.test.ts
+++ b/src/mcpAppRouter.test.ts
@@ -424,6 +424,29 @@ describe("ChatGPT-native MCP app profile", () => {
     ).rejects.toThrow("Invalid MCP token");
   });
 
+  test("keeps OIDC identity scopes out of native tool authorization", async () => {
+    const authService = new AuthService({
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ mcpRevokedAfter: null }),
+      },
+    } as any);
+    const resource = "http://localhost:3000/mcp/app";
+    const issued = authService.createMcpToken({
+      userId: "00000000-0000-4000-8000-000000000001",
+      email: "user@example.com",
+      scopes: ["openid", "email"],
+      resource,
+    });
+
+    const verified = await authService.verifyMcpToken(issued.token, {
+      resource,
+      requireResource: true,
+    });
+    expect(issued.scopes).toEqual(["email", "openid"]);
+    expect(verified.oauthScopes).toEqual(["email", "openid"]);
+    expect(verified.scopes).toEqual([]);
+  });
+
   test("sanitizes planner results and omits internal attribution", async () => {
     const execute = jest.fn().mockResolvedValue({
       status: 200,

--- a/src/mcpOAuthService.test.ts
+++ b/src/mcpOAuthService.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { McpOAuthService } from "./services/mcpOAuthService";
 
 function createMockPrisma() {
@@ -124,6 +124,38 @@ function createMockPrisma() {
 }
 
 describe("McpOAuthService durability", () => {
+  it("persists identity scopes independently from Todos permissions", async () => {
+    const prisma = createMockPrisma();
+    const first = new McpOAuthService(prisma as any);
+    const second = new McpOAuthService(prisma as any);
+    const verifier = "pkce-verifier-oidc-persistence-111111111111111111111111";
+    const challenge = createHash("sha256")
+      .update(verifier, "utf8")
+      .digest("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+
+    const created = await first.createAuthorizationCode({
+      userId: "user-1",
+      email: "user-1@example.com",
+      clientId: "chatgpt-client",
+      redirectUri: "https://chat.openai.com/aip/callback",
+      scopes: ["openid", "email"],
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+    });
+
+    const exchanged = await second.exchangeAuthorizationCode({
+      code: created.code,
+      clientId: "chatgpt-client",
+      redirectUri: "https://chat.openai.com/aip/callback",
+      codeVerifier: verifier,
+    });
+
+    expect(exchanged.scopes).toEqual(["email", "openid"]);
+  });
+
   it("exchanges authorization codes across service instances when backed by Prisma", async () => {
     const prisma = createMockPrisma();
     const first = new McpOAuthService(prisma as any);

--- a/src/mcpPublicRouter.test.ts
+++ b/src/mcpPublicRouter.test.ts
@@ -147,6 +147,128 @@ describe("Public MCP OAuth and discovery routes", () => {
     expect(response.body.revocation_endpoint).toMatch(/\/oauth\/revoke$/);
     expect(response.body.registration_endpoint).toMatch(/\/oauth\/register$/);
     expect(response.body.code_challenge_methods_supported).toContain("S256");
+    expect(response.body.scopes_supported).toEqual(
+      expect.arrayContaining(["openid", "email", "tasks.read"]),
+    );
+  });
+
+  it("publishes OIDC discovery with the verified-email UserInfo contract", async () => {
+    const response = await request(app)
+      .get("/.well-known/openid-configuration")
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      issuer: "http://localhost:3000",
+      authorization_endpoint: "http://localhost:3000/oauth/authorize",
+      token_endpoint: "http://localhost:3000/oauth/token",
+      userinfo_endpoint: "http://localhost:3000/oauth/userinfo",
+      scopes_supported: expect.arrayContaining([
+        "openid",
+        "email",
+        "tasks.read",
+      ]),
+      claims_supported: ["sub", "email", "email_verified"],
+    });
+  });
+
+  it("returns verified identity claims from UserInfo", async () => {
+    currentSession = {
+      ...buildMcpSession("user-1", ["tasks.read"]),
+      oauthScopes: ["openid", "email", "tasks.read"],
+      sessionId: "session-1",
+      resource: "http://localhost:3000/mcp/app",
+    } as any;
+
+    const response = await request(app)
+      .get("/oauth/userinfo")
+      .set("Authorization", "Bearer mcp-token-user-1")
+      .expect(200);
+
+    expect(response.body).toEqual({
+      sub: "user-1",
+      email: "user-1@example.com",
+      email_verified: true,
+    });
+    expect(response.headers["cache-control"]).toBe("no-store");
+    expect(mockAuthService.verifyMcpToken).toHaveBeenCalledWith(
+      "mcp-token-user-1",
+      {
+        resource: "http://localhost:3000/mcp/app",
+        requireResource: true,
+      },
+    );
+  });
+
+  it("supports POST at the UserInfo endpoint", async () => {
+    currentSession = {
+      ...buildMcpSession("user-1", []),
+      oauthScopes: ["openid", "email"],
+      resource: "http://localhost:3000/mcp/app",
+    } as any;
+
+    const response = await request(app)
+      .post("/oauth/userinfo")
+      .set("Authorization", "Bearer mcp-token-user-1")
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      sub: "user-1",
+      email_verified: true,
+    });
+  });
+
+  it("rejects UserInfo tokens without both identity scopes", async () => {
+    currentSession = {
+      ...buildMcpSession("user-1", ["tasks.read"]),
+      oauthScopes: ["openid", "tasks.read"],
+    } as any;
+
+    const response = await request(app)
+      .get("/oauth/userinfo")
+      .set("Authorization", "Bearer mcp-token-user-1")
+      .expect(403);
+
+    expect(response.body.error).toBe("insufficient_scope");
+    expect(response.headers["www-authenticate"]).toContain(
+      'scope="openid email"',
+    );
+  });
+
+  it("rejects UserInfo when the current account email is not verified", async () => {
+    currentSession = {
+      ...buildMcpSession("user-1", []),
+      oauthScopes: ["openid", "email"],
+    } as any;
+    mockAuthService.getUserById.mockResolvedValueOnce({
+      id: "user-1",
+      email: "user-1@example.com",
+      name: "User One",
+      isVerified: false,
+      role: "user",
+      plan: "free",
+    });
+
+    const response = await request(app)
+      .get("/oauth/userinfo")
+      .set("Authorization", "Bearer mcp-token-user-1")
+      .expect(401);
+
+    expect(response.body.error).toBe("invalid_token");
+    expect(response.body).not.toHaveProperty("email");
+  });
+
+  it("rejects missing and invalid UserInfo bearer tokens", async () => {
+    const missing = await request(app).get("/oauth/userinfo").expect(401);
+    expect(missing.body.error).toBe("invalid_token");
+
+    mockAuthService.verifyMcpToken.mockRejectedValueOnce(
+      new Error("Invalid MCP token"),
+    );
+    const invalid = await request(app)
+      .get("/oauth/userinfo")
+      .set("Authorization", "Bearer invalid-token")
+      .expect(401);
+    expect(invalid.body.error).toBe("invalid_token");
   });
 
   it("registers a public PKCE client for connector use", async () => {
@@ -319,6 +441,168 @@ describe("Public MCP OAuth and discovery routes", () => {
     expect(token.body.refresh_token).toEqual(expect.any(String));
     expect(token.body.refresh_token_expires_at).toEqual(expect.any(String));
     expect(token.body.refresh_token_expires_in).toBe(2592000);
+  });
+
+  it("preserves OIDC identity scopes through code exchange and refresh rotation", async () => {
+    const register = await request(app)
+      .post("/oauth/register")
+      .send({
+        redirect_uris: ["https://chat.openai.com/aip/callback"],
+        client_name: "ChatGPT",
+        grant_types: ["authorization_code", "refresh_token"],
+      })
+      .expect(201);
+    const pkce = createPkcePair(
+      "oauth-verifier-oidc-flow-11111111111111111111111111111111",
+    );
+    const scope = "openid email tasks.read";
+    const resource = "http://localhost:3000/mcp/app";
+    const agent = request.agent(app);
+
+    const authorizeUrl = `/oauth/authorize?client_id=${encodeURIComponent(
+      register.body.client_id,
+    )}&redirect_uri=${encodeURIComponent(
+      "https://chat.openai.com/aip/callback",
+    )}&response_type=code&scope=${encodeURIComponent(
+      scope,
+    )}&code_challenge=${encodeURIComponent(
+      pkce.challenge,
+    )}&code_challenge_method=S256&resource=${encodeURIComponent(resource)}`;
+
+    await agent.get(authorizeUrl).expect(200);
+    const login = await agent
+      .post("/oauth/authorize/login")
+      .type("form")
+      .send({
+        email: "user-1@example.com",
+        password: "password123",
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        response_type: "code",
+        scope,
+        code_challenge: pkce.challenge,
+        code_challenge_method: "S256",
+        resource,
+      })
+      .expect(303);
+    await agent.get(login.headers.location).expect(200);
+    const approve = await agent
+      .post("/oauth/authorize/decision")
+      .type("form")
+      .send({
+        decision: "approve",
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        response_type: "code",
+        scope,
+        code_challenge: pkce.challenge,
+        code_challenge_method: "S256",
+        resource,
+      })
+      .expect(303);
+
+    const code = new URL(approve.headers.location).searchParams.get("code");
+    const token = await request(app)
+      .post("/oauth/token")
+      .type("form")
+      .send({
+        grant_type: "authorization_code",
+        code,
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        code_verifier: pkce.verifier,
+        resource,
+      })
+      .expect(200);
+
+    expect(token.body.scope).toBe("email openid tasks.read");
+    expect(mockAuthService.createMcpToken).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        scopes: ["email", "openid", "tasks.read"],
+        resource,
+      }),
+    );
+
+    const refreshed = await request(app)
+      .post("/oauth/token")
+      .type("form")
+      .send({
+        grant_type: "refresh_token",
+        refresh_token: token.body.refresh_token,
+        client_id: register.body.client_id,
+        resource,
+      })
+      .expect(200);
+
+    expect(refreshed.body.scope).toBe("email openid tasks.read");
+    expect(mockAuthService.createMcpToken).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        scopes: ["email", "openid", "tasks.read"],
+        resource,
+      }),
+    );
+  });
+
+  it("does not let identity-only scopes authorize native Todos tools", async () => {
+    currentSession = {
+      ...buildMcpSession("user-1", []),
+      oauthScopes: ["openid", "email"],
+      resource: "http://localhost:3000/mcp/app",
+    } as any;
+
+    const response = await request(app)
+      .post("/mcp/app")
+      .set("Accept", "application/json, text/event-stream")
+      .set("Content-Type", "application/json")
+      .set("Authorization", "Bearer mcp-token-user-1")
+      .send({
+        jsonrpc: "2.0",
+        id: 91,
+        method: "tools/call",
+        params: { name: "list_today", arguments: {} },
+      })
+      .expect(200);
+
+    const body =
+      response.body && Object.keys(response.body).length > 0
+        ? response.body
+        : JSON.parse(
+            response.text
+              .split("\n")
+              .find((line) => line.startsWith("data: "))!
+              .slice("data: ".length),
+          );
+    expect(body.result.isError).toBe(true);
+    expect(body.result.structuredContent.error.code).toBe(
+      "MCP_INSUFFICIENT_SCOPE",
+    );
+  });
+
+  it("rejects the email identity scope without openid", async () => {
+    const register = await request(app)
+      .post("/oauth/register")
+      .send({
+        redirect_uris: ["https://chat.openai.com/aip/callback"],
+        client_name: "ChatGPT",
+      })
+      .expect(201);
+    const pkce = createPkcePair(
+      "oauth-verifier-email-without-openid-1111111111111111111111",
+    );
+
+    const response = await request(app)
+      .get("/oauth/authorize")
+      .query({
+        client_id: register.body.client_id,
+        redirect_uri: "https://chat.openai.com/aip/callback",
+        response_type: "code",
+        scope: "email tasks.read",
+        code_challenge: pkce.challenge,
+        code_challenge_method: "S256",
+      })
+      .expect(400);
+
+    expect(response.text).toContain("scope &quot;email&quot; requires scope");
   });
 
   it("preserves the native resource binding after a failed OAuth login", async () => {

--- a/src/routes/mcpPublicRouter.ts
+++ b/src/routes/mcpPublicRouter.ts
@@ -22,6 +22,7 @@ import { validateRegister } from "../validation/authValidation";
 import { GoogleAuthService } from "../services/googleAuthService";
 import { SocialAuthService } from "../services/socialAuthService";
 import { getMcpAppResource } from "../mcp/appContract";
+import { ALL_MCP_OAUTH_SCOPES, McpOAuthScope } from "../mcp/mcpScopes";
 
 interface McpPublicRouterDeps {
   authService?: AuthService;
@@ -158,6 +159,56 @@ function setRequestId(res: Response, requestId: string) {
 function setNoStoreHeaders(res: Response) {
   res.setHeader("Cache-Control", "no-store");
   res.setHeader("Pragma", "no-cache");
+}
+
+function requestsVerifiedEmail(scopes: readonly McpOAuthScope[]): boolean {
+  return scopes.includes("email");
+}
+
+async function assertIdentityScopeEligibility(input: {
+  authService: AuthService;
+  userId: string;
+  scopes: readonly McpOAuthScope[];
+}) {
+  const user = await input.authService.getUserById(input.userId);
+  if (!user) {
+    throw new Error("Linked user account no longer exists");
+  }
+  if (
+    requestsVerifiedEmail(input.scopes) &&
+    (!user.email || !user.isVerified)
+  ) {
+    throw new Error("Verified email required");
+  }
+  return user;
+}
+
+function readBearerToken(req: Request): string | undefined {
+  const authorization = req.header("authorization");
+  if (!authorization) {
+    return undefined;
+  }
+  const match = /^Bearer ([^\s]+)$/i.exec(authorization.trim());
+  return match?.[1];
+}
+
+function setUserInfoChallenge(
+  res: Response,
+  input: {
+    error: "invalid_token" | "insufficient_scope";
+    description: string;
+    scopes?: string[];
+  },
+) {
+  const parts = [
+    'Bearer realm="todos-api-userinfo"',
+    `error="${input.error}"`,
+    `error_description="${input.description.replace(/"/g, "")}"`,
+  ];
+  if (input.scopes?.length) {
+    parts.push(`scope="${input.scopes.join(" ")}"`);
+  }
+  res.setHeader("WWW-Authenticate", parts.join(", "));
 }
 
 function resolveLinkSession(
@@ -429,6 +480,14 @@ function mapTokenExchangeError(error: unknown) {
         code: "MCP_INVALID_SESSION",
         hint: "Have the user sign in again and reconnect the assistant.",
       };
+    case "Verified email required":
+      return {
+        status: 401,
+        error: "invalid_grant",
+        description: "The linked Todos account needs a verified email address",
+        code: "MCP_VERIFIED_EMAIL_REQUIRED",
+        hint: "Verify the account email, then restart the connector auth flow.",
+      };
     default:
       return {
         status: 500,
@@ -460,6 +519,13 @@ function mapAuthorizeError(message: string): {
           "The redirect URI does not match the assistant client registration.",
         code: "MCP_REDIRECT_URI_MISMATCH",
       };
+    case "Verified email required":
+      return {
+        title: "Verified Email Required",
+        description:
+          "Verify the email address on this Todos account, then restart the connection flow.",
+        code: "MCP_VERIFIED_EMAIL_REQUIRED",
+      };
     default:
       return {
         title: "Authorization Error",
@@ -485,6 +551,75 @@ export function createMcpPublicRouter({
   socialAuthService,
 }: McpPublicRouterDeps): Router {
   const router = Router();
+
+  const handleUserInfo = async (req: Request, res: Response) => {
+    const requestId = buildRequestId(req);
+    setRequestId(res, requestId);
+    setNoStoreHeaders(res);
+
+    if (!authService) {
+      return res.status(501).json({
+        error: "server_error",
+        error_description: "Authentication not configured",
+      });
+    }
+
+    const token = readBearerToken(req);
+    if (!token) {
+      setUserInfoChallenge(res, {
+        error: "invalid_token",
+        description: "A bearer access token is required",
+      });
+      return res.status(401).json({
+        error: "invalid_token",
+        error_description: "A bearer access token is required",
+      });
+    }
+
+    try {
+      const session = await authService.verifyMcpToken(token, {
+        resource: getMcpAppResource(config.baseUrl),
+        requireResource: true,
+      });
+      const oauthScopes = session.oauthScopes ?? session.scopes;
+      const requiredScopes = ["openid", "email"] as const;
+      if (requiredScopes.some((scope) => !oauthScopes.includes(scope))) {
+        setUserInfoChallenge(res, {
+          error: "insufficient_scope",
+          description: "UserInfo requires the openid and email scopes",
+          scopes: [...requiredScopes],
+        });
+        return res.status(403).json({
+          error: "insufficient_scope",
+          error_description: "UserInfo requires the openid and email scopes",
+        });
+      }
+
+      const user = await assertIdentityScopeEligibility({
+        authService,
+        userId: session.userId,
+        scopes: oauthScopes,
+      });
+      if (session.sessionId) {
+        await mcpOAuthService.recordAssistantSessionUsage(session.sessionId);
+      }
+
+      return res.status(200).json({
+        sub: user.id,
+        email: user.email,
+        email_verified: true,
+      });
+    } catch (_error) {
+      setUserInfoChallenge(res, {
+        error: "invalid_token",
+        description: "The access token is invalid, expired, or revoked",
+      });
+      return res.status(401).json({
+        error: "invalid_token",
+        error_description: "The access token is invalid, expired, or revoked",
+      });
+    }
+  };
 
   router.get("/oauth/logout", (_req, res) => {
     clearLinkSession(res);
@@ -532,14 +667,29 @@ export function createMcpPublicRouter({
       grant_types_supported: ["authorization_code", "refresh_token"],
       token_endpoint_auth_methods_supported: ["none"],
       code_challenge_methods_supported: ["S256"],
-      scopes_supported: [
-        "tasks.read",
-        "tasks.write",
-        "projects.read",
-        "projects.write",
-      ],
+      scopes_supported: ALL_MCP_OAUTH_SCOPES,
     });
   });
+
+  router.get("/.well-known/openid-configuration", (_req, res) => {
+    res.status(200).json({
+      issuer: config.baseUrl,
+      authorization_endpoint: `${config.baseUrl}/oauth/authorize`,
+      token_endpoint: `${config.baseUrl}/oauth/token`,
+      userinfo_endpoint: `${config.baseUrl}/oauth/userinfo`,
+      revocation_endpoint: `${config.baseUrl}/oauth/revoke`,
+      registration_endpoint: `${config.baseUrl}/oauth/register`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      token_endpoint_auth_methods_supported: ["none"],
+      code_challenge_methods_supported: ["S256"],
+      scopes_supported: ALL_MCP_OAUTH_SCOPES,
+      claims_supported: ["sub", "email", "email_verified"],
+    });
+  });
+
+  router.get("/oauth/userinfo", handleUserInfo);
+  router.post("/oauth/userinfo", handleUserInfo);
 
   router.post("/oauth/register", (req, res) => {
     const requestId = buildRequestId(req);
@@ -958,6 +1108,12 @@ export function createMcpPublicRouter({
         );
       }
 
+      await assertIdentityScopeEligibility({
+        authService,
+        userId: registeredUser.id,
+        scopes: authorize.scopes,
+      });
+
       // Issue authorization code for the newly registered user
       const authCode = await mcpOAuthService.createAuthorizationCode({
         userId: registeredUser.id,
@@ -1203,6 +1359,12 @@ export function createMcpPublicRouter({
         (userId, email) => authService!.issueTokens(userId, email),
       );
 
+      await assertIdentityScopeEligibility({
+        authService,
+        userId: socialResult.user.id,
+        scopes: authorize.scopes,
+      });
+
       // Issue MCP authorization code directly (implicit consent for Google sign-in)
       const authCode = await mcpOAuthService.createAuthorizationCode({
         userId: socialResult.user.id,
@@ -1309,6 +1471,12 @@ export function createMcpPublicRouter({
           }),
         );
       }
+
+      await assertIdentityScopeEligibility({
+        authService,
+        userId: linkSession.userId,
+        scopes: authorize.scopes,
+      });
 
       const authCode = await mcpOAuthService.createAuthorizationCode({
         userId: linkSession.userId,
@@ -1423,10 +1591,11 @@ export function createMcpPublicRouter({
             })
           : null;
       const linkedSession = exchange || refreshExchange!;
-      const user = await authService.getUserById(linkedSession.userId);
-      if (!user) {
-        throw new Error("Linked user account no longer exists");
-      }
+      await assertIdentityScopeEligibility({
+        authService,
+        userId: linkedSession.userId,
+        scopes: linkedSession.scopes,
+      });
 
       const existingSessionId =
         "sessionId" in linkedSession ? linkedSession.sessionId : undefined;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -4,8 +4,13 @@ import jwt from "jsonwebtoken";
 import { createHash, createHmac, randomUUID, timingSafeEqual } from "crypto";
 import { EmailService } from "./emailService";
 import { config } from "../config";
+import {
+  formatMcpOAuthScopes,
+  getMcpApplicationScopes,
+  McpOAuthScope,
+  normalizeMcpOAuthScopes,
+} from "../mcp/mcpScopes";
 import { McpScope } from "../types";
-import { formatMcpScopes, normalizeMcpScopes } from "../mcp/mcpScopes";
 
 export interface RegisterDto {
   email: string;
@@ -36,6 +41,7 @@ export interface JwtPayload {
 export interface McpTokenPayload extends JwtPayload {
   tokenType: "mcp";
   scopes: McpScope[];
+  oauthScopes?: McpOAuthScope[];
   assistantName?: string;
   clientId?: string;
   sessionId?: string;
@@ -46,7 +52,7 @@ export interface McpTokenResponse {
   token: string;
   tokenType: "Bearer";
   scope: string;
-  scopes: McpScope[];
+  scopes: McpOAuthScope[];
   expiresAt: string;
   expiresIn: number;
   assistantName?: string;
@@ -252,13 +258,13 @@ export class AuthService {
   createMcpToken(input: {
     userId: string;
     email: string;
-    scopes: McpScope[];
+    scopes: McpOAuthScope[];
     assistantName?: string;
     clientId?: string;
     sessionId?: string;
     resource?: string;
   }): McpTokenResponse {
-    const normalizedScopes = normalizeMcpScopes(input.scopes, {
+    const normalizedScopes = normalizeMcpOAuthScopes(input.scopes, {
       requireNonEmpty: true,
     });
     const expiresIn = input.resource
@@ -295,7 +301,7 @@ export class AuthService {
     return {
       token,
       tokenType: "Bearer",
-      scope: formatMcpScopes(normalizedScopes),
+      scope: formatMcpOAuthScopes(normalizedScopes),
       scopes: [...normalizedScopes],
       expiresAt: new Date(Date.now() + expiresInMs).toISOString(),
       expiresIn: Math.floor(expiresInMs / 1000),
@@ -321,9 +327,9 @@ export class AuthService {
         throw new Error("Invalid MCP token");
       }
 
-      let scopes: McpScope[];
+      let oauthScopes: McpOAuthScope[];
       try {
-        scopes = normalizeMcpScopes(payload.scopes, {
+        oauthScopes = normalizeMcpOAuthScopes(payload.scopes, {
           requireNonEmpty: true,
         });
       } catch (_error) {
@@ -352,7 +358,8 @@ export class AuthService {
         userId: payload.userId,
         email: payload.email,
         tokenType: "mcp",
-        scopes,
+        scopes: getMcpApplicationScopes(oauthScopes),
+        oauthScopes,
         issuedAt: payload.iat,
         ...(typeof payload.assistantName === "string" &&
         payload.assistantName.trim()
@@ -425,6 +432,7 @@ export class AuthService {
       email: decoded.email,
       tokenType: "mcp",
       scopes: decoded.scopes,
+      oauthScopes: decoded.oauthScopes,
       ...(decoded.assistantName
         ? { assistantName: decoded.assistantName }
         : {}),

--- a/src/services/mcpOAuthService.ts
+++ b/src/services/mcpOAuthService.ts
@@ -1,15 +1,14 @@
 import { createHash, createHmac, randomUUID } from "crypto";
 import { PrismaClient } from "@prisma/client";
-import { McpScope } from "../types";
 import { config } from "../config";
-import { normalizeMcpScopes } from "../mcp/mcpScopes";
+import { McpOAuthScope, normalizeMcpOAuthScopes } from "../mcp/mcpScopes";
 
 export interface CreateMcpAuthorizationCodeInput {
   userId: string;
   email: string;
   clientId: string;
   redirectUri: string;
-  scopes: McpScope[];
+  scopes: McpOAuthScope[];
   assistantName?: string;
   state?: string;
   codeChallenge: string;
@@ -28,7 +27,7 @@ export interface ExchangeMcpAuthorizationCodeInput {
 
 export interface CreateMcpAssistantSessionInput {
   userId: string;
-  scopes: McpScope[];
+  scopes: McpOAuthScope[];
   assistantName?: string;
   clientId?: string;
   source: "oauth" | "local";
@@ -39,7 +38,7 @@ export interface CreateMcpAssistantSessionInput {
 export interface McpAssistantSessionSummary {
   id: string;
   userId: string;
-  scopes: McpScope[];
+  scopes: McpOAuthScope[];
   source: "oauth" | "local";
   clientId?: string;
   assistantName?: string;
@@ -55,7 +54,7 @@ export interface McpAssistantSessionSummary {
 export interface CreateMcpRefreshTokenInput {
   userId: string;
   email: string;
-  scopes: McpScope[];
+  scopes: McpOAuthScope[];
   assistantName?: string;
   clientId?: string;
   sessionId?: string;
@@ -234,7 +233,7 @@ export class McpOAuthService {
       | {
           userId: string;
           email: string;
-          scopes: McpScope[];
+          scopes: McpOAuthScope[];
           clientId: string;
           redirectUri: string;
           assistantName?: string;
@@ -257,7 +256,7 @@ export class McpOAuthService {
       record = {
         userId: persisted.userId,
         email: persisted.email,
-        scopes: normalizeMcpScopes(persisted.scopes),
+        scopes: normalizeMcpOAuthScopes(persisted.scopes),
         clientId: persisted.clientId,
         redirectUri: persisted.redirectUri,
         ...(persisted.assistantName
@@ -368,7 +367,7 @@ export class McpOAuthService {
       return {
         id: session.id,
         userId: session.userId,
-        scopes: normalizeMcpScopes(session.scopes),
+        scopes: normalizeMcpOAuthScopes(session.scopes),
         source: session.source as "oauth" | "local",
         ...(session.clientId ? { clientId: session.clientId } : {}),
         ...(session.assistantName
@@ -413,7 +412,7 @@ export class McpOAuthService {
       return sessions.map((session) => ({
         id: session.id,
         userId: session.userId,
-        scopes: normalizeMcpScopes(session.scopes),
+        scopes: normalizeMcpOAuthScopes(session.scopes),
         source: session.source as "oauth" | "local",
         ...(session.clientId ? { clientId: session.clientId } : {}),
         ...(session.assistantName
@@ -578,7 +577,7 @@ export class McpOAuthService {
 
   private async ensureSessionForRefreshTokenRecord(input: {
     userId: string;
-    scopes: McpScope[];
+    scopes: McpOAuthScope[];
     assistantName?: string;
     clientId?: string;
     sessionId?: string | null;
@@ -664,7 +663,7 @@ export class McpOAuthService {
       | {
           userId: string;
           email: string;
-          scopes: McpScope[];
+          scopes: McpOAuthScope[];
           assistantName?: string;
           clientId?: string;
           sessionId?: string;
@@ -692,7 +691,7 @@ export class McpOAuthService {
         record = {
           userId: persisted.userId,
           email: persisted.email,
-          scopes: normalizeMcpScopes(persisted.scopes),
+          scopes: normalizeMcpOAuthScopes(persisted.scopes),
           ...(persisted.assistantName
             ? { assistantName: persisted.assistantName }
             : {}),

--- a/src/validation/mcpValidation.ts
+++ b/src/validation/mcpValidation.ts
@@ -1,8 +1,10 @@
 import { McpScope } from "../types";
 import {
   DEFAULT_MCP_SCOPES,
-  formatMcpScopes,
+  formatMcpOAuthScopes,
   hasAllMcpScopes,
+  McpOAuthScope,
+  normalizeMcpOAuthScopes,
   normalizeMcpScopes,
 } from "../mcp/mcpScopes";
 import { ValidationError, validateId } from "./validation";
@@ -63,7 +65,7 @@ export interface OAuthAuthorizeRequestDto {
   responseType: "code";
   clientId: string;
   redirectUri: string;
-  scopes: McpScope[];
+  scopes: McpOAuthScope[];
   state?: string;
   codeChallenge: string;
   codeChallengeMethod: "S256";
@@ -331,7 +333,7 @@ function normalizeTokenEndpointAuthMethod(value: unknown): "none" {
   return "none";
 }
 
-function normalizeScopesFromOAuthField(value: unknown): McpScope[] {
+function normalizeScopesFromOAuthField(value: unknown): McpOAuthScope[] {
   if (value === undefined) {
     return [...DEFAULT_MCP_SCOPES];
   }
@@ -344,7 +346,7 @@ function normalizeScopesFromOAuthField(value: unknown): McpScope[] {
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
 
-  return normalizeMcpScopes(entries, {
+  return normalizeMcpOAuthScopes(entries, {
     defaultScopes: DEFAULT_MCP_SCOPES,
   });
 }
@@ -601,7 +603,7 @@ export function validateOAuthAuthorizeRequest(
 }
 
 export function hasMcpScope(
-  availableScopes: McpScope[],
+  availableScopes: McpOAuthScope[],
   requiredScopes: McpScope | McpScope[],
 ): boolean {
   return hasAllMcpScopes(
@@ -610,6 +612,6 @@ export function hasMcpScope(
   );
 }
 
-export function describeMcpScopes(scopes: McpScope[]): string {
-  return formatMcpScopes(scopes);
+export function describeMcpScopes(scopes: McpOAuthScope[]): string {
+  return formatMcpOAuthScopes(scopes);
 }


### PR DESCRIPTION
## Summary

Implements Phase 4 PR A for the ChatGPT-native Todos app: production-facing OIDC discovery and verified-email UserInfo, while preserving the locked MCP tool contract and legacy `/mcp` behavior.

### Included

- `/.well-known/openid-configuration` with the existing OAuth code + PKCE endpoints
- `openid` and `email` identity scopes advertised by the authorization server
- GET and POST `/oauth/userinfo` with audience-bound bearer authentication
- current-account `sub`, `email`, and `email_verified: true` claims only for verified users
- identity scope persistence across authorization codes, assistant sessions, access tokens, and refresh rotation
- strict separation between identity scopes and Todos application scopes
- rejection of `email` without `openid`
- documented decision not to advertise ID-token/JWKS capabilities in this phase

The native `/mcp/app` metadata snapshot and six-tool surface are unchanged. Phase 4 challenge/policies/review assets remain for a follow-up PR.

## Security and compatibility invariants

- UserInfo accepts only tokens bound to the exact `/mcp/app` audience.
- Signature, issuer, audience, expiry, user revocation, assistant-session revocation, current user existence, current email, and current verification state are revalidated.
- UserInfo requires both `openid` and `email`; failures return bearer challenges without identity claims.
- `openid` and `email` alone produce zero Todos tool scopes and cannot call any MCP tool.
- Existing task/project scopes, protected-resource metadata, token lifetime, `/mcp/app` tools, and legacy `/mcp` remain compatible.
- No Prisma or shared domain contract change; no cross-client transport impact.

## Verification

- [x] TypeScript compilation
- [x] Unit tests: 459/459
- [x] MCP tests: 119/119
- [x] Focused OIDC/MCP tests: 50/50
- [x] Fast UI suite passed
- [x] Coverage ratchet passed
- [x] MCP evaluations: 5/5
- [x] Architecture guard passed
- [x] Changed-file formatting
- [x] `git diff --check`
- [x] `.github/workflows/ci.yml` confirmed unchanged
- [x] Existing native MCP metadata snapshots unchanged

### Formatting exception

> `npm run format:check` fails on the pre-existing, unchanged `.github/workflows/ci.yml` because it contains conflict markers and Prettier reports `All collection items must start at the same column (1:1)`. Changed-file formatting and `git diff --check` pass. This PR does not modify that workflow.

## External acceptance before merge

- [ ] Deploy exact PR commit `69b5f23c701ce48c8d59024181fab82150c4cd45` to reachable HTTPS
- [ ] Confirm OIDC discovery advertises the production issuer, UserInfo endpoint, `openid`, and `email`
- [ ] Complete a real OAuth flow requesting `openid email` plus native Todos scopes
- [ ] Confirm GET and POST UserInfo return verified email for the linked account
- [ ] Confirm wrong-audience, expired, revoked, and missing-scope tokens are rejected
- [ ] Confirm identity-only tokens cannot call any `/mcp/app` tool
- [ ] Confirm refresh preserves identity and application scope separation
- [ ] Relink the current ChatGPT registration so newly advertised identity scopes are granted
- [ ] Attach acceptance evidence against the exact accepted commit

Do not merge until the external acceptance checks pass against the exact commit under review. Do not add the Phase 4 challenge/policy/review-assets work to this branch.
